### PR TITLE
Ensure `files` key is present in document

### DIFF
--- a/papis/commands/addto.py
+++ b/papis/commands/addto.py
@@ -78,6 +78,8 @@ def run(document, filepaths):
         )
         shutil.copy(in_file_path, endDocumentPath)
 
+    if not "files" in document.keys():
+        document["files"] = []
     document['files'] += new_file_list
     document.save()
     papis.database.get().update(document)


### PR DESCRIPTION
Sometimes when adding a document with no files to a library and then
later trying to use `addto` there would be an error because the document
(i.e. the YAML file) had no `files: []` entry. This commit ensures that
in the event that `files` key is not present that the key is added and
instantiated with an empty list.