### PR TITLE
Add support for platforms without multiprocessing (like android)

### DIFF
--- a/papis/database/cache.py
+++ b/papis/database/cache.py
@@ -8,9 +8,16 @@ import papis.config
 import papis.format
 import papis.database.base
 import re
-import multiprocessing
 import time
 import sys
+
+try:
+    import multiprocessing.synchronize  # noqa: F401
+    from multiprocessing import Pool
+    has_multiprocessing = True
+except ImportError:
+    has_multiprocessing = False
+
 from typing import List, Optional, Match, Dict, Tuple
 
 
@@ -90,18 +97,25 @@ def filter_documents(
                         for d in documents] if d is not None]
 
     else:
-        # Doing this multiprocessing in filtering does not seem
-        # to help much, I don't know if it's because I'm doing something
-        # wrong or it is really like this.
-        np = multiprocessing.cpu_count()
-        pool = multiprocessing.Pool(np)
-        logger.debug(
-            "Filtering {0} docs (search {1}) using {2} cores".format(
-                len(documents), search, np))
-        result = pool.map(papis.docmatcher.DocMatcher.return_if_match,
-                          documents)
-        pool.close()
-        pool.join()
+        if has_multiprocessing:
+            # Doing this multiprocessing in filtering does not seem
+            # to help much, I don't know if it's because I'm doing something
+            # wrong or it is really like this.
+            np = os.cpu_count()
+            pool = Pool(np)
+            logger.debug(
+                "Filtering {0} docs (search {1}) using {2} cores".format(
+                    len(documents), search, np))
+            result = pool.map(papis.docmatcher.DocMatcher.return_if_match,
+                              documents)
+            pool.close()
+            pool.join()
+        else:
+            logger.debug("Filtering {0} docs (search {1})".format(
+                len(documents), search))
+            result = map(papis.docmatcher.DocMatcher.return_if_match,
+                         documents)
+
         filtered_docs = [d for d in result if d is not None]
     _delta = 1000 * time.time() - begin_t
     logger.debug("done ({0} ms) ({1} docs)".format(_delta, len(filtered_docs)))


### PR DESCRIPTION
Hi,

Trying to use papis on platforms without multiprocessing (android in
my case) currently fails.  With this PR we check if multiprocessing is
supported before trying to use it.

Without this patch, running for example

```sh
wget http://www.gnu.org/s/libc/manual/pdf/libc.pdf
papis add libc.pdf --set author "Sandra Loosemore" --set title "GNU C reference manual" --set year 2018 --set tags programming --confirm
```

gives

```
INFO:importer:pdf2doi:Trying to parse doi from file libc.pdf
ERROR:yaml:Yaml syntax error: 

'utf-8' codec can't decode byte 0xd0 in position 10: invalid continuation byte
INFO:utils:matcher:libc.pdf matches fallback
ERROR:utils:matcher:Invalid URL 'libc.pdf': No schema supplied. Perhaps you meant http://libc.pdf?
INFO:cli:add:These importers where automatically matched, select the ones you want to use
INFO:add:run:Got an automatic folder name
INFO:add:run:The folder name is 3d8bd4bea1728400147913d830a711dc-sandra-loosemore
INFO:add:run:Created reference [GnuCReferenceSandra2018]
INFO:add:run:Checking if this document is already in the library
Traceback (most recent call last):
  File "/data/data/com.termux/files/usr/lib/python3.9/multiprocessing/synchronize.py", line 28, in <module>
    from _multiprocessing import SemLock, sem_unlink
ImportError: cannot import name 'SemLock' from '_multiprocessing' (/data/data/com.termux/files/usr/lib/python3.9/lib-dynload/_multiprocessing.cpython-39.so)

During handling of the above exception, another exception occurred:

Traceback (most recent call last):
  File "/data/data/com.termux/files/usr/bin/papis", line 33, in <module>
    sys.exit(load_entry_point('papis==0.11.1', 'console_scripts', 'papis')())
  File "/data/data/com.termux/files/usr/lib/python3.9/site-packages/click-8.0.0a1-py3.9.egg/click/core.py", line 1025, in __call__
    return self.main(*args, **kwargs)
  File "/data/data/com.termux/files/usr/lib/python3.9/site-packages/click-8.0.0a1-py3.9.egg/click/core.py", line 955, in main
    rv = self.invoke(ctx)
  File "/data/data/com.termux/files/usr/lib/python3.9/site-packages/click-8.0.0a1-py3.9.egg/click/core.py", line 1517, in invoke
    return _process_result(sub_ctx.command.invoke(sub_ctx))
  File "/data/data/com.termux/files/usr/lib/python3.9/site-packages/click-8.0.0a1-py3.9.egg/click/core.py", line 1279, in invoke
    return ctx.invoke(self.callback, **ctx.params)
  File "/data/data/com.termux/files/usr/lib/python3.9/site-packages/click-8.0.0a1-py3.9.egg/click/core.py", line 710, in invoke
    return callback(*args, **kwargs)
  File "/data/data/com.termux/files/usr/lib/python3.9/site-packages/papis/commands/add.py", line 585, in cli
    return run(
  File "/data/data/com.termux/files/usr/lib/python3.9/site-packages/papis/commands/add.py", line 386, in run
    found_document = papis.utils.locate_document_in_lib(tmp_document)
  File "/data/data/com.termux/files/usr/lib/python3.9/site-packages/papis/utils.py", line 145, in locate_document_in_lib
    docs = db.query_dict({k: document[k]})
  File "/data/data/com.termux/files/usr/lib/python3.9/site-packages/papis/database/cache.py", line 241, in query_dict
    return self.query(query_string)
  File "/data/data/com.termux/files/usr/lib/python3.9/site-packages/papis/database/cache.py", line 251, in query
    return filter_documents(docs, query_string)
  File "/data/data/com.termux/files/usr/lib/python3.9/site-packages/papis/database/cache.py", line 97, in filter_documents
    pool = multiprocessing.Pool(np)
  File "/data/data/com.termux/files/usr/lib/python3.9/multiprocessing/context.py", line 119, in Pool
    return Pool(processes, initializer, initargs, maxtasksperchild,
  File "/data/data/com.termux/files/usr/lib/python3.9/multiprocessing/pool.py", line 191, in __init__
    self._setup_queues()
  File "/data/data/com.termux/files/usr/lib/python3.9/multiprocessing/pool.py", line 343, in _setup_queues
    self._inqueue = self._ctx.SimpleQueue()
  File "/data/data/com.termux/files/usr/lib/python3.9/multiprocessing/context.py", line 113, in SimpleQueue
    return SimpleQueue(ctx=self.get_context())
  File "/data/data/com.termux/files/usr/lib/python3.9/multiprocessing/queues.py", line 342, in __init__
    self._rlock = ctx.Lock()
  File "/data/data/com.termux/files/usr/lib/python3.9/multiprocessing/context.py", line 67, in Lock
    from .synchronize import Lock
  File "/data/data/com.termux/files/usr/lib/python3.9/multiprocessing/synchronize.py", line 30, in <module>
    raise ImportError("This platform lacks a functioning sem_open" +
ImportError: This platform lacks a functioning sem_open implementation, therefore, the required synchronization primitives needed will not function, see issue 3770.

```

I have verified that the code works as expected both on my phone (no multiprocessing) and on a "normal" linux system. `pycodestyle` does not complain about anything in these files either
