### PR TITLE
Non-existent library folder causing crash

### DIFF
--- a/papis/config.py
+++ b/papis/config.py
@@ -484,6 +484,10 @@ def get_lib_from_name(libname):
             raise Exception('Library {0} not defined'.format(libname))
         try:
             paths = [expanduser(config[name]['dir'])]
+            for path in paths:
+                if not os.path.exists(path):
+                    raise Exception(("Path '%s' for library '%s' does not "
+                                    "seem to exist") % (path, name))
         except KeyError:
             try:
                 paths = eval(expanduser(config[name].get('dirs')))

--- a/papis/library.py
+++ b/papis/library.py
@@ -1,6 +1,7 @@
 import os
 import glob
 import logging
+import sys
 
 logger = logging.getLogger("library")
 
@@ -11,16 +12,22 @@ class Library:
         assert(isinstance(paths, list)), '`paths` must be a list'
         self.name = name
 
-        # If any of the paths do not exist, create them.
+        # If any of the paths do not exist, warn the user.
         for path in paths:
             if not os.path.exists(path):
-                os.makedirs(path)
-                logger.info("Initialized library " + name + ".  Created: " + path)
+                logger.warn("Warning: library " + name + " at path '" + path +
+                            "' doesn't exist.  Please create it before " +
+                            "continuing.")
 
         self.paths = sum(
             [glob.glob(os.path.expanduser(p)) for p in paths],
             []
         )
+
+        if len(self.paths) == 0:
+            logger.error("No existing paths found for library " + name +
+                         ".  Exiting.")
+            sys.exit(1)
 
     def path_format(self):
         return ":".join(self.paths)

--- a/papis/library.py
+++ b/papis/library.py
@@ -8,6 +8,14 @@ class Library:
         assert(isinstance(name, str)), '`name` must be a string'
         assert(isinstance(paths, list)), '`paths` must be a list'
         self.name = name
+
+        # If any of the paths do not exist, create them.
+        for path in paths:
+            print(path)
+            if not os.path.exists(path):
+                os.makedirs(path)
+                print("Initialized library", name, ".  Created:", path)
+
         self.paths = sum(
             [glob.glob(os.path.expanduser(p)) for p in paths],
             []

--- a/papis/library.py
+++ b/papis/library.py
@@ -15,7 +15,7 @@ class Library:
         for path in paths:
             if not os.path.exists(path):
                 os.makedirs(path)
-                logger.info("Initialized library", name, ".  Created:", path)
+                logger.info("Initialized library " + name + ".  Created: " + path)
 
         self.paths = sum(
             [glob.glob(os.path.expanduser(p)) for p in paths],

--- a/papis/library.py
+++ b/papis/library.py
@@ -1,6 +1,8 @@
 import os
 import glob
+import logging
 
+logger = logging.getLogger("library")
 
 class Library:
 
@@ -11,10 +13,9 @@ class Library:
 
         # If any of the paths do not exist, create them.
         for path in paths:
-            print(path)
             if not os.path.exists(path):
                 os.makedirs(path)
-                print("Initialized library", name, ".  Created:", path)
+                logger.info("Initialized library", name, ".  Created:", path)
 
         self.paths = sum(
             [glob.glob(os.path.expanduser(p)) for p in paths],

--- a/papis/library.py
+++ b/papis/library.py
@@ -1,9 +1,6 @@
 import os
 import glob
-import logging
-import sys
 
-logger = logging.getLogger("library")
 
 class Library:
 
@@ -12,22 +9,10 @@ class Library:
         assert(isinstance(paths, list)), '`paths` must be a list'
         self.name = name
 
-        # If any of the paths do not exist, warn the user.
-        for path in paths:
-            if not os.path.exists(path):
-                logger.warn("Warning: library " + name + " at path '" + path +
-                            "' doesn't exist.  Please create it before " +
-                            "continuing.")
-
         self.paths = sum(
             [glob.glob(os.path.expanduser(p)) for p in paths],
             []
         )
-
-        if len(self.paths) == 0:
-            logger.error("No existing paths found for library " + name +
-                         ".  Exiting.")
-            sys.exit(1)
 
     def path_format(self):
         return ":".join(self.paths)


### PR DESCRIPTION
Hi,

While setting up papis, I encountered some crashes when the library folder I specified in the config file didn't yet exist.  This addresses that by creating the folder if it doesn't exist rather than crashing.

Steps to reproduce crash:
In the config, create a library where the `dir` field doesn't exist.  Then, run papis -l library open "".

Changes pass the tests with no additional failures.

Jackson