### PR TITLE
[WIP] Adding zotero-connector support

### DIFF
--- a/papis/commands/__init__.py
+++ b/papis/commands/__init__.py
@@ -25,6 +25,7 @@ COMMAND_NAMES = [
     "run",
     "git",
     "gui",
+    "serve",
     "sync"
 ]
 

--- a/papis/commands/serve.py
+++ b/papis/commands/serve.py
@@ -9,10 +9,12 @@ https://raw.githubusercontent.com/zotero/zotero/master/chrome/content/zotero/xpc
 """
 
 import json
+import os
 import argparse
 import logging
 import http.server
 import papis.config
+import papis.document
 
 logger = logging.getLogger("serve")
 
@@ -61,8 +63,13 @@ def papis_add(item):
     # This should just call a papis function that given a dict of
     # properties spit out the correct info.yaml and saves it.
     # I still have to figure out where PDFs are taken
-    print(item)
-    print("PAPIS add NOT IMPLEMENTED.")
+    logger.debug("Adding the document to your library")
+    document = papis.document.from_data(item)
+    lib_dir = os.path.expanduser(papis.config.get('dir'))
+    outdir = os.path.join(lib_dir, papis.utils.clean_document_name(item["title"]))
+    os.makedirs(outdir)
+    document.set_folder(outdir)
+    document.save()
 
 # HTTPRequestHandler class
 class PapisRequestHandler(http.server.BaseHTTPRequestHandler):
@@ -128,8 +135,6 @@ class PapisRequestHandler(http.server.BaseHTTPRequestHandler):
         data = json.loads(self.read_input())
         source_uri = data['uri'] # source page
         # debug info
-        print(data.keys())
-        print(len(data['items']))
         # Add all papers
         for item in data['items']:
             papis_add(item)

--- a/papis/commands/serve.py
+++ b/papis/commands/serve.py
@@ -33,7 +33,8 @@ class Command(papis.commands.Command):
             "--port",
             help="Port to listen to",
             action="store",
-            default=23119
+            default=23119,
+            type = int
         )
 
         self.parser.add_argument(

--- a/papis/commands/serve.py
+++ b/papis/commands/serve.py
@@ -1,0 +1,161 @@
+"""Start a web server listening on port 23119. This server is
+compatible with the `zotero connector`. This means that if zotero is
+*not* running, you can have items from your web browser added directly
+into papis.
+
+This is a rough port of
+https://raw.githubusercontent.com/zotero/zotero/master/chrome/content/zotero/xpcom/server_connector.js
+
+"""
+
+import json
+import argparse
+import logging
+import http.server
+import papis.config
+
+logger = logging.getLogger("serve")
+
+class Command(papis.commands.Command):
+
+    def init(self):
+        self.CONNECTOR_API_VERSION = 2
+
+        self.parser = self.get_subparsers().add_parser(
+            "serve",
+            help="Start a zotero-connector server"
+        )
+
+        self.parser.add_argument(
+            "--port",
+            help="Port to listen to",
+            action="store",
+            default=23119
+        )
+
+        self.parser.add_argument(
+            "--bind",
+            help="Address to bind",
+            action="store",
+            dest="address",
+            default="localhost"
+        )
+
+        # TODO: no clue on how to do this
+        # self.parser.add_argument(
+        #     "--fork",
+        #     help="Fork the server in background",
+        #     action="store_true"
+        # )
+
+    def main(self):
+        server_address = (self.args.address, self.args.port)
+        httpd = http.server.HTTPServer(server_address,
+                                       PapisRequestHandler)
+        global logger
+        logger.info("Starting server")
+        httpd.serve_forever()
+
+def papis_add(item):
+    # This should just call a papis function that given a dict of
+    # properties spit out the correct info.yaml and saves it.
+    # I still have to figure out where PDFs are taken
+    print("PAPIS add NOT IMPLEMENTED.")
+
+# HTTPRequestHandler class
+class PapisRequestHandler(http.server.BaseHTTPRequestHandler):
+    def log_message(self, format, *args):
+        global logger
+        logger.debug(format % args)
+        return
+
+    def set_zotero_headers(self):
+        self.send_header("X-Zotero-Version","5.0.25")
+        self.send_header("X-Zotero-Connector-API-Version", 2)
+        self.end_headers()
+
+    def read_input(self):
+        length = int(self.headers['content-length'])
+        return self.rfile.read(length)
+
+    def pong(self, POST = True):
+        global logger
+        logger.debug("pong")
+
+        print("We have been pinged") # DEBUG
+        # Pong must respond to ping on both GET and POST
+        # It must accepts application/json and text/plain
+        if not POST: # GET
+            logger.debug("GET request")
+            self.send_response(200)
+            self.send_header("Content-Type", "text/html")
+            self.set_zotero_headers()
+            response = '<!DOCTYPE html><html><head>'+\
+                       '<title>Zotero Connector Server is Available</title></head>'+\
+	               '<body>Zotero Connector Server is Available</body></html>'
+        else: # POST
+            logger.debug("POST request")
+            self.send_response(200)
+            self.send_header("Content-Type", "application/json")
+            self.set_zotero_headers()
+
+            response = json.dumps({"prefs":{"automaticSnapshots":
+                                            papis.config.get('snapshot')}})
+
+        self.wfile.write(bytes(response, "utf8"))
+
+    def papis_collection(self):
+        logger.debug("Getting library name")
+        self.send_response(200)
+        self.send_header("Content-Type", "application/json")
+        self.set_zotero_headers()
+        response = json.dumps(
+            {"libraryID":1,
+             "libraryName":papis.config.get_lib(),
+             "libraryEditable":True, # I'm not aware of a read-only papis mode
+             "editable":True,    # collection-level parameters
+             "id":None,          # collection-level
+             "name": papis.config.get_lib()# collection if collection, else library
+            })
+        self.wfile.write(bytes(response, "utf8"))
+
+    def add(self):
+        # Info or debug?
+        logger.info("Adding paper from zotero connector")
+        data = json.loads(self.read_input())
+        source_uri = data['uri'] # source page
+        # debug info
+        print(data.keys())
+        print(len(data['items']))
+        # Add all papers
+        for item in data['items']:
+            papis_add(item)
+
+        self.send_response(201) # Created
+        # print("Sleeping -- Simulating some work")
+        # time.sleep(3)   # Simulate some fetch work
+        self.set_zotero_headers()
+
+    def snapshot(self):
+        logger.warning("NOT IMPLEMENTED")
+        self.send_response(201) # Created
+        self.set_zotero_headers()
+        return
+        # print("Snapshotting")
+        # print(self.read_input())
+        # print("----------input end -----------")
+
+    def do_POST(self):
+        if self.path == "/connector/ping":
+            self.pong()
+        elif self.path == '/connector/getSelectedCollection':
+            self.papis_collection()
+        elif self.path == '/connector/saveSnapshot':
+            self.snapshot()
+        elif self.path == '/connector/saveItems':
+            self.add()
+        return
+
+    def do_GET(self):
+        if self.path == "/connector/ping":
+            self.pong(POST = False)

--- a/papis/commands/serve.py
+++ b/papis/commands/serve.py
@@ -19,8 +19,6 @@ logger = logging.getLogger("serve")
 class Command(papis.commands.Command):
 
     def init(self):
-        self.CONNECTOR_API_VERSION = 2
-
         self.parser = self.get_subparsers().add_parser(
             "serve",
             help="Start a zotero-connector server"
@@ -60,18 +58,25 @@ def papis_add(item):
     # This should just call a papis function that given a dict of
     # properties spit out the correct info.yaml and saves it.
     # I still have to figure out where PDFs are taken
+    print(item)
     print("PAPIS add NOT IMPLEMENTED.")
 
 # HTTPRequestHandler class
 class PapisRequestHandler(http.server.BaseHTTPRequestHandler):
+    def init(self):
+        self.connector_api_version = 2
+        self.zotero_version = "5.0.25"
+
     def log_message(self, format, *args):
         global logger
         logger.debug(format % args)
         return
 
     def set_zotero_headers(self):
-        self.send_header("X-Zotero-Version","5.0.25")
-        self.send_header("X-Zotero-Connector-API-Version", 2)
+        self.send_header("X-Zotero-Version",
+                         self.zotero_version)
+        self.send_header("X-Zotero-Connector-API-Version",
+                         self.connector_api_version)
         self.end_headers()
 
     def read_input(self):

--- a/papis/commands/serve.py
+++ b/papis/commands/serve.py
@@ -16,6 +16,9 @@ import papis.config
 
 logger = logging.getLogger("serve")
 
+connector_api_version = 2
+zotero_version = "5.0.25"
+
 class Command(papis.commands.Command):
 
     def init(self):
@@ -63,9 +66,6 @@ def papis_add(item):
 
 # HTTPRequestHandler class
 class PapisRequestHandler(http.server.BaseHTTPRequestHandler):
-    def init(self):
-        self.connector_api_version = 2
-        self.zotero_version = "5.0.25"
 
     def log_message(self, format, *args):
         global logger
@@ -74,9 +74,9 @@ class PapisRequestHandler(http.server.BaseHTTPRequestHandler):
 
     def set_zotero_headers(self):
         self.send_header("X-Zotero-Version",
-                         self.zotero_version)
+                         zotero_version)
         self.send_header("X-Zotero-Connector-API-Version",
-                         self.connector_api_version)
+                         connector_api_version)
         self.end_headers()
 
     def read_input(self):
@@ -86,8 +86,6 @@ class PapisRequestHandler(http.server.BaseHTTPRequestHandler):
     def pong(self, POST = True):
         global logger
         logger.debug("pong")
-
-        print("We have been pinged") # DEBUG
         # Pong must respond to ping on both GET and POST
         # It must accepts application/json and text/plain
         if not POST: # GET
@@ -137,18 +135,13 @@ class PapisRequestHandler(http.server.BaseHTTPRequestHandler):
             papis_add(item)
 
         self.send_response(201) # Created
-        # print("Sleeping -- Simulating some work")
-        # time.sleep(3)   # Simulate some fetch work
         self.set_zotero_headers()
 
     def snapshot(self):
-        logger.warning("NOT IMPLEMENTED")
+        logger.warning("Snapshot not implemented")
         self.send_response(201) # Created
         self.set_zotero_headers()
         return
-        # print("Snapshotting")
-        # print(self.read_input())
-        # print("----------input end -----------")
 
     def do_POST(self):
         if self.path == "/connector/ping":

--- a/papis/config.py
+++ b/papis/config.py
@@ -306,6 +306,12 @@
     `` and `` then you would have ``<author 1> and <author 2> and ....``
     in the ``author`` field.
 
+.. papis-config:: snapshot
+
+    !NOT IMLEMENTED!
+    Save a snapshot of the a `webpage`. Actually used only by the
+    zotero connector.
+
 """
 import logging
 
@@ -403,6 +409,7 @@ general_settings = {
     "ref-format"      : "{doc[doi]}",
     "multiple-authors-separator": " and ",
     "multiple-authors-format": "{au[surname]}, {au[given_name]}",
+    "snapshot": True
 }
 
 


### PR DESCRIPTION
# WORK IN PROGRESS

Hi, I noticed that zotero translators are inside the connector, so I thought we can gain a lot from the connector itself (the firefox plugin).

This is a draft on the implementation of `papis serve`, a command that create an http server on the same port zotero does and listen for zotero-connector requests. The great part of the server itself is implemented and is in a working state.

I'm opening the PR because I need help on the papis part. Here the function `papis_add(item)` is passed a dictionary containing info like author, title and so on, we should call here the papis method to add the info.yaml, but I still don't know how to do this, if you could point me to the right direction.

You can start testing it by installing the connector from [here](https://www.zotero.org/download/). If you go to a supported site (like scholar.google.com or almost any scientific journal website) and click on the connector icon.

Thanks, Nicolò