### PR TITLE
[RDY] zsh completion automatic pickup attempt

### DIFF
--- a/scripts/shell_completion/Makefile
+++ b/scripts/shell_completion/Makefile
@@ -4,5 +4,10 @@ all: dist/bash-completion.sh
 dist/bash-completion.sh:
 	./tools/bash.sh
 
+zsh:
+	# run from a zsh shell
+	echo "#compdef papis" > click/papis.zsh
+	_PAPIS_COMPLETE=source_zsh papis >> click/papis.zsh
+
 clean:
 	rm -rf dist

--- a/scripts/shell_completion/click/papis.zsh
+++ b/scripts/shell_completion/click/papis.zsh
@@ -1,3 +1,5 @@
+#compdef papis
+
 _papis_completion() {
     local -a completions
     local -a completions_with_descriptions
@@ -25,4 +27,4 @@ _papis_completion() {
     compstate[insert]="automenu"
 }
 
-compdef _papis_completion papis;
+_papis_completion $@


### PR DESCRIPTION
The idea is to have compdef automatically pick it up without having to generate it at runtime (slow) for every shell.
This doesn't work though :/  