### PR TITLE
Use configured default-library instead of default value

### DIFF
--- a/papis/config.py
+++ b/papis/config.py
@@ -595,8 +595,9 @@ def get_lib() -> papis.library.Library:
     if _CURRENT_LIBRARY is None:
         # Do not put papis.config.get because get is a special function
         # that also needs the library to see if some key was overridden!
-        default_settings = get_default_settings()[get_general_settings_name()]
-        lib = default_settings['default-library']
+        config = papis.config.get_configuration()
+        lib = config.get(papis.config.get_general_settings_name(),
+                         'default-library')
         set_lib_from_name(lib)
     assert(isinstance(_CURRENT_LIBRARY, papis.library.Library))
     return _CURRENT_LIBRARY


### PR DESCRIPTION
Fix #249.

Can you think of any circumstances where this approach would fail?