### PR TITLE
Remove { } and \ from the characters translated to latex

### DIFF
--- a/papis/bibtex.py
+++ b/papis/bibtex.py
@@ -291,20 +291,23 @@ def unicode_to_latex(text: str) -> str:
 
     # from six import text_type
 
+    # Some characters we choose not to translate to allow for latex
+    # formatting within yaml files.
+    #    u"\u007B": r"\lbrace{}",
+    #    u"\u007D": r"\rbrace{}",
+    #    u"\u005C": r"\textbackslash{}",
+    #    u"\u005F": r"\_",
+    #    u"\u0024": r"\textdollar{}",
+
     unicode_to_latex_table_base = {
         u"\u0023": r"\#",
-        u"\u0024": r"\textdollar{}",
         u"\u0025": r"\%",
         u"\u0026": r"\&",
         u"\u0027": r"'",
         u"\u002A": r"\ast{}",
-        u"\u005C": r"\textbackslash{}",
         u"\u005E": r"\^{}",
-        u"\u005F": r"\_",
         u"\u0060": r"\textasciigrave{}",
-        u"\u007B": r"\lbrace{}",
         u"\u007C": r"\vert{}",
-        u"\u007D": r"\rbrace{}",
         u"\u007E": r"\textasciitilde{}",
         u"\u00A0": r"~",
         u"\u00A1": r"\textexclamdown{}",


### PR DESCRIPTION
Hi,

When exporting to bibtex, I often find that my documents need a post-export fixup.

This is OK if I only ever export once, but if I export multiple times (e.g. creating different .bib files for different documents), the task of manually fixing the bibtex each time is a bit tiring.

This patch aims to solve this problem by removing key formatting characters from the auto-translator; allowing me to use "{", "}" and "\" directly in the yaml files.  This means I can format my documents properly for latex once in the yaml file, and they are correct each time I run `papis export`.

I'm not certain that this is the best way to achieve this, because it removes some of the format-independence of the papis yaml format.  For my usecase, this is not an issue --- I exclusively use bibtex outputs.  However, I am interested to hear if anyone has any thoughts about how to do this while maintaining output format independence.

Is this OK to go in?

Jackson

EDIT: I've bumped this to include "$" and "_", two other characters I was running into difficulties translating.