### PR TITLE
Clean notes filename when using `update --set`

### DIFF
--- a/papis/commands/edit.py
+++ b/papis/commands/edit.py
@@ -77,7 +77,8 @@ def edit_notes(document: papis.document.Document,
     db = papis.database.get()
     if not document.has("notes"):
         notes_name = papis.config.getstring("notes-name")
-        document["notes"] = papis.format.format(notes_name, document)
+        notes_name = papis.format.format(notes_name, document)
+        document["notes"] = papis.utils.clean_document_name(notes_name)
         document.save()
         db.update(document)
 

--- a/papis/commands/update.py
+++ b/papis/commands/update.py
@@ -142,9 +142,16 @@ def cli(query: str,
 
         ctx.data.update(document)
         if set_tuples:
-            ctx.data.update(
-                {key: papis.format.format(value, document)
-                    for key, value in set_tuples})
+            processed_tuples = {}
+            for tuple in set_tuples:
+                key = tuple[0]
+                value = papis.format.format(tuple[1], document)
+                if key == "notes":
+                    value = papis.utils.clean_document_name(value)
+                    processed_tuples[key] = value
+                else:
+                    processed_tuples[key] = value
+            ctx.data.update(processed_tuples)
 
         matching_importers = []
         if not from_importer and auto:

--- a/papis/commands/update.py
+++ b/papis/commands/update.py
@@ -143,9 +143,8 @@ def cli(query: str,
         ctx.data.update(document)
         if set_tuples:
             processed_tuples = {}
-            for tuple in set_tuples:
-                key = tuple[0]
-                value = papis.format.format(tuple[1], document)
+            for key, value in set_tuples:
+                value = papis.format.format(value, document)
                 if key == "notes":
                     value = papis.utils.clean_document_name(value)
                     processed_tuples[key] = value


### PR DESCRIPTION
Currently, when using `papis update --set notes [notes-name]`, the notes-name gets formatted (enabling dynamic notes filenames), but it does not get cleaned. This is inconsistent with the behaviour of the `papis edit` command (as implemented [here](https://github.com/papis/papis/commit/de95c01606c32c420f532e1413d0f1d7a703cf12)). This PR makes the behaviour of the edit and update commands function the same when adding notes.

An additional advantage is that it allows me to implement my papis neovim plugin more easily (see the discussion [here](https://github.com/papis/papis/discussions/388#discussioncomment-3643124)).

My python and git knowledge is still a bit sketchy, so let me know if there's anything to improve.