### PR TITLE
escape strings in get_regex_from_search

### DIFF
--- a/papis/database/cache.py
+++ b/papis/database/cache.py
@@ -139,7 +139,7 @@ def match_document(
 
 
 def get_regex_from_search(search: str) -> str:
-    """Creates a default regex from a search string.
+    r"""Creates a default regex from a search string.
 
     :param search: A valid search string
     :type  search: str
@@ -147,9 +147,12 @@ def get_regex_from_search(search: str) -> str:
     :rtype: str
 
     >>> get_regex_from_search(' ein 192     photon')
-    '.*.*ein.*192.*photon'
+    '.*ein.*192.*photon.*'
+
+    >>> get_regex_from_search('{1234}')
+    '.*\\{1234\\}.*'
     """
-    return r".*"+re.sub(r"\s+", ".*", search)
+    return ".*" + ".*".join(map(re.escape, search.split())) + ".*"
 
 
 class Database(papis.database.base.Database):


### PR DESCRIPTION
When a string with regex-relevant data is passed into this function, these characters should be escaped. Otherwise, invalid regexes could appear and lead to strange errors.

I think the double `.*` at the beginning is also not ideal, but I am not entirely sure if my edit is the most sensible choice.

The problem which occured in my use case was that I had some bibtex which I wanted to import and that included ISBN numbers which where placed in curly braces. In combination with this function, this lead to regexes like `.*{123456}` which are not valid.