### PR TITLE
Remove most third-party libs from top level imports

### DIFF
--- a/papis/arxiv.py
+++ b/papis/arxiv.py
@@ -17,14 +17,10 @@
 """
 import os
 import re
-import bs4
 import logging
-import urllib.request  # urlopen, Request
-import urllib.parse  # import urlencode
 from typing import Optional, List, Dict, Any
 
 import click
-import arxiv2bib
 
 import papis.filetype
 import papis.downloaders.base
@@ -64,6 +60,8 @@ def get_data(
         [key+':'+str(clean_params[key]) for key in clean_params]
     )
     logger.debug("query = '%s'", search_query)
+
+    import urllib.parse
     params = urllib.parse.urlencode(
         {
             'search_query': search_query,
@@ -74,6 +72,8 @@ def get_data(
     main_url = "http://arxiv.org/api/query?"
     req_url = main_url + params
     logger.debug("url = '%s'", req_url)
+
+    import urllib.request
     url = urllib.request.Request(
         req_url,
         headers={
@@ -81,6 +81,8 @@ def get_data(
         }
     )
     xmldoc = urllib.request.urlopen(url).read()
+
+    import bs4
     soup = bs4.BeautifulSoup(xmldoc, 'html.parser')
 
     entries = soup.find_all("entry")
@@ -107,10 +109,11 @@ def get_data(
 
 
 def validate_arxivid(arxivid: str) -> None:
-    from urllib.error import HTTPError, URLError
+    import urllib.request
     url = "https://arxiv.org/abs/{0}".format(arxivid)
     request = urllib.request.Request(url)
 
+    from urllib.error import HTTPError, URLError
     try:
         urllib.request.urlopen(request)
     except HTTPError:
@@ -260,8 +263,11 @@ class Downloader(papis.downloaders.Downloader):
         bib_url = self.get_bibtex_url()
         if not bib_url:
             return None
+
+        import arxiv2bib
         bibtex_cli = arxiv2bib.Cli([bib_url])
         bibtex_cli.run()
+
         self.logger.debug("bibtex_url = '%s'", bib_url)
         output = bibtex_cli.output  # List[str]
         data = ''.join(output).replace('\n', ' ')

--- a/papis/base.py
+++ b/papis/base.py
@@ -5,10 +5,7 @@ For description refer to
 https://www.base-search.net/about/download/base_interface.pdf
 
 """
-import urllib.parse
-import urllib.request  # import urlencode
 import logging
-import json
 from typing import Optional, Dict, Any, List, Callable, NamedTuple
 
 import click
@@ -35,19 +32,26 @@ def get_data(query: str = "", hits: int = 20) -> List[Dict[str, Any]]:
         "format": "json",
         "hits": hits,
     }
+
+    import urllib.parse
     params = urllib.parse.urlencode(
         {x: dict_params[x] for x in dict_params if dict_params[x]}
     )
     req_url = base_baseurl + "search?" + params
     logger.debug("url = '%s'", req_url)
+
+    import urllib.request
     url = urllib.request.Request(
         req_url,
         headers={
             'User-Agent': 'papis'
         }
     )
+
+    import json
     jsondoc = json.loads(urllib.request.urlopen(url).read().decode())
     docs = jsondoc.get('response').get('docs')
+
     logger.info("Retrieved %d documents", len(docs))
     return list(map(basedoc_to_papisdoc, docs))
 

--- a/papis/bibtex.py
+++ b/papis/bibtex.py
@@ -1,13 +1,11 @@
-from __future__ import unicode_literals
-from __future__ import absolute_import, division, print_function
-
+import os
 import string
 import logging
-import os
 from typing import Optional, List, Dict, Any
 
-import papis.config
 import click
+
+import papis.config
 import papis.importer
 import papis.filetype
 import papis.document

--- a/papis/cli.py
+++ b/papis/cli.py
@@ -1,11 +1,11 @@
+from typing import Optional, Any, Callable
+
 import click
 import click.core
 import click.types
 import click.decorators
 
 import papis.config
-import difflib
-from typing import Optional, Any, Callable
 
 
 DecoratorCallable = Callable[..., Any]
@@ -26,6 +26,8 @@ class AliasedGroup(click.core.Group):
         rv = click.core.Group.get_command(self, ctx, cmd_name)
         if rv is not None:
             return rv
+
+        import difflib
         matches = difflib.get_close_matches(
             cmd_name, self.list_commands(ctx), n=2)
         if not matches:

--- a/papis/commands/__init__.py
+++ b/papis/commands/__init__.py
@@ -1,17 +1,19 @@
 import os
+import re
 import glob
+from typing import Dict, Optional, Union, NamedTuple
+
+from click.core import Command
+
+import papis.cli
 import papis.config
 import papis.plugin
-import re
-from click.core import Command
-from papis.cli import AliasedGroup
-from typing import Dict, Optional, Union, NamedTuple
 
 
 Script = NamedTuple("Script",
                     [("command_name", str),
                      ("path", Optional[str]),
-                     ("plugin", Union[None, Command, AliasedGroup])])
+                     ("plugin", Union[None, Command, papis.cli.AliasedGroup])])
 
 
 def get_external_scripts() -> Dict[str, Script]:

--- a/papis/commands/add.py
+++ b/papis/commands/add.py
@@ -87,18 +87,13 @@ Cli
     :prog: papis add
 
 """
-from typing import List, Any, Optional, Dict, Tuple
-import logging
-from string import ascii_lowercase
 import os
 import re
-import tempfile
-import hashlib
-import shutil
+import logging
+from typing import List, Any, Optional, Dict, Tuple
 
 import click
 
-import time
 import papis.api
 import papis.pick
 import papis.utils
@@ -234,6 +229,7 @@ def get_hash_folder(data: Dict[str, Any], document_paths: List[str]) -> str:
         with open(docpath, 'rb') as fd:
             document_strings += fd.read(2000)
 
+    import hashlib
     md5 = hashlib.md5(
         ''.join(document_paths).encode()
         + str(data).encode()
@@ -284,7 +280,7 @@ def run(paths: List[str],
         in the case of course that the library is a git repository.
     :type  git: bool
     """
-
+    import tempfile
     logger = logging.getLogger('add:run')
 
     # The folder name of the new document that will be created
