### PR TITLE
github: add a template for new issues

### DIFF
--- a/.github/ISSUE_TEMPLATE.md
+++ b/.github/ISSUE_TEMPLATE.md
@@ -1,0 +1,7 @@
+* papis version (`$ papis --version` or commit number):
+
+# how to reproduce the issue
+Command and output of `papis --log INFO <command>`:
+```
+
+```


### PR DESCRIPTION
I've seen a few issues that don't explicit the version in use, which make diagnostic harder.

Eventually we could add a template for feature vs bug as one can see when creating an issue on  https://github.com/NixOS/nixpkgs/issues.