### PR TITLE
Clean up logging

### DIFF
--- a/papis/api.py
+++ b/papis/api.py
@@ -11,7 +11,6 @@ import papis.pick
 import papis.database
 
 logger = logging.getLogger("api")
-logger.debug("importing")
 
 
 def get_lib_name() -> str:

--- a/papis/api.py
+++ b/papis/api.py
@@ -10,8 +10,8 @@ import papis.config
 import papis.pick
 import papis.database
 
-LOGGER = logging.getLogger("api")
-LOGGER.debug("importing")
+logger = logging.getLogger("api")
+logger.debug("importing")
 
 
 def get_lib_name() -> str:

--- a/papis/arxiv.py
+++ b/papis/arxiv.py
@@ -63,7 +63,7 @@ def get_data(
     search_query = '+AND+'.join(
         [key+':'+str(clean_params[key]) for key in clean_params]
     )
-    logger.debug("query = " + search_query)
+    logger.debug("query = '%s'", search_query)
     params = urllib.parse.urlencode(
         {
             'search_query': search_query,
@@ -73,7 +73,7 @@ def get_data(
     )
     main_url = "http://arxiv.org/api/query?"
     req_url = main_url + params
-    logger.debug("url = " + req_url)
+    logger.debug("url = '%s'", req_url)
     url = urllib.request.Request(
         req_url,
         headers={
@@ -208,6 +208,7 @@ def explorer(
     """
     logger = logging.getLogger('explore:arxiv')
     logger.info('Looking up...')
+
     data = get_data(
         query=query,
         author=author,
@@ -222,6 +223,7 @@ def explorer(
         max_results=max)
     docs = [papis.document.from_data(data=d) for d in data]
     ctx.obj['documents'] += docs
+
     logger.info('%s documents found', len(docs))
 
 
@@ -260,16 +262,16 @@ class Downloader(papis.downloaders.Downloader):
             return None
         bibtex_cli = arxiv2bib.Cli([bib_url])
         bibtex_cli.run()
-        self.logger.debug("[bibtex url] = %s" % bib_url)
+        self.logger.debug("bibtex_url = '%s'", bib_url)
         output = bibtex_cli.output  # List[str]
         data = ''.join(output).replace('\n', ' ')
         self.bibtex_data = data
 
     def get_document_url(self) -> Optional[str]:
         arxivid = self._get_identifier()
-        self.logger.debug("arxivid %s" % arxivid)
+        self.logger.debug("arxivid = '%s'", arxivid)
         pdf_url = "https://arxiv.org/pdf/{arxivid}.pdf".format(arxivid=arxivid)
-        self.logger.debug("[pdf url] = %s" % pdf_url)
+        self.logger.debug("pdf_url = '%s'", pdf_url)
         return pdf_url
 
 
@@ -314,14 +316,13 @@ class ArxividFromPdfImporter(papis.importer.Importer):
         return importer if importer.arxivid else None
 
     def fetch(self) -> None:
-        self.logger.info(
-            "trying to parse arxivid from file {0}".format(self.uri))
+        self.logger.info("Trying to parse arxivid from file '%s'", self.uri)
         if not self.arxivid:
             self.arxivid = pdf_to_arxivid(self.uri, maxlines=2000)
         if self.arxivid:
-            self.logger.info("Parsed arxivid {0}".format(self.arxivid))
+            self.logger.info("Parsed arxivid '%s'", self.arxivid)
             self.logger.warning(
-                "There is no guarantee that this arxivid is the one")
+                    "There is no guarantee that this arxivid is the one")
             importer = Importer.match(self.arxivid)
             if importer:
                 importer.fetch()

--- a/papis/base.py
+++ b/papis/base.py
@@ -13,7 +13,7 @@ from typing import Optional, Dict, Any, List, Callable, NamedTuple
 
 import click
 
-LOGGER = logging.getLogger('base')
+logger = logging.getLogger('base')
 
 
 def get_data(query: str = "", max: int = 20) -> List[Dict[str, Any]]:
@@ -22,10 +22,10 @@ def get_data(query: str = "", max: int = 20) -> List[Dict[str, Any]]:
         "cgi-bin/BaseHttpSearchInterface.fcgi/"
     )
 
-    LOGGER.warning('BASE engine in papis is experimental')
+    logger.warning('BASE engine in papis is experimental')
 
     if max > 125:
-        LOGGER.error('BASE only allows a maximum of 125 hits')
+        logger.error('BASE only allows a maximum of 125 hits')
         max = 125
 
     dict_params = {
@@ -38,7 +38,7 @@ def get_data(query: str = "", max: int = 20) -> List[Dict[str, Any]]:
         {x: dict_params[x] for x in dict_params if dict_params[x]}
     )
     req_url = base_baseurl + "search?" + params
-    LOGGER.debug("url = " + req_url)
+    logger.debug("url = " + req_url)
     url = urllib.request.Request(
         req_url,
         headers={
@@ -47,7 +47,7 @@ def get_data(query: str = "", max: int = 20) -> List[Dict[str, Any]]:
     )
     jsondoc = json.loads(urllib.request.urlopen(url).read().decode())
     docs = jsondoc.get('response').get('docs')
-    LOGGER.info("Retrieved {0} documents".format(len(docs)))
+    logger.info("Retrieved {0} documents".format(len(docs)))
     return list(map(basedoc_to_papisdoc, docs))
 
 

--- a/papis/base.py
+++ b/papis/base.py
@@ -16,7 +16,7 @@ import click
 logger = logging.getLogger('base')
 
 
-def get_data(query: str = "", max: int = 20) -> List[Dict[str, Any]]:
+def get_data(query: str = "", hits: int = 20) -> List[Dict[str, Any]]:
     base_baseurl = (
         "https://api.base-search.net/"
         "cgi-bin/BaseHttpSearchInterface.fcgi/"
@@ -24,21 +24,22 @@ def get_data(query: str = "", max: int = 20) -> List[Dict[str, Any]]:
 
     logger.warning('BASE engine in papis is experimental')
 
-    if max > 125:
-        logger.error('BASE only allows a maximum of 125 hits')
-        max = 125
+    if hits > 125:
+        logger.error(
+                'BASE only allows a maximum of 125 hits, got %d hits', hits)
+        hits = 125
 
     dict_params = {
         "func": "PerformSearch",
         "query": query,
         "format": "json",
-        "hits": max,
+        "hits": hits,
     }
     params = urllib.parse.urlencode(
         {x: dict_params[x] for x in dict_params if dict_params[x]}
     )
     req_url = base_baseurl + "search?" + params
-    logger.debug("url = " + req_url)
+    logger.debug("url = '%s'", req_url)
     url = urllib.request.Request(
         req_url,
         headers={
@@ -47,7 +48,7 @@ def get_data(query: str = "", max: int = 20) -> List[Dict[str, Any]]:
     )
     jsondoc = json.loads(urllib.request.urlopen(url).read().decode())
     docs = jsondoc.get('response').get('docs')
-    logger.info("Retrieved {0} documents".format(len(docs)))
+    logger.info("Retrieved %d documents", len(docs))
     return list(map(basedoc_to_papisdoc, docs))
 
 
@@ -106,7 +107,9 @@ def explorer(ctx: click.core.Context, query: str) -> None:
     import papis.document
     logger = logging.getLogger('explore:base')
     logger.info('Looking up...')
+
     data = get_data(query=query)
     docs = [papis.document.from_data(data=d) for d in data]
     ctx.obj['documents'] += docs
-    logger.info('{} documents found'.format(len(docs)))
+
+    logger.info('%d documents found', len(docs))

--- a/papis/bibtex.py
+++ b/papis/bibtex.py
@@ -161,7 +161,6 @@ def bibtex_to_dict(bibtex: str) -> List[Dict[str, str]]:
 
     # bibtexparser has too many debug messages to be useful
     logging.getLogger("bibtexparser.bparser").setLevel(logging.WARNING)
-    global logger
     if os.path.exists(bibtex):
         with open(bibtex) as fd:
             logger.debug("Reading in file %s" % bibtex)

--- a/papis/bibtex.py
+++ b/papis/bibtex.py
@@ -75,13 +75,13 @@ class Importer(papis.importer.Importer):
 
     @papis.importer.cache
     def fetch(self: papis.importer.Importer) -> Any:
-        self.logger.info("Reading input file = %s" % self.uri)
+        self.logger.info("Reading input file = '%s'", self.uri)
         try:
             bib_data = bibtex_to_dict(self.uri)
             if len(bib_data) > 1:
                 self.logger.warning(
-                    'Your bibtex file contains more than one entry,'
-                    ' I will be taking the first entry')
+                    'The bibtex file contains more than one entry, '
+                    'only taking the first entry')
             if bib_data:
                 self.ctx.data = bib_data[0]
         except Exception as e:
@@ -102,12 +102,14 @@ def explorer(ctx: click.core.Context, bibfile: str) -> None:
 
     """
     logger = logging.getLogger('explore:bibtex')
-    logger.info('Reading in bibtex file {}'.format(bibfile))
+    logger.info("Reading in bibtex file '%s'", bibfile)
+
     docs = [
         papis.document.from_data(d)
         for d in bibtex_to_dict(bibfile)]
     ctx.obj['documents'] += docs
-    logger.info('{} documents found'.format(len(docs)))
+
+    logger.info('%d documents found', len(docs))
 
 
 def bibtexparser_entry_to_papis(entry: Dict[str, str]) -> Dict[str, str]:
@@ -163,7 +165,7 @@ def bibtex_to_dict(bibtex: str) -> List[Dict[str, str]]:
     logging.getLogger("bibtexparser.bparser").setLevel(logging.WARNING)
     if os.path.exists(bibtex):
         with open(bibtex) as fd:
-            logger.debug("Reading in file %s" % bibtex)
+            logger.debug("Reading in file '%s'", bibtex)
             text = fd.read()
     else:
         text = bibtex
@@ -202,7 +204,7 @@ def create_reference(doc: Dict[str, Any]) -> str:
             logger.error(e)
             ref = ""
 
-    logger.debug("generated ref=%s" % ref)
+    logger.debug("Generated 'ref = %s'", ref)
     if not ref:
         if doc.get('doi'):
             ref = doc['doi']
@@ -237,7 +239,7 @@ def to_bibtex(document: papis.document.Document) -> str:
         bibtex_type = "article"
 
     ref = create_reference(document)
-    logger.debug("Used ref=%s" % ref)
+    logger.debug("Used 'ref = %s'", ref)
 
     bibtex_string += "@{type}{{{ref},\n".format(type=bibtex_type, ref=ref)
     for bibKey in list(document.keys()):
@@ -245,7 +247,7 @@ def to_bibtex(document: papis.document.Document) -> str:
             new_bibkey = bibtex_key_converter[bibKey]
             document[new_bibkey] = document[bibKey]
     for bibKey in sorted(document.keys()):
-        logger.debug('%s : %s' % (bibKey, document[bibKey]))
+        logger.debug("Bibtex entry: '%s: %s'", bibKey, document[bibKey])
         if bibKey in bibtex_keys:
             value = str(document[bibKey])
             if not papis.config.getboolean('bibtex-unicode'):
@@ -259,8 +261,8 @@ def to_bibtex(document: papis.document.Document) -> str:
                     )
                 elif journal_key not in document.keys():
                     logger.warning(
-                        "Key '{0}' is not present for ref={1}"
-                        .format(journal_key, document["ref"]))
+                            "Key '%s' is not present for ref '%s'",
+                            journal_key, document["ref"])
                     bibtex_string += "  %s = {%s},\n" % ('journal', value)
             else:
                 bibtex_string += "  %s = {%s},\n" % (bibKey, value)

--- a/papis/commands/add.py
+++ b/papis/commands/add.py
@@ -129,8 +129,9 @@ class FromFolderImporter(papis.importer.Importer):
         return FromFolderImporter(uri=uri) if os.path.isdir(uri) else None
 
     def fetch(self) -> None:
+        self.logger.info("Importing from folder '%s'", self.uri)
+
         doc = papis.document.from_folder(self.uri)
-        self.logger.info('importing from folder {0}'.format(self.uri))
         self.ctx.data = papis.document.to_dict(doc)
         self.ctx.files = doc.get_files()
 
@@ -194,8 +195,7 @@ def get_file_name(
 
     if len(file_name_base) > basename_limit:
         logger.warning(
-            "Shortening the name {0} for portability".format(file_name_base)
-        )
+            "Shortening the file name '%s' for portability", file_name_base)
         file_name_base = file_name_base[0:basename_limit]
 
     # Remove extension from file_name_base, if any
@@ -286,6 +286,7 @@ def run(paths: List[str],
     """
 
     logger = logging.getLogger('add:run')
+
     # The folder name of the new document that will be created
     out_folder_name = None
     # The real paths of the documents to be added
@@ -322,9 +323,9 @@ def run(paths: List[str],
             subfolder or '',
             out_folder_name))
 
-    logger.info("The folder name is {0}".format(out_folder_name))
-    logger.debug("Folder path: {0}".format(out_folder_path))
-    logger.debug("File(s): {0}".format(in_documents_paths))
+    logger.info("The folder name is '%s'", out_folder_name)
+    logger.debug("Folder path: '%s'", out_folder_path)
+    logger.debug("File(s): %s", in_documents_paths)
 
     # First prepare everything in the temporary directory
     g = papis.utils.create_identifier(ascii_lowercase)
@@ -351,13 +352,11 @@ def run(paths: List[str],
         if link:
             in_file_abspath = os.path.abspath(in_file_path)
             logger.debug(
-                "[SYMLINK] '%s' to '%s'" %
-                (in_file_abspath, tmp_end_filepath))
+                "[SYMLINK] '%s' to '%s'", in_file_abspath, tmp_end_filepath)
             os.symlink(in_file_abspath, tmp_end_filepath)
         else:
             logger.debug(
-                "[CP] '%s' to '%s'" %
-                (in_file_path, tmp_end_filepath))
+                "[CP] '%s' to '%s'", in_file_path, tmp_end_filepath)
             shutil.copy(in_file_path, tmp_end_filepath)
 
     data['files'] = new_file_list
@@ -365,7 +364,7 @@ def run(paths: List[str],
     # reference building
     if data.get('ref') is None:
         data['ref'] = papis.bibtex.create_reference(data)
-        logger.info("Created reference [%s]", data['ref'])
+        logger.info("Created reference '%s'", data['ref'])
 
     tmp_document.update(data)
     tmp_document.save()
@@ -386,17 +385,13 @@ def run(paths: List[str],
         logger.info("No document matching found already in the library")
     else:
         logger.warning(
-            colorama.Fore.RED
-            + "DUPLICATION WARNING"
-            + colorama.Style.RESET_ALL)
+            "%sDUPLICATION WARNING%s",
+            colorama.Fore.RED, colorama.Style.RESET_ALL)
         logger.warning(
-            "The document beneath is in your library and it seems to match")
+            "A document in the library seems to match the added one.")
         logger.warning(
-            "the one that you're trying to add, "
-            "I will prompt you for confirmation")
-        logger.warning(
-            "(Hint) Use the update command if you just want to update"
-            " the info.")
+            "(Hint) Use the 'papis update' command to just update the info.")
+
         papis.tui.utils.text_area(
             'The following document is already in your library',
             papis.document.dump(found_document),
@@ -412,9 +407,8 @@ def run(paths: List[str],
             return
 
     logger.info(
-        "[MV] '%s' to '%s'" %
-        (tmp_document.get_main_folder(), out_folder_path)
-    )
+        "[MV] '%s' to '%s'", tmp_document.get_main_folder(), out_folder_path)
+
     # This also sets the folder of tmp_document
     papis.document.move(tmp_document, out_folder_path)
     papis.database.get().add(tmp_document)
@@ -550,13 +544,11 @@ def cli(
             logger.exception(e)
 
     if matching_importers:
-        logger.info('There are {0} possible matchings'
-                    .format(len(matching_importers)))
+        logger.info('There are %d possible matchings', len(matching_importers))
 
         for importer in matching_importers:
             if importer.ctx.data:
-                logger.info('Merging data from importer {0}'
-                            .format(importer.name))
+                logger.info('Merging data from importer %s', importer.name)
                 if batch:
                     ctx.data.update(importer.ctx.data)
                 else:
@@ -565,8 +557,9 @@ def cli(
                         importer.ctx.data,
                         str(importer))
             if importer.ctx.files:
-                logger.info('Got files {0} from importer {1}'
-                            .format(importer.ctx.files, importer.name))
+                logger.info(
+                        "Got files %s from importer '%s'",
+                        importer.ctx.files, importer.name)
                 for f in importer.ctx.files:
                     papis.utils.open_file(f)
                     _msg = "Use this file? (from {0})".format(importer.name)
@@ -574,7 +567,7 @@ def cli(
                         ctx.files.append(f)
 
     if not ctx:
-        logger.error('there is nothing to be added')
+        logger.error('There is nothing to be added')
         return
 
     if papis.config.getboolean("time-stamp"):

--- a/papis/commands/add.py
+++ b/papis/commands/add.py
@@ -97,7 +97,6 @@ import hashlib
 import shutil
 
 import click
-import colorama
 
 import time
 import papis.api
@@ -384,9 +383,7 @@ def run(paths: List[str],
     except IndexError:
         logger.info("No document matching found already in the library")
     else:
-        logger.warning(
-            "%sDUPLICATION WARNING%s",
-            colorama.Fore.RED, colorama.Style.RESET_ALL)
+        logger.warning("{c.Fore.RED}DUPLICATION WARNING{c.Style.RESET_ALL}")
         logger.warning(
             "A document in the library seems to match the added one.")
         logger.warning(

--- a/papis/commands/addto.py
+++ b/papis/commands/addto.py
@@ -37,6 +37,7 @@ def run(document: papis.document.Document,
         filepaths: List[str],
         git: bool = False) -> None:
     logger = logging.getLogger('addto')
+
     g = papis.utils.create_identifier(ascii_lowercase)
     string_append = ''
 
@@ -74,18 +75,14 @@ def run(document: papis.document.Document,
         if len(os.path.abspath(end_document_path)) >= 255:
             logger.warning(
                 'Length of absolute path is > 255 characters. '
-                'This may cause some issues with some pdf viewers'
-            )
+                'This may cause some issues with some pdf viewers')
 
         if os.path.exists(end_document_path):
             logger.warning(
-                "%s already exists, ignoring..." % end_document_path
-            )
+                "%s already exists, ignoring...", end_document_path)
             continue
-        logger.info(
-            "[CP] '%s' to '%s'" %
-            (in_file_path, end_document_path)
-        )
+
+        logger.info("[CP] '%s' to '%s'", in_file_path, end_document_path)
         shutil.copy(in_file_path, end_document_path)
 
     if "files" not in document.keys():

--- a/papis/commands/bibtex.py
+++ b/papis/commands/bibtex.py
@@ -139,7 +139,6 @@ import papis.commands.browse
 import papis.commands.export
 import papis.bibtex
 import logging
-import colorama
 
 from typing import List, Optional
 
@@ -228,17 +227,15 @@ def _update(ctx: click.Context, _all: bool,
             libdoc = papis.utils.locate_document_in_lib(doc)
         except IndexError as e:
             logger.info(
-                '{c.Fore.YELLOW}{0}:'
-                '\n\t{c.Back.RED}{doc: <80.80}{c.Style.RESET_ALL}'
-                .format(e, doc=papis.document.describe(doc), c=colorama)
-            )
+                '{c.Fore.YELLOW}%s:'
+                '\n\t{c.Back.RED}%-80.80s{c.Style.RESET_ALL}',
+                e, papis.document.describe(doc))
         else:
             if fromdb:
                 logger.info(
                     'Updating \n\t{c.Fore.GREEN}'
-                    '{c.Back.BLACK}{doc: <80.80}{c.Style.RESET_ALL}'
-                    .format(doc=papis.document.describe(doc), c=colorama)
-                )
+                    '{c.Back.BLACK}%-80.80s{c.Style.RESET_ALL}',
+                    papis.document.describe(doc))
                 if keys:
                     docs[j].update(
                         {k: libdoc.get(k) for k in keys if libdoc.has(k)})
@@ -422,9 +419,8 @@ def _doctor(ctx: click.Context, key: List[str]) -> None:
               if keys]
 
     for j, (doc, keys) in enumerate(failed):
-        logger.info('{} {c.Back.BLACK}{c.Fore.RED}{doc: <80.80}'
-                    '{c.Style.RESET_ALL}'
-                    .format(j, doc=papis.document.describe(doc), c=colorama))
+        logger.info('%s {c.Back.BLACK}{c.Fore.RED}%-80.80s{c.Style.RESET_ALL}',
+                    j, papis.document.describe(doc))
         for k in keys:
             logger.info('\tmissing: %s', k)
 
@@ -477,9 +473,8 @@ def _iscited(ctx: click.Context, _files: List[str]) -> None:
     logger.info('%s documents not cited', len(unfound))
 
     for j, doc in enumerate(unfound):
-        logger.info('{} {c.Back.BLACK}{c.Fore.RED}{doc: <80.80}'
-                    '{c.Style.RESET_ALL}'
-                    .format(j, doc=papis.document.describe(doc), c=colorama))
+        logger.info('%s {c.Back.BLACK}{c.Fore.RED}%-80.80s{c.Style.RESET_ALL}',
+                    j, papis.document.describe(doc))
 
 
 @cli.command('import')
@@ -508,10 +503,10 @@ def _import(ctx: click.Context, out: Optional[str], _all: bool) -> None:
         fileValue = None
         filepaths = []
         for k in ["file", "FILE"]:
-            logger.info('{} {c.Back.BLACK}{c.Fore.YELLOW}{doc: <80.80}'
-                        '{c.Style.RESET_ALL}'
-                        .format(j, doc=papis.document.describe(doc),
-                                c=colorama))
+            logger.info(
+                    '%s {c.Back.BLACK}{c.Fore.YELLOW}%-80.80s'
+                    '{c.Style.RESET_ALL}',
+                    j, papis.document.describe(doc))
             if doc.has(k):
                 fileValue = doc[k]
                 logger.info("\tKey '%s' exists", k)
@@ -521,16 +516,15 @@ def _import(ctx: click.Context, out: Optional[str], _all: bool) -> None:
             logger.info("\t"
                         "{c.Back.YELLOW}{c.Fore.BLACK}"
                         "No pdf files will be imported"
-                        "{c.Style.RESET_ALL}".format(c=colorama))
+                        "{c.Style.RESET_ALL}")
         else:
             filepaths = [f for f in fileValue.split(":") if os.path.exists(f)]
 
         if not filepaths and fileValue is not None:
             logger.info("\t"
                         "{c.Back.BLACK}{c.Fore.RED}"
-                        "No valid file in \n"
-                        "{value}{c.Style.RESET_ALL}"
-                        .format(value=fileValue, c=colorama))
+                        "No valid file in \n%s{c.Style.RESET_ALL}",
+                        fileValue)
         else:
             logger.info("\tfound %s file(s)", len(filepaths))
 

--- a/papis/commands/bibtex.py
+++ b/papis/commands/bibtex.py
@@ -168,14 +168,14 @@ def cli(ctx: click.Context, no_auto_read: bool) -> None:
     ctx.obj = {'documents': []}
 
     if no_auto_read:
-        logger.info('Setting auto-read to False')
+        logger.info("Setting 'auto-read' to False")
         config.set('auto-read', 'False', section='bibtex')
 
     bibfile = config.get('default-read-bibfile', section='bibtex')
     if (bool(config.getboolean('auto-read', section='bibtex'))
             and bibfile
             and os.path.exists(bibfile)):
-        logger.info("auto reading {0}".format(bibfile))
+        logger.info("Auto-reading '%s'", bibfile)
         explorer_mgr['bibtex'].plugin.callback(bibfile)
 
 
@@ -335,7 +335,7 @@ def _save(ctx: click.Context, bibfile: str, force: bool) -> None:
             print('Not saving..')
             return
     with open(bibfile, 'w+') as fd:
-        logger.info('Saving {1} documents in {0}..'.format(bibfile, len(docs)))
+        logger.info("Saving %d documents in '%s'", len(docs), bibfile)
         fd.write(papis.commands.export.run(docs, to_format='bibtex'))
 
 
@@ -386,18 +386,18 @@ def _unique(ctx: click.Context, key: str, o: Optional[str]) -> None:
             if doc.get(key) == bottle.get(key):
                 indices.append(i)
                 duplis_docs.append(bottle)
-                logger.info('{}. repeated {} ⇒ {}'
-                            .format(len(duplis_docs), key, doc.get(key)))
+                logger.info(
+                        '%d repeated %s -> %s',
+                        len(duplis_docs), key, doc.get(key))
         docs = [d for (i, d) in enumerate(docs) if i not in indices]
 
-    logger.info("Unique   : {}".format(len(unique_docs)))
-    logger.info("Discarded: {}".format(len(duplis_docs)))
+    logger.info("Unique   : %d", len(unique_docs))
+    logger.info("Discarded: %d", len(duplis_docs))
 
     ctx.obj['documents'] = unique_docs
     if o:
         with open(o, 'w+') as f:
-            logger.info('Saving {1} documents in {0}..'
-                        .format(o, len(duplis_docs)))
+            logger.info("Saving %d documents in '%s'", len(duplis_docs), o)
             f.write(papis.commands.export.run(duplis_docs, to_format='bibtex'))
 
 
@@ -415,7 +415,7 @@ def _doctor(ctx: click.Context, key: List[str]) -> None:
         e.g. papis bibtex doctor -k title -k url -k doi
 
     """
-    logger.info("Checking for existence of %s", ", ".join(key))
+    logger.info("Checking for existence of keys %s", ", ".join(key))
 
     failed = [(d, keys) for d, keys in [(d, [k for k in key if not d.has(k)])
                                         for d in ctx.obj['documents']]
@@ -514,13 +514,13 @@ def _import(ctx: click.Context, out: Optional[str], _all: bool) -> None:
                                 c=colorama))
             if doc.has(k):
                 fileValue = doc[k]
-                logger.info("\tkey '%s' exists", k)
+                logger.info("\tKey '%s' exists", k)
                 break
 
         if not fileValue:
             logger.info("\t"
                         "{c.Back.YELLOW}{c.Fore.BLACK}"
-                        "no pdf files will be imported"
+                        "No pdf files will be imported"
                         "{c.Style.RESET_ALL}".format(c=colorama))
         else:
             filepaths = [f for f in fileValue.split(":") if os.path.exists(f)]
@@ -528,7 +528,7 @@ def _import(ctx: click.Context, out: Optional[str], _all: bool) -> None:
         if not filepaths and fileValue is not None:
             logger.info("\t"
                         "{c.Back.BLACK}{c.Fore.RED}"
-                        "I could not find a valid file in \n"
+                        "No valid file in \n"
                         "{value}{c.Style.RESET_ALL}"
                         .format(value=fileValue, c=colorama))
         else:

--- a/papis/commands/browse.py
+++ b/papis/commands/browse.py
@@ -78,7 +78,6 @@ def run(document: papis.document.Document,
     :document: Document object
 
     """
-    global logger
     url = None
     key = papis.config.getstring("browse-key")
 

--- a/papis/commands/browse.py
+++ b/papis/commands/browse.py
@@ -107,7 +107,7 @@ def run(document: papis.document.Document,
                    + urlencode(params))
 
     if browse:
-        logger.info("Opening url %s:" % url)
+        logger.info("Opening url '%s'", url)
         papis.utils.general_open(url, "browser", wait=False)
     else:
         print(url)
@@ -156,7 +156,7 @@ def cli(query: str,
     if len(key):
         papis.config.set('browse-key', key)
 
-    logger.info("Using key = %s", papis.config.get("browse-key"))
+    logger.info("Using key '%s'", papis.config.get("browse-key"))
 
     for document in documents:
         run(document, browse=not _print)

--- a/papis/commands/config.py
+++ b/papis/commands/config.py
@@ -43,6 +43,7 @@ from typing import Optional
 
 def run(option_string: str) -> Optional[str]:
     logger = logging.getLogger('config:run')
+
     option = option_string.split(".")
     if len(option) == 1:
         key = option[0]
@@ -50,8 +51,10 @@ def run(option_string: str) -> Optional[str]:
     elif len(option) == 2:
         section = option[0]
         key = option[1]
-    logger.debug("key = %s, sec = %s" % (key, section))
+
+    logger.debug("key = %s, sec = %s", key, section)
     val = papis.config.get(key, section=section)
+
     return val
 
 
@@ -62,4 +65,5 @@ def cli(option: str) -> None:
     """Print configuration values"""
     logger = logging.getLogger('cli:config')
     logger.debug(option)
+
     click.echo(run(option))

--- a/papis/commands/default.py
+++ b/papis/commands/default.py
@@ -48,6 +48,12 @@ import click
 import click.core
 
 
+class ColoramaFormatter(logging.Formatter):
+    def format(self, record: logging.LogRecord) -> str:
+        record.msg = record.msg.format(c=colorama)
+        return super().format(record)
+
+
 class MultiCommand(click.core.MultiCommand):
 
     scripts = papis.commands.get_scripts()
@@ -225,11 +231,15 @@ def run(verbose: bool,
                   )
     if verbose:
         log = "DEBUG"
-        log_format = "%(relativeCreated)d-"+log_format
-    logging.basicConfig(level=getattr(logging, log),
-                        format=log_format,
-                        filename=logfile,
-                        filemode='w+' if logfile is not None else 'a')
+        log_format = "%(relativeCreated)d-{}".format(log_format)
+
+    if logfile is None:
+        handler = logging.StreamHandler()
+        handler.setFormatter(ColoramaFormatter(log_format))
+    else:
+        handler = logging.FileHandler(logfile, mode="a")
+
+    logging.basicConfig(level=getattr(logging, log), handlers=[handler])
     logger = logging.getLogger('default')
 
     if config:

--- a/papis/commands/default.py
+++ b/papis/commands/default.py
@@ -93,7 +93,7 @@ class MultiCommand(click.core.MultiCommand):
                 ))
             # return the match if there was only one match
             if len(matches) == 1:
-                self.logger.warning("I suppose you meant: '%s'", *matches)
+                self.logger.warning("I suppose you meant: '%s'", matches[0])
                 script = self.scripts[matches[0]]
             else:
                 return None
@@ -237,7 +237,7 @@ def run(verbose: bool,
         papis.config.reset_configuration()
 
     for pair in set_list:
-        logger.debug('Setting "{0}" to "{1}"'.format(*pair))
+        logger.debug("Setting '%s' to '%s'", *pair)
         papis.config.set(pair[0], pair[1])
 
     if pick_lib:

--- a/papis/commands/edit.py
+++ b/papis/commands/edit.py
@@ -55,6 +55,7 @@ def edit_notes(document: papis.document.Document,
                git: bool = False) -> None:
     logger = logging.getLogger('edit:notes')
     logger.debug("Editing notes")
+
     if not document.has("notes"):
         document["notes"] = papis.config.getstring("notes-name")
         document.save()
@@ -64,7 +65,7 @@ def edit_notes(document: papis.document.Document,
     )
 
     if not os.path.exists(notes_path):
-        logger.debug("Creating {0}".format(notes_path))
+        logger.debug("Creating '%s'", notes_path)
         open(notes_path, "w+").close()
 
     papis.api.edit_file(notes_path)

--- a/papis/commands/explore.py
+++ b/papis/commands/explore.py
@@ -136,11 +136,13 @@ def lib(ctx: click.Context, query: str,
 
     """
     logger = logging.getLogger('explore:lib')
+
     if doc_folder:
         ctx.obj['documents'] += [papis.document.from_folder(doc_folder)]
     db = papis.database.get(library_name=library)
     docs = db.query(query)
-    logger.info('{} documents found'.format(len(docs)))
+    logger.info('%d documents found', len(docs))
+
     ctx.obj['documents'] += docs
     assert(isinstance(ctx.obj['documents'], list))
 
@@ -239,12 +241,10 @@ def citations(ctx: click.Context, query: str, doc_folder: str,
 
     if os.path.exists(citations_file):
         if rmfile:
-            logger.info('Removing {0}'.format(citations_file))
+            logger.info("Removing citations file '%s'", citations_file)
             os.remove(citations_file)
         else:
-            logger.info(
-                'A citations file exists in {0}'.format(citations_file)
-            )
+            logger.info("A citations file exists in '%s'", citations_file)
             if papis.tui.utils.confirm('Do you want to use it?'):
                 # TODO: here it complains that papis.yaml.explorer.callback
                 #       None, somehow mypy does not get that.
@@ -257,14 +257,14 @@ def citations(ctx: click.Context, query: str, doc_folder: str,
 
     dois = [d.get('doi') for d in doc['citations'] if d.get('doi')]
     if not dois:
-        logger.error('No dois retrieved from the document\'s information')
+        logger.error("No DOIs retrieved from the document's information")
         return
 
     if max_citations < 0:
         max_citations = len(dois)
     dois = dois[0:min(max_citations, len(dois))]
 
-    logger.info("%s citations found" % len(dois))
+    logger.info("%d citations found", len(dois))
     dois_with_data = [
     ]  # type: List[Union[papis.document.Document, Dict[str, Any]]]
     found_in_lib_dois = [
@@ -292,8 +292,8 @@ def citations(ctx: click.Context, query: str, doc_folder: str,
     for doi in found_in_lib_dois:
         dois.remove(doi)
 
-    logger.info("Found {0} dois in library".format(len(found_in_lib_dois)))
-    logger.info("Fetching {} citations from crossref".format(len(dois)))
+    logger.info("Found %d DOIs in library", len(found_in_lib_dois))
+    logger.info("Fetching %d citations from crossref", len(dois))
 
     with tqdm.tqdm(iterable=dois) as progress:
         for doi in progress:
@@ -308,14 +308,12 @@ def citations(ctx: click.Context, query: str, doc_folder: str,
 
     docs = [papis.document.Document(data=d) for d in dois_with_data]
     if save:
-        logger.info('Storing citations in "{0}"'.format(citations_file))
+        logger.info("Storing citations in '%s'", citations_file)
         with open(citations_file, 'a+') as fd:
             logger.info(
-                "Writing {} documents' yaml into {}".format(
-                    len(docs),
-                    citations_file
-                )
-            )
+                "Writing %d documents' yaml into '%s'",
+                len(docs), citations_file)
+
             yamldata = papis.commands.export.run(docs, to_format='yaml')
             fd.write(yamldata)
     ctx.obj['documents'] += docs
@@ -352,7 +350,7 @@ def cmd(ctx: click.Context, command: str) -> None:
     for doc in docs:
         fcommand = papis.format.format(command, doc)
         splitted_command = shlex.split(fcommand)
-        logger.info('Calling %s' % splitted_command)
+        logger.info("Calling '%s'", splitted_command)
         call(splitted_command)
 
 

--- a/papis/commands/export.py
+++ b/papis/commands/export.py
@@ -70,7 +70,7 @@ def _extension_name() -> str:
     return "papis.exporter"
 
 
-def run(documents: List[papis.document.Document], to_format: str,) -> str:
+def run(documents: List[papis.document.Document], to_format: str) -> str:
     """
     Exports several documents into something else.
 
@@ -123,7 +123,7 @@ def cli(query: str,
         documents = papis.database.get().query(query)
 
     if fmt and folder:
-        logger.warning("Only --folder flag will be considered")
+        logger.warning("Only --folder flag will be considered (--fmt ignored)")
 
     if not documents:
         logger.warning(papis.strings.no_documents_retrieved_message)
@@ -146,7 +146,7 @@ def cli(query: str,
 
     if ret_string is not None and not folder:
         if out is not None:
-            logger.info("Dumping to {0}".format(out))
+            logger.info("Dumping to '%s'", out)
             with open(out, 'a+') as fd:
                 fd.write(ret_string)
         else:
@@ -163,9 +163,9 @@ def cli(query: str,
                 raise Exception(papis.strings.no_folder_attached_to_document)
             if not len(documents) == 1:
                 outdir = os.path.join(out, _doc_folder_name)
-            logger.info("Exporting doc {0} to {1}".format(
-                papis.document.describe(document), outdir
-            ))
+            logger.info(
+                    "Exporting doc '%s' to '%s'",
+                    papis.document.describe(document), outdir)
             shutil.copytree(_doc_folder, outdir)
 
 
@@ -199,8 +199,7 @@ def explorer(ctx: click.Context, fmt: str, out: str) -> None:
     if out is not None:
         with open(out, 'a+') as fd:
             logger.info(
-                "Writing {} documents' in {} into {}".format(
-                    len(docs), fmt, out))
+                "Writing %d documents in %s into '%s'", len(docs), fmt, out)
             fd.write(outstring)
     else:
         print(outstring)

--- a/papis/commands/external.py
+++ b/papis/commands/external.py
@@ -53,7 +53,9 @@ def external_cli(ctx: click.core.Context, flags: List[str]) -> None:
     path = script.path
     if not path:
         raise Exception("Path for script {} not found".format(script))
+
     cmd = [path] + list(flags)
-    logger.debug("Calling %s", cmd)
+    logger.debug("Calling '%s'", cmd)
+
     export_variables()
     subprocess.call(cmd)

--- a/papis/commands/external.py
+++ b/papis/commands/external.py
@@ -14,7 +14,7 @@ import papis.config
 import papis.commands
 
 
-LOGGER = logging.getLogger("external")
+logger = logging.getLogger("external")
 
 
 def get_command_help(path: str) -> str:
@@ -54,6 +54,6 @@ def external_cli(ctx: click.core.Context, flags: List[str]) -> None:
     if not path:
         raise Exception("Path for script {} not found".format(script))
     cmd = [path] + list(flags)
-    LOGGER.debug("Calling %s", cmd)
+    logger.debug("Calling %s", cmd)
     export_variables()
     subprocess.call(cmd)

--- a/papis/commands/list.py
+++ b/papis/commands/list.py
@@ -88,7 +88,7 @@ def run(
 
     if template is not None:
         if not os.path.exists(template):
-            logger.error("Template file {} not found".format(template))
+            logger.error("Template file '%s' not found", template)
             return []
         with open(template) as fd:
             fmt = fd.read()

--- a/papis/commands/merge.py
+++ b/papis/commands/merge.py
@@ -49,10 +49,10 @@ def run(keep: Document,
             keep["files"] += [os.path.basename(f)]
     update.run(keep, data, git=git)
     if not keep_both:
-        logger.info("removing {}".format(erase))
+        logger.info("Removing '%s'", erase)
         rm.run(erase, git=git)
     else:
-        logger.info("keeping both documents")
+        logger.info("Keeping both documents")
 
 
 @click.command("merge")
@@ -109,7 +109,9 @@ def cli(query: str,
         documents += other_documents
 
     if len(documents) != 2:
-        logger.error("You have to pick exactly two documents!")
+        logger.error(
+                "You have to pick exactly two documents (picked %d)!",
+                len(documents))
         return
 
     a = documents[0]
@@ -152,7 +154,7 @@ def cli(query: str,
             keep["files"] += [os.path.basename(f)]
         keep.update(data_a)
         keep.save()
-        logger.info("saving the new document in %s", out)
+        logger.info("Saving the new document in '%s'", out)
         return
 
     run(keep, erase, data_a, files, keep_both, git)

--- a/papis/commands/mv.py
+++ b/papis/commands/mv.py
@@ -25,6 +25,7 @@ def run(document: papis.document.Document,
         new_folder_path: str,
         git: bool = False) -> None:
     logger = logging.getLogger('mv:run')
+
     folder = document.get_main_folder()
     if not folder:
         raise Exception(papis.strings.no_folder_attached_to_document)
@@ -32,12 +33,14 @@ def run(document: papis.document.Document,
     cmd += ['mv', folder, new_folder_path]
     db = papis.database.get()
     logger.debug(cmd)
+
     subprocess.call(cmd)
     db.delete(document)
     new_document_folder = os.path.join(
         new_folder_path,
         os.path.basename(folder))
-    logger.debug("New document folder: {}".format(new_document_folder))
+    logger.debug("New document folder: '%s'", new_document_folder)
+
     document.set_folder(new_document_folder)
     db.add(document)
 
@@ -104,7 +107,7 @@ def cli(query: str,
     logger.info(new_folder)
 
     if not os.path.exists(new_folder):
-        logger.info("Creating path %s" % new_folder)
+        logger.info("Creating path %s", new_folder)
         os.makedirs(new_folder, mode=papis.config.getint('dir-umask') or 0o666)
 
     run(document, new_folder, git=git)

--- a/papis/commands/rename.py
+++ b/papis/commands/rename.py
@@ -34,7 +34,7 @@ def run(document: papis.document.Document,
     new_folder_path = os.path.join(subfolder, new_name)
 
     if os.path.exists(new_folder_path):
-        logger.warning("Path %s already exists" % new_folder_path)
+        logger.warning("Path '%s' already exists", new_folder_path)
         return
 
     cmd = ['git', '-C', folder] if git else []
@@ -49,7 +49,7 @@ def run(document: papis.document.Document,
             "Rename from {} to '{}'".format(folder, new_name))
 
     db.delete(document)
-    logger.debug("New document folder: {}".format(new_folder_path))
+    logger.debug("New document folder: '%s'", new_folder_path)
     document.set_folder(new_folder_path)
     db.add(document)
 

--- a/papis/commands/rm.py
+++ b/papis/commands/rm.py
@@ -106,7 +106,7 @@ def cli(query: str,
                 if not papis.tui.utils.confirm(
                         "Are you sure?", bottom_toolbar=tbar):
                     continue
-            logger.info("Removing %s..." % filepath)
+            logger.info("Removing '%s'...", filepath)
             run(document, filepath=filepath, git=git)
     else:
         for document in documents:
@@ -121,5 +121,6 @@ def cli(query: str,
                 if not papis.tui.utils.confirm(
                         "Are you sure?", bottom_toolbar=tbar):
                     continue
-            logger.warning("removing ...")
+
+            logger.warning("Removing ...")
             run(document, git=git)

--- a/papis/commands/run.py
+++ b/papis/commands/run.py
@@ -62,14 +62,14 @@ import papis.config
 import papis.document
 import papis.database
 
-LOGGER = logging.getLogger('run')
+logger = logging.getLogger('run')
 
 
 def run(folder: str, command: List[str] = []) -> int:
-    LOGGER.debug("Changing directory into %s", folder)
+    logger.debug("Changing directory into %s", folder)
     os.chdir(os.path.expanduser(folder))
     commandstr = " ".join(command)
-    LOGGER.debug("Command: %s", commandstr)
+    logger.debug("Command: %s", commandstr)
     return os.system(commandstr)
 
 

--- a/papis/commands/run.py
+++ b/papis/commands/run.py
@@ -66,7 +66,7 @@ logger = logging.getLogger('run')
 
 
 def run(folder: str, command: List[str] = []) -> int:
-    logger.debug("Changing directory into %s", folder)
+    logger.debug("Changing directory to '%s'", folder)
     os.chdir(os.path.expanduser(folder))
     commandstr = " ".join(command)
     logger.debug("Command: %s", commandstr)

--- a/papis/commands/update.py
+++ b/papis/commands/update.py
@@ -175,21 +175,20 @@ def cli(query: str,
 
         if matching_importers:
             logger.info(
-                'There are {0} possible matchings'
-                .format(len(matching_importers)))
+                'There are %d possible matchings', len(matching_importers))
 
             for importer in matching_importers:
                 if importer.ctx.data:
                     logger.info(
-                        'Merging data from importer {0}'.format(importer.name))
+                        "Merging data from importer '%s'", importer.name)
                     papis.utils.update_doc_from_data_interactively(
                         ctx.data,
                         importer.ctx.data,
                         str(importer))
                 if importer.ctx.files:
                     logger.info(
-                        'Got files {0} from importer {1}'
-                        .format(importer.ctx.files, importer.name))
+                        "Got files %s from importer '%s'",
+                        importer.ctx.files, importer.name)
                     for f in importer.ctx.files:
                         papis.utils.open_file(f)
                         if papis.tui.utils.confirm("Use this file?"):

--- a/papis/commands/update.py
+++ b/papis/commands/update.py
@@ -41,7 +41,6 @@ Cli
 """
 
 import click
-import colorama
 import logging
 
 import papis.utils
@@ -138,8 +137,8 @@ def cli(query: str,
         ctx = papis.importer.Context()
 
         logger.info('Updating '
-                    '{c.Back.WHITE}{c.Fore.BLACK}{0}{c.Style.RESET_ALL}'
-                    .format(papis.document.describe(document), c=colorama))
+                    '{c.Back.WHITE}{c.Fore.BLACK}%s{c.Style.RESET_ALL}',
+                    papis.document.describe(document))
 
         ctx.data.update(document)
         if set_tuples:

--- a/papis/config.py
+++ b/papis/config.py
@@ -10,7 +10,6 @@ from typing import Dict, Any, List, Optional, Callable  # noqa: ignore
 PapisConfigType = Dict[str, Dict[str, Any]]
 
 logger = logging.getLogger("config")
-logger.debug("importing")
 
 _CURRENT_LIBRARY = None  #: Current library in use
 _CONFIGURATION = None  # type: Optional[Configuration]
@@ -163,26 +162,25 @@ class Configuration(configparser.ConfigParser):
     def handle_includes(self) -> None:
         if "include" in self.keys():
             for name in self["include"]:
-                self.logger.debug("including %s" % name)
+                self.logger.debug("Including '%s'", name)
                 fullpath = os.path.expanduser(self.get("include", name))
                 if os.path.exists(fullpath):
                     self.read(fullpath)
                 else:
                     self.logger.warning(
-                        "{0} not included because it does not exist"
-                        .format(fullpath))
+                        "'%s' not included because it does not exist",
+                        fullpath)
 
     def initialize(self) -> None:
         if not os.path.exists(self.dir_location):
             self.logger.warning(
-                'Creating configuration folder in {0}'
-                .format(self.dir_location))
+                "Creating configuration folder in '%s'", self.dir_location)
             os.makedirs(self.dir_location)
         if not os.path.exists(self.scripts_location):
             os.makedirs(self.scripts_location)
         if os.path.exists(self.file_location):
             self.logger.debug(
-                'Reading configuration from {0}'.format(self.file_location))
+                "Reading configuration from '%s'", self.file_location)
             self.read(self.file_location)
             self.handle_includes()
         else:
@@ -191,12 +189,12 @@ class Configuration(configparser.ConfigParser):
                 for field in self.default_info[section]:
                     self[section][field] = self.default_info[section][field]
             with open(self.file_location, "w") as configfile:
-                self.logger.info('Creating config file at {0}'
-                                 .format(self.file_location))
+                self.logger.info(
+                        "Creating config file at '%s'", self.file_location)
                 self.write(configfile)
         configpy = get_configpy_file()
         if os.path.exists(configpy):
-            self.logger.debug('Executing {0}'.format(configpy))
+            self.logger.debug("Executing '%s'", configpy)
             with open(configpy) as fd:
                 exec(fd.read())
 
@@ -307,7 +305,7 @@ def get_config_file() -> str:
         config_file = _OVERRIDE_VARS["file"]
     else:
         config_file = os.path.join(get_config_folder(), "config")
-    logger.debug("Getting config file %s" % config_file)
+    logger.debug("Getting config file '%s'", config_file)
     return config_file
 
 
@@ -322,7 +320,7 @@ def set_config_file(filepath: str) -> None:
     """Override the main configuration file path
     """
     global _OVERRIDE_VARS
-    logger.debug("Setting config file to %s" % filepath)
+    logger.debug("Setting config file to '%s'", filepath)
     _OVERRIDE_VARS["file"] = filepath
 
 
@@ -500,7 +498,7 @@ def merge_configuration_from_path(path: Optional[str],
     """
     if path is None or not os.path.exists(path):
         return
-    logger.debug("Merging configuration from " + path)
+    logger.debug("Merging configuration from '%s'", path)
     configuration.read(path)
     configuration.handle_includes()
 
@@ -533,9 +531,9 @@ def get_lib_from_name(libname: str) -> papis.library.Library:
     if libname not in config.keys():
         if os.path.isdir(libname):
             # Check if the path exists, then use this path as a new library
-            logger.warning("Since the path '{0}' exists, "
-                           "I'm interpreting it as a library"
-                           .format(libname))
+            logger.warning(
+                    "Since the path '%s' exists, interpreting it as a library",
+                    libname)
             library_obj = papis.library.from_paths([libname])
             name = library_obj.path_format()
             # the configuration object can only store strings

--- a/papis/crossref.py
+++ b/papis/crossref.py
@@ -355,7 +355,7 @@ class Importer(papis.importer.Importer):
 
             if doc_url is not None:
                 self.logger.info(
-                    "Trying to download document from '%s'..", doc_url)
+                    "Trying to download document from '%s'", doc_url)
                 session = requests.Session()
                 session.headers = requests.structures.CaseInsensitiveDict({
                     "user-agent": papis.config.getstring("user-agent")})

--- a/papis/crossref.py
+++ b/papis/crossref.py
@@ -17,8 +17,8 @@ import papis.document
 import papis.importer
 import papis.downloaders.base
 
-LOGGER = logging.getLogger("crossref")  # type: logging.Logger
-LOGGER.debug("importing")
+logger = logging.getLogger("crossref")  # type: logging.Logger
+logger.debug("importing")
 KeyConversionPair = papis.document.KeyConversionPair
 
 _filter_names = set([
@@ -195,14 +195,14 @@ def get_data(
     try:
         results = _get_crossref_works(filter=filters, **kwargs)
     except Exception as e:
-        LOGGER.error(e)
+        logger.error(e)
         return []
 
     if isinstance(results, list):
         docs = [d["message"] for d in results]
     elif isinstance(results, dict):
         if 'message' not in results.keys():
-            LOGGER.error("Error retrieving from xref: incorrect message")
+            logger.error("Error retrieving from xref: incorrect message")
             return []
         message = results['message']
         if "items" in message.keys():
@@ -210,9 +210,9 @@ def get_data(
         else:
             docs = [message]
     else:
-        LOGGER.error("Error retrieving from xref: incorrect message")
+        logger.error("Error retrieving from xref: incorrect message")
         return []
-    LOGGER.debug("Retrieved %s documents", len(docs))
+    logger.debug("Retrieved %s documents", len(docs))
     return [
         crossref_data_to_papis_data(d)
         for d in docs]
@@ -227,7 +227,6 @@ def doi_to_data(doi_string: str) -> Dict[str, Any]:
     :raises ValueError: If no data could be retrieved for the doi
 
     """
-    global LOGGER
     doi_string = doi.get_clean_doi(doi_string)
     results = get_data(dois=[doi_string])
     if results:

--- a/papis/database/__init__.py
+++ b/papis/database/__init__.py
@@ -2,6 +2,7 @@ import logging
 from typing import Optional, Dict  # noqa: ignore
 from .base import Database
 from papis.library import Library
+
 logger = logging.getLogger('database')
 
 DATABASES = dict()  # type: Dict[Library, Database]

--- a/papis/database/cache.py
+++ b/papis/database/cache.py
@@ -84,21 +84,22 @@ def filter_documents(
     # FIXME: find a better solution for this that works for both OSes
     if sys.platform == "win32":
         logger.debug(
-            "Filtering {0} docs (search {1})".format(
-                len(documents), search))
+                "Filtering %d docs (search '%s')", len(documents), search)
         filtered_docs = [
             d for d in [papis.docmatcher.DocMatcher.return_if_match(d)
                         for d in documents] if d is not None]
 
     else:
-        logger.debug("Filtering {0} docs (search {1})".format(
-                     len(documents), search))
+        logger.debug(
+                "Filtering %d docs (search '%s')", len(documents), search)
         result = \
             papis.utils.parmap(papis.docmatcher.DocMatcher.return_if_match,
                                documents)
         filtered_docs = [d for d in result if d is not None]
+
     _delta = 1000 * time.time() - begin_t
-    logger.debug("done ({0} ms) ({1} docs)".format(_delta, len(filtered_docs)))
+    logger.debug("Done (in %.2fms) (%d docs)", _delta, len(filtered_docs))
+
     return filtered_docs
 
 
@@ -171,7 +172,7 @@ class Database(papis.database.base.Database):
         cache_path = self._get_cache_file_path()
         if use_cache and os.path.exists(cache_path):
             self.logger.debug(
-                "Getting documents from cache in {0}".format(cache_path))
+                "Getting documents from cache in '%s'", cache_path)
             with open(cache_path, 'rb') as fd:
                 self.documents = pickle.load(fd)
         else:
@@ -183,12 +184,13 @@ class Database(papis.database.base.Database):
             if use_cache:
                 self.save()
         self.logger.debug(
-            "Loaded documents (%s documents)", len(self.documents))
+            "Loaded documents (%d documents)", len(self.documents))
         return self.documents
 
     def add(self, document: papis.document.Document) -> None:
+        self.logger.debug('Adding document...')
+
         docs = self.get_documents()
-        self.logger.debug('adding ...')
         docs.append(document)
         assert(docs[-1].get_main_folder() == document.get_main_folder())
         _folder = document.get_main_folder()
@@ -199,8 +201,9 @@ class Database(papis.database.base.Database):
     def update(self, document: papis.document.Document) -> None:
         if not papis.config.getboolean("use-cache"):
             return
+        self.logger.debug('Updating document...')
+
         docs = self.get_documents()
-        self.logger.debug('updating document')
         result = self._locate_document(document)
         index = result[0][0]
         docs[index] = document
@@ -209,8 +212,9 @@ class Database(papis.database.base.Database):
     def delete(self, document: papis.document.Document) -> None:
         if not papis.config.getboolean("use-cache"):
             return
+        self.logger.debug('Deleting document...')
+
         docs = self.get_documents()
-        self.logger.debug('deleting document')
         result = self._locate_document(document)
         index = result[0][0]
         docs.pop(index)
@@ -223,7 +227,8 @@ class Database(papis.database.base.Database):
 
     def clear(self) -> None:
         cache_path = self._get_cache_file_path()
-        self.logger.warning("clearing cache {0}".format(cache_path))
+        self.logger.warning("Clearing cache at '%s'", cache_path)
+
         if os.path.exists(cache_path):
             os.remove(cache_path)
 
@@ -235,7 +240,8 @@ class Database(papis.database.base.Database):
         return self.query(query_string)
 
     def query(self, query_string: str) -> List[papis.document.Document]:
-        self.logger.debug('Querying')
+        self.logger.debug("Querying '%s'...", query_string)
+
         docs = self.get_documents()
         # This makes it faster, if it's the all query string, return everything
         # without filtering
@@ -252,8 +258,8 @@ class Database(papis.database.base.Database):
 
     def save(self) -> None:
         docs = self.get_documents()
-        self.logger.debug(
-            'Saving ... ({} documents)'.format(len(docs)))
+        self.logger.debug('Saving %d documents...', len(docs))
+
         path = self._get_cache_file_path()
         with open(path, "wb+") as fd:
             pickle.dump(docs, fd)

--- a/papis/database/cache.py
+++ b/papis/database/cache.py
@@ -176,15 +176,14 @@ class Database(papis.database.base.Database):
             with open(cache_path, 'rb') as fd:
                 self.documents = pickle.load(fd)
         else:
-            self.logger.info('Indexing library, this might take a while')
+            self.logger.info('Indexing library, this might take a while...')
             folders = sum([
                 papis.utils.get_folders(d)
                 for d in self.get_dirs()], [])  # type: List[str]
             self.documents = papis.utils.folders_to_documents(folders)
             if use_cache:
                 self.save()
-        self.logger.debug(
-            "Loaded documents (%d documents)", len(self.documents))
+        self.logger.debug("Loaded %d documents", len(self.documents))
         return self.documents
 
     def add(self, document: papis.document.Document) -> None:

--- a/papis/database/whoosh.py
+++ b/papis/database/whoosh.py
@@ -89,7 +89,7 @@ class Database(papis.database.base.Database):
         writer = self.get_writer()
         self.add_document_with_writer(document, writer, schema_keys)
 
-        self.logger.debug("Commiting document..")
+        self.logger.debug("Committing document..")
         writer.commit()
 
     def update(self, document: papis.document.Document) -> None:
@@ -106,7 +106,7 @@ class Database(papis.database.base.Database):
             Database.get_id_key(),
             self.get_id_value(document))
 
-        self.logger.debug("Commiting deletion..")
+        self.logger.debug("Committing deletion..")
         writer.commit()
 
     def query_dict(
@@ -117,7 +117,7 @@ class Database(papis.database.base.Database):
         return self.query(query_string)
 
     def query(self, query_string: str) -> List[papis.document.Document]:
-        self.logger.debug("Querying '%s'", query_string)
+        self.logger.debug("Querying '%s'...", query_string)
 
         index = self.get_index()
         qp = whoosh.qparser.MultifieldParser(['title', 'author', 'tags'],
@@ -215,7 +215,7 @@ class Database(papis.database.base.Database):
         expensive and will be called only if no index is present, so
         at the time of building a brand new index.
         """
-        self.logger.debug('Indexing the library, this might take a while')
+        self.logger.debug('Indexing the library, this might take a while...')
         folders = sum(
                 [get_folders(d)
                     for d in self.get_dirs()], [])  # type: List[str]

--- a/papis/database/whoosh.py
+++ b/papis/database/whoosh.py
@@ -84,10 +84,12 @@ class Database(papis.database.base.Database):
 
     def add(self, document: papis.document.Document) -> None:
         schema_keys = self.get_schema_init_fields().keys()
-        self.logger.debug("adding document")
+
+        self.logger.debug("Adding document...")
         writer = self.get_writer()
         self.add_document_with_writer(document, writer, schema_keys)
-        self.logger.debug("commiting document..")
+
+        self.logger.debug("Commiting document..")
         writer.commit()
 
     def update(self, document: papis.document.Document) -> None:
@@ -98,11 +100,13 @@ class Database(papis.database.base.Database):
 
     def delete(self, document: papis.document.Document) -> None:
         writer = self.get_writer()
-        self.logger.debug("deleting document..")
+
+        self.logger.debug("Deleting document..")
         writer.delete_by_term(
             Database.get_id_key(),
             self.get_id_value(document))
-        self.logger.debug("commiting deletion..")
+
+        self.logger.debug("Commiting deletion..")
         writer.commit()
 
     def query_dict(
@@ -113,7 +117,8 @@ class Database(papis.database.base.Database):
         return self.query(query_string)
 
     def query(self, query_string: str) -> List[papis.document.Document]:
-        self.logger.debug('Query string %s' % query_string)
+        self.logger.debug("Querying '%s'", query_string)
+
         index = self.get_index()
         qp = whoosh.qparser.MultifieldParser(['title', 'author', 'tags'],
                                              schema=self.get_schema())
@@ -164,7 +169,7 @@ class Database(papis.database.base.Database):
         """
         self.logger.debug('Creating index...')
         if not os.path.exists(self.index_dir):
-            self.logger.debug('Creating dir %s' % self.index_dir)
+            self.logger.debug("Creating index directory '%s'", self.index_dir)
             os.makedirs(self.index_dir)
         whoosh.index.create_in(self.index_dir, self.create_schema())
 
@@ -210,7 +215,7 @@ class Database(papis.database.base.Database):
         expensive and will be called only if no index is present, so
         at the time of building a brand new index.
         """
-        self.logger.debug('Indexing the library, this might take a while...')
+        self.logger.debug('Indexing the library, this might take a while')
         folders = sum(
                 [get_folders(d)
                     for d in self.get_dirs()], [])  # type: List[str]
@@ -239,9 +244,9 @@ class Database(papis.database.base.Database):
             # aren't the same, then we have to rebuild the
             # database.
             if user_field_names != db_field_names:
+                self.logger.debug(
+                        "Rebuilding database because field names do not match")
                 self.rebuild()
-                self.logger.debug("Rebuilt database because field names"
-                                  "don't match")
             else:
                 # Otherwise, verify that the fields are
                 # all the same and rebuild if any have
@@ -249,9 +254,11 @@ class Database(papis.database.base.Database):
                 rebuilt_db = False
                 for field in user_field_names:
                     if user_fields[field] != db_fields[field]:
+                        self.logger.debug(
+                                "Rebuilding database because "
+                                "field types do not match")
+
                         self.rebuild()
-                        self.logger.debug("Rebuilt DB because field types"
-                                          " don't match")
                         rebuilt_db = True
                         break
 
@@ -297,7 +304,7 @@ class Database(papis.database.base.Database):
         :rtype:  whoosh.fields.Schema
         """
         from whoosh.fields import Schema
-        self.logger.debug('Creating schema')
+        self.logger.debug('Creating schema...')
         fields = self.get_schema_init_fields()
         schema = Schema(**fields)
         return schema
@@ -306,16 +313,17 @@ class Database(papis.database.base.Database):
         """Returns the arguments to be passed to the whoosh schema
         object instantiation found in the method `get_schema`.
         """
-        # This we need for the eval code beneath
         from whoosh.fields import TEXT, ID, KEYWORD, STORED  # noqa: F401
         # This part is non-negotiable
         fields = {Database.get_id_key(): ID(stored=True, unique=True)}
+
         # TODO: this is a security risk, find a way to fix it
         user_prototype = eval(
             papis.config.getstring('whoosh-schema-prototype'))  # KeysView[str]
         fields.update(user_prototype)
+
         fields_list = papis.config.getlist('whoosh-schema-fields')
         for field in fields_list:
             fields.update({field: TEXT(stored=True)})
-        # self.logger.debug('Schema prototype: {}'.format(fields))
+
         return fields

--- a/papis/dissemin.py
+++ b/papis/dissemin.py
@@ -57,7 +57,7 @@ def get_data(query: str = "") -> List[Dict[str, Any]]:
     params = urllib.parse.urlencode(dict_params)
     main_url = "https://dissem.in/api/search/?"
     req_url = main_url + params
-    logger.debug("url = {}".format(req_url))
+    logger.debug("url = '%s'", req_url)
     url = urllib.request.Request(
         req_url,
         headers={
@@ -84,7 +84,9 @@ def explorer(ctx: click.core.Context, query: str) -> None:
     """
     logger = logging.getLogger('explore:dissemin')
     logger.info('Looking up...')
+
     data = get_data(query=query)
     docs = [papis.document.from_data(data=d) for d in data]
     ctx.obj['documents'] += docs
-    logger.info('{} documents found'.format(len(docs)))
+
+    logger.info('%s documents found', len(docs))

--- a/papis/docmatcher.py
+++ b/papis/docmatcher.py
@@ -116,8 +116,8 @@ class DocMatcher(object):
 
 def parse_query(query_string: str) -> List[List[str]]:
     import pyparsing
-    logger = logging.getLogger('query_parser')
-    logger.debug('Parsing search')
+    logger = logging.getLogger('parse_query')
+    logger.debug("Parsing query: '%s'", query_string)
 
     papis_key_word = pyparsing.Word(pyparsing.alphanums + '-._/')
     papis_value_word = pyparsing.Word(pyparsing.alphanums + '-._/()')
@@ -143,5 +143,5 @@ def parse_query(query_string: str) -> List[List[str]]:
     )
     parsed = papis_query.parseString(query_string)  # type: List[List[str]]
 
-    logger.debug('Parsed query = %s' % parsed)
+    logger.debug("Parsed query: '%s'", parsed)
     return parsed

--- a/papis/document.py
+++ b/papis/document.py
@@ -50,7 +50,7 @@ def keyconversion_to_data(conversion_list: List[KeyConversionPair],
                 action = conv_data.get('action') or (lambda x: x)
                 new_data[papis_key] = action(papis_value)
             except Exception as ex:
-                logger.debug("Error while trying to parse %s (%s)",
+                logger.debug("Error while trying to parse '%s' (%s)",
                              papis_key, ex)
 
     if keep_unknown_keys:
@@ -235,9 +235,9 @@ class Document(Dict[str, Any]):
             data = papis.yaml.yaml_to_data(self.get_info_file(),
                                            raise_exception=True)
         except Exception as ex:
-            logger.error('Error reading yaml file in %s'
-                         '\nPlease check it!\n\n%s',
-                         self.get_info_file(), str(ex))
+            logger.error(
+                    "Error reading yaml file in '%s'. Please check it!\n%s",
+                    self.get_info_file(), ex)
         else:
             for key in data:
                 self[key] = data[key]
@@ -409,7 +409,7 @@ def sort(docs: List[Document], key: str, reverse: bool) -> List[Document]:
             # The key does not appear in the document, ensure
             # it comes last.
             return (sort_rankings["None"], zero_date, 0, '')
-    logger.debug("sorting %d documents", len(docs))
+    logger.debug("Sorting %d documents", len(docs))
     return sorted(docs, key=lambda d: _sort_for_key(key, d), reverse=reverse)
 
 

--- a/papis/document.py
+++ b/papis/document.py
@@ -12,7 +12,7 @@ from typing_extensions import TypedDict
 import papis.config
 import papis
 
-LOGGER = logging.getLogger("document")  # type: logging.Logger
+logger = logging.getLogger("document")  # type: logging.Logger
 
 KeyConversion = TypedDict(
     "KeyConversion", {"key": Optional[str],
@@ -50,7 +50,7 @@ def keyconversion_to_data(conversion_list: List[KeyConversionPair],
                 action = conv_data.get('action') or (lambda x: x)
                 new_data[papis_key] = action(papis_value)
             except Exception as ex:
-                LOGGER.debug("Error while trying to parse %s (%s)",
+                logger.debug("Error while trying to parse %s (%s)",
                              papis_key, ex)
 
     if keep_unknown_keys:
@@ -235,7 +235,7 @@ class Document(Dict[str, Any]):
             data = papis.yaml.yaml_to_data(self.get_info_file(),
                                            raise_exception=True)
         except Exception as ex:
-            LOGGER.error('Error reading yaml file in %s'
+            logger.error('Error reading yaml file in %s'
                          '\nPlease check it!\n\n%s',
                          self.get_info_file(), str(ex))
         else:
@@ -409,7 +409,7 @@ def sort(docs: List[Document], key: str, reverse: bool) -> List[Document]:
             # The key does not appear in the document, ensure
             # it comes last.
             return (sort_rankings["None"], zero_date, 0, '')
-    LOGGER.debug("sorting %d documents", len(docs))
+    logger.debug("sorting %d documents", len(docs))
     return sorted(docs, key=lambda d: _sort_for_key(key, d), reverse=reverse)
 
 

--- a/papis/downloaders/__init__.py
+++ b/papis/downloaders/__init__.py
@@ -15,7 +15,7 @@ import papis.importer
 import papis.plugin
 import papis.utils
 
-LOGGER = logging.getLogger("downloader")
+logger = logging.getLogger("downloader")
 
 
 def _extension_name() -> str:
@@ -348,13 +348,13 @@ def get_info_from_url(
 
     downloaders = get_matching_downloaders(url)
     if not downloaders:
-        LOGGER.warning("No matching downloader found for (%s)", url)
+        logger.warning("No matching downloader found for (%s)", url)
         return papis.importer.Context()
 
-    LOGGER.debug('Found %s matching downloaders', len(downloaders))
+    logger.debug('Found %s matching downloaders', len(downloaders))
     downloader = downloaders[0]
 
-    LOGGER.info("Using downloader '%s'", downloader)
+    logger.info("Using downloader '%s'", downloader)
     if downloader.expected_document_extension is None and \
             expected_doc_format is not None:
         downloader.expected_document_extension = expected_doc_format

--- a/papis/downloaders/__init__.py
+++ b/papis/downloaders/__init__.py
@@ -39,7 +39,7 @@ class Importer(papis.importer.Importer):
         )
 
     def fetch(self) -> None:
-        self.logger.info("attempting to import from url %s", self.uri)
+        self.logger.info("Attempting to import from url '%s'", self.uri)
         self.ctx = get_info_from_url(self.uri) or papis.importer.Context()
 
     def fetch_data(self) -> None:
@@ -63,8 +63,9 @@ class Downloader(papis.importer.Importer):
                                          ctx=ctx,
                                          name=name
                                          or os.path.basename(__file__))
-        self.logger = logging.getLogger("downloader:"+self.name)
-        self.logger.debug("uri {0}".format(uri))
+        self.logger = logging.getLogger("downloader:{}".format(self.name))
+        self.logger.debug("uri '%s'", uri)
+
         self.expected_document_extension = None  # type: Optional[str]
         self.priority = 1  # type: int
         self._soup = None  # type: Optional[bs4.BeautifulSoup]
@@ -130,7 +131,7 @@ class Downloader(papis.importer.Importer):
                 with tempfile.NamedTemporaryFile(
                         mode="wb+", delete=False) as f:
                     f.write(doc_rawdata)
-                    self.logger.info("Saving downloaded file in %s", f.name)
+                    self.logger.info("Saving downloaded file in '%s'", f.name)
                     self.ctx.files.append(f.name)
 
     def fetch(self) -> None:
@@ -191,7 +192,7 @@ class Downloader(papis.importer.Importer):
         if not url:
             return
         res = self.session.get(url, cookies=self.cookies)
-        self.logger.info("downloading bibtex from {0}".format(url))
+        self.logger.info("Downloading bibtex from '%s'", url)
         self.bibtex_data = res.content.decode()
 
     def get_document_url(self) -> Optional[str]:
@@ -246,7 +247,7 @@ class Downloader(papis.importer.Importer):
         url = self.get_document_url()
         if not url:
             return
-        self.logger.info("downloading file from {0}".format(url))
+        self.logger.info("Downloading file from '%s'", url)
         res = self.session.get(url, cookies=self.cookies)
         self.document_data = res.content
 
@@ -261,9 +262,9 @@ class Downloader(papis.importer.Importer):
         """
         def print_warning() -> None:
             self.logger.error(
-                "The downloaded data does not seem to be of"
-                "the correct type ({})"
-                .format(self.expected_document_extension))
+                "The downloaded data does not seem to be of "
+                "the correct type ('%s')",
+                self.expected_document_extension)
 
         if self.expected_document_extension is None:
             return True
@@ -275,8 +276,8 @@ class Downloader(papis.importer.Importer):
             return False
 
         self.logger.debug(
-            'retrieved kind of document seems to be {0}'
-            .format(retrieved_kind.mime))
+            "Retrieved kind of document seems to be '%s'",
+            retrieved_kind.mime)
 
         if not isinstance(self.expected_document_extension, list):
             expected_document_extensions = [self.expected_document_extension]
@@ -348,10 +349,10 @@ def get_info_from_url(
 
     downloaders = get_matching_downloaders(url)
     if not downloaders:
-        logger.warning("No matching downloader found for (%s)", url)
+        logger.warning("No matching downloader found for '%s'", url)
         return papis.importer.Context()
 
-    logger.debug('Found %s matching downloaders', len(downloaders))
+    logger.debug('Found %d matching downloaders', len(downloaders))
     downloader = downloaders[0]
 
     logger.info("Using downloader '%s'", downloader)

--- a/papis/downloaders/annualreviews.py
+++ b/papis/downloaders/annualreviews.py
@@ -22,7 +22,7 @@ class Downloader(papis.downloaders.Downloader):
         if 'doi' in self.ctx.data:
             doi = self.ctx.data['doi']
             url = "http://annualreviews.org/doi/pdf/{doi}".format(doi=doi)
-            self.logger.debug("doc url = %s" % url)
+            self.logger.debug("doc url = '%s'", url)
             return url
         else:
             return None
@@ -32,7 +32,7 @@ class Downloader(papis.downloaders.Downloader):
             url = ("http://annualreviews.org/action/downloadCitation"
                    "?format=bibtex&cookieSet=1&doi={doi}"
                    .format(doi=self.ctx.data['doi']))
-            self.logger.debug("bibtex url = %s" % url)
+            self.logger.debug("bibtex url = '%s'", url)
             return url
         else:
             return None

--- a/papis/downloaders/aps.py
+++ b/papis/downloaders/aps.py
@@ -23,5 +23,5 @@ class Downloader(papis.downloaders.fallback.Downloader):
         burl = "{}?{}".format(
             re.sub(r'/abstract', r'/export', self.uri),
             "type=bibtex&download=true")
-        self.logger.debug("[bibtex url] = %s" % burl)
+        self.logger.debug("bibtex url = '%s'", burl)
         return burl

--- a/papis/downloaders/fallback.py
+++ b/papis/downloaders/fallback.py
@@ -26,7 +26,7 @@ class Downloader(papis.downloaders.Downloader):
             _doi = self.ctx.data['doi']
             return str(_doi) if _doi else None
         soup = self._get_soup()
-        self.logger.info('trying to parse doi from url body...')
+        self.logger.info('Trying to parse doi from url body...')
         if soup:
             return doi.find_doi_in_text(str(soup))
         else:
@@ -35,7 +35,7 @@ class Downloader(papis.downloaders.Downloader):
     def get_document_url(self) -> Optional[str]:
         if 'pdf_url' in self.ctx.data:
             url = self.ctx.data.get('pdf_url')
-            self.logger.debug("got a pdf url = %s" % url)
+            self.logger.debug("Got a pdf url = '%s'", url)
             return url
         else:
             return None

--- a/papis/downloaders/frontiersin.py
+++ b/papis/downloaders/frontiersin.py
@@ -21,7 +21,7 @@ class Downloader(papis.downloaders.Downloader):
 
     def get_doi(self) -> Optional[str]:
         url = self.uri
-        self.logger.info('Parsing doi from {0}'.format(url))
+        self.logger.info("Parsing DOI from '%s'", url)
         mdoi = re.match(r'.*/articles/([^/]+/[^/?&%^$]+).*', url)
         if mdoi:
             doi = mdoi.group(1)
@@ -31,11 +31,11 @@ class Downloader(papis.downloaders.Downloader):
     def get_document_url(self) -> Optional[str]:
         durl = ("https://www.frontiersin.org/articles/{doi}/pdf"
                 .format(doi=self.get_doi()))
-        self.logger.debug("[doc url] = %s" % durl)
+        self.logger.debug("doc url = '%s'", durl)
         return durl
 
     def get_bibtex_url(self) -> Optional[str]:
         url = ("https://www.frontiersin.org/articles/{doi}/bibTex"
                .format(doi=self.get_doi()))
-        self.logger.debug("[bibtex url] = %s" % url)
+        self.logger.debug("bibtex url = '%s'", url)
         return url

--- a/papis/downloaders/get.py
+++ b/papis/downloaders/get.py
@@ -24,8 +24,7 @@ class Downloader(papis.downloaders.Downloader):
         if m:
             d = Downloader(url)
             extension = m.group(1)
-            d.logger.info(
-                'Expecting a document of type "{0}"'.format(extension))
+            d.logger.info("Expecting a document of type '%s'", extension)
             d.expected_document_extension = extension
             return d
         else:

--- a/papis/downloaders/hal.py
+++ b/papis/downloaders/hal.py
@@ -21,7 +21,7 @@ class Downloader(papis.downloaders.fallback.Downloader):
     def get_bibtex_url(self) -> Optional[str]:
         if 'pdf_url' in self.ctx.data:
             url = re.sub(r'document', 'bibtex', self.uri)
-            self.logger.debug('bibtex url = {url}'.format(url=url))
+            self.logger.debug("bibtex url = '%s'", url)
             return url
         else:
             return None

--- a/papis/downloaders/ieee.py
+++ b/papis/downloaders/ieee.py
@@ -44,7 +44,7 @@ class Downloader(papis.downloaders.Downloader):
         bib_url, values = self._get_bibtex_url()
         post_data = urllib.parse.urlencode(values).encode('ascii')
 
-        self.logger.debug("[bibtex url] = %s" % bib_url)
+        self.logger.debug("bibtex url = '%s'", bib_url)
 
         req = urllib.request.Request(bib_url, post_data)
         with urllib.request.urlopen(req) as response:
@@ -55,10 +55,10 @@ class Downloader(papis.downloaders.Downloader):
 
     def get_document_url(self) -> Optional[str]:
         identifier = self.get_identifier()
-        self.logger.debug("[paper id] = %s" % identifier)
+        self.logger.debug("paper id = '%s'", identifier)
         pdf_url = "{}{}{}".format(
             "http://ieeexplore.ieee.org/",
             "stampPDF/getPDF.jsp?tp=&isnumber=&arnumber=",
             identifier)
-        self.logger.debug("[pdf url] = %s" % pdf_url)
+        self.logger.debug("pdf url = '%s'", pdf_url)
         return pdf_url

--- a/papis/downloaders/iopscience.py
+++ b/papis/downloaders/iopscience.py
@@ -29,7 +29,7 @@ class Downloader(papis.downloaders.Downloader):
         doi = self.get_doi()
         if doi:
             durl = 'https://iopscience.iop.org/article/{0}/pdf'.format(doi)
-            self.logger.debug("doc url = %s" % durl)
+            self.logger.debug("doc url = '%s'", durl)
             return durl
         else:
             return None
@@ -41,7 +41,7 @@ class Downloader(papis.downloaders.Downloader):
         doi = self.get_doi()
         if doi:
             article_id = doi.replace('10.1088/', '')
-            self.logger.debug("article_id = %s" % article_id)
+            self.logger.debug("article_id = '%s'", article_id)
             return article_id
         else:
             return None
@@ -55,7 +55,7 @@ class Downloader(papis.downloaders.Downloader):
                 "&exportFormat=iopexport_bib&exportType=abs"
                 "&navsubmit=Export%2Babstract"
             )
-            self.logger.debug("bibtex url = %s" % url)
+            self.logger.debug("bibtex url = '%s'", url)
             return url
         else:
             return None

--- a/papis/downloaders/sciencedirect.py
+++ b/papis/downloaders/sciencedirect.py
@@ -68,8 +68,8 @@ class Downloader(papis.downloaders.Downloader):
         scripts = soup.find_all(name="script", attrs={'data-iso-key': '_0'})
         if scripts:
             rawdata = json.loads(scripts[0].text)
-            self.logger.debug(
-                "found {0} scripts data-iso-key".format(len(scripts)))
+            self.logger.debug("Found %d scripts data-iso-key", len(scripts))
+
             converted_data = papis.document.keyconversion_to_data(
                 script_keyconv, rawdata)
             data.update(converted_data["_article_data"])

--- a/papis/downloaders/scitationaip.py
+++ b/papis/downloaders/scitationaip.py
@@ -30,12 +30,12 @@ class Downloader(papis.downloaders.Downloader):
         # http://aip.scitation.org/doi/pdf/10.1063/1.4873138
         durl = ("http://aip.scitation.org/doi/pdf/{doi}"
                 .format(doi=self.get_doi()))
-        self.logger.debug("[doc url] = %s" % durl)
+        self.logger.debug("doc url = '%s'", durl)
         return durl
 
     def get_bibtex_url(self) -> Optional[str]:
         url = ("http://aip.scitation.org/action/downloadCitation"
                "?format=bibtex&cookieSet=1&doi={doi}"
                .format(doi=self.get_doi()))
-        self.logger.debug("[bibtex url] = %s" % url)
+        self.logger.debug("bibtex url = '%s'", url)
         return url

--- a/papis/downloaders/springer.py
+++ b/papis/downloaders/springer.py
@@ -59,7 +59,7 @@ class Downloader(papis.downloaders.Downloader):
             url = ("http://citation-needed.springer.com/v2/"
                    "references/{doi}?format=bibtex&amp;flavour=citation"
                    .format(doi=self.ctx.data['doi']))
-            self.logger.debug("bibtex url = %s" % url)
+            self.logger.debug("bibtex url = '%s'", url)
             return url
         else:
             return None
@@ -68,7 +68,7 @@ class Downloader(papis.downloaders.Downloader):
         if 'doi' in self.ctx.data:
             url = ("https://link.springer.com/content/pdf/"
                    "{doi}.pdf".format(doi=self.ctx.data['doi']))
-            self.logger.debug("doc url = %s" % url)
+            self.logger.debug("doc url = '%s'", url)
             return url
         else:
             return None

--- a/papis/downloaders/tandfonline.py
+++ b/papis/downloaders/tandfonline.py
@@ -71,7 +71,7 @@ class Downloader(papis.downloaders.Downloader):
             url = ("http://www.tandfonline.com/action/downloadCitation"
                    "?format=bibtex&cookieSet=1&doi={doi}"
                    .format(doi=self.ctx.data['doi']))
-            self.logger.debug("bibtex url = %s" % url)
+            self.logger.debug("bibtex url = '%s'", url)
             return url
         else:
             return None
@@ -80,7 +80,7 @@ class Downloader(papis.downloaders.Downloader):
         if 'doi' in self.ctx.data:
             durl = ("http://www.tandfonline.com/doi/pdf/{doi}"
                     .format(doi=self.ctx.data['doi']))
-            self.logger.debug("doc url = %s" % durl)
+            self.logger.debug("doc url = '%s'", durl)
             return durl
         else:
             return None

--- a/papis/downloaders/thesesfr.py
+++ b/papis/downloaders/thesesfr.py
@@ -59,7 +59,7 @@ class Downloader(papis.downloaders.Downloader):
         ))
 
         if not a:
-            self.logger.error('No document url in {0}'.format(second_url))
+            self.logger.error("No document url in '%s'", second_url)
             return None
 
         return str(a[0]['href'])
@@ -71,5 +71,5 @@ class Downloader(papis.downloaders.Downloader):
         'http://www.theses.fr/2014TOU30305.bib'
         """
         url = "http://www.theses.fr/{id}.bib".format(id=self.get_identifier())
-        self.logger.debug("[bibtex url] = %s" % url)
+        self.logger.debug("bibtex url = '%s'", url)
         return url

--- a/papis/downloaders/worldscientific.py
+++ b/papis/downloaders/worldscientific.py
@@ -21,7 +21,7 @@ class Downloader(papis.downloaders.Downloader):
 
     def get_doi(self) -> Optional[str]:
         url = self.uri
-        self.logger.debug('Parsing doi from {0}'.format(url))
+        self.logger.debug("Parsing DOI from '%s'", url)
         mdoi = re.match(r'.*/doi/(.*/[^?&%^$]*).*', url)
         if mdoi:
             doi = mdoi.group(1).replace("abs/", "").replace("full/", "")
@@ -37,11 +37,11 @@ class Downloader(papis.downloaders.Downloader):
     def get_document_url(self) -> Optional[str]:
         durl = ("https://www.worldscientific.com/doi/pdf/{doi}"
                 .format(doi=self.get_doi()))
-        self.logger.debug("[doc url] = %s" % durl)
+        self.logger.debug("doc url = '%s'", durl)
         return durl
 
     def get_bibtex_url(self) -> Optional[str]:
         url = "https://www.worldscientific.com/action/downloadCitation"\
               "?format=bibtex&cookieSet=1&doi=%s" % self.get_doi()
-        self.logger.debug("[bibtex url] = %s" % url)
+        self.logger.debug("bibtex url = '%s'", url)
         return url

--- a/papis/format.py
+++ b/papis/format.py
@@ -12,7 +12,7 @@ logger = logging.getLogger("format")
 _FORMATER = None  # type: Optional[Formater]
 
 
-class InvalidFormatterValue(KeyError):
+class InvalidFormatterValue(Exception):
     pass
 
 

--- a/papis/format.py
+++ b/papis/format.py
@@ -8,7 +8,7 @@ from papis.document import Document
 
 
 FormatDocType = Union[Document, Dict[str, Any]]
-LOGGER = logging.getLogger("format")
+logger = logging.getLogger("format")
 _FORMATER = None  # type: Optional[Formater]
 
 
@@ -59,7 +59,7 @@ class Jinja2Formater(Formater):
         try:
             import jinja2
         except ImportError as exception:
-            LOGGER.exception("""
+            logger.exception("""
             You're trying to format strings using jinja2
             Jinja2 is not installed by default, so just install it
                 pip3 install jinja2
@@ -95,11 +95,11 @@ def get_formater() -> Formater:
             _FORMATER = papis.plugin.get_extension_manager(
                 _extension_name())[name].plugin()
         except KeyError:
-            LOGGER.error("Invalid formater (%s)", name)
+            logger.error("Invalid formater (%s)", name)
             raise Exception(
                 "Registered formaters are: %s",
                 papis.plugin.get_available_entrypoints(_extension_name()))
-        LOGGER.debug("Getting {}".format(name))
+        logger.debug("Getting {}".format(name))
     return _FORMATER
 
 

--- a/papis/format.py
+++ b/papis/format.py
@@ -12,6 +12,10 @@ logger = logging.getLogger("format")
 _FORMATER = None  # type: Optional[Formater]
 
 
+class InvalidFormatterValue(KeyError):
+    pass
+
+
 class Formater:
     def format(self,
                fmt: str,
@@ -58,13 +62,12 @@ class Jinja2Formater(Formater):
     def __init__(self) -> None:
         try:
             import jinja2
-        except ImportError as exception:
+        except ImportError:
             logger.exception("""
             You're trying to format strings using jinja2
             Jinja2 is not installed by default, so just install it
                 pip3 install jinja2
             """)
-            str(exception)
         else:
             self.jinja2 = jinja2
 
@@ -95,11 +98,12 @@ def get_formater() -> Formater:
             _FORMATER = papis.plugin.get_extension_manager(
                 _extension_name())[name].plugin()
         except KeyError:
-            logger.error("Invalid formater (%s)", name)
-            raise Exception(
+            logger.error("Invalid formater: %s", name)
+            raise InvalidFormatterValue(
                 "Registered formaters are: %s",
                 papis.plugin.get_available_entrypoints(_extension_name()))
-        logger.debug("Getting {}".format(name))
+        logger.debug("Getting %s", name)
+
     return _FORMATER
 
 

--- a/papis/git.py
+++ b/papis/git.py
@@ -5,7 +5,7 @@ import os
 import shlex
 import logging
 
-LOGGER = logging.getLogger("papis.git")
+logger = logging.getLogger("papis.git")
 
 
 def _issue_git_command(path: str, cmd: str) -> None:
@@ -23,7 +23,7 @@ def _issue_git_command(path: str, cmd: str) -> None:
     assert os.path.exists(path)
     split_cmd = shlex.split(cmd)
     os.chdir(path)
-    LOGGER.debug(split_cmd)
+    logger.debug(split_cmd)
     subprocess.call(split_cmd)
 
 
@@ -37,7 +37,7 @@ def commit(path: str, message: str) -> None:
     :returns: None
 
     """
-    LOGGER.info('Commiting %s with message %s', path, message)
+    logger.info('Commiting %s with message %s', path, message)
     cmd = 'git commit -m "{0}"'.format(message)
     _issue_git_command(path, cmd)
 
@@ -52,7 +52,7 @@ def add(path: str, resource: str) -> None:
     :returns: None
 
     """
-    LOGGER.info('Adding %s', path)
+    logger.info('Adding %s', path)
     cmd = 'git add "{0}"'.format(resource)
     _issue_git_command(path, cmd)
 
@@ -67,7 +67,7 @@ def remove(path: str, resource: str, recursive: bool = False) -> None:
     :returns: None
 
     """
-    LOGGER.info('Removing %s', path)
+    logger.info('Removing %s', path)
     # force removal always
     cmd = 'git rm -f {r} "{0}"'.format(resource, r="-r" if recursive else "")
     _issue_git_command(path, cmd)

--- a/papis/git.py
+++ b/papis/git.py
@@ -5,7 +5,7 @@ import os
 import shlex
 import logging
 
-logger = logging.getLogger("papis.git")
+logger = logging.getLogger("git")
 
 
 def _issue_git_command(path: str, cmd: str) -> None:
@@ -37,7 +37,7 @@ def commit(path: str, message: str) -> None:
     :returns: None
 
     """
-    logger.info('Commiting %s with message %s', path, message)
+    logger.info("Committing '%s' with message '%s'", path, message)
     cmd = 'git commit -m "{0}"'.format(message)
     _issue_git_command(path, cmd)
 
@@ -52,7 +52,7 @@ def add(path: str, resource: str) -> None:
     :returns: None
 
     """
-    logger.info('Adding %s', path)
+    logger.info("Adding '%s'", path)
     cmd = 'git add "{0}"'.format(resource)
     _issue_git_command(path, cmd)
 
@@ -67,7 +67,7 @@ def remove(path: str, resource: str, recursive: bool = False) -> None:
     :returns: None
 
     """
-    logger.info('Removing %s', path)
+    logger.info("Removing '%s'", path)
     # force removal always
     cmd = 'git rm -f {r} "{0}"'.format(resource, r="-r" if recursive else "")
     _issue_git_command(path, cmd)

--- a/papis/hooks.py
+++ b/papis/hooks.py
@@ -6,7 +6,7 @@ import logging
 import papis.plugin
 
 
-LOGGER = logging.getLogger('hooks')
+logger = logging.getLogger('hooks')
 NON_STEVEDORE_HOOKS = {}  # type: Dict[str, List[Callable[[Any], None]]]
 
 
@@ -20,7 +20,7 @@ def get(name: str) -> ExtensionManager:
 
 def run(name: str, *args: Any, **kwargs: Any) -> None:
     full_name = _get_namespace(name)
-    LOGGER.debug("running hooks for %s", full_name)
+    logger.debug("running hooks for %s", full_name)
     for callback in papis.plugin.get_available_plugins(full_name):
         callback(*args, **kwargs)
     hooks = NON_STEVEDORE_HOOKS.get(full_name)
@@ -31,6 +31,6 @@ def run(name: str, *args: Any, **kwargs: Any) -> None:
 
 def add(name: str, fun: Callable[[Any], None]) -> None:
     full_name = _get_namespace(name)
-    LOGGER.debug("adding hook for %s", full_name)
+    logger.debug("adding hook for %s", full_name)
     hooks = NON_STEVEDORE_HOOKS.setdefault(full_name, [])
     hooks.append(fun)

--- a/papis/hooks.py
+++ b/papis/hooks.py
@@ -20,7 +20,7 @@ def get(name: str) -> ExtensionManager:
 
 def run(name: str, *args: Any, **kwargs: Any) -> None:
     full_name = _get_namespace(name)
-    logger.debug("running hooks for %s", full_name)
+    logger.debug("Running hooks for %s", full_name)
     for callback in papis.plugin.get_available_plugins(full_name):
         callback(*args, **kwargs)
     hooks = NON_STEVEDORE_HOOKS.get(full_name)
@@ -31,6 +31,6 @@ def run(name: str, *args: Any, **kwargs: Any) -> None:
 
 def add(name: str, fun: Callable[[Any], None]) -> None:
     full_name = _get_namespace(name)
-    logger.debug("adding hook for %s", full_name)
+    logger.debug("Adding hook for %s", full_name)
     hooks = NON_STEVEDORE_HOOKS.setdefault(full_name, [])
     hooks.append(fun)

--- a/papis/importer.py
+++ b/papis/importer.py
@@ -31,7 +31,7 @@ class Importer:
         self.ctx = ctx or Context()  # type: Context
         self.uri = uri  # type: str
         self.name = name or os.path.basename(__file__)  # type: str
-        self.logger = logging.getLogger("importer:{0}".format(self.name))
+        self.logger = logging.getLogger("importer:{}".format(self.name))
 
     @classmethod
     def match(cls, uri: str) -> Optional['Importer']:

--- a/papis/isbn.py
+++ b/papis/isbn.py
@@ -11,14 +11,14 @@ logger = logging.getLogger('papis:isbnlib')
 
 def get_data(query: str = "",
              service: str = 'openl') -> List[Dict[str, Any]]:
+    logger.debug('Trying to retrieve isbn from query: %s', query)
+
     results = []  # type: List[Dict[str, Any]]
-    logger.debug('Trying to retrieve isbn')
     isbn = isbnlib.isbn_from_words(query)
     data = isbnlib.meta(isbn, service=service)
     if data is None:
         return results
     else:
-        logger.debug('Trying to retrieve isbn')
         assert(isinstance(data, dict))
         results.append(data_to_papis(data))
         return results
@@ -67,10 +67,12 @@ def explorer(ctx: click.core.Context, query: str, service: str) -> None:
     """
     logger = logging.getLogger('explore:isbn')
     logger.info('Looking up...')
+
     data = get_data(query=query, service=service)
     docs = [papis.document.from_data(data=d) for d in data]
-    logger.info('{} documents found'.format(len(docs)))
     ctx.obj['documents'] += docs
+
+    logger.info('%s documents found', len(docs))
 
 
 class Importer(papis.importer.Importer):

--- a/papis/isbn.py
+++ b/papis/isbn.py
@@ -11,7 +11,7 @@ logger = logging.getLogger('papis:isbnlib')
 
 def get_data(query: str = "",
              service: str = 'openl') -> List[Dict[str, Any]]:
-    logger.debug('Trying to retrieve isbn from query: %s', query)
+    logger.debug("Trying to retrieve isbn from query: '%s'", query)
 
     results = []  # type: List[Dict[str, Any]]
     isbn = isbnlib.isbn_from_words(query)
@@ -72,7 +72,7 @@ def explorer(ctx: click.core.Context, query: str, service: str) -> None:
     docs = [papis.document.from_data(data=d) for d in data]
     ctx.obj['documents'] += docs
 
-    logger.info('%s documents found', len(docs))
+    logger.info('%d documents found', len(docs))
 
 
 class Importer(papis.importer.Importer):

--- a/papis/isbn.py
+++ b/papis/isbn.py
@@ -11,7 +11,6 @@ logger = logging.getLogger('papis:isbnlib')
 
 def get_data(query: str = "",
              service: str = 'openl') -> List[Dict[str, Any]]:
-    global logger
     results = []  # type: List[Dict[str, Any]]
     logger.debug('Trying to retrieve isbn')
     isbn = isbnlib.isbn_from_words(query)

--- a/papis/isbnplus.py
+++ b/papis/isbnplus.py
@@ -115,7 +115,7 @@ def get_data(
     for book in root.find_all('book'):
         book_data = book_to_data(book)
         results.append(book_data)
-    logger.debug('%s records retrieved', len(results))
+    logger.debug('%d records retrieved', len(results))
     return results
 
 

--- a/papis/isbnplus.py
+++ b/papis/isbnplus.py
@@ -69,7 +69,7 @@ import click
 import papis.config
 import papis.document
 
-LOGGER = logging.getLogger('isbnplus')
+logger = logging.getLogger('isbnplus')
 
 ISBNPLUS_KEY = "98a765346bc0ffee6ede527499b6a4ee"  # type: str
 ISBNPLUS_APPID = "4846a7d1"  # type: str
@@ -104,7 +104,7 @@ def get_data(
         {x: dict_params[x] for x in dict_params if dict_params[x]}
     )
     req_url = ISBNPLUS_BASEURL + "search?" + params
-    LOGGER.debug("url = %s", req_url)
+    logger.debug("url = %s", req_url)
     url = urllib.request.Request(
         req_url,
         headers={'User-Agent': papis.config.getstring('user-agent')}
@@ -115,7 +115,7 @@ def get_data(
     for book in root.find_all('book'):
         book_data = book_to_data(book)
         results.append(book_data)
-    LOGGER.debug('%s records retrieved', len(results))
+    logger.debug('%s records retrieved', len(results))
     return results
 
 

--- a/papis/isbnplus.py
+++ b/papis/isbnplus.py
@@ -104,7 +104,7 @@ def get_data(
         {x: dict_params[x] for x in dict_params if dict_params[x]}
     )
     req_url = ISBNPLUS_BASEURL + "search?" + params
-    logger.debug("url = %s", req_url)
+    logger.debug("url = '%s'", req_url)
     url = urllib.request.Request(
         req_url,
         headers={'User-Agent': papis.config.getstring('user-agent')}
@@ -170,4 +170,5 @@ def explorer(ctx: click.core.Context,
         data = []
     docs = [papis.document.from_data(data=d) for d in data]
     ctx.obj['documents'] += docs
+
     logger.info('%s documents found', len(docs))

--- a/papis/json.py
+++ b/papis/json.py
@@ -24,7 +24,9 @@ def explorer(ctx: click.Context, jsonfile: str) -> None:
 
     """
     logger = logging.getLogger('explore:json')
-    logger.info('Reading in json file {}'.format(jsonfile))
+    logger.info("Reading in json file '%s'", jsonfile)
+
     docs = [papis.document.from_data(d) for d in json.load(open(jsonfile))]
     ctx.obj['documents'] += docs
-    logger.info('{} documents found'.format(len(docs)))
+
+    logger.info('%s documents found', len(docs))

--- a/papis/pick.py
+++ b/papis/pick.py
@@ -8,7 +8,7 @@ import papis.config
 import papis.document
 import papis.plugin
 
-LOGGER = logging.getLogger("pick")
+logger = logging.getLogger("pick")
 T = TypeVar("T")
 Option = TypeVar("Option")
 
@@ -47,8 +47,8 @@ def pick(
     try:
         picker = get_picker(name)  # type: Type[Picker[Option]]
     except KeyError:
-        LOGGER.error("Invalid picker (%s)", name)
-        LOGGER.error(
+        logger.error("Invalid picker (%s)", name)
+        logger.error(
             "Registered pickers are: %s",
             papis.plugin.get_available_entrypoints(_extension_name()))
         return []

--- a/papis/pick.py
+++ b/papis/pick.py
@@ -47,10 +47,10 @@ def pick(
     try:
         picker = get_picker(name)  # type: Type[Picker[Option]]
     except KeyError:
-        logger.error("Invalid picker (%s)", name)
+        logger.error("Invalid picker: %s", name)
         logger.error(
-            "Registered pickers are: %s",
-            papis.plugin.get_available_entrypoints(_extension_name()))
+                "Registered pickers are: %s",
+                papis.plugin.get_available_entrypoints(_extension_name()))
         return []
     else:
         return picker()(options,

--- a/papis/plugin.py
+++ b/papis/plugin.py
@@ -68,13 +68,13 @@ MANAGERS = dict()  # type: Dict[str, ExtensionManager]
 
 def stevedore_error_handler(manager: ExtensionManager,
                             entrypoint: str, exception: str) -> None:
-    logger.error("Error while loading entrypoint [%s]", entrypoint)
+    logger.error("Error while loading entrypoint '%s'", entrypoint)
     logger.error(exception)
 
 
 def _load_extensions(namespace: str) -> None:
     global MANAGERS
-    logger.debug("creating manager for {0}".format(namespace))
+    logger.debug("creating manager for %s", namespace)
     MANAGERS[namespace] = ExtensionManager(
         namespace=namespace,
         invoke_on_load=False,

--- a/papis/plugin.py
+++ b/papis/plugin.py
@@ -74,7 +74,7 @@ def stevedore_error_handler(manager: ExtensionManager,
 
 def _load_extensions(namespace: str) -> None:
     global MANAGERS
-    logger.debug("creating manager for %s", namespace)
+    logger.debug("Creating manager for %s", namespace)
     MANAGERS[namespace] = ExtensionManager(
         namespace=namespace,
         invoke_on_load=False,

--- a/papis/tui/widgets/list.py
+++ b/papis/tui/widgets/list.py
@@ -279,7 +279,7 @@ class OptionsList(ConditionalContainer, Generic[Option]):  # type: ignore
             operator.add,
             [self.options_headers[i] for i in self.indices],
             [])  # type: List[Tuple[str, str]]
-        logger.debug("Create items in %f", time.time() - _t)
+        logger.debug("Created items in %f", time.time() - _t)
         return internal_text
 
     def index_to_line(self, index: int) -> int:
@@ -295,7 +295,7 @@ class OptionsList(ConditionalContainer, Generic[Option]):  # type: ignore
         return self._indices_to_lines[index]
 
     def process_options(self) -> None:
-        logger.debug('processing %s options', len(self.get_options()))
+        logger.debug('Processing %d options', len(self.get_options()))
         self.marks = []
 
         def _get_linecount(_o: Option) -> int:
@@ -304,7 +304,7 @@ class OptionsList(ConditionalContainer, Generic[Option]):  # type: ignore
         self.options_headers_linecount = list(map(_get_linecount,
                                                   self.get_options()))
         self.max_entry_height = max(self.options_headers_linecount)
-        logger.debug('processing headers')
+        logger.debug('Processing headers')
         self.options_headers = []
         for _opt in self.get_options():
             prestring = self.header_filter(_opt) + '\n'
@@ -312,12 +312,12 @@ class OptionsList(ConditionalContainer, Generic[Option]):  # type: ignore
                 htmlobject = HTML(prestring).formatted_text
             except Exception as e:
                 logger.error(
-                    'Error processing html for \n %s \n %s', prestring, e)
+                        'Error processing html for\n %s\n %s', prestring, e)
                 htmlobject = [('fg:red', prestring)]
             self.options_headers += [htmlobject]
-        logger.debug('got %s headers', len(self.options_headers))
-        logger.debug('processing matchers')
+        logger.debug('Got %d headers', len(self.options_headers))
+        logger.debug('Processing matchers')
         self.options_matchers = list(
             map(self.match_filter, self.get_options()))
         self.indices = list(range(len(self.get_options())))
-        logger.debug('got %s matchers', len(self.options_matchers))
+        logger.debug('Got %d matchers', len(self.options_matchers))

--- a/papis/tui/widgets/list.py
+++ b/papis/tui/widgets/list.py
@@ -23,7 +23,7 @@ import papis.utils
 
 Option = TypeVar("Option")
 
-LOGGER = logging.getLogger('tui:widget:list')
+logger = logging.getLogger('tui:widget:list')
 
 
 def match_against_regex(
@@ -279,7 +279,7 @@ class OptionsList(ConditionalContainer, Generic[Option]):  # type: ignore
             operator.add,
             [self.options_headers[i] for i in self.indices],
             [])  # type: List[Tuple[str, str]]
-        LOGGER.debug("Create items in %f", time.time() - _t)
+        logger.debug("Create items in %f", time.time() - _t)
         return internal_text
 
     def index_to_line(self, index: int) -> int:
@@ -295,7 +295,7 @@ class OptionsList(ConditionalContainer, Generic[Option]):  # type: ignore
         return self._indices_to_lines[index]
 
     def process_options(self) -> None:
-        LOGGER.debug('processing %s options', len(self.get_options()))
+        logger.debug('processing %s options', len(self.get_options()))
         self.marks = []
 
         def _get_linecount(_o: Option) -> int:
@@ -304,20 +304,20 @@ class OptionsList(ConditionalContainer, Generic[Option]):  # type: ignore
         self.options_headers_linecount = list(map(_get_linecount,
                                                   self.get_options()))
         self.max_entry_height = max(self.options_headers_linecount)
-        LOGGER.debug('processing headers')
+        logger.debug('processing headers')
         self.options_headers = []
         for _opt in self.get_options():
             prestring = self.header_filter(_opt) + '\n'
             try:
                 htmlobject = HTML(prestring).formatted_text
             except Exception as e:
-                LOGGER.error(
+                logger.error(
                     'Error processing html for \n %s \n %s', prestring, e)
                 htmlobject = [('fg:red', prestring)]
             self.options_headers += [htmlobject]
-        LOGGER.debug('got %s headers', len(self.options_headers))
-        LOGGER.debug('processing matchers')
+        logger.debug('got %s headers', len(self.options_headers))
+        logger.debug('processing matchers')
         self.options_matchers = list(
             map(self.match_filter, self.get_options()))
         self.indices = list(range(len(self.get_options())))
-        LOGGER.debug('got %s matchers', len(self.options_matchers))
+        logger.debug('got %s matchers', len(self.options_matchers))

--- a/papis/tui/widgets/list.py
+++ b/papis/tui/widgets/list.py
@@ -274,12 +274,12 @@ class OptionsList(ConditionalContainer, Generic[Option]):  # type: ignore
         where the tuples follow the FormattedText structure.
         """
         self.update_cursor()
-        _t = time.time()
+        begin_t = time.time()
         internal_text = functools.reduce(
             operator.add,
             [self.options_headers[i] for i in self.indices],
             [])  # type: List[Tuple[str, str]]
-        logger.debug("Created items in %f", time.time() - _t)
+        logger.debug("Created items in %.1f ms", 1000*(time.time() - begin_t))
         return internal_text
 
     def index_to_line(self, index: int) -> int:

--- a/papis/utils.py
+++ b/papis/utils.py
@@ -9,8 +9,6 @@ import shlex
 import subprocess
 import time
 
-import colorama
-
 try:
     import multiprocessing.synchronize  # noqa: F401
     from multiprocessing import Pool
@@ -254,8 +252,8 @@ def get_matching_importer_or_downloader(matching_string: str
     _all_importers = list(_imps) + list(_downs)
     for importer_cls in _all_importers:
         logger.debug("trying with importer "
-                     "{c.Back.BLACK}{c.Fore.YELLOW}{name}{c.Style.RESET_ALL}"
-                     .format(c=colorama, name=importer_cls))
+                     "{c.Back.BLACK}{c.Fore.YELLOW}%s{c.Style.RESET_ALL}",
+                     importer_cls)
         try:
             importer = importer_cls.match(
                 matching_string)  # type: Optional[papis.importer.Importer]
@@ -263,10 +261,10 @@ def get_matching_importer_or_downloader(matching_string: str
             logger.error(e)
             continue
         if importer:
-            logger.info("{f} {c.Back.BLACK}{c.Fore.GREEN}matches {name}"
-                        "{c.Style.RESET_ALL}".format(f=matching_string,
-                                                     c=colorama,
-                                                     name=importer.name))
+            logger.info(
+                    "%s {c.Back.BLACK}{c.Fore.GREEN}"
+                    "matches %s{c.Style.RESET_ALL}",
+                    matching_string, importer.name)
             try:
                 importer.fetch()
             except Exception as e:

--- a/papis/utils.py
+++ b/papis/utils.py
@@ -60,7 +60,7 @@ def general_open(file_name: str,
     cmd = shlex.split("{0} '{1}'".format(opener, file_name))
     logger.debug("cmd: %s", cmd)
     if wait:
-        logger.debug("Waiting for process to finsih")
+        logger.debug("Waiting for process to finish")
         subprocess.call(cmd)
     else:
         logger.debug("Not waiting for process to finish")
@@ -214,7 +214,7 @@ def folders_to_documents(folders: List[str]) -> List[papis.document.Document]:
     begin_t = time.time()
     result = parmap(papis.document.from_folder, folders)
 
-    logger.debug("done in %.1f ms", 1000*(time.time() - begin_t))
+    logger.debug("Done in %.1f ms", 1000*(time.time() - begin_t))
     return result
 
 

--- a/papis/utils.py
+++ b/papis/utils.py
@@ -26,7 +26,6 @@ import papis.document
 import papis.database
 
 logger = logging.getLogger("utils")
-logger.debug("importing")
 
 A = TypeVar("A")
 B = TypeVar("B")
@@ -61,7 +60,7 @@ def general_open(file_name: str,
             default_opener = papis.config.get_default_opener()
         opener = default_opener
     cmd = shlex.split("{0} '{1}'".format(opener, file_name))
-    logger.debug("cmd:  %s", cmd)
+    logger.debug("cmd: %s", cmd)
     if wait:
         logger.debug("Waiting for process to finsih")
         subprocess.call(cmd)
@@ -95,13 +94,16 @@ def get_folders(folder: str) -> List[str]:
     :returns: List of folders containing an info file.
     :rtype: list
     """
-    logger.debug("Indexing folders in '{0}'".format(folder))
-    folders = list()
+    logger.debug("Indexing folders in '%s'", folder)
+
+    folders = []
     for root, dirnames, filenames in os.walk(folder):
         if os.path.exists(
                 os.path.join(root, papis.config.getstring('info-name'))):
             folders.append(root)
-    logger.debug("{0} valid folders retrieved".format(len(folders)))
+
+    logger.debug("%d valid folders retrieved", len(folders))
+
     return folders
 
 
@@ -209,10 +211,12 @@ def folders_to_documents(folders: List[str]) -> List[papis.document.Document]:
     :rtype:  list
 
     """
-    logger = logging.getLogger("utils:dir2doc")
+    logger = logging.getLogger("utils:folders_to_documents")
+
     begin_t = time.time()
     result = parmap(papis.document.from_folder, folders)
-    logger.debug("done in %.1f ms" % (1000*time.time()-1000*begin_t))
+
+    logger.debug("done in %.1f ms", 1000*(time.time() - begin_t))
     return result
 
 
@@ -242,8 +246,9 @@ def get_cache_home() -> str:
 
 def get_matching_importer_or_downloader(matching_string: str
                                         ) -> List[papis.importer.Importer]:
-    importers = []  # type: List[papis.importer.Importer]
     logger = logging.getLogger("utils:matcher")
+
+    importers = []  # type: List[papis.importer.Importer]
     _imps = papis.importer.get_importers()
     _downs = papis.downloaders.get_available_downloaders()
     _all_importers = list(_imps) + list(_downs)

--- a/papis/utils.py
+++ b/papis/utils.py
@@ -25,8 +25,8 @@ import papis.downloaders
 import papis.document
 import papis.database
 
-LOGGER = logging.getLogger("utils")
-LOGGER.debug("importing")
+logger = logging.getLogger("utils")
+logger.debug("importing")
 
 A = TypeVar("A")
 B = TypeVar("B")
@@ -61,12 +61,12 @@ def general_open(file_name: str,
             default_opener = papis.config.get_default_opener()
         opener = default_opener
     cmd = shlex.split("{0} '{1}'".format(opener, file_name))
-    LOGGER.debug("cmd:  %s", cmd)
+    logger.debug("cmd:  %s", cmd)
     if wait:
-        LOGGER.debug("Waiting for process to finsih")
+        logger.debug("Waiting for process to finsih")
         subprocess.call(cmd)
     else:
-        LOGGER.debug("Not waiting for process to finish")
+        logger.debug("Not waiting for process to finish")
         subprocess.Popen(
             cmd, shell=False,
             stdin=None, stdout=None, stderr=None, close_fds=True)
@@ -95,13 +95,13 @@ def get_folders(folder: str) -> List[str]:
     :returns: List of folders containing an info file.
     :rtype: list
     """
-    LOGGER.debug("Indexing folders in '{0}'".format(folder))
+    logger.debug("Indexing folders in '{0}'".format(folder))
     folders = list()
     for root, dirnames, filenames in os.walk(folder):
         if os.path.exists(
                 os.path.join(root, papis.config.getstring('info-name'))):
             folders.append(root)
-    LOGGER.debug("{0} valid folders retrieved".format(len(folders)))
+    logger.debug("{0} valid folders retrieved".format(len(folders)))
     return folders
 
 

--- a/papis/yaml.py
+++ b/papis/yaml.py
@@ -54,7 +54,7 @@ def yaml_to_data(
         except Exception as e:
             if raise_exception:
                 raise ValueError(e)
-            logger.error("Yaml syntax error: \n\n{0}".format(e))
+            logger.error("Yaml syntax error. %s", e)
             return dict()
         else:
             assert isinstance(data, dict)
@@ -75,11 +75,13 @@ def explorer(ctx: click.Context, yamlfile: str) -> None:
 
     """
     logger = logging.getLogger('explore:yaml')
-    logger.info('reading in yaml file {}'.format(yamlfile))
+    logger.info("Reading in yaml file '%s'", yamlfile)
+
     docs = [papis.document.from_data(d)
             for d in yaml.safe_load_all(open(yamlfile))]
     ctx.obj['documents'] += docs
-    logger.info('{} documents found'.format(len(docs)))
+
+    logger.info('%d documents found', len(docs))
 
 
 class Importer(papis.importer.Importer):
@@ -101,4 +103,4 @@ class Importer(papis.importer.Importer):
     def fetch(self: papis.importer.Importer) -> Any:
         self.ctx.data = yaml_to_data(self.uri, raise_exception=False)
         if self.ctx:
-            self.logger.info("successfully read file = %s" % self.uri)
+            self.logger.info("successfully read file '%s'", self.uri)

--- a/papis/yaml.py
+++ b/papis/yaml.py
@@ -48,7 +48,6 @@ def yaml_to_data(
     :rtype:  dict
     :raises ValueError: If a yaml parsing error happens
     """
-    global logger
     with open(yaml_path) as fd:
         try:
             data = yaml.safe_load(fd)


### PR DESCRIPTION
The main change here is to use the `logger.log(fmt, *args)` way as it should be a bit faster according to the [logging module docs](https://docs.python.org/3/howto/logging.html#optimization) (basically it avoids any unnecessary string interpolation).

Besides that, a few random changes along the way:
* use `logger` instead of `LOGGER` in all modules
* capitalize logging messages (probably didn't get them all, but at least a few more than before)
* reworded a few messages as well.
* added a `ColoramaFormatter` to automagically pick up any `{c.Fore.Red}` sort of things without having to pass it to the log calls. Not sure about this one though. What do you think?