### PR TITLE
Improve isbn_to_papis conversion

### DIFF
--- a/papis/bibtex.py
+++ b/papis/bibtex.py
@@ -4,7 +4,6 @@ from __future__ import absolute_import, division, print_function
 import string
 import logging
 import os
-import re
 from typing import Optional, List, Dict, Any
 
 import papis.config
@@ -120,25 +119,16 @@ def bibtexparser_entry_to_papis(entry: Dict[str, str]) -> Dict[str, str]:
     :returns: Dictionary with keys of papis format.
 
     """
-    from bibtexparser.customization import splitname
-
-    def to_author_list(authors: str) -> List[Dict[str, str]]:
-        author_list = []
-        for author in re.split(r"\s+and\s+", authors):
-            parts = splitname(author)
-            given = " ".join(parts["first"])
-            family = " ".join(parts["von"] + parts["last"] + parts["jr"])
-
-            author_list.append(dict(family=family, given=given))
-
-        return author_list
 
     _k = papis.document.KeyConversionPair
     key_conversion = [
         _k("ID", [{"key": "ref", "action": None}]),
         _k("ENTRYTYPE", [{"key": "type", "action": None}]),
         _k("link", [{"key": "url", "action": None}]),
-        _k("author", [{"key": "author_list", "action": to_author_list}]),
+        _k("author", [{
+            "key": "author_list", "action":
+                lambda author: papis.document.split_authors_name([author])
+            }]),
     ]
 
     result = papis.document.keyconversion_to_data(

--- a/papis/document.py
+++ b/papis/document.py
@@ -1,6 +1,7 @@
 """Module defining the main document type.
 """
 import os
+import re
 import datetime
 import shutil
 import logging
@@ -82,6 +83,28 @@ def author_list_to_author(data: Dict[str, Any]) -> str:
             ])
         )
     return author
+
+
+def split_authors_name(
+        authors: List[str], separator: str = "and") -> List[Dict[str, str]]:
+    """
+    Convert a list of authors to papis formatted data.
+
+    :arg authors: A list of single author names or multiple authors separated
+        by *separator*.
+    """
+    from bibtexparser.customization import splitname
+
+    author_list = []
+    for subauthors in authors:
+        for author in re.split(r"\s+{}\s+".format(separator), subauthors):
+            parts = splitname(author)
+            given = " ".join(parts["first"])
+            family = " ".join(parts["von"] + parts["last"] + parts["jr"])
+
+            author_list.append(dict(family=family, given=given))
+
+    return author_list
 
 
 class DocHtmlEscaped(Dict[str, Any]):

--- a/papis/isbn.py
+++ b/papis/isbn.py
@@ -26,15 +26,28 @@ def get_data(query: str = "",
 
 
 def data_to_papis(data: Dict[str, Any]) -> Dict[str, Any]:
-    """Convert data from isbnlib into papis formated data
+    """
+    Convert data from isbnlib into papis formated data
 
     :param data: Dictionary with data
     :type  data: dict
-    :returns: Dictionary with papis keynames
-
+    :returns: Dictionary with papis key names
     """
+    _k = papis.document.KeyConversionPair
+    key_conversion = [
+            _k("authors", [{
+                "key": "author_list",
+                "action": papis.document.split_authors_name
+                }]),
+            _k("isbn-13", [
+                {"key": "isbn", "action": None},
+                {"key": "isbn-13", "action": None},
+                ]),
+            ]
+
     data = {k.lower(): data[k] for k in data}
-    return data
+    return papis.document.keyconversion_to_data(
+            key_conversion, data, keep_unknown_keys=True)
 
 
 @click.command('isbn')
@@ -77,7 +90,7 @@ class Importer(papis.importer.Importer):
     def fetch(self) -> None:
         try:
             data = get_data(self.uri)
-        except isbnlib.ISBNLibDevException:
+        except isbnlib.ISBNLibException:
             pass
         else:
             if data:

--- a/tests/resources/isbn/test_isbn_1.json
+++ b/tests/resources/isbn/test_isbn_1.json
@@ -1,0 +1,10 @@
+{
+    "Authors": [
+        "Wesseling, Pieter Dr. Ir."
+    ],
+    "ISBN-13": "9781930217089",
+    "Language": "",
+    "Publisher": "R.T. Edwards",
+    "Title": "An introduction to multigrid methods",
+    "Year": "2004"
+}

--- a/tests/resources/isbn/test_isbn_1_out.json
+++ b/tests/resources/isbn/test_isbn_1_out.json
@@ -1,0 +1,15 @@
+{
+    "author": "Wesseling, Pieter Dr. Ir.",
+    "author_list": [
+        {
+            "family": "Wesseling",
+            "given": "Pieter Dr. Ir."
+        }
+    ],
+    "isbn": "9781930217089",
+    "isbn-13": "9781930217089",
+    "language": "",
+    "publisher": "R.T. Edwards",
+    "title": "An introduction to multigrid methods",
+    "year": "2004"
+}

--- a/tests/test_isbn.py
+++ b/tests/test_isbn.py
@@ -1,4 +1,8 @@
+import os
+import pytest
+
 import papis.isbn
+
 
 def test_get_data():
     mattuck = papis.isbn.get_data(query='Mattuck feynan diagrams')
@@ -16,3 +20,44 @@ def test_importer_match():
     importer = papis.isbn.Importer.match('9781930217089')
     assert(importer)
     assert(importer.uri == '9781930217089')
+
+
+def load_json(filename, data_getter=None):
+    import json
+    path = os.path.join(
+            os.path.dirname(__file__),
+            "resources", "isbn",
+            filename)
+
+    if os.path.exists(path):
+        with open(path, "r") as f:
+            data = json.load(f)
+    else:
+        data = data_getter()
+        with open(path, "w") as f:
+            json.dump(data, f, indent=4, sort_keys=True)
+
+    return data
+
+
+def get_unmodified_isbn_data(query):
+    import isbnlib
+    isbn = isbnlib.isbn_from_words(query)
+    data = isbnlib.meta(isbn, service="openl")
+    assert data is not None
+
+    return data
+
+
+@pytest.mark.parametrize("basename", [
+    "test_isbn_1"
+    ])
+def test_isbn_to_papis(basename):
+    data = load_json("{}.json".format(basename),
+            data_getter=lambda: get_unmodified_isbn_data("9781930217089"))
+
+    to_papis_data = papis.isbn.data_to_papis(data)
+    result = load_json("{}_out.json".format(basename),
+            data_getter=lambda: to_papis_data)
+
+    assert to_papis_data == result


### PR DESCRIPTION
Extracts a papis friendly `author_list` from isbnlib's list of authors.

The added test data has an example of before/after.