### PR TITLE
Fix git flags in documentation

### DIFF
--- a/doc/source/git.rst
+++ b/doc/source/git.rst
@@ -101,7 +101,7 @@ When editing a document's info file:
 
     ::
 
-      papis git add -a
+      papis git add --all
 
   - Commit
 


### PR DESCRIPTION
Update documentation to use the correct git flag: `-a` doesn't exist. `-A` does (and was probably meant), but its long version `--all` is IMHO more understandable.