### PR TITLE
Extended config parser interpolation

### DIFF
--- a/papis/config.py
+++ b/papis/config.py
@@ -988,7 +988,7 @@ class Configuration(configparser.ConfigParser):
     logger = logging.getLogger("Configuration")
 
     def __init__(self):
-        configparser.ConfigParser.__init__(self)
+        configparser.ConfigParser.__init__(self, interpolation=configparser.ExtendedInterpolation())
         self.dir_location = get_config_folder()
         self.scripts_location = get_scripts_folder()
         self.file_location = get_config_file()


### PR DESCRIPTION
When using jinja2, it's nice to be able to use conditionals `{%- if %}`, etc., for `add-name` and `file-name` for example. However, the `%`s are used by `configparser`'s basic interpolation scheme. In order to deconflict, we can have `configparser` use extended interpolation, which utilizes the `$` symbol.