### PR TITLE
added option to delete notes-file of a document

### DIFF
--- a/papis/commands/edit.py
+++ b/papis/commands/edit.py
@@ -74,10 +74,13 @@ def edit_notes(document: papis.document.Document,
     logger = logging.getLogger('edit:notes')
     logger.debug("Editing notes")
 
+    db = papis.database.get()
     if not document.has("notes"):
         notes_name = papis.config.getstring("notes-name")
         document["notes"] = papis.format.format(notes_name, document)
         document.save()
+        db.update(document)
+
     notes_path = os.path.join(
         str(document.get_main_folder()),
         document["notes"]

--- a/papis/commands/rm.py
+++ b/papis/commands/rm.py
@@ -50,7 +50,7 @@ def run(document: papis.document.Document,
             papis.git.remove(_doc_folder, notespath)
             papis.git.add(_doc_folder, document.get_info_file())
             papis.git.commit(_doc_folder,
-                             "Remove notes file '{}'".format(filepath))
+                             "Remove notes file '{}'".format(notespath))
 
     # if neither files nor notes were deleted -> delete whole document
     if not (filepath or notespath):


### PR DESCRIPTION
Similar to `papis rm --file`, I added the option `-n`/`--notes` to delete the notes-file. Thereby, the info file of the document is updated accordingly. Deleting the notes-file works also with the options `--all` and `--force`. Furthermore, it's also possible to use both options `--file` and `--notes` simultaneously.

Besides that, I discovered and fixed a bug that occurred, when creating new notes for a document. Before the fix, the database would not update the document after adding a new notes-file. Therefore, one had to run `papis --cc` after creating new notes. I didn't find any open issue about that.