### PR TITLE
User format throws if missing key

### DIFF
--- a/doc/source/default-settings.rst
+++ b/doc/source/default-settings.rst
@@ -92,27 +92,6 @@ General settings
 
     Default format that is used to show a document in order to select it.
 
-.. papis-config:: format-jinja2-enable
-
-    This setting is to enable the `jinja2 <http://jinja.pocoo.org//>`_ template
-    engine to render the papis templates being used, as ``header-format``,
-    ``match-format`` etc...
-
-    For instance you could set the option ``header-format`` to
-
-    .. code:: html
-
-        <span color='#ff00ff'>{{doc.html_escape["title"]}}</span>
-        <span color='#00ff00'>  {{doc.html_escape["author"]}}</span>
-        <span color='#00ffaa'>   ({{doc.html_escape["year"]}}) </span>
-        {%- if doc.has('tags') %}<span>[<yellow>{{doc['tags']}}</yellow>] </span>{%- endif %}
-        {%- if doc.has('citations') %}<red>{{doc['citations']|length}}</red>{%- endif %}
-        {%- if doc.has('url') %}
-        <span>    {{doc.html_escape["url"]}}</span>
-        {%- endif %}
-
-    To use it, just install jinja2.
-
 .. papis-config:: header-format-file
 
     This option should have the path of a file with the ``header-format``

--- a/papis/commands/addto.py
+++ b/papis/commands/addto.py
@@ -78,6 +78,8 @@ def run(document, filepaths):
         )
         shutil.copy(in_file_path, endDocumentPath)
 
+    if not "files" in document.keys():
+        document["files"] = []
     document['files'] += new_file_list
     document.save()
     papis.database.get().update(document)

--- a/papis/commands/list.py
+++ b/papis/commands/list.py
@@ -118,7 +118,7 @@ def run(
 
     if libraries:
         return [
-            config[section]['dir']
+            section + '\t' + config[section]['dir']
             for section in config
             if 'dir' in config[section]
         ]

--- a/papis/config.py
+++ b/papis/config.py
@@ -79,7 +79,6 @@ general_settings = {
     "format-doc-name": "doc",
     "match-format":
         "{doc[tags]}{doc.subfolder}{doc[title]}{doc[author]}{doc[year]}",
-    "format-jinja2-enable": False,
     "header-format-file": None,
     "header-format": (
         "<ansired>{doc.html_escape[title]}</ansired>\n"

--- a/papis/docmatcher.py
+++ b/papis/docmatcher.py
@@ -19,15 +19,7 @@ class DocMatcher(object):
     """
     search = ""
     parsed_search = None
-    if papis.config.get('format-jinja2-enable'):
-        doc_format = (
-            '{{' +
-            papis.config.get('format-doc-name') +
-            '["DOC_KEY"]' +
-            '}}'
-        )
-    else:
-        doc_format = '{' + papis.config.get('format-doc-name') + '[DOC_KEY]}'
+    doc_format = '{' + papis.config.get('format-doc-name') + '[DOC_KEY]}'
     logger = logging.getLogger('DocMatcher')
     matcher = None
 

--- a/papis/fzf.py
+++ b/papis/fzf.py
@@ -1,0 +1,22 @@
+import os
+import difflib
+import sys
+import papis
+import papis.api
+import papis.config
+import papis.commands
+import papis.database
+import colorama
+import logging
+
+
+logger = logging.getLogger('fzf')
+
+# get all get_all_documents
+
+
+def main():
+
+    documents = papis.database.get_all_query_string()
+    # documents = papis.database.get().query(query)
+    print("Documents", documents)

--- a/papis/utils.py
+++ b/papis/utils.py
@@ -97,19 +97,6 @@ def format_doc(python_format, document, key=""):
     doc = key or papis.config.get("format-doc-name")
     fdoc = papis.document.Document()
     fdoc.update(document)
-    if papis.config.getboolean('format-jinja2-enable') is True:
-        try:
-            import jinja2
-        except ImportError:
-            logger.error("""
-            You're trying to format strings using jinja2
-            Jinja2 is not installed by default, so just install it
-
-                pip3 install jinja2
-
-            """)
-        else:
-            return jinja2.Template(python_format).render(**{doc: fdoc})
     try:
         res = python_format.format(**{doc: document})
     except KeyError as e:

--- a/papis/utils.py
+++ b/papis/utils.py
@@ -111,9 +111,11 @@ def format_doc(python_format, document, key=""):
         else:
             return jinja2.Template(python_format).render(**{doc: fdoc})
     try:
-        return python_format.format(**{doc: fdoc})
-    except Exception as e:
-        return str(e)
+        res = python_format.format(**{doc: document})
+    except KeyError as e:
+        res = "missing_key_" + e.args[0]
+
+    return res
 
 
 def get_folders(folder):

--- a/setup.py
+++ b/setup.py
@@ -96,7 +96,6 @@ setup(
         # for example:
         # $ pip install -e .[develop]
         optional=[
-            "Jinja2>=2.10",
             "Whoosh>=2.7.4",
         ],
         develop=[

--- a/setup.py
+++ b/setup.py
@@ -128,6 +128,7 @@ setup(
     entry_points={
         'console_scripts': [
             'papis=papis.commands.default:run',
+            'papiz=papis.fzf:main',
         ],
         'papis.exporter': [
             'bibtex=papis.commands.export:export_to_bibtex',

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -106,14 +106,6 @@ def test_format_doc():
     tests.setup_test_library()
     document = from_data(dict(author='Fulano', title='Something'))
 
-    papis.config.set('format-jinja2-enable', True)
-    assert format_doc('{{doc["author"]}}{{doc["title"]}}', document) == \
-        'FulanoSomething'
-    assert format_doc(
-        '{{doc["author"]}}{{doc["title"]}}{{doc["blahblah"]}}', document
-    ) == 'FulanoSomething'
-
-    papis.config.set('format-jinja2-enable', False)
     assert format_doc('{doc[author]}{doc[title]}', document) == \
         'FulanoSomething'
     assert format_doc('{doc[author]}{doc[title]}{doc[blahblah]}', document) ==\


### PR DESCRIPTION
Catch it and provide a default that names the missing key instead.

Not sure that's a fantastic fix but at least it helped me go through the issue in https://github.com/papis/papis/issues/167