### PR TITLE
Modernized PR #177

### DIFF
--- a/papis/bibtex.py
+++ b/papis/bibtex.py
@@ -231,12 +231,12 @@ def to_bibtex(document: papis.document.Document) -> str:
     logger.debug("Used ref=%s" % ref)
 
     bibtex_string += "@{type}{{{ref},\n".format(type=bibtex_type, ref=ref)
-    for bibKey in sorted(document.keys()):
-        logger.debug('%s : %s' % (bibKey, document[bibKey]))
+    for bibKey in document.keys():
         if bibKey in bibtex_key_converter:
             new_bibkey = bibtex_key_converter[bibKey]
             document[new_bibkey] = document[bibKey]
-            continue
+    for bibKey in sorted(document.keys()):
+        logger.debug('%s : %s' % (bibKey, document[bibKey]))
         if bibKey in bibtex_keys:
             value = str(document[bibKey])
             if not papis.config.get('bibtex-unicode'):

--- a/papis/bibtex.py
+++ b/papis/bibtex.py
@@ -239,7 +239,7 @@ def to_bibtex(document: papis.document.Document) -> str:
         logger.debug('%s : %s' % (bibKey, document[bibKey]))
         if bibKey in bibtex_keys:
             value = str(document[bibKey])
-            if not papis.config.get('bibtex-unicode'):
+            if not papis.config.getboolean('bibtex-unicode'):
                 value = unicode_to_latex(value)
             if bibKey == 'journal':
                 journal_key = papis.config.getstring('bibtex-journal-key')

--- a/papis/bibtex.py
+++ b/papis/bibtex.py
@@ -231,7 +231,7 @@ def to_bibtex(document: papis.document.Document) -> str:
     logger.debug("Used ref=%s" % ref)
 
     bibtex_string += "@{type}{{{ref},\n".format(type=bibtex_type, ref=ref)
-    for bibKey in document.keys():
+    for bibKey in list(document.keys()):
         if bibKey in bibtex_key_converter:
             new_bibkey = bibtex_key_converter[bibKey]
             document[new_bibkey] = document[bibKey]


### PR DESCRIPTION
Performed bugfix on current code base. Original PR message:

> Moved the translation of keys to proper bibtex keys to its own loop.
>
> Avoids ambiguity with the loop iterator in the following loop for bibKey in sorted(document.keys())
> Fixes #134