### PR TITLE
Update readthedocs config to version 2

### DIFF
--- a/.readthedocs.yml
+++ b/.readthedocs.yml
@@ -1,5 +1,17 @@
+version: 2
+
+sphinx:
+  configuration: docs/source/conf.py
+
+build:
+  os: ubuntu-20.04
+  tools:
+    python: "3.10"
+
 python:
-  version: 3.5
-  pip_install: true
-  extra_requirements:
-    - develop
+  install:
+    - method: pip
+      path: .
+      extra_requirements:
+        - develop
+  system_packages: true


### PR DESCRIPTION
The documentation for the new config format is at
https://docs.readthedocs.io/en/stable/config-file/v2.html#python-install

As far as I can tell, this is correct, but I obviously can't test it :(
I haven't managed to get these configs right from the first try, so it's likely it'll need some fiddling after merging..