### PR TITLE
Fix deadlock when filtering with the list widget

### DIFF
--- a/papis/database/cache.py
+++ b/papis/database/cache.py
@@ -102,19 +102,18 @@ def filter_documents(
             # to help much, I don't know if it's because I'm doing something
             # wrong or it is really like this.
             np = os.cpu_count()
-            pool = Pool(np)
             logger.debug(
                 "Filtering {0} docs (search {1}) using {2} cores".format(
                     len(documents), search, np))
-            result = pool.map(papis.docmatcher.DocMatcher.return_if_match,
-                              documents)
-            pool.close()
-            pool.join()
+            with Pool(np) as pool:
+                result = pool.map(
+                        papis.docmatcher.DocMatcher.return_if_match,
+                        documents)
         else:
             logger.debug("Filtering {0} docs (search {1})".format(
                 len(documents), search))
             result = list(map(papis.docmatcher.DocMatcher.return_if_match,
-                         documents))
+                          documents))
 
         filtered_docs = [d for d in result if d is not None]
     _delta = 1000 * time.time() - begin_t

--- a/papis/tui/widgets/list.py
+++ b/papis/tui/widgets/list.py
@@ -240,6 +240,7 @@ class OptionsList(ConditionalContainer, Generic[Option]):  # type: ignore
                     for i, opt in enumerate(self.options_matchers)
                     if i in search_indices
                 ]
+                results = [d.get() for d in results]
         else:
             results = [
                 match_against_regex(regex, opt, i)
@@ -247,8 +248,7 @@ class OptionsList(ConditionalContainer, Generic[Option]):  # type: ignore
                 if i in search_indices
             ]
 
-        _maybe_indices = [d.get() for d in results]
-        self.indices = [i for i in _maybe_indices if i is not None]
+        self.indices = [i for i in results if i is not None]
 
         if (self.indices
                 and self.current_index is not None

--- a/papis/utils.py
+++ b/papis/utils.py
@@ -194,11 +194,9 @@ def folders_to_documents(folders: List[str]) -> List[papis.document.Document]:
         np = os.cpu_count()
         logger.debug(
             "converting folder into documents on {0} cores".format(np))
-        pool = Pool(np)
         begin_t = time.time()
-        result = pool.map(papis.document.from_folder, folders)
-        pool.close()
-        pool.join()
+        with Pool(np) as pool:
+            result = pool.map(papis.document.from_folder, folders)
     else:
         logger.debug("converting folder into documents")
         begin_t = time.time()


### PR DESCRIPTION
Before trying to open a document with `papis open` and then starting to type would freeze the tui completely.