### PR TITLE
[RDY] poc for export plugins

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,11 @@ VERSION v0.9
 ============
 
 ## Add command ##
+- The configuration settings `export-text-format` has been removed along with
+  the export --text command. papis now support plugins so you should write your
+  own instead.
+- The flags --bibtex/--json/--yaml of the `export` command have been replaced
+  by `export --format=bibtex/json/yaml`
 
 - The configuration settings `file-name` and `folder-name` are now
   ```

--- a/doc/source/default-settings.rst
+++ b/doc/source/default-settings.rst
@@ -73,10 +73,6 @@ General settings
     The name of the library that is to be searched when ``papis``
     is run without library arguments.
 
-.. papis-config:: export-text-format
-
-    The default output papis format for ``papis export --text``.
-
 .. papis-config:: format-doc-name
 
     This setting controls the name of the document in the papis format strings

--- a/papis/commands/export.py
+++ b/papis/commands/export.py
@@ -55,57 +55,73 @@ import papis.api
 import papis.database
 import papis.strings
 import logging
+from stevedore import extension
 
+logger = logging.getLogger('cli:export')
+
+def stevedore_error_handler(manager, entrypoint, exception):
+    logger.error("Error while loading entrypoint [%s]" % entrypoint)
+    logger.error(exception)
+
+
+def export_to_yaml(documents):
+    import yaml
+    return yaml.dump_all(
+        [
+            papis.document.to_dict(document) for document in documents
+        ],
+        allow_unicode=True
+    )
+
+def export_to_json(documents):
+    import json
+    return json.dumps(
+        [
+            papis.document.to_dict(document) for document in documents
+        ]
+    )
+
+def export_to_bibtex(documents):
+    return '\n'.join([
+        papis.document.to_bibtex(document) for document in documents
+    ])
+
+def export_to_text(documents):
+    text_format = papis.config.get('export-text-format')
+    return '\n'.join([
+        papis.utils.format_doc(text_format, document)
+        for document in documents
+    ])
+
+def available_formats():
+    return exporters_mgr.entry_points_names()
+
+
+exporters_mgr = extension.ExtensionManager(
+    namespace='papis.exporter',
+    invoke_on_load=False,
+    verify_requirements=True,
+    propagate_map_exceptions=True,
+    on_load_failure_callback=stevedore_error_handler
+)
 
 def run(
     documents,
-    yaml=False,
-    bibtex=False,
-    json=False,
-    text=False
+    to_format,
 ):
     """
     Exports several documents into something else.
 
     :param document: A ist of papis document
     :type  document: [papis.document.Document]
-    :param yaml: Wether to return a yaml string
-    :type  yaml: bool
-    :param bibtex: Wether to return a bibtex string
-    :type  bibtex: bool
-    :param json: Wether to return a json string
-    :type  json: bool
-    :param text: Wether to return a text string representing the document
-    :type  text: bool
+    :param to_format: what format to use
+    :type  to_format: str
     """
-    if json:
-        import json
-        return json.dumps(
-            [
-                papis.document.to_dict(document) for document in documents
-            ]
-        )
-
-    if yaml:
-        import yaml
-        return yaml.dump_all(
-            [
-                papis.document.to_dict(document) for document in documents
-            ],
-            allow_unicode=True
-        )
-
-    if bibtex:
-        return '\n'.join([
-            papis.document.to_bibtex(document) for document in documents
-        ])
-
-    if text:
-        text_format = papis.config.get('export-text-format')
-        return '\n'.join([
-            papis.utils.format_doc(text_format, document)
-            for document in documents
-        ])
+    try:
+        ret_string = exporters_mgr[to_format].plugin(document for document in documents)
+        return ret_string
+    except KeyError as e:
+        logger.error("Format %s not supported." % to_format)
 
     return None
 
@@ -113,24 +129,6 @@ def run(
 @click.command("export")
 @click.help_option('--help', '-h')
 @papis.cli.query_option()
-@click.option(
-    "--yaml",
-    help="Export into yaml",
-    default=False,
-    is_flag=True
-)
-@click.option(
-    "--bibtex",
-    help="Export into bibtex",
-    default=False,
-    is_flag=True
-)
-@click.option(
-    "--json",
-    help="Export into json",
-    default=False,
-    is_flag=True
-)
 @click.option(
     "--folder",
     help="Export document folder to share",
@@ -144,11 +142,11 @@ def run(
     default=None
 )
 @click.option(
-    "-t",
-    "--text",
+    "--format",
+    "-f",
     help="Text formated reference",
-    default=False,
-    is_flag=True
+    type=click.Choice(available_formats()),
+    default="bibtex",
 )
 @click.option(
     "-a", "--all",
@@ -164,21 +162,18 @@ def run(
 )
 def cli(
         query,
-        yaml,
-        bibtex,
-        json,
         folder,
         out,
-        text,
+        format,
         all,
-        file
+        file,
+        **kwargs
         ):
     """Export a document from a given library"""
 
-    logger = logging.getLogger('cli:export')
     documents = papis.database.get().query(query)
 
-    if json and folder or yaml and folder:
+    if format == "json" and folder or format == "yaml" and folder:
         logger.warning("Only --folder flag will be considered")
 
     if not documents:
@@ -191,12 +186,10 @@ def cli(
             return 0
         documents = [document]
 
+
     ret_string = run(
         documents,
-        yaml=yaml,
-        bibtex=bibtex,
-        json=json,
-        text=text
+        to_format=format,
     )
 
     if ret_string is not None:

--- a/papis/commands/export.py
+++ b/papis/commands/export.py
@@ -86,16 +86,8 @@ def export_to_bibtex(documents):
         papis.document.to_bibtex(document) for document in documents
     ])
 
-def export_to_text(documents):
-    text_format = papis.config.get('export-text-format')
-    return '\n'.join([
-        papis.utils.format_doc(text_format, document)
-        for document in documents
-    ])
-
 def available_formats():
     return exporters_mgr.entry_points_names()
-
 
 exporters_mgr = extension.ExtensionManager(
     namespace='papis.exporter',

--- a/papis/config.py
+++ b/papis/config.py
@@ -76,9 +76,6 @@ general_settings = {
     "extra-bibtex-keys": "[]",
     "extra-bibtex-types": "[]",
     "default-library": "papers",
-    "export-text-format":
-        "{doc[author]}. {doc[title]}. {doc[journal]} {doc[pages]}"
-        " {doc[month]} {doc[year]}",
     "format-doc-name": "doc",
     "match-format":
         "{doc[tags]}{doc.subfolder}{doc[title]}{doc[author]}{doc[year]}",

--- a/setup.py
+++ b/setup.py
@@ -139,8 +139,6 @@ setup(
             'bibtex=papis.commands.export:export_to_bibtex',
             'json=papis.commands.export:export_to_json',
             'yaml=papis.commands.export:export_to_yaml',
-            'text=papis.commands.export:export_to_text',
-
         ],
     },
     platforms=['linux', 'osx'],

--- a/setup.py
+++ b/setup.py
@@ -56,6 +56,7 @@ setup(
         "isbnlib>=3.9.1,<4.0.0",
         "prompt_toolkit>=2.0.5",
         "pygments>=2.2.0",
+        "stevedore",
     ],
     python_requires='>=3',
     classifiers=[
@@ -130,10 +131,17 @@ setup(
 
     ],
     packages=included_packages,
-    entry_points=dict(
-        console_scripts=[
+    entry_points={
+        'console_scripts':[
             'papis=papis.commands.default:run'
-        ]
-    ),
+        ],
+        'papis.exporter':[
+            'bibtex=papis.commands.export:export_to_bibtex',
+            'json=papis.commands.export:export_to_json',
+            'yaml=papis.commands.export:export_to_yaml',
+            'text=papis.commands.export:export_to_text',
+
+        ],
+    },
     platforms=['linux', 'osx'],
 )


### PR DESCRIPTION
Just a Proof of concept to show how it would work, the plugin can be a class instance but here a function was enough.
I added a --format parameter to the export command since the exporters are now dynamically loaded.
The current syntax is kinda strange since you don't really know what to expect from `export --json --yaml --text`, better to enforce a single export format.
`papis export --format=bibtex --all`.

Whit this design, if you install a package that registers an entry_point for 'papis.exporter', it would appear in papis `export --format` options.