### PR TITLE
Initialize previously empty files list as a list

### DIFF
--- a/papis/commands/addto.py
+++ b/papis/commands/addto.py
@@ -78,7 +78,10 @@ def run(document, filepaths):
         )
         shutil.copy(in_file_path, endDocumentPath)
 
-    document['files'] += new_file_list
+    if document['files'] == '':
+        document['files'] = new_file_list
+    else:
+        document['files'] += new_file_list
     document.save()
     papis.database.get().update(document)
 


### PR DESCRIPTION
Hi,

Previously, running the following sequence of commands resulted in a crash:

    papis -l papers add --from-doi 10.1145/3168824

    papis -l papers addto "Bastian" -f Downloads/file.pdf

Error message:
```
Traceback (most recent call last):                                    
  File "/usr/local/bin/papis", line 11, in <module>                   
    load_entry_point('papis==0.8.2', 'console_scripts', 'papis')()    
  File "/home/jackson/.local/lib/python3.6/site-packages/click/core.py"
, line 764, in __call__                                               
    return self.main(*args, **kwargs)                                 
  File "/home/jackson/.local/lib/python3.6/site-packages/click/core.py"
, line 717, in main                                                   
    rv = self.invoke(ctx)                                             
  File "/home/jackson/.local/lib/python3.6/site-packages/click/core.py"
, line 1137, in invoke                                                
    return _process_result(sub_ctx.command.invoke(sub_ctx))           
  File "/home/jackson/.local/lib/python3.6/site-packages/click/core.py"
, line 956, in invoke
    return ctx.invoke(self.callback, **ctx.params)                    
  File "/home/jackson/.local/lib/python3.6/site-packages/click/core.py"
, line 555, in invoke
    return callback(*args, **kwargs)                                  
  File "/mnt/ubuntu/Projects/Python/papis/papis/commands/addto.py", lin
e 115, in cli
    return run(document, files)
  File "/mnt/ubuntu/Projects/Python/papis/papis/commands/addto.py", lin
e 82, in run
    document['files'] += new_file_list                                
TypeError: must be str, not list

```

This fixes this issue by checking if `document[files]` is empty.  If so, it is set to a list rather than appending to an assumed existent list.

Is this OK?

Jackson