### PR TITLE
Add rm --all option

### DIFF
--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -80,7 +80,19 @@ test_data = [
         "volume": "s2-42",
         "year": "1937",
         "_test_files": 2,
-    }
+    },
+    {
+        "author": "test_author",
+        "title": "Test Document 1",
+        "year": "2019",
+        "_test_files": 1
+    },
+    {
+        "author": "test_author",
+        "title": "Test Document 2",
+        "year": "2019",
+        "_test_files": 1
+    },
 ]
 
 

--- a/tests/commands/test_rm.py
+++ b/tests/commands/test_rm.py
@@ -144,3 +144,15 @@ class TestCli(tests.cli.TestCli):
         self.assertTrue(len(docs) == 1)
         Nf = len(docs[0].get_files())
         self.assertTrue(N == Nf+1)
+
+
+    def test_rm_all(self):
+        db = papis.database.get()
+        docs = db.query_dict(dict(author='test_author'))
+        self.assertTrue(len(docs) == 2)
+        
+        result = self.invoke(['test_author', '--all', '--force'])
+        self.assertTrue(result.exit_code == 0)
+
+        docs = db.query_dict(dict(author='test_author'))
+        self.assertTrue(len(docs) == 0)


### PR DESCRIPTION
Hi,

I noticed many of the commands have an --all option to repeat the command for all matches.  This adds an identical option to the rm command.

There are no additional test failures.

Any thoughts?

Jackson