### PR TITLE
Update supported Python version to 3.5, 3.6, 3.7 & 3.8

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,11 +3,10 @@ language: python
 os:
 - linux
 python:
-- '3.4'
 - '3.5'
 - '3.6'
 - '3.7'
-#- '3.3'
+- '3.8'
 script:
 - python -m pytest papis/ tests/ --cov=papis
 install:

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -7,16 +7,14 @@ environment:
     # The list here is complete (excluding Python 2.6, which
     # isn't covered by this document) at the time of writing.
 
-    - PYTHON: "C:\\Python33"
-    - PYTHON: "C:\\Python34"
     - PYTHON: "C:\\Python35"
     - PYTHON: "C:\\Python36"
-    - PYTHON: "C:\\Python33-x64"
-      DISTUTILS_USE_SDK: "1"
-    - PYTHON: "C:\\Python34-x64"
-      DISTUTILS_USE_SDK: "1"
+    - PYTHON: "C:\\Python37"
+    - PYTHON: "C:\\Python38"
     - PYTHON: "C:\\Python35-x64"
     - PYTHON: "C:\\Python36-x64"
+    - PYTHON: "C:\\Python37-x64"
+    - PYTHON: "C:\\Python38-x64"
 
 install:
 

--- a/setup.py
+++ b/setup.py
@@ -86,10 +86,10 @@ setup(
         'Operating System :: MacOS',
         'Operating System :: POSIX',
         'Operating System :: Unix',
-        'Programming Language :: Python :: 3.3',
-        'Programming Language :: Python :: 3.4',
         'Programming Language :: Python :: 3.5',
         'Programming Language :: Python :: 3.6',
+        'Programming Language :: Python :: 3.7',
+        'Programming Language :: Python :: 3.8',
         'Topic :: Utilities',
     ],
     extras_require=dict(


### PR DESCRIPTION
It's probably safe to drop support for Python <= 3.4 as they are neither maintained nor receiving security fixes.  (Unless there's another reason for keeping this support)