### PR TITLE
Pin flake8<6 until flake8-quotes is fixed

### DIFF
--- a/papis/commands/serve.py
+++ b/papis/commands/serve.py
@@ -642,7 +642,7 @@ class PapisRequestHandler(http.server.BaseHTTPRequestHandler):
         else:
             raise Exception("File {} does not exist".format(path))
 
-    def do_ROUTES(self,
+    def do_ROUTES(self,                     # noqa: N802
                   routes: List[Tuple[str, Any]]) -> None:
         try:
             for route, method in routes:
@@ -676,14 +676,14 @@ class PapisRequestHandler(http.server.BaseHTTPRequestHandler):
         back_url = self.headers.get("Referer", "/library")
         self.redirect(back_url)
 
-    def do_POST(self) -> None:
+    def do_POST(self) -> None:              # noqa: N802
         routes = [
             ("^/library/?([^/]+)?/document/ref:(.*)$",
                 self.update_page_document),
         ]
         self.do_ROUTES(routes)
 
-    def do_GET(self) -> None:
+    def do_GET(self) -> None:               # noqa: N802
         routes = [
             # html serving
             ("^/$",

--- a/tools/ci-install.sh
+++ b/tools/ci-install.sh
@@ -1,7 +1,7 @@
 #!/usr/bin/env bash
 
 python -m pip install --upgrade pip setuptools
-python -m pip install flake8 flake8-quotes flake8-bugbear
+python -m pip install 'flake8<6' flake8-quotes flake8-bugbear
 python -m pip install \
     "pep8-naming; python_version>='3.6'" \
     "pep8-naming<0.13.0; python_version<'3.6'"


### PR DESCRIPTION
Turns out `flake8-quotes` is incompatible with `flake8` v6, so this just pins it to older versions for now.

I'll go ahead and merge once the CI passes again.