### PR TITLE
ref-format: use dynamically

### DIFF
--- a/examples/scripts/papis-zotero-sql
+++ b/examples/scripts/papis-zotero-sql
@@ -96,7 +96,7 @@ def getCreators(connection, itemId):
   creatorCursor.execute(
     itemCreatorQuery.format(itemID=itemId)
   )
-  creators = {}
+  creators = {} # type: ignore
 
   for creatorRow in creatorCursor:
     creatorName = creatorRow[0]
@@ -217,9 +217,14 @@ parser = argparse.ArgumentParser(
 parser.add_argument('zotero_dir', type=str, default=".",
     help="Path to zotero's documents directory")
 
+parser.add_argument('papis_lib_dir', type=str, default="Documents",
+    help="Path towards papis' library directory")
+
+
 args, unknown = parser.parse_known_args()
 
 inputPath = args.zotero_dir
+outputPath = args.papis_lib_dir
 
 connection = sqlite3.connect(os.path.join(inputPath, "zotero.sqlite"))
 cursor = connection.cursor()

--- a/papis/commands/export.py
+++ b/papis/commands/export.py
@@ -176,7 +176,10 @@ def cli(
     """Export a document from a given library"""
 
     logger = logging.getLogger('cli:export')
-    documents = papis.database.get().query(query)
+    if all:
+        documents = papis.database.get().get_all_documents()
+    else:
+        documents = papis.database.get().query(query)
 
     if json and folder or yaml and folder:
         logger.warning("Only --folder flag will be considered")

--- a/papis/document.py
+++ b/papis/document.py
@@ -113,7 +113,17 @@ def to_bibtex(document):
     if not bibtexType:
         bibtexType = "article"
 
-    ref = document["ref"]
+    # REFERENCE BUILDING
+    print("Using ref-format = %s" % papis.config.get("ref-format"))
+    print("on %r" % document)
+    ref = papis.utils.format_doc(
+        papis.config.get("ref-format"), 
+        # "toto",
+        document
+    ).replace(" ", "")
+
+    print("generated ref=%s" % ref)
+    # ref = document["ref"]
     if not ref:
         try:
             ref = os.path.basename(document.get_main_folder())
@@ -124,6 +134,7 @@ def to_bibtex(document):
                 ref = 'noreference'
 
     ref = re.sub(r'[;,()\/{}\[\]]', '', ref)
+    print("Used ref=%s" % ref)
 
     bibtexString += "@%s{%s,\n" % (bibtexType, ref)
     for bibKey in sorted(document.keys()):

--- a/papis/document.py
+++ b/papis/document.py
@@ -114,28 +114,28 @@ def to_bibtex(document):
         bibtexType = "article"
 
     # REFERENCE BUILDING
-    print("Using ref-format = %s" % papis.config.get("ref-format"))
-    print("on %r" % document)
-    try:
-        ref = papis.utils.format_doc(
-            papis.config.get("ref-format"), 
-            # "toto",
-            document
-        ).replace(" ", "")
-    except Exception as e:
-        print(e)
-        ref = "unknown"
-
+    # print("Using ref-format = %s" % papis.config.get("ref-format"))
+    # print("on %r" % document)
+    if document.has("ref"):
+        ref = document["ref"]
+    elif papis.config.get('ref-format'):
+        try:
+            ref = papis.utils.format_doc(
+                papis.config.get("ref-format"),
+                document
+            ).replace(" ", "")
+        except Exception as e:
+            print(e)
+            ref = None
 
     print("generated ref=%s" % ref)
-    # ref = document["ref"]
     if not ref:
-        try:
-            ref = os.path.basename(document.get_main_folder())
-        except:
-            if document.has('doi'):
-                ref = document['doi']
-            else:
+        if document.has('doi'):
+            ref = document['doi']
+        else:
+            try:
+                ref = os.path.basename(document.get_main_folder())
+            except:
                 ref = 'noreference'
 
     ref = re.sub(r'[;,()\/{}\[\]]', '', ref)

--- a/papis/document.py
+++ b/papis/document.py
@@ -116,11 +116,16 @@ def to_bibtex(document):
     # REFERENCE BUILDING
     print("Using ref-format = %s" % papis.config.get("ref-format"))
     print("on %r" % document)
-    ref = papis.utils.format_doc(
-        papis.config.get("ref-format"), 
-        # "toto",
-        document
-    ).replace(" ", "")
+    try:
+        ref = papis.utils.format_doc(
+            papis.config.get("ref-format"), 
+            # "toto",
+            document
+        ).replace(" ", "")
+    except Exception as e:
+        print(e)
+        ref = "unknown"
+
 
     print("generated ref=%s" % ref)
     # ref = document["ref"]


### PR DESCRIPTION
I would like to change the ref according to ref-format dynamically rather than on import
see https://github.com/papis/papis/issues/141.

For the behavior, I wonder what to do if it can't generate the ref : fallback on a ref if it exists but otherwise ? use a default key "unknown" ?
```
Using ref-format = {doc[author_list][0][surname]}{doc[year]}
on <papis.document.Document object at 0x7f2abbe9d0b8>
Traceback (most recent call last):
  File "/run/user/1000/tmp.6p8bvkMjc8/bin/papis", line 11, in <module>
    load_entry_point('papis', 'console_scripts', 'papis')()
  File "/home/teto/papis/papis/main.py", line 10, in main
    papis.commands.default.run()
  File "/nix/store/83glni8a99pkal667qckk0ibb6rc0jca-python3.7-click-7.0/lib/python3.7/site-packages/click/core.py", line 764, in __call__
    return self.main(*args, **kwargs)
  File "/nix/store/83glni8a99pkal667qckk0ibb6rc0jca-python3.7-click-7.0/lib/python3.7/site-packages/click/core.py", line 717, in main
    rv = self.invoke(ctx)
  File "/nix/store/83glni8a99pkal667qckk0ibb6rc0jca-python3.7-click-7.0/lib/python3.7/site-packages/click/core.py", line 1137, in invoke
    return _process_result(sub_ctx.command.invoke(sub_ctx))
  File "/nix/store/83glni8a99pkal667qckk0ibb6rc0jca-python3.7-click-7.0/lib/python3.7/site-packages/click/core.py", line 956, in invoke
    return ctx.invoke(self.callback, **ctx.params)
  File "/nix/store/83glni8a99pkal667qckk0ibb6rc0jca-python3.7-click-7.0/lib/python3.7/site-packages/click/core.py", line 555, in invoke
    return callback(*args, **kwargs)
  File "/home/teto/papis/papis/commands/export.py", line 195, in cli
    text=text
  File "/home/teto/papis/papis/commands/export.py", line 100, in run
    papis.document.to_bibtex(document) for document in documents
  File "/home/teto/papis/papis/commands/export.py", line 100, in <listcomp>
    papis.document.to_bibtex(document) for document in documents
  File "/home/teto/papis/papis/document.py", line 122, in to_bibtex
    document
  File "/home/teto/papis/papis/utils.py", line 94, in format_doc
    return python_format.format(**{doc: document})
IndexError: string index out of range
```
