### PR TITLE
Document timestamps

### DIFF
--- a/papis/commands/add.py
+++ b/papis/commands/add.py
@@ -94,6 +94,8 @@ import re
 import tempfile
 import hashlib
 import shutil
+import subprocess
+import time
 import papis.api
 import papis.pick
 import papis.utils
@@ -101,6 +103,8 @@ import papis.config
 import papis.document
 import papis.importer
 import papis.cli
+import papis.yaml
+import papis.strings
 import click
 import colorama
 import papis.downloaders
@@ -540,6 +544,8 @@ def cli(files, set_list, subfolder, folder_name, file_name, from_importer,
     if not ctx:
         logger.error('there is nothing to be added')
         return
+
+    ctx.data['time-added'] = time.strftime(papis.strings.time_format)
 
     return run(
         ctx.files,

--- a/papis/document.py
+++ b/papis/document.py
@@ -395,6 +395,19 @@ class Document(dict):
         """
         return key in self
 
+    def sort_for_key(self, key):
+        # The tuple represents:
+        # (is not None?, is an integer?, integer value, string value)
+        if key in self.keys():
+            if str(self[key]).isdigit():
+                return (False, True, int(self[key]), self[key])
+            else:
+                return (False, False, 0, self[key])
+        else:
+            # The key does not appear in the document, ensure
+            # it comes last.
+            return (True, False, 0, '')
+
     def save(self):
         """Saves the current document's information into the info file.
         """
@@ -448,4 +461,4 @@ class Document(dict):
 
 
 def sort(docs: [Document], key: str, reverse: bool) -> [Document]:
-    return sorted(docs, key=lambda d: str(d.get(key)), reverse=reverse)
+    return sorted(docs, key=lambda d: d.sort_for_key(key), reverse=reverse)

--- a/papis/document.py
+++ b/papis/document.py
@@ -1,3 +1,4 @@
+import datetime
 import os
 import re
 import shutil
@@ -7,6 +8,7 @@ import papis.utils
 import papis.config
 import papis.bibtex
 
+zero_date = datetime.datetime.fromtimestamp(0)
 
 def keyconversion_to_data(key_conversion, data, keep_unknown_keys=False):
     new_data = dict()
@@ -399,14 +401,23 @@ class Document(dict):
         # The tuple represents:
         # (is not None?, is an integer?, integer value, string value)
         if key in self.keys():
+            if key == 'time-added':
+                try:
+                    date_value = \
+                        datetime.datetime.strptime(str(self[key]),
+                                                   papis.strings.time_format)
+                    return (False, False, date_value, False, 0, '')
+                except ValueError:
+                    pass
+
             if str(self[key]).isdigit():
-                return (False, True, int(self[key]), self[key])
+                return (False, True, zero_date, True, int(self[key]), str(self[key]))
             else:
-                return (False, False, 0, self[key])
+                return (False, True, zero_date, False, 0, self[key])
         else:
             # The key does not appear in the document, ensure
             # it comes last.
-            return (True, False, 0, '')
+            return (True, False, zero_date, True, 0, '')
 
     def save(self):
         """Saves the current document's information into the info file.

--- a/papis/document.py
+++ b/papis/document.py
@@ -10,6 +10,7 @@ import papis.bibtex
 
 zero_date = datetime.datetime.fromtimestamp(0)
 
+
 def keyconversion_to_data(key_conversion, data, keep_unknown_keys=False):
     new_data = dict()
     for orig_key in key_conversion:
@@ -397,27 +398,38 @@ class Document(dict):
         """
         return key in self
 
-    def sort_for_key(self, key):
+    def sort_for_key(self, key, reverse=False):
         # The tuple represents:
         # (is not None?, is an integer?, integer value, string value)
+
+        # If the sort is reversed, it's still a nice feature to have the
+        # fields with the value specified first.  This keeps that ordering,
+        # while reversing the sorts within each type of item.
+        if reverse:
+            before = True
+            after = False
+        else:
+            before = False
+            after = True
+
         if key in self.keys():
             if key == 'time-added':
                 try:
                     date_value = \
                         datetime.datetime.strptime(str(self[key]),
                                                    papis.strings.time_format)
-                    return (False, False, date_value, False, 0, '')
+                    return (before, before, date_value, before, 0, '')
                 except ValueError:
                     pass
 
             if str(self[key]).isdigit():
-                return (False, True, zero_date, True, int(self[key]), str(self[key]))
+                return (before, after, zero_date, after, int(self[key]), str(self[key]))
             else:
-                return (False, True, zero_date, False, 0, self[key])
+                return (before, after, zero_date, before, 0, self[key])
         else:
             # The key does not appear in the document, ensure
             # it comes last.
-            return (True, False, zero_date, True, 0, '')
+            return (after, before, zero_date, after, 0, '')
 
     def save(self):
         """Saves the current document's information into the info file.
@@ -472,4 +484,4 @@ class Document(dict):
 
 
 def sort(docs: [Document], key: str, reverse: bool) -> [Document]:
-    return sorted(docs, key=lambda d: d.sort_for_key(key), reverse=reverse)
+    return sorted(docs, key=lambda d: d.sort_for_key(key, reverse=reverse), reverse=reverse)

--- a/papis/strings.py
+++ b/papis/strings.py
@@ -1,1 +1,2 @@
 no_documents_retrieved_message = "No documents retrieved"
+time_format = "%Y-%m-%d-%H:%M:%S"


### PR DESCRIPTION
Hi,

This pull request introduces several changes.  The aim is to allow papis to sort documents by how recently they were added, with the most recently added documents appearing first.

First, it builds on sorting algorithm introduced in #251; I can't figure out how to make Github's diff actually show that this is just building on that, but commit 81901e is just that patch.

a8f2a4a adds a timestamp field to each document as it is added with the `papis add` command.  The format is human readable (as opposed to UNIX time) since that seems most in-line with papis's design.

4f15f24 updates the sorting algorithm to parse these dates properly and sort appropriately on them.  This enables sorting on time added.

c766995 again changes the sorting algorithm: it changes --reverse to not mean true reversal, but rather, to mean reversal of documents with a field instead.  Here's an example of what I mean:

Lets say we have documents with 'year' values of 'None', 1988, 2000.

In the old algorithm, this would sort as: [1988, 2000, None], and using --reverse, this would become [None, 2000, 1988]. 

Using this version, this sorts as: [1988, 2000, None], and using --reverse turns the sort into [2000, 1988, None].  I think this is a more intuitive reverse option.

This last part is relevant to this patch in particular, because to find the most recently added document, you can now do `papis edit "*" --sort time-added --reverse` in libraries where many documents do not already have added times.


Is this good to go in?
(Sorry, don't know why there is a merge conflict)

Jackson

