### PR TITLE
Fix typing `invalid syntax`

### DIFF
--- a/papis/tui/widgets/list.py
+++ b/papis/tui/widgets/list.py
@@ -70,7 +70,7 @@ class OptionsList(ConditionalContainer, Generic[Option]):  # type: ignore
 
         # options are processed here also through the setter
         # ##################################################
-        self.set_options(options)  # type: List[Option]
+        self.set_options(options)
         self.cursor = Point(0, 0)  # type: Point
         # ##################################################
 


### PR DESCRIPTION
In reference to [this comment](https://github.com/papis/papis/issues/234#issuecomment-571373570) in #234 : not sure, but the error looks a lot like [this](https://github.com/python/mypy/issues/8218) bug report.

Either way, I would argue that the fix for this case is to remove the type info since that's a function call and it doesn't get assigned to a new variable, so the type doesn't refer to anything. 

With this "fix", I get no errors/warnings on python 3.8 with mypy 0.761 running `mypy --strict papis/`. Does it give type errors on other versions?

