### PR TITLE
CodeQL fixes

### DIFF
--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -22,30 +22,33 @@ class MockDownloader(Downloader):
 
 
 def create_random_pdf(suffix: str = "", prefix: str = "") -> str:
-    tempf = tempfile.mktemp(suffix=suffix, prefix=prefix)
-    with open(tempf, "wb+") as fd:
+    with tempfile.NamedTemporaryFile(suffix=suffix, prefix=prefix, delete=False) as fd:
         fd.write("%PDF-1.5%\n".encode())
-    return tempf
+
+    return fd.name
 
 
 def create_random_epub(suffix: str = "", prefix: str = "") -> str:
-    tempf = tempfile.mktemp(suffix=suffix, prefix=prefix)
-    buf = [0x50, 0x4B, 0x3, 0x4]
-    buf += [0x00 for i in range(26)]
-    buf += [0x6D, 0x69, 0x6D, 0x65, 0x74, 0x79, 0x70, 0x65, 0x61, 0x70,
-            0x70, 0x6C, 0x69, 0x63, 0x61, 0x74, 0x69, 0x6F, 0x6E, 0x2F,
-            0x65, 0x70, 0x75, 0x62, 0x2B, 0x7A, 0x69, 0x70]
-    buf += [0x00 for i in range(1)]
-    with open(tempf, "wb+") as fd:
+    buf = bytearray(
+        [0x50, 0x4B, 0x3, 0x4]
+        + [0x00 for i in range(26)]
+        + [0x6D, 0x69, 0x6D, 0x65, 0x74, 0x79, 0x70, 0x65, 0x61, 0x70,
+           0x70, 0x6C, 0x69, 0x63, 0x61, 0x74, 0x69, 0x6F, 0x6E, 0x2F,
+           0x65, 0x70, 0x75, 0x62, 0x2B, 0x7A, 0x69, 0x70]
+        + [0x00 for i in range(1)]
+        )
+
+    with tempfile.NamedTemporaryFile(suffix=suffix, prefix=prefix, delete=False) as fd:
         fd.write(bytearray(buf))
-    return tempf
+
+    return fd.name
 
 
 def create_random_file(suffix: str = "", prefix: str = "") -> str:
-    tempf = tempfile.mktemp(suffix=suffix, prefix=prefix)
-    with open(tempf, "wb+") as fd:
+    with tempfile.NamedTemporaryFile(suffix=suffix, prefix=prefix, delete=False) as fd:
         fd.write("hello".encode())
