### PR TITLE
docs: add papis.nvim plugin

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -195,6 +195,7 @@ project                                                    maintainer(s)
 `papis-rofi <https://github.com/papis/papis-rofi/>`__      `Etn40ff <https://github.com/Etn40ff>`__
 `papis-dmenu <https://github.com/papis/papis-dmenu>`__     YOU?
 `papis-vim <https://github.com/papis/papis-vim>`__         YOU?
+`papis.nvim <https://github.com/jghauser/papis.nvim>`__    `Julian Hauser <https://github.com/jghauser>`__
 `papis-emacs <https://github.com/papis/papis.el>`__        `alejandrogallo <https://alejandrogallo.github.io/>`__
 `papis-zotero <https://github.com/papis/papis-zotero>`__   `lennonhill <https://github.com/lennonhill>`__
 `papis-libgen <https://github.com/papis/papis-zotero>`__   YOU?


### PR DESCRIPTION
I've recently published the first iteration of a [neovim plugin for papis](https://github.com/jghauser/papis.nvim). While definitely still work-in-progress, it's probably quite a bit more advanced than the existing vim plugin and should be stable enough for most. I'm using it myself and am committed to further updating and improving it.