### PR TITLE
Fix link to papis zotero, minor typesetting.

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -46,10 +46,10 @@ Main features
    matter of seconds, also you can check the documentation
    `here <http://papis.readthedocs.io/en/latest/scihub.html>`__.
 -  Import from Zotero and other managers using
-   `papis-zotero <https://github.com/papis/papis-zotero>__`.
+   `papis-zotero <https://github.com/papis/papis-zotero>`__.
 -  Create custom scripts to help you achieve great tasks easily
    (`doc <http://papis.readthedocs.io/en/latest/scripting.html>`__).
--  Export documents into many formats (bibtex, yaml..)
+-  Export documents into many formats (bibtex, yaml, ...)
 -  Command-line granularity, all the power of a library at the tip of
    your fingers.
 


### PR DESCRIPTION
This PR moves a backtick around to fix the link to papis zotero and formats the the export format list.
