### PR TITLE
Fix LICENSE file rename in setup.py

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -22,7 +22,7 @@ else:
             "README.rst",
             "CHANGELOG.md",
             "AUTHORS",
-            "LICENSE.txt",
+            "LICENSE",
         ]),
 
         ("etc/bash_completion.d/", [


### PR DESCRIPTION
The `LICENSE.txt` was removed the other day.