### PR TITLE
Default command

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -125,3 +125,10 @@ See the ``AUTHORS`` list for a list of authored commits.
    :target: https://asciinema.org/a/3otatlbqXIsI102uAywMhT4fP
 .. |Code_Quality| image:: https://img.shields.io/lgtm/grade/python/g/papis/papis.svg?logo=lgtm&logoWidth=18
    :target: https://lgtm.com/projects/g/papis/papis/context:python
+
+Related software
+----------------
+
+- `Mendeley <https://www.mendeley.org/>`__.
+- `Zotero <https://www.mendeley.org/>`__.
+- `Xapers <https://finestructure.net/xapers/>`__.

--- a/papis/commands/default.py
+++ b/papis/commands/default.py
@@ -41,7 +41,7 @@ import papis.cli
 
 @click.group(
     cls=papis.cli.MultiCommand,
-    invoke_without_command=True
+    invoke_without_command=False
 )
 @click.help_option('--help', '-h')
 @click.version_option(version=papis.__version__)


### PR DESCRIPTION
Displays the help if you just type "papis". I find this behavior better though it's debatable.

Also references similar software as it's good practice. I didn't know about xapers, looks interesting though no release since 2017.