### PR TITLE
Fixed DocMatchers query string for jinja2

### DIFF
--- a/papis/docmatcher.py
+++ b/papis/docmatcher.py
@@ -19,7 +19,10 @@ class DocMatcher(object):
     """
     search = ""
     parsed_search = None
-    doc_format = '{' + papis.config.get('format-doc-name') + '[DOC_KEY]}'
+    if papis.config.get('format-jinja2-enable'):
+        doc_format = '{{' + papis.config.get('format-doc-name') + '["DOC_KEY"]}}' 
+    else:
+        doc_format = '{' + papis.config.get('format-doc-name') + '[DOC_KEY]}'
     logger = logging.getLogger('DocMatcher')
     matcher = None
 


### PR DESCRIPTION
`DocMatcher` needs to be able to handle jinja2 templating when a query of the form `key=value` is given to a papis command.