### PR TITLE
added template functionality for new notes

### DIFF
--- a/doc/source/default-settings.rst
+++ b/doc/source/default-settings.rst
@@ -335,6 +335,17 @@ Bibtex options
     is the default name of the notes file, which by default is supposed
     to be a TeX file.
 
+.. papis-config:: notes-template
+
+    In ``papis edit`` you can edit notes about the document. ``notes-template``
+    is the path to a template, that will be loaded and formated using the
+    ``formater``. This can be useful to enforce the same style in the notes
+    for all documents.
+
+    Default value is set to ``""``, which will return an empty notes file. If
+    no file is found at the path to the template, then also an empty notes file
+    will be generated.
+
 .. _marks-options:
 
 Marks

--- a/papis/commands/edit.py
+++ b/papis/commands/edit.py
@@ -53,6 +53,21 @@ def run(document: papis.document.Document,
                 papis.document.describe(document)))
 
 
+def create_notes(document: papis.document.Document,
+                 notes_path: str) -> None:
+
+    templ_path = os.path.expanduser(papis.config.getstring("notes-template"))
+    templ_out = ""
+
+    if os.path.exists(templ_path):
+        with open(templ_path, 'r') as f:
+            templ_src = f.read()
+            templ_out = papis.format.format(templ_src, document)
+
+    with open(notes_path, 'w+') as f:
+        f.write(templ_out)
+
+
 def edit_notes(document: papis.document.Document,
                git: bool = False) -> None:
     logger = logging.getLogger('edit:notes')
@@ -68,7 +83,7 @@ def edit_notes(document: papis.document.Document,
 
     if not os.path.exists(notes_path):
         logger.debug("Creating '%s'", notes_path)
-        open(notes_path, "w+").close()
+        create_notes(document, notes_path)
 
     papis.api.edit_file(notes_path)
     if git:

--- a/papis/config.py
+++ b/papis/config.py
@@ -48,6 +48,7 @@ general_settings = {
                         or os.environ.get('VISUAL')
                         or get_default_opener(),
     "notes-name": "notes.tex",
+    "notes-template": "",
     "use-cache": True,
     "cache-dir": None,
     "use-git": False,


### PR DESCRIPTION
Added the ability to create a template for notes. The template is then formatted with the configured formater. This makes it easy to quickly edit new notes in a standardized way, which can be especially useful when writing notes in markdown, latex, ect. To use a template-file, one needs to specify the path to the template-file in the 'notes-template'-variable in the configuration. Templates are generated when editing notes of a reference for the first time (`papis edit -n`).

The following gives an example of a somewhat useful template-file for markdown, using the jinja2-formater:

```md
### <u>Notes</u>: {{ doc.get("title", "") }}

**Authors**: {{ doc.get( "author", "" ) }}

---

**Tags**:

**Files**:
{% for l in doc.get('files', []) %}
- [{{l}}]({{l}})
{%- endfor %}

---

```
which would look like this:
```md
### <u>Notes</u>: Title of paper

**Authors**: Author1, Author2

---

**Tags**:

**Files**:
- [file1.pdf](file1.pdf)
- [file2.pdf](file2.pdf)

---

```
