### PR TITLE
Improved search citations (hubation)

### DIFF
--- a/examples/scripts/papis-hubation
+++ b/examples/scripts/papis-hubation
@@ -43,15 +43,19 @@ if 'citations' not in doc.keys():
 dois = [d.get('doi') for d in doc['citations']]
 
 print("%s citations found" % len(dois))
-print("Fetching citations' information online")
+print("Fetching citations'")
 dois_with_data = []
 for j,doi in enumerate(dois):
     progress = "%s/%s (doi: %s)" % (j+1, len(dois), doi)
     sys.stdout.write(progress)
     sys.stdout.flush()
-    dois_with_data.append(
-        papis.crossref.doi_to_data(doi)
-    )
+    citation = papis.api.get_documents_in_lib(papis.api.get_lib(),search='doi = "%s"' % doi)
+    if citation:
+        dois_with_data.append(papis.api.pick_doc(citation))
+    else:
+        dois_with_data.append(
+            papis.crossref.doi_to_data(doi)
+        )
     sys.stdout.write("\b" * (len(progress)))
     sys.stdout.write(" " * (len(progress)))
     sys.stdout.flush()
@@ -65,9 +69,32 @@ doi or sys.exit(0)
 
 print('DOI %s selected' % doi)
 
-papis.commands.main(
-    [
-        'scihub', doi
-    ] + add_flags
-)
+# set citation as the doc if it's already in the library
+citation = papis.api.get_documents_in_lib(papis.api.get_lib(),search='doi = "%s"' % doi)
 
+# get hubation options
+config_options = papis.config.get('hubation')
+
+# if open in config_options...
+if 'open' in config_options:
+    # Check if the citation is already in your library
+    if citation:
+        # and open the associated file
+        papis.commands.main(
+            [
+                'open', "ref=%s" % doc['ref']
+            ]
+        )
+    else:
+        # if it isn't, open in a browser
+        papis.document.open_in_browser(doc)
+
+elif 'browse' in config_options:
+    papis.document.open_in_browser(doc)
+
+else:
+    papis.commands.main(
+        [
+            papis.config.get('hubation'), "ref=%s" % doc['ref']
+        ] + add_flags
+    )

--- a/papis/config.py
+++ b/papis/config.py
@@ -446,6 +446,23 @@ Databases
     `the documentation <https://whoosh.readthedocs.io/en/latest/schema.html/>`_
     for more information.
 
+.. papis-config:: hubation
+
+   This allows the operation after picking be set when using the
+   script papis-hubation. Running ``papis hubation`` provides a list
+   of citations, which once picked, can undergo the operation
+   'e.g. open, browse, scihub' that is set. Current tested options are
+   ``open``, ``browse``, ``export``, and ``scihub``.
+
+   Default behaviour is set to scihub.
+
+.. papis-config:: citation-string
+
+    string that can be displayed in header if the reference has a
+    citation
+
+    Default set to '*'
+
 """
 import logging
 
@@ -551,6 +568,8 @@ general_settings = {
     '"tags": TEXT(stored=True),\n'
     '}',
 
+    "hubation": "scihub",
+    "citation-string": "*"
 }
 
 

--- a/papis/document.py
+++ b/papis/document.py
@@ -362,6 +362,31 @@ class Document(object):
         """
         return self._keys
 
+    @property
+    def has_citations(self):
+        """Returns string defined in config if keys contains citations
+        else returns None.
+
+        :returns: String or None
+        :rtype: str OR None
+        """
+
+        if 'citations' in self.keys():
+            return papis.config.get('citation-string')
+        else:
+            return ''
+
+    def dump(self):
+        """Return information string without any obvious format
+        :returns: String with document's information
+        :rtype:  str
+
+        """
+        string = ""
+        for i in self.keys():
+            string += str(i)+":   "+str(self[i])+"\n"
+        return string
+
     def load(self):
         """Load information from info file
         """


### PR DESCRIPTION
(1) `papis hubation` now searches the users library to see if
documents are already present.

(2) Some users are unable to use the scihub script. These
modifications to the hubation script allow users to tell hubation what
to do after a citation is picked, defined in `config` as
'hubation'. So far, `open`, `browse`, and `export` have been tested
and are working. With changes described in (1), `open` will try to
open the document file if the document is already present in the users
library. If not, a browser is opened using the scraped url.

(3) Added has_citations property to papis.document to check if the
document entry has citations associated with it. This can be set in
any 'header' option and returns 'citation-string' if True.

(4) Added 'citation-string' config option. If `has_citation`, defined in
(2), is True, this string is returned allowing an indicator to show up
if a document has citations.

Closes #65