### PR TITLE
Fix sort ordering

### DIFF
--- a/papis/document.py
+++ b/papis/document.py
@@ -395,6 +395,19 @@ class Document(dict):
         """
         return key in self
 
+    def sort_for_key(self, key):
+        # The tuple represents:
+        # (is not None?, is an integer?, integer value, string value)
+        if key in self.keys():
+            if str(self[key]).isdigit():
+                return (False, True, int(self[key]), self[key])
+            else:
+                return (False, False, 0, self[key])
+        else:
+            # The key does not appear in the document, ensure
+            # it comes last.
+            return (True, False, 0, '')
+
     def save(self):
         """Saves the current document's information into the info file.
         """
@@ -448,4 +461,4 @@ class Document(dict):
 
 
 def sort(docs: [Document], key: str, reverse: bool) -> [Document]:
-    return sorted(docs, key=lambda d: str(d.get(key)), reverse=reverse)
+    return sorted(docs, key=lambda d: d.sort_for_key(key), reverse=reverse)


### PR DESCRIPTION
Hi,

With the latest changes to the sorting algorithm, the sorting order was no longer as intuitive as it could be.

For example, in the current code, sorting by 'year' with years: [914, 1066, 1929, 2019] results in [1066, 1929, 2019, 914].

Similarly, the current sorting algorithm brings 'None' values to the top of the sort, rather than the end, where IMO they more intuitively belong.

Unlike my first attempt at this sorting algorithm, this doesn't sort negative numbers properly, which means it can use the (faster) isnumeric() function rather than the slower try/except block.

Is this OK to go in? 

Jackson