### PR TITLE
Add lxml dependency

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -72,6 +72,7 @@ setup(
         "pygments>=2.2.0",
         "stevedore>=1.30",
         "python-doi>=0.1.1",
+        "lxml"
     ],
     python_requires='>=3',
     classifiers=[


### PR DESCRIPTION
This is required [here](https://github.com/papis/papis/blob/v0.9/papis/downloaders/base.py#L210) and not installed on the CI, so it caused a few failures for the downloader tests.

I didn't add a minimum version because I'm not sure what a good one would be.