### PR TITLE
adds -p/--pick-subfolder option to `papis add`

### DIFF
--- a/papis/commands/add.py
+++ b/papis/commands/add.py
@@ -250,6 +250,7 @@ def run(paths: List[str],
         folder_name: Optional[str] = None,
         file_name: Optional[str] = None,
         subfolder: Optional[str] = None,
+        base_path: Optional[pathlib.Path] = None,
         confirm: bool = False,
         open_file: bool = False,
         edit: bool = False,
@@ -305,7 +306,8 @@ def run(paths: List[str],
 
     tmp_document = papis.document.Document(temp_dir)
 
-    base_path = pathlib.Path(papis.config.get_lib_dirs()[0]).expanduser()
+    if base_path is None:
+        base_path = pathlib.Path(papis.config.get_lib_dirs()[0]).expanduser()
     out_folder_path = base_path
 
     if subfolder:
@@ -450,6 +452,11 @@ def run(paths: List[str],
     help="Subfolder in the library",
     default=lambda: papis.config.getstring('add-subfolder'))
 @click.option(
+    "-p", "--pick-subfolder",
+    help="Pick from existing subfolders",
+    is_flag=True,
+    default=False)
+@click.option(
     "--folder-name",
     help="Name for the document's folder (papis format)",
     default=lambda: papis.config.getstring('add-folder-name'))
@@ -502,6 +509,7 @@ def cli(
         files: List[str],
         set_list: List[Tuple[str, str]],
         subfolder: str,
+        pick_subfolder: bool,
         folder_name: str,
         file_name: Optional[str],
         from_importer: List[Tuple[str, str]],
@@ -596,12 +604,17 @@ def cli(
         import time
         ctx.data['time-added'] = time.strftime(papis.strings.time_format)
 
+    base_path = pathlib.Path(
+        papis.pick.pick_subfolder_from_lib(papis.config.get_lib_name())[0]
+    ) if pick_subfolder else None
+
     return run(
         ctx.files,
         data=ctx.data,
         folder_name=folder_name,
         file_name=file_name,
         subfolder=subfolder,
+        base_path=base_path,
         confirm=confirm,
         open_file=open_file,
         edit=edit,

--- a/papis/pick.py
+++ b/papis/pick.py
@@ -7,6 +7,7 @@ from typing import Callable, TypeVar, Generic, Sequence, Type
 import papis.config
 import papis.document
 import papis.plugin
+import papis.api
 
 logger = logging.getLogger("pick")
 T = TypeVar("T")
@@ -80,3 +81,24 @@ def pick_doc(
     return pick(documents,
                 header_filter=header_filter,
                 match_filter=match_filter)
+
+
+def pick_subfolder_from_lib(lib: str) -> Sequence[str]:
+    """Pick a subfolder from all existings subfolders in library
+
+    Args:
+        lib (str): Library to search for subfolders
+
+    Returns:
+        Sequence[str]: Paths to subfolder
+    """
+    documents = papis.api.get_all_documents_in_lib(lib)
+
+    # find all folders containing documents
+    folders = [os.path.dirname(str(d.get_main_folder())) for d in documents]
+    folders.append(*papis.config.get_lib_dirs())
+
+    # remove duplicates and sort paths
+    folders = sorted([*set(folders)])
+
+    return pick(folders)


### PR DESCRIPTION
This pull-request adds the option `-p`/`--pick-subfolder` to the `papis add` command. When using this flag, then the configured picker is called to choose a parent-subfolder. This option can be used together with the `-d`/`--subfolder` flag, to create a new subfolder inside the picked subfolder.

The list of subfolders to pick from is defined by iterating over all documents in the library, setting the parent folder of each document as a subfolder. This leads to the problem of not finding empty subfolders (folders that do not containing any documents) in the library, though this might be also the expected/logical behavior?