-    return tempf
+
+    return fd.name
 
 
 def create_real_document(

--- a/tests/commands/test_explore.py
+++ b/tests/commands/test_explore.py
@@ -5,6 +5,7 @@ import tempfile
 from papis.commands.explore import cli
 
 import tests
+import tests.cli
 
 
 class TestCli(tests.cli.TestCli):
@@ -28,14 +29,18 @@ class TestCli(tests.cli.TestCli):
         self.assertTrue(result.exit_code == 0)
 
     def test_export_bibtex(self):
-        path = tempfile.mktemp()
+        with tempfile.NamedTemporaryFile(delete=False) as f:
+            path = f.name
+
         result = self.invoke([
             "lib", "krishnamurti", "export", "--format", "bibtex", "-o", path
         ])
         self.assertTrue(result.exit_code == 0)
         self.assertTrue(os.path.exists(path))
+
         with open(path) as fd:
             bibtex = fd.read()
+
         expected_bibtex = (
             "@article{FreedomFromThJKri2009,",
             "  year = {2009},",
@@ -48,14 +53,18 @@ class TestCli(tests.cli.TestCli):
             self.assertTrue(chunk in bibtex.split("\n"))
 
     def test_export_yaml(self):
-        path = tempfile.mktemp()
+        with tempfile.NamedTemporaryFile(delete=False) as f:
+            path = f.name
+
         result = self.invoke([
             "lib", "krishnamurti", "export", "--format", "yaml", "-o", path
         ])
         self.assertTrue(result.exit_code == 0)
         self.assertTrue(os.path.exists(path))
+
         with open(path) as fd:
             yaml = fd.read()
+
         expected_yaml = (
             r"author: J. Krishnamurti",
             r"title: Freedom from the known",
@@ -65,13 +74,20 @@ class TestCli(tests.cli.TestCli):
         for ey in expected_yaml:
             self.assertTrue(re.findall(ey, yaml))
 
+        os.unlink(path)
+
     def test_citations_and_json(self):
-        path = tempfile.mktemp()
+        with tempfile.NamedTemporaryFile(delete=False) as f:
+            path = f.name
+
         result = self.invoke([
             "citations", "krishnamurti", "export", "--format", "json", "--out",
             path
         ])
         self.assertTrue(result.exit_code == 0)
+
         with open(path) as fd:
             yaml = fd.read()
+
         self.assertTrue(yaml == "[]")
+        os.unlink(path)

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -19,61 +19,71 @@ def test_default_opener():
 
 
 @pytest.mark.skipif(sys.platform != "linux", reason="uses linux paths")
-def test_get_config_home():
-    os.environ["XDG_CONFIG_HOME"] = "/tmp"
-    assert papis.config.get_config_home() == "/tmp"
-    del os.environ["XDG_CONFIG_HOME"]
-    assert re.match(r".+config", papis.config.get_config_home()) is not None
+def test_get_config_home(monkeypatch):
+    tmpdir = tempfile.gettempdir()
+
+    with monkeypatch.context() as m:
+        m.setenv("XDG_CONFIG_HOME", tmpdir)
+        assert papis.config.get_config_home() == tmpdir
+
+    with monkeypatch.context() as m:
+        m.delenv("XDG_CONFIG_HOME", raising=False)
+        assert re.match(r".+config", papis.config.get_config_home()) is not None
 
 
 @pytest.mark.skipif(sys.platform != "linux", reason="uses linux paths")
-def test_get_config_dirs():
-    tmpdir = "/tmp"
-    os.environ["XDG_CONFIG_HOME"] = tmpdir
-    if os.environ.get("XDG_CONFIG_DIRS") is not None:
-        del os.environ["XDG_CONFIG_DIRS"]
-    dirs = papis.config.get_config_dirs()
-    assert os.environ.get("XDG_CONFIG_DIRS") is None
-    assert len(dirs) == 2
-    assert os.path.join("/", "tmp", "papis") == dirs[0]
+def test_get_config_dirs(monkeypatch):
+    tmpdir = tempfile.gettempdir()
 
-    os.environ["XDG_CONFIG_DIRS"] = "/etc/:/usr/local/etc"
-    os.environ["XDG_CONFIG_HOME"] = "~"
-    dirs = papis.config.get_config_dirs()
-    assert len(dirs) == 4
-    assert os.path.abspath("/etc/papis") == os.path.abspath(dirs[0])
-    assert os.path.abspath("/usr/local/etc/papis") == os.path.abspath(dirs[1])
-    assert (os.path.abspath(os.path.expanduser("~/papis"))
-            == os.path.abspath(dirs[2]))
-    assert (os.path.abspath(os.path.expanduser("~/.papis"))
-            == os.path.abspath(dirs[3]))
+    with monkeypatch.context() as m:
+        m.setenv("XDG_CONFIG_HOME", tmpdir)
+        m.delenv("XDG_CONFIG_DIRS", raising=False)
+
+        dirs = papis.config.get_config_dirs()
+        assert os.environ.get("XDG_CONFIG_DIRS") is None
+        assert len(dirs) == 2
+        assert os.path.join("/", "tmp", "papis") == dirs[0]
+
+    with monkeypatch.context() as m:
+        m.setenv("XDG_CONFIG_DIRS", "/etc/:/usr/local/etc")
+        m.setenv("XDG_CONFIG_HOME", os.path.expanduser("~"))
+
+        dirs = papis.config.get_config_dirs()
+        assert len(dirs) == 4
+        assert os.path.abspath("/etc/papis") == os.path.abspath(dirs[0])
+        assert os.path.abspath("/usr/local/etc/papis") == os.path.abspath(dirs[1])
+        assert os.path.expanduser("~/papis") == os.path.abspath(dirs[2])
+        assert os.path.expanduser("~/.papis") == os.path.abspath(dirs[3])
 
 
 @pytest.mark.skipif(sys.platform != "linux", reason="uses linux paths")
-def test_get_config_folder():
+def test_get_config_folder(monkeypatch):
     with tempfile.TemporaryDirectory() as d:
-        os.environ["XDG_CONFIG_HOME"] = d
-        configpath = os.path.join(os.environ["XDG_CONFIG_HOME"], "papis")
-        if not os.path.exists(configpath):
-            os.mkdir(configpath)
-        assert papis.config.get_config_folder() == configpath
+        with monkeypatch.context() as m:
+            m.setenv("XDG_CONFIG_HOME", d)
+            configpath = os.path.join(os.environ["XDG_CONFIG_HOME"], "papis")
+            if not os.path.exists(configpath):
+                os.mkdir(configpath)
+            assert papis.config.get_config_folder() == configpath
 
 
 @pytest.mark.skipif(sys.platform != "linux", reason="uses linux paths")
-def test_get_config_file():
+def test_get_config_file(monkeypatch):
     with tempfile.TemporaryDirectory() as d:
-        os.environ["XDG_CONFIG_HOME"] = d
-        configpath = os.path.join(papis.config.get_config_folder(), "config")
-        assert configpath == papis.config.get_config_file()
+        with monkeypatch.context() as m:
+            m.setenv("XDG_CONFIG_HOME", d)
+            configpath = os.path.join(papis.config.get_config_folder(), "config")
+            assert configpath == papis.config.get_config_file()
 
 
 @pytest.mark.skipif(sys.platform != "linux", reason="uses linux paths")
-def test_get_configpy_file():
+def test_get_configpy_file(monkeypatch):
     with tempfile.TemporaryDirectory() as d:
-        os.environ["XDG_CONFIG_HOME"] = d
-        configpath = os.path.join(papis.config.get_config_folder(), "config.py")
-        assert configpath == papis.config.get_configpy_file()
-        assert os.environ["XDG_CONFIG_HOME"] in configpath
+        with monkeypatch.context() as m:
+            m.setenv("XDG_CONFIG_HOME", d)
+            configpath = os.path.join(papis.config.get_config_folder(), "config.py")
+            assert configpath == papis.config.get_configpy_file()
+            assert os.environ["XDG_CONFIG_HOME"] in configpath
 
 
 def test_set_config_file():

--- a/tests/test_document.py
+++ b/tests/test_document.py
@@ -19,25 +19,29 @@ from tests import create_random_file
 def test_new() -> None:
     nfiles = 10
     files = [create_random_file(suffix=".{}".format(i)) for i in range(nfiles)]
-    tmp = os.path.join(tempfile.mkdtemp(), "doc")
-    doc = new(tmp, {"author": "hello"}, files)
 
-    assert os.path.exists(doc.get_main_folder())
-    assert doc.get_main_folder() == tmp
-    assert len(doc["files"]) == nfiles
-    assert len(doc.get_files()) == nfiles
+    with tempfile.TemporaryDirectory() as d:
+        tmp = os.path.join(d, "doc")
+        doc = new(tmp, {"author": "hello"}, files)
 
-    for i in range(nfiles):
-        assert doc["files"][i].endswith(str(i))
-        assert not os.path.exists(doc["files"][i])
-        assert os.path.exists(doc.get_files()[i])
+        assert os.path.exists(doc.get_main_folder())
+        assert doc.get_main_folder() == tmp
+        assert len(doc["files"]) == nfiles
+        assert len(doc.get_files()) == nfiles
 
-    tmp = os.path.join(tempfile.mkdtemp(), "doc")
-    doc = new(tmp, {"author": "hello"}, [])
-    assert os.path.exists(doc.get_main_folder())
-    assert doc.get_main_folder() == tmp
-    assert len(doc["files"]) == 0
-    assert len(doc.get_files()) == 0
+        for i in range(nfiles):
+            assert doc["files"][i].endswith(str(i))
+            assert not os.path.exists(doc["files"][i])
+            assert os.path.exists(doc.get_files()[i])
+
+    with tempfile.TemporaryDirectory() as d:
+        tmp = os.path.join(d, "doc")
+        doc = new(tmp, {"author": "hello"}, [])
+
+        assert os.path.exists(doc.get_main_folder())
+        assert doc.get_main_folder() == tmp
+        assert len(doc["files"]) == 0
+        assert len(doc.get_files()) == 0
 
 
 def test_from_data() -> None:
@@ -133,11 +137,10 @@ def test_pickle() -> None:
         from_data({"title": "Hello World"}),
         from_data({"author": "Turing"}),
     ]
-    filepath = tempfile.mktemp()
-    with open(filepath, "wb+") as fd:
-        pickle.dump(docs, fd)
 
-    with open(filepath, "rb") as fd:
+    with tempfile.TemporaryFile() as fd:
+        pickle.dump(docs, fd)
+        fd.seek(0)
         gotdocs = pickle.load(fd)
 
     assert gotdocs[0]["title"] == docs[0]["title"]

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -29,9 +29,10 @@ def test_get_cache_home():
     assert get_cache_home() == os.path.abspath(
         os.path.expanduser(os.path.join("~/.cache", "papis")))
 
-    tmp = os.path.join(tempfile.mkdtemp(), "blah")
-    papis.config.set("cache-dir", tmp)
-    assert get_cache_home() == tmp
+    with tempfile.TemporaryDirectory() as d:
+        tmp = os.path.join(d, "blah")
+        papis.config.set("cache-dir", tmp)
+        assert get_cache_home() == tmp
 
 
 def test_create_identifier():
@@ -54,10 +55,10 @@ def test_create_identifier():
 
 @pytest.mark.skipif(sys.platform != "linux", reason="uses linux tools")
 def test_general_open_with_spaces():
-    filename = tempfile.mktemp("File with at least a couple of spaces")
-
-    with open(filename, "w+") as fd:
-        fd.write("Some content")
+    suffix = "File with at least a couple of spaces"
+    with tempfile.NamedTemporaryFile("w", suffix=suffix, delete=False) as f:
+        filename = f.name
+        f.write("Some content")
 
     assert os.path.exists(filename)
 
@@ -70,7 +71,9 @@ def test_general_open_with_spaces():
 
     with open(filename) as fd:
         content = fd.read()
-        assert content == "Sume cuntent"
+
+    assert content == "Sume cuntent"
+    os.unlink(filename)
 
 
 def test_locate_document():


### PR DESCRIPTION
This fixes two issues:
* do not use `tempfile.mktemp` (e.g. https://github.com/papis/papis/security/code-scanning/329) and use `tempfile.TemporaryFile` and friends in a context manager instead. This should also have the benefit of cleaning up the tests files after the test is run.
* use `pytest.monkeypatch` to change `os.environ` (see https://docs.pytest.org/en/7.1.x/how-to/monkeypatch.html)

The changes are just in the tests, so I'll merge when this passes :rocket: 