### PR TITLE
Check msg is a string in ColoramaFormatter

### DIFF
--- a/papis/commands/default.py
+++ b/papis/commands/default.py
@@ -47,8 +47,10 @@ if TYPE_CHECKING:
 
 class ColoramaFormatter(logging.Formatter):
     def format(self, record: logging.LogRecord) -> str:
-        import colorama
-        record.msg = record.msg.format(c=colorama)
+        if isinstance(record.msg, str):
+            import colorama
+            record.msg = record.msg.format(c=colorama)
+
         return super().format(record)
 
 


### PR DESCRIPTION
This fixed a breakage from #345 (sorry!). There are a few places that do
```
logger.error(e)
```
where `e` is an exception, that made this give a scarier error message.