### PR TITLE
[WiP] Add open note functionality to picker (issue 316)

### DIFF
--- a/papis/tui/__init__.py
+++ b/papis/tui/__init__.py
@@ -22,6 +22,7 @@ def get_default_settings() -> PapisConfigType:
         'move_up_while_info_window_active_key': 'c-p',
         'focus_command_line_key': 'tab',
         'edit_document_key': 'c-e',
+        'edit_notes_key': 'c-q',
         'open_document_key': 'c-o',
         'show_help_key': 'f1',
         'show_info_key': 's-tab',

--- a/papis/tui/app.py
+++ b/papis/tui/app.py
@@ -67,6 +67,10 @@ def get_keys_info() -> Dict[str, KeyInfo]:
                 'key': config.getstring('edit_document_key', section='tui'),
                 'help': 'Edit currently selected document',
             },
+            "edit_notes_key": {
+                'key': config.getstring('edit_notes_key', section='tui'),
+                'help': 'Edit notes of currently selected document',
+            },
             "open_document_key": {
                 'key': config.getstring('open_document_key', section='tui'),
                 'help': 'Open currently selected document',
@@ -208,6 +212,15 @@ def get_commands(app: Application) -> Tuple[List[Command], KeyBindings]:
         docs = cmd.app.get_selection()
         for doc in docs:
             run(doc)
+        cmd.app.renderer.clear()
+
+    @kb.add(keys_info["edit_notes_key"]["key"],  # type: ignore
+            filter=has_focus(app.options_list.search_buffer))
+    def edit_notes(cmd: Command) -> None:
+        from papis.commands.edit import edit_notes
+        docs = cmd.app.get_selection()
+        for doc in docs:
+            edit_notes(doc)
         cmd.app.renderer.clear()
 
     @kb.add(keys_info["show_help_key"]["key"],  # type: ignore


### PR DESCRIPTION
This commit adds possibility to edit notes from the default picker (see #316). 

Currently, I set the default keybinding to `c-m` but that's mostly just to have anything (both `c-n` and `c-e` which would seem like the obvious choices are already in use).

With this commit, I want to get some feedback on how to best implement the feature. What I've done is to separate out, in `edit.py` from the function`cli` everything that relates to editing notes and created a new function (`edit_notes`) with it. This is so i can call that function in `app.py`. I'm not sure this is the best way of doing this; it breaks a bit with how the other command files are structured. I've also commented out a bunch of logging stuff as maybe we want to call these only when the function is called as a cli command?

What do you think is the best way of implementing this?

I ran the tests and a bunch of them failed, but I'm not sure this is because of my changes. I'm rather new to github and only slightly more experienced with python -- so, happy about any pointers on what to do!