### PR TITLE
Allow to escape dots and underscores with a backslash in ref-format

### DIFF
--- a/doc/source/default-settings.rst
+++ b/doc/source/default-settings.rst
@@ -249,6 +249,21 @@ Bibtex options
     ``mesh-ki-ang-nuna`` then the built reference will be
     ``StudiesAboutEMeshKi``.
 
+    .. note::
+        Special characters will be replaced when generating the ``ref`` entry
+        (e.g.  ``Ö → O``, ``.`` and other symbols will be striped from the
+        string). 
+
+    If you want to add some punctuation, dots (``.``) and underscores (``_``)
+    can be escaped by a backslash. For example,
+
+    ::
+
+        ref-format = {doc[author_list][0][surname]}\.{doc[year]}
+
+    would result in 'Plews.2019'. To ensure correct capitalization you might
+    consider inserting whitespaces after an escaped character.
+
 .. papis-config:: add-confirm
 
     If set to ``True``, every time you run ``papis add``

--- a/papis/bibtex.py
+++ b/papis/bibtex.py
@@ -188,7 +188,7 @@ def ref_cleanup(ref: str) -> str:
     Function to cleanup references to be acceptable for latex
     """
     import slugify
-    allowed_characters = r'[^a-zA-Z0-9]+'
+    allowed_characters = r'([^a-zA-Z0-9._]+|(?<!\\)[._])'
     return string.capwords(str(slugify.slugify(
                ref,
                lowercase=False,

--- a/tests/test_bibtex.py
+++ b/tests/test_bibtex.py
@@ -74,6 +74,8 @@ def test_clean_ref() -> None:
     for (r, rc) in [("Einstein über etwas und so 1923",
                      "EinsteinUberEtwasUndSo1923"),
                     ("Äöasf () : Aλבert Eιنς€in",
-                     "AoasfAlbertEinseurin")
+                     "AoasfAlbertEinseurin"),
+                    ("Albert_Ein\_stein\.1923.b",
+                     "AlbertEin_stein.1923B")
                    ]:
         assert rc == papis.bibtex.ref_cleanup(r)


### PR DESCRIPTION
Hey,

first of all: thanks for writing papis, its a very useful tool for me. 

While the cleanup when generating a ``ref`` introduced in 216616839754771602ec29f4f2a10d111ea409a7 is very useful, I'd like to place a dot in my refs (e.g. to divide author and year). Therefore, I would like to suggest the possibility to escape characters in `ref-format` -- here implemented for ``.`` and ``_``.

Specifying ``ref-format = {doc[author]:.10}\.{doc[year]}`` would result in refs like ``MeshKiAngN.2020``.
