### PR TITLE
Automatically retrieve DOI from PDF

### DIFF
--- a/papis/commands/add.py
+++ b/papis/commands/add.py
@@ -98,6 +98,7 @@ import shutil
 
 import click
 import colorama
+import pdf2doi
 
 import time
 import papis.api
@@ -539,6 +540,12 @@ def cli(
                 for imp in matching_importers],
             "Select matching importers (for instance 0, 1, 3-10, a, all...)")
         matching_importers = [matching_importers[i] for i in _range]
+        
+        for f in files:
+            doi = pdf2doi.pdf2doi(f)['identifier']
+            if doi is not None:
+                from_importer.append(('doi', doi))
+                
 
     for importer_tuple in from_importer:
         try:

--- a/setup.py
+++ b/setup.py
@@ -74,6 +74,7 @@ setup(
         "typing-extensions>=3.7",
         "lxml>=4.3.5 ; python_version>'3.5'",
         "python-slugify>=1.2.6 ; python_version>'3.4'",
+        "pdf2doi>=0.4"
     ],
     python_requires='>=3.5',
     classifiers=[


### PR DESCRIPTION
I think this feature is fairly critical and easily implemented. This change may belong in `get_matching_importer_or_downloader' but for some reason that wasn't working.

Also, there may be a way that does not rely on pdf2doi (MicheleCotrufo/pdf2doi).