### PR TITLE
Slightly more robust bibtex handling

### DIFF
--- a/papis/bibtex.py
+++ b/papis/bibtex.py
@@ -24,6 +24,12 @@ bibtex_types = [
   "unpublished"
 ] + re.sub(r" *", "", papis.config.get('extra-bibtex-types')).split(',')
 
+bibtex_type_converter = {
+  "conferencePaper" : "inproceedings",
+  "journalArticle" : "article",
+  "journal" : "article"
+}
+
 bibtex_keys = [
     "addendum",
     "address",
@@ -86,9 +92,9 @@ bibtex_keys = [
     "series",
     "subtitle",
     "title",
-    "titleaddon",
     "translator",
     "type",
+    "titleaddon",
     "url",
     "urldate",
     "venue",
@@ -98,6 +104,14 @@ bibtex_keys = [
     "year",
   ] + re.sub(r" *", "", papis.config.get('extra-bibtex-keys')).split(',')
 
+bibtex_key_converter = {
+    "abstractNote" : "abstract",
+    "university" : "school",
+    "conferenceName" : "eventtitle",
+    "place" : "location",
+    "publicationTitle" : "journal",
+    "proceedingsTitle" : "booktitle"
+}
 
 def bibtexparser_entry_to_papis(entry):
     """Convert keys of a bib entry in bibtexparser format to papis compatible

--- a/papis/config.py
+++ b/papis/config.py
@@ -599,6 +599,7 @@ general_settings = {
 
     "tui-editmode": "emacs",
     "downloader-proxy": None,
+    "bibtex-unicode": False,
 
 }
 

--- a/papis/document.py
+++ b/papis/document.py
@@ -108,6 +108,8 @@ def to_bibtex(document):
     if "type" in document.keys():
         if document["type"] in papis.bibtex.bibtex_types:
             bibtexType = document["type"]
+        elif document["type"] in papis.bibtex.bibtex_type_converter.keys():
+            bibtexType = papis.bibtex.bibtex_type_converter[document["type"]]
     if not bibtexType:
         bibtexType = "article"
 
@@ -124,8 +126,16 @@ def to_bibtex(document):
     ref = re.sub(r'[;,()\/{}\[\]]', '', ref)
 
     bibtexString += "@%s{%s,\n" % (bibtexType, ref)
-    for bibKey in papis.bibtex.bibtex_keys:
-        if bibKey in document.keys():
+    for bibKey in document.keys():
+        logger.debug('%s : %s' % (bibKey, document[bibKey]))
+        if bibKey in papis.bibtex.bibtex_key_converter:
+            newBibKey = papis.bibtex.bibtex_key_converter[bibKey]
+            document[newBibKey] = document[bibKey]
+            continue
+        if bibKey in papis.bibtex.bibtex_keys:
+            value = str(document[bibKey])
+            if not papis.config.get('bibtex-unicode'):
+                value = papis.bibtex.unicode_to_latex(value)
             if bibKey == 'journal':
                 bibtex_journal_key = papis.config.get('bibtex-journal-key')
                 if bibtex_journal_key in document.keys():
@@ -146,16 +156,12 @@ def to_bibtex(document):
                     )
                     bibtexString += "  %s = { %s },\n" % (
                         'journal',
-                        papis.bibtex.unicode_to_latex(
-                            str(document['journal'])
-                        )
+                        value
                     )
             else:
                 bibtexString += "  %s = { %s },\n" % (
                     bibKey,
-                    papis.bibtex.unicode_to_latex(
-                        str(document[bibKey])
-                    )
+                    value
                 )
     bibtexString += "}\n"
     return bibtexString


### PR DESCRIPTION
I was having issues where I had papis field names that didn't match a corresponding bibtex key. So I made two conversion dictionaries (one for types, one for fields). Also, since I'm using XeLaTeX most of the time I added a configuration variable to allow unicode in the bibtex output.