@@ -328,6 +324,7 @@ def run(paths: List[str],
     logger.debug("File(s): %s", in_documents_paths)
 
     # First prepare everything in the temporary directory
+    from string import ascii_lowercase
     g = papis.utils.create_identifier(ascii_lowercase)
     string_append = ''
     if file_name is not None:  # Use args if set
@@ -357,6 +354,8 @@ def run(paths: List[str],
         else:
             logger.debug(
                 "[CP] '%s' to '%s'", in_file_path, tmp_end_filepath)
+
+            import shutil
             shutil.copy(in_file_path, tmp_end_filepath)
 
     data['files'] = new_file_list
@@ -569,6 +568,7 @@ def cli(
         return
 
     if papis.config.getboolean("time-stamp"):
+        import time
         ctx.data['time-added'] = time.strftime(papis.strings.time_format)
 
     return run(

--- a/papis/commands/addto.py
+++ b/papis/commands/addto.py
@@ -16,21 +16,20 @@ Cli
 .. click:: papis.commands.addto:cli
     :prog: papis addto
 """
-from string import ascii_lowercase
 import os
-import shutil
+import logging
+from typing import List, Optional
+
+import click
+
 import papis.pick
 import papis.utils
 import papis.document
 import papis.git
 import papis.config
 import papis.commands.add
-import logging
 import papis.cli
-import click
 import papis.strings
-
-from typing import List, Optional
 
 
 def run(document: papis.document.Document,
@@ -38,6 +37,7 @@ def run(document: papis.document.Document,
         git: bool = False) -> None:
     logger = logging.getLogger('addto')
 
+    from string import ascii_lowercase
     g = papis.utils.create_identifier(ascii_lowercase)
     string_append = ''
 
@@ -82,6 +82,7 @@ def run(document: papis.document.Document,
                 "%s already exists, ignoring...", end_document_path)
             continue
 
+        import shutil
         logger.info("[CP] '%s' to '%s'", in_file_path, end_document_path)
         shutil.copy(in_file_path, end_document_path)
 

--- a/papis/commands/bibtex.py
+++ b/papis/commands/bibtex.py
@@ -125,9 +125,12 @@ Cli
 """
 import os
 import re
+import click
+import logging
+from typing import List, Optional
+
 import papis.api
 import papis.cli
-import click
 import papis.config as config
 import papis.utils
 import papis.tui.utils
@@ -138,9 +141,7 @@ import papis.commands.edit
 import papis.commands.browse
 import papis.commands.export
 import papis.bibtex
-import logging
 
-from typing import List, Optional
 
 logger = logging.getLogger('papis:bibtex')
 

--- a/papis/commands/browse.py
+++ b/papis/commands/browse.py
@@ -54,19 +54,20 @@ Cli
 .. click:: papis.commands.browse:cli
     :prog: papis browse
 """
+import logging
+from typing import Optional
+
+import click
+
 import papis
 import papis.utils
 import papis.config
 import papis.cli
 import papis.pick
-import click
 import papis.database
 import papis.strings
 import papis.document
-from urllib.parse import urlencode
-import logging
 
-from typing import Optional
 
 logger = logging.getLogger('browse')
 
@@ -97,6 +98,7 @@ def run(document: papis.document.Document,
 
     except KeyError:
         if not url or key == 'search-engine':
+            import urllib.parse
             params = {
                 'q': papis.format.format(
                     papis.config.getstring('browse-query-format'),
@@ -104,7 +106,7 @@ def run(document: papis.document.Document,
             }
             url = (papis.config.getstring('search-engine')
                    + '/?'
-                   + urlencode(params))
+                   + urllib.parse.urlencode(params))
 
     if browse:
         logger.info("Opening url '%s'", url)

--- a/papis/commands/config.py
+++ b/papis/commands/config.py
@@ -35,10 +35,12 @@ Cli
 .. click:: papis.commands.config:cli
     :prog: papis config
 """
-import papis.commands
 import logging
-import click
 from typing import Optional
+
+import click
+
+import papis.commands
 
 
 def run(option_string: str) -> Optional[str]:

--- a/papis/commands/edit.py
+++ b/papis/commands/edit.py
@@ -7,8 +7,13 @@ Cli
 .. click:: papis.commands.edit:cli
     :prog: papis edit
 """
-import papis
 import os
+import logging
+from typing import Optional
+
+import click
+
+import papis
 import papis.hooks
 import papis.api
 import papis.pick
@@ -17,12 +22,8 @@ import papis.utils
 import papis.config
 import papis.database
 import papis.cli
-import click
-import logging
 import papis.strings
 import papis.git
-
-from typing import Optional
 
 
 def run(document: papis.document.Document,

--- a/papis/commands/exec.py
+++ b/papis/commands/exec.py
@@ -30,9 +30,10 @@ Cli
 .. click:: papis.commands.exec:cli
     :prog: papis exec
 """
-import click
 import sys
 from typing import List
+
+import click
 
 
 def run(_file: str) -> None:

--- a/papis/commands/explore.py
+++ b/papis/commands/explore.py
@@ -86,14 +86,17 @@ Cli
     :show-nested:
 """
 import os
+import logging
+from typing import List, Optional, Union, Any, Dict, TYPE_CHECKING
+
+import click
+
 import papis.tui.utils
 import papis.commands
 import papis.document
 import papis.config
 import papis.strings
 import papis.cli
-import click
-import logging
 import papis.commands.add
 import papis.commands.export
 import papis.api
@@ -101,8 +104,9 @@ import papis.pick
 import papis.format
 import papis.crossref
 import papis.plugin
-from stevedore import ExtensionManager
-from typing import List, Optional, Union, Any, Dict  # noqa: ignore
+
+if TYPE_CHECKING:
+    from stevedore import ExtensionManager
 
 logger = logging.getLogger('explore')
 
@@ -115,7 +119,7 @@ def get_available_explorers() -> List[click.Command]:
     return papis.plugin.get_available_plugins(_extension_name())
 
 
-def get_explorer_mgr() -> ExtensionManager:
+def get_explorer_mgr() -> "ExtensionManager":
     return papis.plugin.get_extension_manager(_extension_name())
 
 

--- a/papis/commands/export.py
+++ b/papis/commands/export.py
@@ -45,19 +45,20 @@ Cli
 .. click:: papis.commands.export:cli
     :prog: papis export
 """
-import papis
 import os
-import shutil
+import logging
+from typing import List, Optional
+
+import click
+
+import papis
 import papis.utils
 import papis.document
-import click
 import papis.cli
 import papis.api
 import papis.database
 import papis.strings
-import logging
 import papis.plugin
-from typing import List, Optional
 
 logger = logging.getLogger('cli:export')
 
@@ -154,6 +155,7 @@ def cli(query: str,
             print(ret_string)
         return
 
+    import shutil
     for document in documents:
         if folder:
             _doc_folder = document.get_main_folder()

--- a/papis/commands/external.py
+++ b/papis/commands/external.py
@@ -4,7 +4,6 @@ to be called by papis.
 """
 import os
 import re
-import subprocess
 import logging
 from typing import List
 
@@ -58,4 +57,6 @@ def external_cli(ctx: click.core.Context, flags: List[str]) -> None:
     logger.debug("Calling '%s'", cmd)
 
     export_variables()
+
+    import subprocess
     subprocess.call(cmd)

--- a/papis/commands/git.py
+++ b/papis/commands/git.py
@@ -21,7 +21,9 @@ CLI Examples
 
 """
 import copy
+
 import click
+
 import papis.commands.run
 
 cli = copy.deepcopy(papis.commands.run.cli)

--- a/papis/commands/list.py
+++ b/papis/commands/list.py
@@ -47,9 +47,13 @@ Cli
     :prog: papis list
 """
 
-import logging
-import papis
 import os
+import logging
+from typing import List, Optional, Union, Sequence
+
+import click
+
+import papis
 import papis.utils
 import papis.strings
 import papis.config
@@ -59,9 +63,6 @@ import papis.downloaders
 import papis.cli
 import papis.pick
 import papis.format
-import click
-
-from typing import List, Optional, Union, Sequence
 
 logger = logging.getLogger('list')
 

--- a/papis/commands/mv.py
+++ b/papis/commands/mv.py
@@ -6,8 +6,9 @@ Cli
     :prog: papis mv
 """
 import os
-import subprocess
 import logging
+from typing import Optional
+
 import click
 
 import papis.config
@@ -17,8 +18,6 @@ import papis.document
 import papis.cli
 import papis.pick
 import papis.strings
-
-from typing import Optional
 
 
 def run(document: papis.document.Document,
@@ -34,6 +33,7 @@ def run(document: papis.document.Document,
     db = papis.database.get()
     logger.debug(cmd)
 
+    import subprocess
     subprocess.call(cmd)
     db.delete(document)
     new_document_folder = os.path.join(

--- a/papis/commands/open.py
+++ b/papis/commands/open.py
@@ -74,6 +74,7 @@ Cli
 import os
 import logging
 from typing import Optional
+
 import click
 
 import papis
@@ -83,12 +84,13 @@ import papis.utils
 import papis.config
 import papis.cli
 import papis.database
-from papis.document import from_folder, Document, from_data
+import papis.document
 import papis.format
 import papis.strings
 
 
-def run(document: Document, opener: Optional[str] = None,
+def run(document: papis.document.Document,
+        opener: Optional[str] = None,
         folder: bool = False,
         mark: bool = False) -> None:
     logger = logging.getLogger('open:run')
@@ -124,9 +126,10 @@ def run(document: Document, opener: Optional[str] = None,
                 if mark_dict:
                     if not _mark_opener:
                         raise Exception("mark-opener-format not set")
-                    opener = papis.format.format(_mark_opener,
-                                                 from_data(mark_dict[0]),
-                                                 doc_key=_mark_name)
+                    opener = papis.format.format(
+                            _mark_opener,
+                            papis.document.from_data(mark_dict[0]),
+                            doc_key=_mark_name)
                     logger.info("Setting opener to '%s'", opener)
                     papis.config.set("opentool", opener)
         files = document.get_files()
@@ -169,7 +172,7 @@ def cli(query: str, doc_folder: str, tool: str, folder: bool,
     logger = logging.getLogger('cli:run')
 
     if doc_folder:
-        documents = [from_folder(doc_folder)]
+        documents = [papis.document.from_folder(doc_folder)]
     else:
         documents = papis.database.get().query(query)
 

--- a/papis/commands/rename.py
+++ b/papis/commands/rename.py
@@ -6,9 +6,11 @@ Cli
     :prog: papis rename
 """
 import os
-import subprocess
 import logging
+from typing import Optional
+
 import click
+
 import papis.cli
 import papis.database
 import papis.strings
@@ -16,8 +18,6 @@ import papis.git
 import papis.pick
 import papis.document
 import papis.tui.utils
-
-from typing import Optional
 
 
 def run(document: papis.document.Document,
@@ -40,6 +40,7 @@ def run(document: papis.document.Document,
     cmd = ['git', '-C', folder] if git else []
     cmd += ['mv', folder, new_folder_path]
 
+    import subprocess
     logger.debug(cmd)
     subprocess.call(cmd)
 

--- a/papis/commands/rm.py
+++ b/papis/commands/rm.py
@@ -5,9 +5,11 @@ Cli
 .. click:: papis.commands.rm:cli
     :prog: papis rm
 """
-import click
-import logging
 import os
+import logging
+from typing import Optional
+
+import click
 
 import papis.pick
 import papis.tui.utils
@@ -16,8 +18,6 @@ import papis.cli
 import papis.strings
 import papis.database
 import papis.git
-
-from typing import Optional
 
 
 def run(document: papis.document.Document,

--- a/papis/commands/update.py
+++ b/papis/commands/update.py
@@ -40,8 +40,10 @@ Cli
     :prog: papis update
 """
 
-import click
 import logging
+from typing import List, Dict, Tuple, Optional, Any
+
+import click
 
 import papis.utils
 import papis.tui.utils
@@ -54,8 +56,6 @@ import papis.format
 import papis.cli
 import papis.importer
 import papis.git
-
-from typing import List, Dict, Tuple, Optional, Any
 
 
 def _update_with_database(document: papis.document.Document) -> None:

--- a/papis/config.py
+++ b/papis/config.py
@@ -1,11 +1,12 @@
-import sys
 import os
-from os.path import expanduser
+import sys
+import logging
 import configparser
+from typing import Dict, Any, List, Optional, Callable  # noqa: ignore
+
 import papis.exceptions
 import papis.library
-import logging
-from typing import Dict, Any, List, Optional, Callable  # noqa: ignore
+
 
 PapisConfigType = Dict[str, Dict[str, Any]]
 
@@ -258,9 +259,9 @@ def get_config_home() -> str:
     """
     xdg_home = os.environ.get('XDG_CONFIG_HOME')
     if xdg_home:
-        return expanduser(xdg_home)
+        return os.path.expanduser(xdg_home)
     else:
-        return os.path.join(expanduser('~'), '.config')
+        return os.path.join(os.path.expanduser('~'), '.config')
 
 
 def get_config_dirs() -> List[str]:
@@ -277,7 +278,7 @@ def get_config_dirs() -> List[str]:
     # compatibility
     dirs += [
         os.path.join(get_config_home(), 'papis'),
-        os.path.join(expanduser('~'), '.papis')]
+        os.path.join(os.path.expanduser('~'), '.papis')]
     return dirs
 
 
@@ -549,10 +550,10 @@ def get_lib_from_name(libname: str) -> papis.library.Library:
                             .format(libname, cpath=get_config_file()))
     else:
         try:
-            paths = [expanduser(config[libname]['dir'])]
+            paths = [os.path.expanduser(config[libname]['dir'])]
         except KeyError:
             try:
-                paths = eval(expanduser(config[libname].get('dirs')))
+                paths = eval(os.path.expanduser(config[libname].get('dirs')))
             except Exception as e:
                 raise Exception("To define a library you have to set either"
                                 " dir or dirs in the configuration file.\n"

--- a/papis/crossref.py
+++ b/papis/crossref.py
@@ -2,13 +2,10 @@ import re
 import os
 import logging
 import tempfile
-from typing import Set, List, Dict, Any, Optional, Tuple  # noqa: ignore
+from typing import Set, List, Dict, Any, Optional, Tuple, TYPE_CHECKING
 
-import requests
-import requests.structures
-import click
 import doi
-import habanero
+import click
 
 import papis.config
 import papis.pick
@@ -16,6 +13,10 @@ import papis.filetype
 import papis.document
 import papis.importer
 import papis.downloaders.base
+
+if TYPE_CHECKING:
+    import habanero
+
 
 logger = logging.getLogger("crossref")  # type: logging.Logger
 KeyConversionPair = papis.document.KeyConversionPair
@@ -158,8 +159,8 @@ def crossref_data_to_papis_data(data: Dict[str, Any]) -> Dict[str, Any]:
     return new_data
 
 
-def _get_crossref_works(
-        **kwargs: Any) -> habanero.request_class.Request:
+def _get_crossref_works(**kwargs: Any) -> "habanero.request_class.Request":
+    import habanero
     cr = habanero.Crossref()
     return cr.works(**kwargs)
 
@@ -356,7 +357,11 @@ class Importer(papis.importer.Importer):
             if doc_url is not None:
                 self.logger.info(
                     "Trying to download document from '%s'", doc_url)
+
+                import requests
                 session = requests.Session()
+
+                import requests.structures
                 session.headers = requests.structures.CaseInsensitiveDict({
                     "user-agent": papis.config.getstring("user-agent")})
 

--- a/papis/database/__init__.py
+++ b/papis/database/__init__.py
@@ -1,5 +1,6 @@
 import logging
-from typing import Optional, Dict  # noqa: ignore
+from typing import Optional, Dict
+
 from .base import Database
 from papis.library import Library
 

--- a/papis/database/base.py
+++ b/papis/database/base.py
@@ -2,13 +2,13 @@
 Here the database abstraction for the libraries is defined.
 """
 
+from abc import ABC, abstractmethod
+from typing import Optional, List, Dict
+
 import papis.utils
 import papis.config
 import papis.library
 import papis.document
-
-from typing import Optional, List, Dict
-from abc import ABC, abstractmethod
 
 
 class Database(ABC):

--- a/papis/database/cache.py
+++ b/papis/database/cache.py
@@ -1,18 +1,15 @@
-import pickle
-import logging
 import os
+import re
+import sys
+import logging
+from typing import List, Optional, Match, Dict, Tuple
+
 import papis.utils
 import papis.docmatcher
 import papis.document
 import papis.config
 import papis.format
 import papis.database.base
-import re
-import time
-import sys
-
-
-from typing import List, Optional, Match, Dict, Tuple
 
 
 logger = logging.getLogger("cache")
@@ -80,6 +77,8 @@ def filter_documents(
     papis.docmatcher.DocMatcher.set_search(search)
     papis.docmatcher.DocMatcher.parse()
     papis.docmatcher.DocMatcher.set_matcher(match_document)
+
+    import time
     begin_t = 1000 * time.time()
     # FIXME: find a better solution for this that works for both OSes
     if sys.platform == "win32":
@@ -173,6 +172,8 @@ class Database(papis.database.base.Database):
         if use_cache and os.path.exists(cache_path):
             self.logger.debug(
                 "Getting documents from cache in '%s'", cache_path)
+
+            import pickle
             with open(cache_path, 'rb') as fd:
                 self.documents = pickle.load(fd)
         else:
@@ -259,6 +260,7 @@ class Database(papis.database.base.Database):
         docs = self.get_documents()
         self.logger.debug('Saving %d documents...', len(docs))
 
+        import pickle
         path = self._get_cache_file_path()
         with open(path, "wb+") as fd:
             pickle.dump(docs, fd)

--- a/papis/dissemin.py
+++ b/papis/dissemin.py
@@ -1,12 +1,10 @@
 import logging
-import urllib.request  # urlopen, Request
-import urllib.parse  # import urlencode
-import papis.config
-import json
-import click
-import papis.document
-
 from typing import List, Dict, Any
+
+import click
+
+import papis.config
+import papis.document
 
 logger = logging.getLogger('dissemin')
 
@@ -53,6 +51,9 @@ def get_data(query: str = "") -> List[Dict[str, Any]]:
     Get data using the dissemin API
     https://dissem.in/api/search/?q=pregroup
     """
+    import urllib.parse
+    import urllib.request
+
     dict_params = {"q": query}
     params = urllib.parse.urlencode(dict_params)
     main_url = "https://dissem.in/api/search/?"
@@ -65,6 +66,8 @@ def get_data(query: str = "") -> List[Dict[str, Any]]:
         }
     )
     jsondoc = urllib.request.urlopen(url).read().decode()
+
+    import json
     paperlist = json.loads(jsondoc)
     return sum([dissemindoc_to_papis(d) for d in paperlist['papers']], [])
 

--- a/papis/docmatcher.py
+++ b/papis/docmatcher.py
@@ -1,7 +1,9 @@
-import papis.config
-import papis.document
 import logging
 from typing import Optional, List, Any, Callable
+
+import papis.config
+import papis.document
+
 MATCHER_TYPE = Callable[[papis.document.Document, str, Optional[str]], Any]
 
 

--- a/papis/document.py
+++ b/papis/document.py
@@ -2,8 +2,6 @@
 """
 import os
 import re
-import datetime
-import shutil
 import logging
 from typing import (
     List, Dict, Any, Optional, Union, NamedTuple, Callable, Tuple)
@@ -307,6 +305,7 @@ def delete(document: Document) -> None:
     """
     folder = document.get_main_folder()
     if folder:
+        import shutil
         shutil.rmtree(folder)
 
 
@@ -346,6 +345,7 @@ def move(document: Document, path: str) -> None:
         )
     folder = document.get_main_folder()
     if folder:
+        import shutil
         shutil.move(folder, path)
         # Let us chmod it because it might come from a temp folder
         # and temp folders are per default 0o600
@@ -384,6 +384,7 @@ def sort(docs: List[Document], key: str, reverse: bool) -> List[Document]:
         for sort_type in sort_rankings:
             sort_rankings[sort_type] = -sort_rankings[sort_type]
 
+    import datetime
     zero_date = datetime.datetime.fromtimestamp(0)
 
     def _sort_for_key(key: str, doc: Document
@@ -432,6 +433,8 @@ def new(folder_path: str, data: Dict[str, Any],
     :raises FileExistsError: If folder_path exists
     """
     os.makedirs(folder_path)
+
+    import shutil
     doc = Document(folder=folder_path, data=data)
     doc['files'] = []
     for _file in files:

--- a/papis/downloaders/__init__.py
+++ b/papis/downloaders/__init__.py
@@ -1,12 +1,7 @@
-from typing import List, Optional, Any, Sequence, Type, Dict
-import logging
 import os
 import re
-import tempfile
-
-import requests
-import bs4
-import filetype
+import logging
+from typing import List, Optional, Any, Sequence, Type, Dict, TYPE_CHECKING
 
 import papis.bibtex
 import papis.config
@@ -14,6 +9,9 @@ import papis.document
 import papis.importer
 import papis.plugin
 import papis.utils
+
+if TYPE_CHECKING:
+    import bs4
 
 logger = logging.getLogger("downloader")
 
@@ -73,6 +71,7 @@ class Downloader(papis.importer.Importer):
         self.bibtex_data = None  # type: Optional[str]
         self.document_data = None  # type: Optional[bytes]
 
+        import requests
         self.session = requests.Session()  # type: requests.Session
         self.session.headers = requests.structures.CaseInsensitiveDict({
             'User-Agent': papis.config.getstring('user-agent')
@@ -128,6 +127,7 @@ class Downloader(papis.importer.Importer):
         else:
             doc_rawdata = self.get_document_data()
             if doc_rawdata and self.check_document_format():
+                import tempfile
                 with tempfile.NamedTemporaryFile(
                         mode="wb+", delete=False) as f:
                     f.write(doc_rawdata)
@@ -147,10 +147,12 @@ class Downloader(papis.importer.Importer):
         """Get body of the uri, this is also important for unittesting"""
         return self.session.get(self.uri).content
 
-    def _get_soup(self) -> bs4.BeautifulSoup:
+    def _get_soup(self) -> "bs4.BeautifulSoup":
         """Get body of the uri, this is also important for unittesting"""
         if self._soup:
             return self._soup
+
+        import bs4
         self._soup = bs4.BeautifulSoup(self._get_body(), features='lxml')
         return self._soup
 
@@ -269,6 +271,7 @@ class Downloader(papis.importer.Importer):
         if self.expected_document_extension is None:
             return True
 
+        import filetype
         retrieved_kind = filetype.guess(self.get_document_data())
 
         if retrieved_kind is None:

--- a/papis/downloaders/annualreviews.py
+++ b/papis/downloaders/annualreviews.py
@@ -1,6 +1,7 @@
 import re
-import papis.downloaders.base
 from typing import Optional, Dict, Any
+
+import papis.downloaders.base
 
 
 class Downloader(papis.downloaders.Downloader):

--- a/papis/downloaders/aps.py
+++ b/papis/downloaders/aps.py
@@ -1,7 +1,7 @@
 import re
-import papis.downloaders.fallback
-
 from typing import Optional
+
+import papis.downloaders.fallback
 
 
 class Downloader(papis.downloaders.fallback.Downloader):

--- a/papis/downloaders/base.py
+++ b/papis/downloaders/base.py
@@ -1,12 +1,11 @@
 import re
-from typing import Any, List, Dict, Iterator, Tuple, Union, Pattern
+from typing import (
+        Any, List, Dict, Iterator, Tuple, Union, Pattern, TYPE_CHECKING)
 
 try:
     from typing import TypedDict  # Python 3.8+
 except ImportError:
     from typing_extensions import TypedDict
-
-import bs4
 
 import papis.bibtex
 import papis.config
@@ -14,6 +13,8 @@ import papis.document
 import papis.importer
 import papis.utils
 
+if TYPE_CHECKING:
+    import bs4
 
 MetaEquivalence = TypedDict(
     "MetaEquivalence", {
@@ -103,7 +104,7 @@ meta_equivalences = [
 ]  # type: List[MetaEquivalence]
 
 
-def parse_meta_headers(soup: bs4.BeautifulSoup) -> Dict[str, Any]:
+def parse_meta_headers(soup: "bs4.BeautifulSoup") -> Dict[str, Any]:
     global meta_equivalences
     # metas = soup.find_all(name="meta")
     data = dict()  # type: Dict[str, Any]
@@ -121,7 +122,7 @@ def parse_meta_headers(soup: bs4.BeautifulSoup) -> Dict[str, Any]:
     return data
 
 
-def parse_meta_authors(soup: bs4.BeautifulSoup) -> List[Dict[str, Any]]:
+def parse_meta_authors(soup: "bs4.BeautifulSoup") -> List[Dict[str, Any]]:
     author_list = []  # type: List[Dict[str, Any]]
     authors = soup.find_all(name='meta', attrs={'name': 'citation_author'})
     if not authors:

--- a/papis/downloaders/citeseerx.py
+++ b/papis/downloaders/citeseerx.py
@@ -1,7 +1,7 @@
 import re
-import papis.downloaders.fallback
-
 from typing import Optional
+
+import papis.downloaders.fallback
 
 
 class Downloader(papis.downloaders.fallback.Downloader):

--- a/papis/downloaders/fallback.py
+++ b/papis/downloaders/fallback.py
@@ -1,7 +1,7 @@
 import doi
-import papis.downloaders.base
-
 from typing import Dict, Any, Optional
+
+import papis.downloaders.base
 
 
 class Downloader(papis.downloaders.Downloader):

--- a/papis/downloaders/frontiersin.py
+++ b/papis/downloaders/frontiersin.py
@@ -1,7 +1,7 @@
 import re
-import papis.downloaders.base
-
 from typing import Optional
+
+import papis.downloaders.base
 
 
 class Downloader(papis.downloaders.Downloader):

--- a/papis/downloaders/get.py
+++ b/papis/downloaders/get.py
@@ -1,6 +1,7 @@
 import re
-import papis.downloaders.base
 from typing import Optional
+
+import papis.downloaders.base
 
 
 class Downloader(papis.downloaders.Downloader):

--- a/papis/downloaders/hal.py
+++ b/papis/downloaders/hal.py
@@ -1,6 +1,7 @@
 import re
-import papis.downloaders.fallback
 from typing import Optional
+
+import papis.downloaders.fallback
 
 
 class Downloader(papis.downloaders.fallback.Downloader):

--- a/papis/downloaders/ieee.py
+++ b/papis/downloaders/ieee.py
@@ -1,8 +1,7 @@
 import re
-import urllib.parse
-import urllib.request
-import papis.downloaders.base
 from typing import Optional, Tuple, Dict
+
+import papis.downloaders.base
 
 
 class Downloader(papis.downloaders.Downloader):
@@ -41,6 +40,9 @@ class Downloader(papis.downloaders.Downloader):
         return bibtex_url, data
 
     def download_bibtex(self) -> None:
+        import urllib.parse
+        import urllib.request
+
         bib_url, values = self._get_bibtex_url()
         post_data = urllib.parse.urlencode(values).encode('ascii')
 

--- a/papis/downloaders/iopscience.py
+++ b/papis/downloaders/iopscience.py
@@ -1,6 +1,7 @@
 import re
-import papis.downloaders.base
 from typing import Dict, Any, Optional
+
+import papis.downloaders.base
 
 
 class Downloader(papis.downloaders.Downloader):

--- a/papis/downloaders/sciencedirect.py
+++ b/papis/downloaders/sciencedirect.py
@@ -1,5 +1,4 @@
 import re
-import json
 from typing import Dict, Optional, Any, List
 
 import papis.downloaders
@@ -67,6 +66,7 @@ class Downloader(papis.downloaders.Downloader):
         soup = self._get_soup()
         scripts = soup.find_all(name="script", attrs={'data-iso-key': '_0'})
         if scripts:
+            import json
             rawdata = json.loads(scripts[0].text)
             self.logger.debug("Found %d scripts data-iso-key", len(scripts))
 

--- a/papis/downloaders/scitationaip.py
+++ b/papis/downloaders/scitationaip.py
@@ -1,6 +1,7 @@
 import re
-import papis.downloaders.base
 from typing import Optional
+
+import papis.downloaders.base
 
 
 class Downloader(papis.downloaders.Downloader):

--- a/papis/downloaders/springer.py
+++ b/papis/downloaders/springer.py
@@ -1,7 +1,8 @@
 import re
+from typing import Optional, Any, Dict
+
 import papis.downloaders.base
 import papis.document
-from typing import Optional, Any, Dict
 
 
 class Downloader(papis.downloaders.Downloader):

--- a/papis/downloaders/tandfonline.py
+++ b/papis/downloaders/tandfonline.py
@@ -1,9 +1,8 @@
 import re
-import urllib.parse
+from typing import Optional, Any, Dict
 
 import papis.downloaders.base
 import papis.document
-from typing import Optional, Any, Dict
 
 
 class Downloader(papis.downloaders.Downloader):
@@ -46,6 +45,7 @@ class Downloader(papis.downloaders.Downloader):
             fullname = author.find_all('a', attrs={'class': 'entryAuthor'})
             fullname = fullname[0].get('href').split('/')[-1]
 
+            import urllib.parse
             fullname = urllib.parse.unquote_plus(fullname)
             family, given = re.split(r',\s+', fullname)
             given = self.re_add_dot.sub(r'\1.', given)

--- a/papis/downloaders/thesesfr.py
+++ b/papis/downloaders/thesesfr.py
@@ -1,7 +1,7 @@
 import re
-import papis.downloaders.base
-import bs4
 from typing import Optional
+
+import papis.downloaders.base
 
 
 class Downloader(papis.downloaders.Downloader):
@@ -38,6 +38,8 @@ class Downloader(papis.downloaders.Downloader):
         >>> d.get_document_url()
         'https://pastel.archives-ouvertes.fr/tel-00005590v2/file/Cances.pdf'
         """
+        import bs4
+
         # TODO: Simplify this function for typing
         raw_data = self.session.get(self.uri).content.decode('utf-8')
         soup = bs4.BeautifulSoup(raw_data, "html.parser")

--- a/papis/filetype.py
+++ b/papis/filetype.py
@@ -1,6 +1,5 @@
 import re
 import os
-import filetype
 
 
 def get_document_extension(document_path: str) -> str:
@@ -10,6 +9,7 @@ def get_document_extension(document_path: str) -> str:
     :returns: Extension (string)
 
     """
+    import filetype
     filetype.guess(document_path)
     kind = filetype.guess(document_path)
     if kind is None:

--- a/papis/fzf.py
+++ b/papis/fzf.py
@@ -1,9 +1,7 @@
-from typing import Callable, Sequence, TypeVar, List, Optional, Generic
-from typing.re import Pattern
-from abc import ABC, abstractmethod
-import subprocess as sp
 import re
-import colorama
+from abc import ABC, abstractmethod
+from typing.re import Pattern
+from typing import Callable, Sequence, TypeVar, List, Optional, Generic
 
 import papis.pick
 import papis.config
@@ -89,6 +87,7 @@ class Picker(papis.pick.Picker[T]):
 
         def _header_filter(d: T) -> str:
             if isinstance(d, papis.document.Document):
+                import colorama
                 return papis.format.format(_fmt,
                                            d,
                                            additional=dict(c=colorama))
@@ -98,6 +97,7 @@ class Picker(papis.pick.Picker[T]):
         headers = [_header_filter(o) for o in options]
         docs = []  # type: Sequence[T]
 
+        import subprocess as sp
         with sp.Popen(command, stdin=sp.PIPE, stdout=sp.PIPE) as p:
             if p.stdin is not None:
                 with p.stdin as stdin:

--- a/papis/git.py
+++ b/papis/git.py
@@ -1,8 +1,6 @@
 """This module serves as an lightweight interface for git related functions.
 """
-import subprocess
 import os
-import shlex
 import logging
 
 logger = logging.getLogger("git")
@@ -21,9 +19,13 @@ def _issue_git_command(path: str, cmd: str) -> None:
     assert isinstance(cmd, str)
     path = os.path.expanduser(path)
     assert os.path.exists(path)
+
+    import shlex
     split_cmd = shlex.split(cmd)
-    os.chdir(path)
     logger.debug(split_cmd)
+
+    import subprocess
+    os.chdir(path)
     subprocess.call(split_cmd)
 
 

--- a/papis/hooks.py
+++ b/papis/hooks.py
@@ -1,9 +1,11 @@
-from typing import List, Dict, Any, Callable  # noqa: ignore
+from typing import List, Dict, Any, Callable, TYPE_CHECKING
 
-from stevedore import ExtensionManager
 import logging
 
 import papis.plugin
+
+if TYPE_CHECKING:
+    from stevedore import ExtensionManager
 
 
 logger = logging.getLogger('hooks')
@@ -14,7 +16,7 @@ def _get_namespace(name: str) -> str:
     return ("papis.hook.{}".format(name))
 
 
-def get(name: str) -> ExtensionManager:
+def get(name: str) -> "ExtensionManager":
     return papis.plugin.get_extension_manager(_get_namespace(name))
 
 

--- a/papis/importer.py
+++ b/papis/importer.py
@@ -1,10 +1,13 @@
-import logging
-from stevedore import ExtensionManager
-from typing import Optional, List, Dict, Any, Callable, Type
 import os.path
+import logging
+from typing import Optional, List, Dict, Any, Callable, Type, TYPE_CHECKING
 
 import papis
 import papis.plugin
+
+
+if TYPE_CHECKING:
+    from stevedore import ExtensionManager
 
 
 class Context:
@@ -90,7 +93,7 @@ def _extension_name() -> str:
     return "papis.importer"
 
 
-def get_import_mgr() -> ExtensionManager:
+def get_import_mgr() -> "ExtensionManager":
     """Get the import manager
     :returns: Import manager
     """

--- a/papis/isbn.py
+++ b/papis/isbn.py
@@ -1,10 +1,11 @@
+# See https://github.com/xlcnd/isbnlib for details
+import logging
+from typing import Dict, Any, List, Optional
+
+import click
+
 import papis.document
 import papis.importer
-import logging
-import isbnlib
-import click
-# See https://github.com/xlcnd/isbnlib for details
-from typing import Dict, Any, List, Optional
 
 logger = logging.getLogger('papis:isbnlib')
 
@@ -13,6 +14,7 @@ def get_data(query: str = "",
              service: str = 'openl') -> List[Dict[str, Any]]:
     logger.debug("Trying to retrieve isbn from query: '%s'", query)
 
+    import isbnlib
     results = []  # type: List[Dict[str, Any]]
     isbn = isbnlib.isbn_from_words(query)
     data = isbnlib.meta(isbn, service=service)
@@ -84,11 +86,13 @@ class Importer(papis.importer.Importer):
 
     @classmethod
     def match(cls, uri: str) -> Optional[papis.importer.Importer]:
+        import isbnlib
         if isbnlib.notisbn(uri):
             return None
         return Importer(uri=uri)
 
     def fetch(self) -> None:
+        import isbnlib
         try:
             data = get_data(self.uri)
         except isbnlib.ISBNLibException:

--- a/papis/isbnplus.py
+++ b/papis/isbnplus.py
@@ -59,15 +59,16 @@ An example of successful returns:
     </book>
     ...
 """
-import urllib.parse
-import urllib.request  # import urlencode
 import logging
-from typing import List, Dict, Any
+from typing import List, Dict, Any, TYPE_CHECKING
 
-import bs4
 import click
+
 import papis.config
 import papis.document
+
+if TYPE_CHECKING:
+    import bs4
 
 logger = logging.getLogger('isbnplus')
 
@@ -88,6 +89,9 @@ def get_data(
         app_id: str = ISBNPLUS_APPID,
         app_key: str = ISBNPLUS_KEY
         ) -> List[Dict[str, Any]]:
+    import urllib.parse
+    import urllib.request
+
     results = []
     dict_params = {
         "q": query,
@@ -110,6 +114,8 @@ def get_data(
         headers={'User-Agent': papis.config.getstring('user-agent')}
     )
     xmldoc = urllib.request.urlopen(url).read()
+
+    import bs4
     root = bs4.BeautifulSoup(xmldoc, 'html.parser')
 
     for book in root.find_all('book'):
@@ -119,7 +125,7 @@ def get_data(
     return results
 
 
-def book_to_data(booknode: bs4.Tag) -> Dict[str, Any]:
+def book_to_data(booknode: "bs4.Tag") -> Dict[str, Any]:
     """Convert book xml node into dictionary
 
     :booknode: Bs4 book node

--- a/papis/json.py
+++ b/papis/json.py
@@ -1,12 +1,13 @@
-import click
-import json
 import logging
 from typing import List
+
+import click
 
 import papis.document
 
 
 def exporter(documents: List[papis.document.Document]) -> str:
+    import json
     return json.dumps([papis.document.to_dict(doc) for doc in documents])
 
 
@@ -26,6 +27,7 @@ def explorer(ctx: click.Context, jsonfile: str) -> None:
     logger = logging.getLogger('explore:json')
     logger.info("Reading in json file '%s'", jsonfile)
 
+    import json
     docs = [papis.document.from_data(d) for d in json.load(open(jsonfile))]
     ctx.obj['documents'] += docs
 

--- a/papis/pick.py
+++ b/papis/pick.py
@@ -1,8 +1,8 @@
-import logging
 import os
+import logging
 import functools
-from typing import Callable, TypeVar, Generic, Sequence, Type
 from abc import ABC, abstractmethod
+from typing import Callable, TypeVar, Generic, Sequence, Type
 
 import papis.config
 import papis.document

--- a/papis/plugin.py
+++ b/papis/plugin.py
@@ -57,8 +57,10 @@ in the package if they have been declared in the entry points of
 the ``setup.py`` script of the named package.
 """
 import logging
-from stevedore import ExtensionManager
-from typing import List, Dict, Any  # noqa: ignore
+from typing import List, Dict, Any, TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from stevedore import ExtensionManager
 
 logger = logging.getLogger("papis:plugin")
 
@@ -66,7 +68,7 @@ logger = logging.getLogger("papis:plugin")
 MANAGERS = dict()  # type: Dict[str, ExtensionManager]
 
 
-def stevedore_error_handler(manager: ExtensionManager,
+def stevedore_error_handler(manager: "ExtensionManager",
                             entrypoint: str, exception: str) -> None:
     logger.error("Error while loading entrypoint '%s'", entrypoint)
     logger.error(exception)
@@ -75,6 +77,8 @@ def stevedore_error_handler(manager: ExtensionManager,
 def _load_extensions(namespace: str) -> None:
     global MANAGERS
     logger.debug("Creating manager for %s", namespace)
+
+    from stevedore import ExtensionManager
     MANAGERS[namespace] = ExtensionManager(
         namespace=namespace,
         invoke_on_load=False,
@@ -84,7 +88,7 @@ def _load_extensions(namespace: str) -> None:
     )
 
 
-def get_extension_manager(namespace: str) -> ExtensionManager:
+def get_extension_manager(namespace: str) -> "ExtensionManager":
     global MANAGERS
     if not MANAGERS.get(namespace):
         _load_extensions(namespace)

--- a/papis/pubmed.py
+++ b/papis/pubmed.py
@@ -1,9 +1,6 @@
 from typing import Any, Dict, List, Optional
 
-import json
-import urllib
-import requests
-
+import papis
 import papis.importer
 import papis.document
 import papis.downloaders.base
@@ -72,6 +69,7 @@ def is_valid_pmid(pmid: str) -> bool:
     if not pmid.isdigit():
         return False
 
+    import urllib
     url = PUBMED_URL.format(pmid=pmid, database=PUBMED_DATABASE)
     request = urllib.request.Request(url)
 
@@ -87,7 +85,7 @@ def is_valid_pmid(pmid: str) -> bool:
 def get_data(query: str = "") -> Dict[str, Any]:
     # NOTE: being nice and using the project version as a user agent
     # as requested in https://api.ncbi.nlm.nih.gov/lit/ctxp
-    import papis
+    import requests
     headers = requests.structures.CaseInsensitiveDict({
         'user-agent': "papis/{}".format(papis.__version__)
         })
@@ -97,6 +95,7 @@ def get_data(query: str = "") -> Dict[str, Any]:
     response = session.get(PUBMED_URL.format(
         pmid=query.strip(), database=PUBMED_DATABASE))
 
+    import json
     return pubmed_data_to_papis_data(json.loads(response.content.decode()))
 
 

--- a/papis/tui/__init__.py
+++ b/papis/tui/__init__.py
@@ -1,4 +1,5 @@
 from typing import Dict, Any
+
 PapisConfigType = Dict[str, Dict[str, Any]]
 
 

--- a/papis/tui/utils.py
+++ b/papis/tui/utils.py
@@ -1,5 +1,5 @@
-from typing import Optional, List, Callable, Any
 import re
+from typing import Optional, List, Callable, Any
 
 
 def confirm(prompt_string: str,

--- a/papis/tui/widgets/command_line_prompt.py
+++ b/papis/tui/widgets/command_line_prompt.py
@@ -1,3 +1,5 @@
+from typing import Any, List, Callable
+
 from prompt_toolkit.application import Application
 from prompt_toolkit.layout.processors import BeforeInput
 from prompt_toolkit.buffer import Buffer
@@ -10,8 +12,6 @@ from prompt_toolkit.layout.controls import (
 )
 from prompt_toolkit.application.current import get_app
 from prompt_toolkit.filters import has_focus
-import shlex
-from typing import Any, List, Callable
 
 
 class Command:
@@ -64,6 +64,7 @@ class CommandLinePrompt(ConditionalContainer):  # type: ignore
         )
 
     def trigger(self) -> None:
+        import shlex
         input_cmd = shlex.split(self.buf.text)
         if not input_cmd:
             return

--- a/papis/tui/widgets/diff.py
+++ b/papis/tui/widgets/diff.py
@@ -1,4 +1,6 @@
-import difflib
+from typing import (
+    Dict, Any, List, Union, NamedTuple, Callable, Sequence)
+
 from prompt_toolkit import Application, print_formatted_text
 from prompt_toolkit.utils import Event
 from prompt_toolkit.layout.containers import HSplit, Window, WindowAlign
@@ -6,9 +8,6 @@ from prompt_toolkit.formatted_text import FormattedText, HTML
 from prompt_toolkit.layout.controls import FormattedTextControl
 from prompt_toolkit.layout.layout import Layout
 from prompt_toolkit.key_binding import KeyBindings
-
-from typing import (  # noqa: ignore
-    Dict, Any, List, Union, NamedTuple, Callable, Sequence)
 
 Action = NamedTuple('Action',
                     [
@@ -93,6 +92,7 @@ def diffshow(texta: str,
     assert(isinstance(texta, str))
     assert(isinstance(textb, str))
 
+    import difflib
     # diffs = difflib.unified_diff(
     #         str(texta).splitlines(keepends=True),
     #         str(textb).splitlines(keepends=True),

--- a/papis/tui/widgets/list.py
+++ b/papis/tui/widgets/list.py
@@ -1,9 +1,7 @@
 import os
 import re
-import operator
-import functools
-import time
 import logging
+import functools
 from typing import (
     Optional, Any, List, Generic, Sequence,
     Callable, Tuple, Pattern, TypeVar)
@@ -273,6 +271,9 @@ class OptionsList(ConditionalContainer, Generic[Option]):  # type: ignore
         """Creates the body of the list, which is just a list of tuples,
         where the tuples follow the FormattedText structure.
         """
+        import time
+        import operator
+
         self.update_cursor()
         begin_t = time.time()
         internal_text = functools.reduce(

--- a/papis/utils.py
+++ b/papis/utils.py
@@ -1,13 +1,9 @@
+import os
+import re
+import logging
 from itertools import count, product
 from typing import (Optional, List, Iterator, Any, Dict,
                     Union, Callable, TypeVar)
-import copy
-import logging
-import os
-import re
-import shlex
-import subprocess
-import time
 
 try:
     import multiprocessing.synchronize  # noqa: F401
@@ -57,8 +53,12 @@ def general_open(file_name: str,
         if default_opener is None:
             default_opener = papis.config.get_default_opener()
         opener = default_opener
+
+    import shlex
     cmd = shlex.split("{0} '{1}'".format(opener, file_name))
     logger.debug("cmd: %s", cmd)
+
+    import subprocess
     if wait:
         logger.debug("Waiting for process to finish")
         subprocess.call(cmd)
@@ -211,6 +211,7 @@ def folders_to_documents(folders: List[str]) -> List[papis.document.Document]:
     """
     logger = logging.getLogger("utils:folders_to_documents")
 
+    import time
     begin_t = time.time()
     result = parmap(papis.document.from_folder, folders)
 
@@ -277,8 +278,10 @@ def get_matching_importer_or_downloader(matching_string: str
 def update_doc_from_data_interactively(
         document: Union[papis.document.Document, Dict[str, Any]],
         data: Dict[str, Any], data_name: str) -> None:
-    import papis.tui.widgets.diff
+    import copy
     docdata = copy.copy(document)
+
+    import papis.tui.widgets.diff
     # do not compare some entries
     docdata.pop('files', None)
     docdata.pop('tags', None)


### PR DESCRIPTION
This is supposed to make running quick commands (`papis add`, `papis list`, etc) a bit faster by delaying importing bigger modules. 

From a quick profile the main culprits seemed to be `requests` and `bs4`, but I went ahead and cleaned all of them up. The only remaining top level imports in a file now should be
* `click`
* `os`, `re`, `sys`, `logging` and `typing` from python
* whatever `papis` modules are needed.

From a quick unscientific timing of `papis list`, before it was
```
papis -l papers list -a "ar"  0.55s user 0.19s system 143% cpu 0.513 total
```
and now it is
```
papis -l papers list -a "ar"  0.35s user 0.22s system 164% cpu 0.342 total
```  
(for a library of about 1000 entries with about 800 matching the search)