### PR TITLE
Template notes

### DIFF
--- a/doc/source/default-settings.rst
+++ b/doc/source/default-settings.rst
@@ -333,14 +333,17 @@ Bibtex options
 
     In ``papis edit`` you can edit notes about the document. ``notes-name``
     is the default name of the notes file, which by default is supposed
-    to be a TeX file.
+    to be a TeX file. The ``notes-name`` is formated by the ``formater``, so
+    that the filename of notes can be dynamically defined, e.g.:  ::
+    
+        notes-name = notes_{doc[title]:.15}.tex
 
 .. papis-config:: notes-template
 
-    In ``papis edit`` you can edit notes about the document. ``notes-template``
-    is the path to a template, that will be loaded and formated using the
-    ``formater``. This can be useful to enforce the same style in the notes
-    for all documents.
+    When editing notes for the first time, a preliminary note will be generated
+    based on a template. The path to this template is specified by
+    ``notes-template``. The template will then be formated by ``formater``.
+    This can be useful to enforce the same style in the notes for all documents.
 
     Default value is set to ``""``, which will return an empty notes file. If
     no file is found at the path to the template, then also an empty notes file

--- a/papis/commands/edit.py
+++ b/papis/commands/edit.py
@@ -75,7 +75,8 @@ def edit_notes(document: papis.document.Document,
     logger.debug("Editing notes")
 
     if not document.has("notes"):
-        document["notes"] = papis.config.getstring("notes-name")
+        notes_name = papis.config.getstring("notes-name")
+        document["notes"] = papis.format.format(notes_name, document)
         document.save()
     notes_path = os.path.join(
         str(document.get_main_folder()),

--- a/papis/commands/edit.py
+++ b/papis/commands/edit.py
@@ -24,6 +24,7 @@ import papis.database
 import papis.cli
 import papis.strings
 import papis.git
+import papis.format
 
 
 def run(document: papis.document.Document,


### PR DESCRIPTION
I thought it would be more consistent to use the formater on the ``notes-name`` as well. This could for example be useful if one would like to name the notes similar to the title of the reference. Static notes-names can of course still be used (at least with the default ``python``-formater or ``jinja``-formater).

Also, I added a little more documentation for ``notes-name`` and ``notes-template``.

Finally, I forgot to import ``papis.format`` and fixed it herewith. However, I must admit that I don't understand why calling ``papis.format.format()`` works in the first place, without importing ``papis.format``. Is ``papis.format`` imported globally?