### PR TITLE
Import zotero collections to project

### DIFF
--- a/examples/scripts/papis-zotero-sql
+++ b/examples/scripts/papis-zotero-sql
@@ -182,6 +182,24 @@ def getTags(connection, itemId):
 
   return {"tags":tags}
 
+def getCollections(connection, itemId):
+    itemCollectionQuery = """
+      SELECT
+        collections.collectionName
+      FROM
+        collections,
+        collectionItems
+      WHERE
+        collectionItems.itemID = {itemID} AND
+        collections.collectionID = collectionItems.collectionID
+    """
+    collectionCursor = connection.cursor()
+    collectionCursor.execute(itemCollectionQuery.format(itemID=itemId))
+    collections = []
+    for collectionRow in collectionCursor:
+        collections.append(collectionRow[0])
+
+    return {"project":collections}
 
 def cleanItem(item):
   if item.get("year") is None and item.get("date") is not None:
@@ -250,6 +268,7 @@ for row in cursor:
   item.update(getFields(connection, itemId))
   item.update(getCreators(connection, itemId))
   item.update(getTags(connection, itemId))
+  item.update(getCollections(connection, itemId))
   item.update(getFiles(connection, itemId, itemKey))
   cleanItem(item)
 


### PR DESCRIPTION
- When importing from Zotero SQL, the items' 'collections' should also be imported
- Collection in Zotero corresponds to `project` metadata for papis
- Does not respect collection hierarchy from Zotero (projects are all at the same level in papis)
- Treats collections with the same name as the same collection