### PR TITLE
Add python3.10 to versions to run tests on

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -9,7 +9,7 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest, macos-latest, windows-latest]
-        python-version: [3.5, 3.6, 3.7, 3.8, 3.9]
+        python-version: ['3.5', '3.6', '3.7', '3.8', '3.9', '3.10']
 
     steps:
     - uses: actions/checkout@v2

--- a/papis/commands/browse.py
+++ b/papis/commands/browse.py
@@ -71,7 +71,8 @@ from typing import Optional
 logger = logging.getLogger('browse')
 
 
-def run(document: papis.document.Document, browse: bool=True) -> Optional[str]:
+def run(document: papis.document.Document,
+        browse: bool = True) -> Optional[str]:
     """Browse document's url whenever possible and returns the url
 
     :document: Document object

--- a/papis/commands/merge.py
+++ b/papis/commands/merge.py
@@ -112,7 +112,6 @@ def cli(query: str,
         logger.error("You have to pick exactly two documents!")
         return
 
-
     a = documents[0]
     data_a = to_dict(a)
     b = documents[1]

--- a/papis/config.py
+++ b/papis/config.py
@@ -544,7 +544,7 @@ def get_lib_from_name(libname: str) -> papis.library.Library:
             raise Exception("Library '{0}' does not seem to exist"
                             "\n\n"
                             "To add a library simply write the following"
-                            "in your configuration file located at '{cpath}'"
+                            " in your configuration file located at '{cpath}'"
                             "\n\n"
                             "\t[{0}]\n"
                             "\tdir = path/to/your/{0}/folder"


### PR DESCRIPTION
And fix minor issues that the coverage check complained about in browse.py and merge.py. Also add a missing space to the message that is printed if library does not exist.