### PR TITLE
Fix logger message in MultiCommand class

### DIFF
--- a/papis/commands/default.py
+++ b/papis/commands/default.py
@@ -91,11 +91,13 @@ class MultiCommand(click.core.MultiCommand):
             matches = list(map(
                 str, difflib.get_close_matches(name, self.scripts, n=2)))
 
+            import colorama
             self.logger.error(
-                '{c.Fore.RED}{c.Style.BRIGHT}{c.Back.BLACK}'
-                'did you mean {0}?'
-                '{c.Style.RESET_ALL}',
-                ' or '.join(matches))
+                "{c.Fore.RED}{c.Style.BRIGHT}{c.Back.BLACK}"
+                "Command '{name}' is unknown! Did you mean '{matches}'?"
+                "{c.Style.RESET_ALL}"
+                .format(c=colorama, name=name, matches="' or '".join(matches))
+                )
 
             # return the match if there was only one match
             if len(matches) == 1:


### PR DESCRIPTION
Another fix after #345 :(. I'm starting to think that `ColoramaFormatter` thing is more trouble than it's worth!

The issue here was that logger in the `MultiCommand` class gets created and stored before the `default` command gets a chance to execute and set up all the logging infrastructure. This means that `ColoramaFormatter` does not get set and called, so the logged message contained the `colorama` codes.