### PR TITLE
Query debug

### DIFF
--- a/examples/scripts/papis-zotero-sql
+++ b/examples/scripts/papis-zotero-sql
@@ -77,20 +77,19 @@ def getCreators(connection, itemId):
   itemCreatorQuery = """
     SELECT
       creatorTypes.creatorType,
-      creatorData.firstName,
-      creatorData.lastName
+      creators.firstName,
+      creators.lastName
     FROM
       creatorTypes,
       creators,
-      creatorData,
       itemCreators
     WHERE
       itemCreators.itemID = {itemID} AND
       creatorTypes.creatorTypeID = itemCreators.creatorTypeID AND
-      creators.creatorID = itemCreators.creatorID AND
-      creatorData.creatorDataID = creators.creatorDataID
+      creators.creatorID = itemCreators.creatorID 
     ORDER BY
-      creatorTypes.creatorType
+      creatorTypes.creatorType,
+      itemCreators.orderIndex
   """
   creatorCursor = connection.cursor()
   creatorCursor.execute(
@@ -123,13 +122,13 @@ def getFiles(connection, itemId, itemKey):
     SELECT
       items.key,
       itemAttachments.path,
-      itemAttachments.mimeType
+      itemAttachments.contentType
     FROM
       itemAttachments,
       items
     WHERE
-      itemAttachments.sourceItemID = {itemID} AND
-      itemAttachments.mimeType IN {mimeTypes} AND
+      itemAttachments.parentItemID = {itemID} AND
+      itemAttachments.contentType IN {mimeTypes} AND
       items.itemID = itemAttachments.itemID
   """
   mimeTypes = getTuple(includedAttachments.keys())

--- a/papis/docmatcher.py
+++ b/papis/docmatcher.py
@@ -19,7 +19,10 @@ class DocMatcher(object):
     """
     search = ""
     parsed_search = None
-    doc_format = '{' + papis.config.get('format-doc-name') + '[DOC_KEY]}'
+    if papis.config.get('format-jinja2-enable'):
+        doc_format = '{{' + papis.config.get('format-doc-name') + '["DOC_KEY"]}}' 
+    else:
+        doc_format = '{' + papis.config.get('format-doc-name') + '[DOC_KEY]}'
     logger = logging.getLogger('DocMatcher')
     matcher = None
 


### PR DESCRIPTION
After switching to using `jinja2` I wasn't getting any results when my commands had a `QUERY` at the end. I tracked down the culprit to the `DocMatcher` which lacked any logic to handle the jinja2 format.