### PR TITLE
Different opentools for different file types

### DIFF
--- a/doc/source/configuration.rst
+++ b/doc/source/configuration.rst
@@ -37,7 +37,9 @@ A more complete example of a configuration file is the following
   # "cygstart"
   #
   opentool = rifle
-  # Specify a PDF editing program for PDF filetypes
+  # Specify a PDF editing program for PDF filetypes.
+  # More generally, a tool for a filetype .XYZ can be specified as 
+  # "opentool-XYZ = <tool>"
   opentool-pdf = evince
   # Use ranger as a file browser, a nice python program
   file-browser = ranger

--- a/doc/source/configuration.rst
+++ b/doc/source/configuration.rst
@@ -37,6 +37,8 @@ A more complete example of a configuration file is the following
   # "cygstart"
   #
   opentool = rifle
+  # Specify a PDF editing program for PDF filetypes
+  opentool-pdf = evince
   # Use ranger as a file browser, a nice python program
   file-browser = ranger
   # Ask for confirmation when doing papis add

--- a/papis/api.py
+++ b/papis/api.py
@@ -3,11 +3,12 @@ create papis scripts.
 """
 
 import logging
-import papis.utils
 import papis.commands
 import papis.config
-import papis.pick
 import papis.database
+import papis.pick
+import papis.utils
+import pathlib
 
 logger = logging.getLogger("api")
 logger.debug("importing")
@@ -90,8 +91,10 @@ def pick(options, pick_config={}):
 
 
 def open_file(file_path, wait=True):
-    """Open file using the ``opentool`` key value as a program to
-    handle file_path.
+    """Open file using the most specific tool possible.  The config is
+    searched for an ``opentool-<extension>'' key.  If that exists, use the
+    associated value as a program to handle file_path.  Otherwise, use the
+    ``opentool'' key value as a program to handle file_path.
 
     :param file_path: File path to be handled.
     :type  file_path: str
@@ -99,7 +102,15 @@ def open_file(file_path, wait=True):
     :type  wait: bool
 
     """
-    papis.utils.general_open(file_path, "opentool", wait=wait)
+    extension = pathlib.Path(file_path).suffix
+    if extension.startswith('.'):
+        extension = extension[1:]
+
+    if papis.config.get_configuration().has_option("settings", "opentool-" + extension):
+        papis.utils.general_open(file_path, "opentool-" + extension, wait=wait)
+    else:
+        # Use the default opentool.
+        papis.utils.general_open(file_path, "opentool", wait=wait)
 
 
 def open_dir(dir_path, wait=True):


### PR DESCRIPTION
Hi,

This patch uses the file extension on the files opened to select a different opener program.

An example usecase is:
I download a .pdf paper, and want to use evince to open it.
I download an RFC (which is a .txt file), and want to use a text editor to open it.

So, in the config file, I can write:

opentool-pdf = evince
opentool-txt = gvim

And the appropriate program will be used.  This doesn't destroy any old behaviour: if a filetype without a specified opentool is opened, it will fallback to the old behaviour of using the `opentool' program.

Documentation has been updated to reflect this.

There are no additional test failures.

Is this OK?

Jackson