### PR TITLE
Print paper name and author list when fetching from DOI

### DIFF
--- a/papis/commands/add.py
+++ b/papis/commands/add.py
@@ -670,7 +670,12 @@ def cli(
         logger.info("using doi {0}".format(from_doi))
         doidata = papis.crossref.get_data(dois=[from_doi])
         if doidata:
-            data.update(doidata[0])
+            doidata = doidata[0]
+            data.update(doidata)
+            if 'title' in doidata and 'author' in doidata:
+                logger.info('DOI points to: ' + doidata['title'] + '\n' +
+                            doidata['author'])
+
         if (len(files) == 0 and
                 papis.config.get('doc-url-key-name') in data.keys()):
 


### PR DESCRIPTION
Hi,

A typical workflow for me is to do something like:

    papis add --from-doi <something> Downloads/bland_filename.pdf

Followed by an attempt to run:

    papis open "some search phrase"

I have found myself forgetting a unique search phrase I can use to subsequently open the document.

To address this, this patch prints the title and author list (provided they exist in the DOI information).  (So, I can immediately do `papis open "authors"`)

This patch also helps with cases where the DOI might have been misread or miscopied.

Is this OK?

Jackson