### PR TITLE
Document Timestamps

### DIFF
--- a/papis/commands/add.py
+++ b/papis/commands/add.py
@@ -99,6 +99,7 @@ import shutil
 import click
 import colorama
 
+import time
 import papis.api
 import papis.pick
 import papis.utils
@@ -108,6 +109,7 @@ import papis.config
 import papis.document
 import papis.importer
 import papis.cli
+import papis.strings
 import papis.downloaders
 import papis.git
 
@@ -570,6 +572,8 @@ def cli(
     if not ctx:
         logger.error('there is nothing to be added')
         return
+
+    ctx.data['time-added'] = time.strftime(papis.strings.time_format)
 
     return run(
         ctx.files,

--- a/papis/document.py
+++ b/papis/document.py
@@ -339,19 +339,28 @@ def from_data(data: Dict[str, Any]) -> Document:
 
 
 def sort(docs: List[Document], key: str, reverse: bool) -> List[Document]:
+    # The tuple returned by the _sort_for_key function represents:
+    # (ranking, integer value, string value)
+    # Rankings are:
+    #   integers:   0 (come first)
+    #   strings:    1 (come after integers)
+    #   None:       2 (come last)
+    sort_rankings = {
+        "int": 0,
+        "string": 1,
+        "None": 2
+    }
 
-    def _sort_for_key(key: str, doc: Document) -> Tuple[bool, bool, int, str]:
-        # The tuple represents:
-        # (is not None?, is an integer?, integer value, string value)
+    def _sort_for_key(key: str, doc: Document) -> Tuple[int, int, str]:
         if key in doc.keys():
             if str(doc[key]).isdigit():
-                return (False, True, int(doc[key]), str(doc[key]))
+                return (sort_rankings["int"], int(doc[key]), str(doc[key]))
             else:
-                return (False, False, 0, str(doc[key]))
+                return (sort_rankings["string"], 0, str(doc[key]))
         else:
             # The key does not appear in the document, ensure
             # it comes last.
-            return (True, False, 0, '')
+            return (sort_rankings["None"], 0, '')
     LOGGER.debug("sorting %d documents", len(docs))
     return sorted(docs, key=lambda d: _sort_for_key(key, d), reverse=reverse)
 

--- a/papis/document.py
+++ b/papis/document.py
@@ -351,6 +351,11 @@ def sort(docs: List[Document], key: str, reverse: bool) -> List[Document]:
         "None": 2
     }
 
+    # Preserve the ordering of types even if --reverse is used.
+    if reverse:
+        for sort_type in sort_rankings:
+            sort_rankings[sort_type] = -sort_rankings[sort_type]
+
     def _sort_for_key(key: str, doc: Document) -> Tuple[int, int, str]:
         if key in doc.keys():
             if str(doc[key]).isdigit():

--- a/papis/strings.py
+++ b/papis/strings.py
@@ -1,2 +1,3 @@
 no_documents_retrieved_message = "No documents retrieved"  # type: str
 no_folder_attached_to_document = "Document has no folder attached"  # type: str
+time_format = "%Y-%m-%d-%H:%M:%S"  # type: str


### PR DESCRIPTION
Hi,

(Replaces #256 )

This patch series introduces timestamps when documents are added to papis, using a `time-added` field in the document metadata.
The big benefit of these timestamps is that they allow document sorting by recency of addition.

The patches are as follows:


4bdb4b:  In add.py, put a timestamp in the document metadata.


9baf197 and 031b46c modify the sorting algorithm in a way that makes sense regardless, but makes the following changes easier.

a660ce7: Adds a special condition to the sorting algorithm to check if each document has a field called `time-added`.  If it does, that document is sorted by date instead.

Notes: There are a couple things I have left out here that could go in.  First, `time-added` is a human-readable date.  An alternative that would not require change 2cb2ec9 is to use Unix time, but IMO this is much less readable.  IMO there could also be some config file settings to enable/disable this, any thoughts on that?

Is this good to go in?

Jackson