### PR TITLE
papis-zotero now honours library options

### DIFF
--- a/examples/scripts/papis-zotero
+++ b/examples/scripts/papis-zotero
@@ -42,6 +42,7 @@ def add(entry, pdf_file=None):
     fd.close()
     papis.commands.main(
         [
+            '-l', papis.api.get_lib(),
             'add', pdf_file or '--no-document', '--from-yaml', temp
         ] + add_flags
     )


### PR DESCRIPTION
papis-zotero will now add a bib file to a specified library using
the `--pick-lib` or `-l my_lib` flags.

Closes #75