### PR TITLE
Added `bibtex-journal-key` option

### DIFF
--- a/papis/config.py
+++ b/papis/config.py
@@ -168,6 +168,15 @@ Tools options
 Bibtex options
 ^^^^^^^^^^^^^^
 
+.. papis-config:: bibtex-journal-key
+
+    Journal publishers may request abbreviated journal titles. This
+    option allows the user to set the key for the journal entry when using
+    ``papis export --bibtex``.
+
+    Set as ``full_journal_title`` or ``abbrev_journal_title`` for
+    whichever style required. Default is ``journal``.
+
 .. papis-config:: extra-bibtex-keys
 
     When exporting documents in bibtex format, you might want to add
@@ -525,6 +534,7 @@ general_settings = {
     "mark-opener-format": get_default_opener(),
 
     "file-browser": get_default_opener(),
+    "bibtex-journal-key": 'journal',
     "extra-bibtex-keys": "",
     "extra-bibtex-types": "",
     "default-library": "papers",

--- a/papis/document.py
+++ b/papis/document.py
@@ -94,9 +94,33 @@ def to_bibtex(document):
     bibtexString += "@%s{%s,\n" % (bibtexType, ref)
     for bibKey in papis.bibtex.bibtex_keys:
         if bibKey in document.keys():
-            bibtexString += "  %s = { %s },\n" % (
-                bibKey, papis.bibtex.unicode_to_latex(str(document[bibKey]))
-            )
+            if bibKey == 'journal' and papis.config.get('bibtex-journal-key') in document.keys():
+                bibtexString += "  %s = { %s },\n" % (
+                    'journal',
+                    papis.bibtex.unicode_to_latex(
+                        str(document[papis.config.get('bibtex-journal-key')])
+                    )
+                )
+            elif bibKey == 'journal' and papis.config.get('bibtex-journal-key') not in document.keys():
+                logger.warning(
+                    "Key '%s' is not present for ref=%s" % (
+                        papis.config.get('bibtex-journal-key'),
+                        document["ref"]
+                    )
+                )
+                bibtexString += "  %s = { %s },\n" % (
+                    'journal',
+                    papis.bibtex.unicode_to_latex(
+                        str(document['journal'])
+                    )
+                )
+            else:
+                bibtexString += "  %s = { %s },\n" % (
+                    bibKey,
+                    papis.bibtex.unicode_to_latex(
+                        str(document[bibKey])
+                    )
+                )
     bibtexString += "}\n"
     return bibtexString
 


### PR DESCRIPTION
`bibtex-journal-key` lets the user define the key that `papis
export --bibtex` uses when assigning the `journal` bibtex
entry. This allows the user to define `full_journal_title` or
`abbrev_journal_title` depending on the publishers requirements.

Closes #73