### PR TITLE
Move the sort call in `papis list` so it is applied before the picker

### DIFF
--- a/papis/commands/list.py
+++ b/papis/commands/list.py
@@ -192,13 +192,14 @@ def cli(
     if not libraries and not downloaders:
         db = papis.database.get()
         documents = db.query(query)
+        if sort_field:
+            documents = \
+                papis.document.sort(documents, sort_field, sort_reverse)
+
         if not documents:
             logger.warning(papis.strings.no_documents_retrieved_message)
         if not _all:
             documents = list(papis.pick.pick_doc(documents))
-
-    if sort_field:
-        documents = papis.document.sort(documents, sort_field, sort_reverse)
 
     objects = run(
         documents,


### PR DESCRIPTION
Hi,

Previously,

`papis list "*" --sort ...` did not actually sort anything, becuase the sorting function was applied after the picker.

This patch moves the application of the sorting function to before the picker to fix this bug.

Good to go in?

Jackson