### PR TITLE
Add a py.typed file

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -126,6 +126,7 @@ setup(
     ],
     package_data=dict(
         papis=[
+            "py.typed"
         ],
     ),
     data_files=data_files,


### PR DESCRIPTION
Allows plugins that use `papis` to also be type checked. From https://www.python.org/dev/peps/pep-0561/#packaging-type-information.