### PR TITLE
adds jinja2 support for query string

### DIFF
--- a/papis/docmatcher.py
+++ b/papis/docmatcher.py
@@ -28,8 +28,21 @@ class DocMatcher(object):
     """
     search = ""  # type: str
     parsed_search = []  # type: List[Any]
-    doc_format = '{%s[DOC_KEY]}' % (papis.config.getstring('format-doc-name'))
     logger = logging.getLogger('DocMatcher')
+
+    formater = papis.config.getstring("formater")
+    if formater == "python":
+        doc_format = '{%s[DOC_KEY]}' % (
+            papis.config.getstring('format-doc-name'))
+
+    elif formater == "jinja2":
+        doc_format = '{{%s["DOC_KEY"]}}' % (
+            papis.config.getstring('format-doc-name'))
+
+    else:
+        doc_format = ''
+        logger.error(f"doc_format not implemented for {formater=}")
+
     matcher = None  # type: Optional[MATCHER_TYPE]
 
     @classmethod

--- a/papis/docmatcher.py
+++ b/papis/docmatcher.py
@@ -41,7 +41,7 @@ class DocMatcher(object):
 
     else:
         doc_format = ''
-        logger.error(f"doc_format not implemented for {formater=}")
+        logger.error("doc_format not implemented for formater='%s'", formater)
 
     matcher = None  # type: Optional[MATCHER_TYPE]
 


### PR DESCRIPTION
Up until now, it was not possible to use query-strings with the jinja2-formater in the papis-database (= cache-based database). This should fix the `DocMatcher` which is being used in the papis-database. Honestly, I think this issue should be fixed in a more elegant way, since it will not work with formaters other than `python` and `jinja2` ([since custom formaters can also be imported as plugins I think](https://papis.readthedocs.io/en/latest/configuration.html#config-settings-formater)). Maybe you can come up with a better idea :)

I haven't tested the whoosh-database yet and am not sure if this is there also a problem.