### PR TITLE
Print the library name when `papis list --libraries` is called

### DIFF
--- a/papis/commands/list.py
+++ b/papis/commands/list.py
@@ -118,7 +118,7 @@ def run(
 
     if libraries:
         return [
-            config[section]['dir']
+            section + '\t' + config[section]['dir']
             for section in config
             if 'dir' in config[section]
         ]


### PR DESCRIPTION
Hi,

This changes the behaviour of the `papis list --libraries` command to print the name of the library in addition to its location.

I found it useful because I couldn't remember the exact names of some of the libraries I have.  It was helpful to be able to print them out with a single command.

Is this OK to go in?

Jackson