### PR TITLE
More CodeQL fixes

### DIFF
--- a/papis/arxiv.py
+++ b/papis/arxiv.py
@@ -232,7 +232,7 @@ def explorer(
 
 class Downloader(papis.downloaders.Downloader):
 
-    def __init__(self, url: str):
+    def __init__(self, url: str) -> None:
         super().__init__(uri=url, name="arxiv", expected_document_extension="pdf")
         self.arxivid = None  # type: Optional[str]
 
@@ -284,7 +284,7 @@ class Importer(papis.importer.Importer):
 
     """Importer accepting an arxiv id and downloading files and data"""
 
-    def __init__(self, uri: str):
+    def __init__(self, uri: str) -> None:
         papis.importer.Importer.__init__(self, name="arxiv", uri=uri)
         aid = find_arxivid_in_text(uri)
         self.downloader = Downloader("https://arxiv.org/abs/{}".format(aid))
@@ -307,7 +307,7 @@ class ArxividFromPdfImporter(papis.importer.Importer):
 
     """Importer parsing an arxivid from a pdf file"""
 
-    def __init__(self, uri: str):
+    def __init__(self, uri: str) -> None:
         papis.importer.Importer.__init__(self, name="pdf2arxivid", uri=uri)
         self.arxivid = None  # type: Optional[str]
 

--- a/papis/arxiv.py
+++ b/papis/arxiv.py
@@ -233,8 +233,7 @@ def explorer(
 class Downloader(papis.downloaders.Downloader):
 
     def __init__(self, url: str):
-        papis.downloaders.Downloader.__init__(self, uri=url, name="arxiv")
-        self.expected_document_extension = "pdf"
+        super().__init__(uri=url, name="arxiv", expected_document_extension="pdf")
         self.arxivid = None  # type: Optional[str]
 
     @classmethod

--- a/papis/bibtex.py
+++ b/papis/bibtex.py
@@ -59,7 +59,7 @@ class Importer(papis.importer.Importer):
 
     """Importer that parses a bibtex files"""
 
-    def __init__(self, **kwargs: Any):
+    def __init__(self, **kwargs: Any) -> None:
         papis.importer.Importer.__init__(self, name="bibtex", **kwargs)
 
     @classmethod

--- a/papis/commands/add.py
+++ b/papis/commands/add.py
@@ -116,7 +116,7 @@ class FromFolderImporter(papis.importer.Importer):
 
     """Importer that gets files and data from a valid papis folder"""
 
-    def __init__(self, **kwargs: Any):
+    def __init__(self, **kwargs: Any) -> None:
         papis.importer.Importer.__init__(self, name="folder", **kwargs)
 
     @classmethod
@@ -137,7 +137,7 @@ class FromLibImporter(papis.importer.Importer):
     and data
     """
 
-    def __init__(self, **kwargs: Any):
+    def __init__(self, **kwargs: Any) -> None:
         papis.importer.Importer.__init__(self, name="lib", **kwargs)
 
     @classmethod

--- a/papis/commands/add.py
+++ b/papis/commands/add.py
@@ -592,7 +592,7 @@ def cli(
         papis.pick.pick_subfolder_from_lib(papis.config.get_lib_name())[0]
     ) if pick_subfolder else None
 
-    return run(
+    run(
         ctx.files,
         data=ctx.data,
         folder_name=folder_name,

--- a/papis/commands/config.py
+++ b/papis/commands/config.py
@@ -47,12 +47,14 @@ def run(option_string: str) -> Optional[str]:
     logger = logging.getLogger("config:run")
 
     option = option_string.split(".")
+    key = section = None
     if len(option) == 1:
         key = option[0]
-        section = None
     elif len(option) == 2:
         section = option[0]
         key = option[1]
+    else:
+        raise ValueError("unrecognized option: {}".format(option_string))
 
     logger.debug("key = %s, sec = %s", key, section)
     val = papis.config.get(key, section=section)

--- a/papis/crossref.py
+++ b/papis/crossref.py
@@ -431,7 +431,7 @@ class FromCrossrefImporter(papis.importer.Importer):
 class Downloader(papis.downloaders.Downloader):
 
     def __init__(self, uri: str):
-        papis.downloaders.Downloader.__init__(self, uri=uri, name="doi")
+        super().__init__(uri=uri, name="doi")
 
     @classmethod
     def match(cls, uri: str) -> Optional[papis.downloaders.Downloader]:

--- a/papis/crossref.py
+++ b/papis/crossref.py
@@ -430,7 +430,7 @@ class FromCrossrefImporter(papis.importer.Importer):
 
 class Downloader(papis.downloaders.Downloader):
 
-    def __init__(self, uri: str):
+    def __init__(self, uri: str) -> None:
         super().__init__(uri=uri, name="doi")
 
     @classmethod

--- a/papis/database/base.py
+++ b/papis/database/base.py
@@ -15,7 +15,7 @@ class Database(ABC):
     """Abstract class for the database backends
     """
 
-    def __init__(self, library: Optional[papis.library.Library] = None):
+    def __init__(self, library: Optional[papis.library.Library] = None) -> None:
         self.lib = library or papis.config.get_lib()
         assert isinstance(self.lib, papis.library.Library)
 

--- a/papis/database/base.py
+++ b/papis/database/base.py
@@ -21,11 +21,11 @@ class Database(ABC):
 
     @abstractmethod
     def initialize(self) -> None:
-        ...
+        pass
 
     @abstractmethod
     def get_backend_name(self) -> str:
-        ...
+        pass
 
     def get_lib(self) -> str:
         """Get library name
@@ -51,33 +51,33 @@ class Database(ABC):
 
     @abstractmethod
     def clear(self) -> None:
-        ...
+        pass
 
     @abstractmethod
     def add(self, document: papis.document.Document) -> None:
-        ...
+        pass
 
     @abstractmethod
     def update(self, document: papis.document.Document) -> None:
-        ...
+        pass
 
     @abstractmethod
     def delete(self, document: papis.document.Document) -> None:
-        ...
+        pass
 
     @abstractmethod
     def query(self, query_string: str) -> List[papis.document.Document]:
-        ...
+        pass
 
     @abstractmethod
     def query_dict(
             self, query: Dict[str, str]) -> List[papis.document.Document]:
-        ...
+        pass
 
     @abstractmethod
     def get_all_documents(self) -> List[papis.document.Document]:
-        ...
+        pass
 
     @abstractmethod
     def get_all_query_string(self) -> str:
-        ...
+        pass

--- a/papis/database/cache.py
+++ b/papis/database/cache.py
@@ -140,7 +140,7 @@ def get_regex_from_search(search: str) -> str:
 
 class Database(papis.database.base.Database):
 
-    def __init__(self, library: Optional[papis.library.Library] = None):
+    def __init__(self, library: Optional[papis.library.Library] = None) -> None:
         papis.database.base.Database.__init__(self, library)
         self.logger = logging.getLogger("db:cache")
         self.documents = None  # type: Optional[List[papis.document.Document]]

--- a/papis/database/whoosh.py
+++ b/papis/database/whoosh.py
@@ -58,7 +58,7 @@ if TYPE_CHECKING:
 
 class Database(papis.database.base.Database):
 
-    def __init__(self, library: Optional[papis.library.Library] = None):
+    def __init__(self, library: Optional[papis.library.Library] = None) -> None:
         papis.database.base.Database.__init__(self, library)
         self.logger = logging.getLogger("db:whoosh")
         self.cache_dir = os.path.join(get_cache_home(), "database", "whoosh")

--- a/papis/document.py
+++ b/papis/document.py
@@ -136,7 +136,7 @@ class Document(Dict[str, Any]):
     _info_file_path = ""  # type: str
 
     def __init__(self, folder: Optional[str] = None,
-                 data: Optional[Dict[str, Any]] = None):
+                 data: Optional[Dict[str, Any]] = None) -> None:
         self._folder = None  # type: Optional[str]
 
         if folder is not None:

--- a/papis/downloaders/__init__.py
+++ b/papis/downloaders/__init__.py
@@ -283,8 +283,9 @@ class Downloader(papis.importer.Importer):
             "Retrieved kind of document seems to be '%s'",
             retrieved_kind.mime)
 
-        if not isinstance(self.expected_document_extension, list):
-            expected_document_extensions = [self.expected_document_extension]
+        expected_document_extensions = self.expected_document_extension
+        if not isinstance(expected_document_extensions, list):
+            expected_document_extensions = [expected_document_extensions]
 
         if retrieved_kind.extension in expected_document_extensions:
             return True

--- a/papis/downloaders/__init__.py
+++ b/papis/downloaders/__init__.py
@@ -2,7 +2,7 @@ import os
 import re
 import sys
 import logging
-from typing import List, Optional, Any, Sequence, Type, Dict, TYPE_CHECKING
+from typing import List, Optional, Any, Sequence, Type, Dict, Union, TYPE_CHECKING
 
 import papis.bibtex
 import papis.config
@@ -26,7 +26,7 @@ class Importer(papis.importer.Importer):
     """Importer that tries to get data and files from implemented downloaders
     """
 
-    def __init__(self, **kwargs: Any):
+    def __init__(self, **kwargs: Any) -> None:
         papis.importer.Importer.__init__(self, name="url", **kwargs)
 
     @classmethod
@@ -57,7 +57,7 @@ class Downloader(papis.importer.Importer):
                  uri: str = "",
                  name: str = "",
                  ctx: Optional[papis.importer.Context] = None,
-                 expected_document_extension: Optional[str] = None,
+                 expected_document_extension: Optional[Union[str, List[str]]] = None,
                  cookies: Optional[Dict[str, str]] = None,
                  priority: int = 1,
                  ) -> None:
@@ -283,9 +283,10 @@ class Downloader(papis.importer.Importer):
             "Retrieved kind of document seems to be '%s'",
             retrieved_kind.mime)
 
-        expected_document_extensions = self.expected_document_extension
-        if not isinstance(expected_document_extensions, list):
-            expected_document_extensions = [expected_document_extensions]
+        if isinstance(self.expected_document_extension, list):
+            expected_document_extensions = self.expected_document_extension
+        else:
+            expected_document_extensions = [self.expected_document_extension]
 
         if retrieved_kind.extension in expected_document_extensions:
             return True

--- a/papis/downloaders/__init__.py
+++ b/papis/downloaders/__init__.py
@@ -56,20 +56,26 @@ class Downloader(papis.importer.Importer):
     def __init__(self,
                  uri: str = "",
                  name: str = "",
-                 ctx: Optional[papis.importer.Context] = None):
+                 ctx: Optional[papis.importer.Context] = None,
+                 expected_document_extension: Optional[str] = None,
+                 cookies: Optional[Dict[str, str]] = None,
+                 priority: int = 1,
+                 ) -> None:
         if ctx is None:
             ctx = papis.importer.Context()
 
-        papis.importer.Importer.__init__(self,
-                                         uri=uri,
-                                         ctx=ctx,
-                                         name=name
-                                         or os.path.basename(__file__))
+        if cookies is None:
+            cookies = {}
+
+        super().__init__(
+            uri=uri,
+            ctx=ctx,
+            name=name or os.path.basename(__file__))
         self.logger = logging.getLogger("downloader:{}".format(self.name))
         self.logger.debug("uri '%s'", uri)
 
-        self.expected_document_extension = None  # type: Optional[str]
-        self.priority = 1  # type: int
+        self.expected_document_extension = expected_document_extension
+        self.priority = priority
         self._soup = None  # type: Optional[bs4.BeautifulSoup]
 
         self.bibtex_data = None  # type: Optional[str]
@@ -86,7 +92,7 @@ class Downloader(papis.importer.Importer):
                 "http": proxy,
                 "https": proxy,
             }
-        self.cookies = {}  # type: Dict[str, str]
+        self.cookies = cookies
 
     def fetch_data(self) -> None:
         """

--- a/papis/downloaders/acm.py
+++ b/papis/downloaders/acm.py
@@ -6,7 +6,7 @@ import papis.downloaders.base
 
 class Downloader(papis.downloaders.Downloader):
 
-    def __init__(self, url: str):
+    def __init__(self, url: str) -> None:
         super().__init__(
             url, "acm",
             expected_document_extension="pdf",

--- a/papis/downloaders/acm.py
+++ b/papis/downloaders/acm.py
@@ -7,10 +7,11 @@ import papis.downloaders.base
 class Downloader(papis.downloaders.Downloader):
 
     def __init__(self, url: str):
-        papis.downloaders.Downloader.__init__(
-            self, url, name="acm")
-        self.expected_document_extension = "pdf"
-        self.cookies = {"gdpr": "true"}
+        super().__init__(
+            url, "acm",
+            expected_document_extension="pdf",
+            cookies={"gdpr": "true"},
+            )
 
     @classmethod
     def match(cls, url: str) -> Optional[papis.downloaders.Downloader]:

--- a/papis/downloaders/acs.py
+++ b/papis/downloaders/acs.py
@@ -7,7 +7,7 @@ import papis.document
 
 class Downloader(papis.downloaders.Downloader):
 
-    def __init__(self, url: str):
+    def __init__(self, url: str) -> None:
         super().__init__(
             url, "acs",
             expected_document_extension="pdf",

--- a/papis/downloaders/acs.py
+++ b/papis/downloaders/acs.py
@@ -8,11 +8,12 @@ import papis.document
 class Downloader(papis.downloaders.Downloader):
 
     def __init__(self, url: str):
-        papis.downloaders.Downloader.__init__(self, url, name="acs")
-        self.expected_document_extension = "pdf"
-        # It seems to be necessary so that acs lets us download the bibtex
-        self.cookies = {"gdpr": "true"}
-        self.priority = 10
+        super().__init__(
+            url, "acs",
+            expected_document_extension="pdf",
+            cookies={"gdpr": "true"},
+            priority=10,
+            )
 
     @classmethod
     def match(cls, url: str) -> Optional[papis.downloaders.Downloader]:

--- a/papis/downloaders/annualreviews.py
+++ b/papis/downloaders/annualreviews.py
@@ -7,10 +7,11 @@ import papis.downloaders.base
 class Downloader(papis.downloaders.Downloader):
 
     def __init__(self, url: str):
-        papis.downloaders.Downloader.__init__(
-            self, url, name="annualreviews")
-        self.expected_document_extension = "pdf"
-        self.priority = 10
+        super().__init__(
+            url, "annualreviews",
+            expected_document_extension="pdf",
+            priority=10,
+            )
 
     @classmethod
     def match(cls, url: str) -> Optional[papis.downloaders.Downloader]:

--- a/papis/downloaders/annualreviews.py
+++ b/papis/downloaders/annualreviews.py
@@ -6,7 +6,7 @@ import papis.downloaders.base
 
 class Downloader(papis.downloaders.Downloader):
 
-    def __init__(self, url: str):
+    def __init__(self, url: str) -> None:
         super().__init__(
             url, "annualreviews",
             expected_document_extension="pdf",

--- a/papis/downloaders/aps.py
+++ b/papis/downloaders/aps.py
@@ -7,12 +7,11 @@ import papis.downloaders.fallback
 class Downloader(papis.downloaders.fallback.Downloader):
 
     def __init__(self, url: str):
-        papis.downloaders.fallback.Downloader.__init__(
-            self,
-            uri=url,
-            name="aps")
-        self.expected_document_extension = "pdf"
-        self.priority = 10
+        super.__init__(
+            url, "aps",
+            expected_document_extension="pdf",
+            priority=10,
+            )
 
     @classmethod
     def match(

--- a/papis/downloaders/aps.py
+++ b/papis/downloaders/aps.py
@@ -6,9 +6,9 @@ import papis.downloaders.fallback
 
 class Downloader(papis.downloaders.fallback.Downloader):
 
-    def __init__(self, url: str):
-        super.__init__(
-            url, "aps",
+    def __init__(self, url: str) -> None:
+        super().__init__(
+            url, name="aps",
             expected_document_extension="pdf",
             priority=10,
             )

--- a/papis/downloaders/citeseerx.py
+++ b/papis/downloaders/citeseerx.py
@@ -9,7 +9,7 @@ class Downloader(papis.downloaders.fallback.Downloader):
     BASE = "https://citeseerx.ist.psu.edu"
     jsessionid = "012341666D7AD1C5C931FC0CFBA34BFA"
 
-    def __init__(self, url: str):
+    def __init__(self, url: str) -> None:
         super().__init__(
             url, "citeseerx",
             expected_document_extension="pdf",

--- a/papis/downloaders/citeseerx.py
+++ b/papis/downloaders/citeseerx.py
@@ -10,11 +10,11 @@ class Downloader(papis.downloaders.fallback.Downloader):
     jsessionid = "012341666D7AD1C5C931FC0CFBA34BFA"
 
     def __init__(self, url: str):
-        papis.downloaders.fallback.Downloader.__init__(self,
-                                                       uri=url,
-                                                       name="citeseerx")
-        self.expected_document_extension = "pdf"
-        self.priority = 10
+        super().__init__(
+            url, "citeseerx",
+            expected_document_extension="pdf",
+            priority=10,
+            )
 
     @classmethod
     def match(cls,

--- a/papis/downloaders/fallback.py
+++ b/papis/downloaders/fallback.py
@@ -6,10 +6,15 @@ import papis.downloaders.base
 
 class Downloader(papis.downloaders.Downloader):
 
-    def __init__(self, uri: str, name: str = "fallback"):
-        papis.downloaders.Downloader.__init__(
-            self, uri=uri, name=name)
-        self.priority = -1
+    def __init__(self, uri: str, name: str = "fallback",
+                 expected_document_extension: Optional[str] = None,
+                 priority: int = -1,
+                 ):
+        super().__init__(
+            uri, name,
+            expected_document_extension=expected_document_extension,
+            priority=priority,
+            )
 
     @classmethod
     def match(cls, url: str) -> Optional[papis.downloaders.Downloader]:

--- a/papis/downloaders/fallback.py
+++ b/papis/downloaders/fallback.py
@@ -1,5 +1,5 @@
 import doi
-from typing import Dict, Any, Optional
+from typing import Dict, Any, Optional, List, Union
 
 import papis.downloaders.base
 
@@ -7,9 +7,9 @@ import papis.downloaders.base
 class Downloader(papis.downloaders.Downloader):
 
     def __init__(self, uri: str, name: str = "fallback",
-                 expected_document_extension: Optional[str] = None,
+                 expected_document_extension: Optional[Union[str, List[str]]] = None,
                  priority: int = -1,
-                 ):
+                 ) -> None:
         super().__init__(
             uri, name,
             expected_document_extension=expected_document_extension,

--- a/papis/downloaders/frontiersin.py
+++ b/papis/downloaders/frontiersin.py
@@ -7,10 +7,11 @@ import papis.downloaders.base
 class Downloader(papis.downloaders.Downloader):
 
     def __init__(self, url: str):
-        papis.downloaders.Downloader.__init__(
-            self, url, name="frontiersin")
-        self.expected_document_extension = "pdf"
-        self.cookies = {"gdpr": "true"}
+        super().__init__(
+            url, name="frontiersin",
+            expected_document_extension="pdf",
+            cookies={"gdpr": "true"},
+            )
 
     @classmethod
     def match(cls, url: str) -> Optional[papis.downloaders.Downloader]:

--- a/papis/downloaders/frontiersin.py
+++ b/papis/downloaders/frontiersin.py
@@ -6,7 +6,7 @@ import papis.downloaders.base
 
 class Downloader(papis.downloaders.Downloader):
 
-    def __init__(self, url: str):
+    def __init__(self, url: str) -> None:
         super().__init__(
             url, name="frontiersin",
             expected_document_extension="pdf",

--- a/papis/downloaders/get.py
+++ b/papis/downloaders/get.py
@@ -7,8 +7,7 @@ import papis.downloaders.base
 class Downloader(papis.downloaders.Downloader):
 
     def __init__(self, url: str):
-        papis.downloaders.Downloader.__init__(self, url, name="get")
-        self.priority = 0
+        super().__init__(url, name="get", priority=0)
 
     @classmethod
     def match(cls, url: str) -> Optional[papis.downloaders.Downloader]:

--- a/papis/downloaders/get.py
+++ b/papis/downloaders/get.py
@@ -6,7 +6,7 @@ import papis.downloaders.base
 
 class Downloader(papis.downloaders.Downloader):
 
-    def __init__(self, url: str):
+    def __init__(self, url: str) -> None:
         super().__init__(url, name="get", priority=0)
 
     @classmethod

--- a/papis/downloaders/hal.py
+++ b/papis/downloaders/hal.py
@@ -6,7 +6,7 @@ import papis.downloaders.fallback
 
 class Downloader(papis.downloaders.fallback.Downloader):
 
-    def __init__(self, url: str):
+    def __init__(self, url: str) -> None:
         super().__init__(
             url, name="hal",
             expected_document_extension="pdf",

--- a/papis/downloaders/hal.py
+++ b/papis/downloaders/hal.py
@@ -7,9 +7,11 @@ import papis.downloaders.fallback
 class Downloader(papis.downloaders.fallback.Downloader):
 
     def __init__(self, url: str):
-        papis.downloaders.fallback.Downloader.__init__(self, url, name="hal")
-        self.expected_document_extension = "pdf"
-        self.priority = 10
+        super().__init__(
+            url, name="hal",
+            expected_document_extension="pdf",
+            priority=10,
+            )
 
     @classmethod
     def match(

--- a/papis/downloaders/ieee.py
+++ b/papis/downloaders/ieee.py
@@ -6,7 +6,7 @@ import papis.downloaders.base
 
 class Downloader(papis.downloaders.Downloader):
 
-    def __init__(self, url: str):
+    def __init__(self, url: str) -> None:
         super().__init__(url, name="ieee", expected_document_extension="pdf")
 
     @classmethod

--- a/papis/downloaders/ieee.py
+++ b/papis/downloaders/ieee.py
@@ -7,8 +7,7 @@ import papis.downloaders.base
 class Downloader(papis.downloaders.Downloader):
 
     def __init__(self, url: str):
-        papis.downloaders.Downloader.__init__(self, url, name="ieee")
-        self.expected_document_extension = "pdf"
+        super().__init__(url, name="ieee", expected_document_extension="pdf")
 
     @classmethod
     def match(cls, url: str) -> Optional[papis.downloaders.Downloader]:

--- a/papis/downloaders/iopscience.py
+++ b/papis/downloaders/iopscience.py
@@ -7,11 +7,11 @@ import papis.downloaders.base
 class Downloader(papis.downloaders.Downloader):
 
     def __init__(self, url: str):
-        papis.downloaders.Downloader.__init__(self,
-                                              url,
-                                              name="iopscience")
-        self.expected_document_extension = "pdf"
-        self.priority = 10
+        super().__init__(
+            url, name="iopscience",
+            expected_document_extension="pdf",
+            priority=10,
+            )
 
     @classmethod
     def match(cls, url: str) -> Optional[papis.downloaders.Downloader]:

--- a/papis/downloaders/iopscience.py
+++ b/papis/downloaders/iopscience.py
@@ -6,7 +6,7 @@ import papis.downloaders.base
 
 class Downloader(papis.downloaders.Downloader):
 
-    def __init__(self, url: str):
+    def __init__(self, url: str) -> None:
         super().__init__(
             url, name="iopscience",
             expected_document_extension="pdf",

--- a/papis/downloaders/projecteuclid.py
+++ b/papis/downloaders/projecteuclid.py
@@ -8,10 +8,11 @@ class Downloader(papis.downloaders.fallback.Downloader):
     _BIBTEX_URL = "https://projecteuclid.org/citation/download/citation-{}.bib"
 
     def __init__(self, url: str) -> None:
-        super().__init__(uri=url, name="projecteuclid")
-
-        self.expected_document_extension = "pdf"
-        self.priority = 10
+        super().__init__(
+            uri=url, name="projecteuclid",
+            expected_document_extension="pdf",
+            priority=10,
+            )
 
     @classmethod
     def match(cls, url: str) -> Optional["Downloader"]:

--- a/papis/downloaders/sciencedirect.py
+++ b/papis/downloaders/sciencedirect.py
@@ -50,7 +50,7 @@ script_keyconv = [
 
 class Downloader(papis.downloaders.Downloader):
 
-    def __init__(self, url: str):
+    def __init__(self, url: str) -> None:
         super().__init__(
             url, name="sciencedirect",
             expected_document_extension="pdf",

--- a/papis/downloaders/sciencedirect.py
+++ b/papis/downloaders/sciencedirect.py
@@ -51,9 +51,10 @@ script_keyconv = [
 class Downloader(papis.downloaders.Downloader):
 
     def __init__(self, url: str):
-        papis.downloaders.Downloader.__init__(
-            self, url, name="sciencedirect")
-        self.expected_document_extension = "pdf"
+        super().__init__(
+            url, name="sciencedirect",
+            expected_document_extension="pdf",
+            )
 
     @classmethod
     def match(cls, url: str) -> Optional[papis.downloaders.Downloader]:

--- a/papis/downloaders/scitationaip.py
+++ b/papis/downloaders/scitationaip.py
@@ -6,7 +6,7 @@ import papis.downloaders.base
 
 class Downloader(papis.downloaders.Downloader):
 
-    def __init__(self, url: str):
+    def __init__(self, url: str) -> None:
         super().__init__(
             url, name="scitationaip",
             expected_document_extension="pdf",

--- a/papis/downloaders/scitationaip.py
+++ b/papis/downloaders/scitationaip.py
@@ -7,9 +7,10 @@ import papis.downloaders.base
 class Downloader(papis.downloaders.Downloader):
 
     def __init__(self, url: str):
-        papis.downloaders.Downloader.__init__(
-            self, url, name="scitationaip")
-        self.expected_document_extension = "pdf"
+        super().__init__(
+            url, name="scitationaip",
+            expected_document_extension="pdf",
+            )
 
     @classmethod
     def match(cls, url: str) -> Optional[papis.downloaders.Downloader]:

--- a/papis/downloaders/springer.py
+++ b/papis/downloaders/springer.py
@@ -7,7 +7,7 @@ import papis.document
 
 class Downloader(papis.downloaders.Downloader):
 
-    def __init__(self, url: str):
+    def __init__(self, url: str) -> None:
         super().__init__(
             url, name="springer",
             expected_document_extension="pdf",

--- a/papis/downloaders/springer.py
+++ b/papis/downloaders/springer.py
@@ -8,10 +8,11 @@ import papis.document
 class Downloader(papis.downloaders.Downloader):
 
     def __init__(self, url: str):
-        papis.downloaders.Downloader.__init__(
-            self, url, name="springer")
-        self.expected_document_extension = "pdf"
-        self.priority = 10
+        super().__init__(
+            url, name="springer",
+            expected_document_extension="pdf",
+            priority=10,
+            )
 
     @classmethod
     def match(cls, url: str) -> Optional[papis.downloaders.Downloader]:

--- a/papis/downloaders/tandfonline.py
+++ b/papis/downloaders/tandfonline.py
@@ -10,7 +10,7 @@ class Downloader(papis.downloaders.Downloader):
     re_comma = re.compile(r"(\s*,\s*)")
     re_add_dot = re.compile(r"(\b\w\b)")
 
-    def __init__(self, url: str):
+    def __init__(self, url: str) -> None:
         super().__init__(
             url, name="tandfonline",
             expected_document_extension="pdf",

--- a/papis/downloaders/tandfonline.py
+++ b/papis/downloaders/tandfonline.py
@@ -11,10 +11,11 @@ class Downloader(papis.downloaders.Downloader):
     re_add_dot = re.compile(r"(\b\w\b)")
 
     def __init__(self, url: str):
-        papis.downloaders.Downloader.__init__(
-            self, url, name="tandfonline")
-        self.expected_document_extension = "pdf"
-        self.priority = 10
+        super().__init__(
+            url, name="tandfonline",
+            expected_document_extension="pdf",
+            priority=10,
+            )
 
     @classmethod
     def match(cls, url: str) -> Optional[papis.downloaders.Downloader]:

--- a/papis/downloaders/thesesfr.py
+++ b/papis/downloaders/thesesfr.py
@@ -7,8 +7,7 @@ import papis.downloaders.base
 class Downloader(papis.downloaders.Downloader):
 
     def __init__(self, url: str):
-        papis.downloaders.Downloader.__init__(self, url, name="thesesfr")
-        self.expected_document_extension = "pdf"
+        super().__init__(url, name="thesesfr", expected_document_extension="pdf")
 
     @classmethod
     def match(cls, url: str) -> Optional[papis.downloaders.Downloader]:

--- a/papis/downloaders/thesesfr.py
+++ b/papis/downloaders/thesesfr.py
@@ -6,7 +6,7 @@ import papis.downloaders.base
 
 class Downloader(papis.downloaders.Downloader):
 
-    def __init__(self, url: str):
+    def __init__(self, url: str) -> None:
         super().__init__(url, name="thesesfr", expected_document_extension="pdf")
 
     @classmethod

--- a/papis/downloaders/worldscientific.py
+++ b/papis/downloaders/worldscientific.py
@@ -6,7 +6,7 @@ import papis.downloaders.base
 
 class Downloader(papis.downloaders.Downloader):
 
-    def __init__(self, url: str):
+    def __init__(self, url: str) -> None:
         super().__init__(
             url, "worldscientific",
             expected_document_extension="pdf",

--- a/papis/downloaders/worldscientific.py
+++ b/papis/downloaders/worldscientific.py
@@ -7,10 +7,11 @@ import papis.downloaders.base
 class Downloader(papis.downloaders.Downloader):
 
     def __init__(self, url: str):
-        papis.downloaders.Downloader.__init__(
-            self, url, name="worldscientific")
-        self.expected_document_extension = "pdf"
-        self.cookies = {"gdpr": "true"}
+        super().__init__(
+            url, "worldscientific",
+            expected_document_extension="pdf",
+            cookies={"gdpr": "true"},
+            )
 
     @classmethod
     def match(cls, url: str) -> Optional[papis.downloaders.Downloader]:

--- a/papis/fzf.py
+++ b/papis/fzf.py
@@ -24,7 +24,7 @@ class Command(ABC, Generic[T]):
 
     @abstractmethod
     def run(self, docs: Sequence[T]) -> Sequence[T]:
-        ...
+        pass
 
 
 class Choose(Command[T]):

--- a/papis/importer.py
+++ b/papis/importer.py
@@ -24,7 +24,7 @@ class Importer:
     """This is the base class for every importer"""
 
     def __init__(self, uri: str = "", name: str = "",
-                 ctx: Optional[Context] = None):
+                 ctx: Optional[Context] = None) -> None:
         """
         :param uri: uri
         :param name: Name of the importer

--- a/papis/json.py
+++ b/papis/json.py
@@ -28,7 +28,9 @@ def explorer(ctx: click.Context, jsonfile: str) -> None:
     logger.info("Reading in json file '%s'", jsonfile)
 
     import json
-    docs = [papis.document.from_data(d) for d in json.load(open(jsonfile))]
-    ctx.obj["documents"] += docs
+
+    with open(jsonfile) as f:
+        docs = [papis.document.from_data(d) for d in json.load(f)]
+        ctx.obj["documents"] += docs
 
     logger.info("%s documents found", len(docs))

--- a/papis/library.py
+++ b/papis/library.py
@@ -5,7 +5,7 @@ from typing import List
 
 class Library:
 
-    def __init__(self, name: str, paths: List[str]):
+    def __init__(self, name: str, paths: List[str]) -> None:
         """Create a Library object."""
         self.name = name
         self.paths = sum(

--- a/papis/pick.py
+++ b/papis/pick.py
@@ -24,7 +24,7 @@ class Picker(ABC, Generic[T]):
             match_filter: Callable[[T], str],
             default_index: int = 0
             ) -> Sequence[T]:
-        ...
+        pass
 
 
 def _extension_name() -> str:

--- a/papis/pubmed.py
+++ b/papis/pubmed.py
@@ -23,6 +23,14 @@ type_converter = {
 }   # type: Dict[str, str]
 
 
+def handle_pubmed_pages(pages: str) -> str:
+    # returned data is in the form 561-7 meaning 562-567
+    start, end = [x.strip() for x in pages.split("-")]
+    end = "{}{}".format(start[:max(0, len(start) - len(end))], end)
+
+    return "{}--{}".format(start, end)
+
+
 KeyConversionPair = papis.document.KeyConversionPair
 key_conversion = [
     KeyConversionPair("container-title", [{"key": "journal", "action": None}]),
@@ -33,7 +41,7 @@ key_conversion = [
     KeyConversionPair("ISSN", [{"key": "issn", "action": None}]),
     KeyConversionPair("DOI", [{"key": "doi", "action": None}]),
     KeyConversionPair("page", [
-        {"key": "pages", "action": lambda x: handle_pubmed_pages(x)}
+        {"key": "pages", "action": handle_pubmed_pages}
         ]),
     KeyConversionPair("type", [
         {"key": "type", "action": lambda x: type_converter.get(x, "misc")}
@@ -47,14 +55,6 @@ key_conversion = [
     KeyConversionPair("title", [papis.document.EmptyKeyConversion]),
     KeyConversionPair("publisher", [papis.document.EmptyKeyConversion]),
 ]   # type: List[KeyConversionPair]
-
-
-def handle_pubmed_pages(pages: str) -> str:
-    # returned data is in the form 561-7 meaning 562-567
-    start, end = [x.strip() for x in pages.split("-")]
-    end = "{}{}".format(start[:max(0, len(start) - len(end))], end)
-
-    return "{}--{}".format(start, end)
 
 
 def pubmed_data_to_papis_data(data: Dict[str, Any]) -> Dict[str, Any]:

--- a/papis/pubmed.py
+++ b/papis/pubmed.py
@@ -102,7 +102,7 @@ def get_data(query: str = "") -> Dict[str, Any]:
 class Importer(papis.importer.Importer):
     """Importer downloading data from a pubmed id"""
 
-    def __init__(self, uri: str = ""):
+    def __init__(self, uri: str = "") -> None:
         papis.importer.Importer.__init__(self, name="pubmed", uri=uri)
 
     @classmethod

--- a/papis/tui/app.py
+++ b/papis/tui/app.py
@@ -283,7 +283,7 @@ class Picker(Application, Generic[Option]):  # type: ignore
             options: Sequence[Option],
             default_index: int = 0,
             header_filter: Callable[[Option], str] = str,
-            match_filter: Callable[[Option], str] = str):
+            match_filter: Callable[[Option], str] = str) -> None:
 
         self.info_window = InfoWindow()
         self.help_window = HelpWindow()

--- a/papis/tui/app.py
+++ b/papis/tui/app.py
@@ -237,9 +237,6 @@ def get_commands(app: Application) -> Tuple[List[Command], KeyBindings]:
         event.app.layout.focus(app.help_window.window)
         event.app.message_toolbar.text = "Press q to quit"
 
-    # def _echo(cmd, *args) -> None:
-        # cmd.app.message_toolbar.text = ' '.join(args)
-
     @kb.add(keys_info["show_info_key"]["key"],  # type: ignore
             filter=~has_focus(app.info_window))
     def info(cmd: Command) -> None:

--- a/papis/tui/widgets/command_line_prompt.py
+++ b/papis/tui/widgets/command_line_prompt.py
@@ -35,7 +35,7 @@ class Command:
             self,
             name: str,
             run: Callable[["Command"], Any],
-            aliases: Optional[List[str]] = None):
+            aliases: Optional[List[str]] = None) -> None:
         if aliases is None:
             aliases = []
 
@@ -57,7 +57,7 @@ class CommandLinePrompt(ConditionalContainer):  # type: ignore
     A vim-like command line prompt widget.
     It's supposed to be instantiated only once.
     """
-    def __init__(self, commands: Optional[List[Command]] = None):
+    def __init__(self, commands: Optional[List[Command]] = None) -> None:
         if commands is None:
             commands = []
 

--- a/papis/tui/widgets/list.py
+++ b/papis/tui/widgets/list.py
@@ -49,7 +49,7 @@ class OptionsList(ConditionalContainer, Generic[Option]):  # type: ignore
             match_filter: Callable[[Option], str] = str,
             custom_filter: Optional[Callable[[str], bool]] = None,
             search_buffer: Optional[Buffer] = None,
-            cpu_count: Optional[int] = None):
+            cpu_count: Optional[int] = None) -> None:
         if search_buffer is None:
             search_buffer = Buffer(multiline=False)
 

--- a/tests/cli.py
+++ b/tests/cli.py
@@ -15,16 +15,15 @@ class TestCli(unittest.TestCase):
     def setUp(self):
         from click.testing import CliRunner
         self.runner = CliRunner()
-        self.assertTrue(
-            papis.config.get_lib_name() == tests.get_test_lib_name())
+        self.assertEqual(papis.config.get_lib_name(), tests.get_test_lib_name())
 
     def invoke(self, *args, **kwargs):
         return self.runner.invoke(self.cli, *args, **kwargs)
 
     def do_test_cli_function_exists(self):
-        self.assertTrue(self.cli is not None)
+        self.assertIsNot(self.cli, None)
 
     def do_test_help(self):
         for flag in ["-h", "--help"]:
             result = self.invoke([flag])
-            self.assertFalse(len(result.output) == 0)
+            self.assertNotEqual(len(result.output), 0)

--- a/tests/commands/test_add.py
+++ b/tests/commands/test_add.py
@@ -121,10 +121,10 @@ class TestRun(unittest.TestCase):
         )
         db = papis.database.get()
         docs = db.query_dict(dict(author="Evangelista"))
-        self.assertTrue(len(docs) == 1)
+        self.assertEqual(len(docs), 1)
         doc = docs[0]
-        self.assertTrue(doc is not None)
-        self.assertTrue(len(doc.get_files()) == 0)
+        self.assertIsNot(doc, None)
+        self.assertEqual(len(doc.get_files()), 0)
 
     def test_add_with_data(self):
         data = {
@@ -152,10 +152,10 @@ class TestRun(unittest.TestCase):
 
             db = papis.database.get()
             docs = db.query_dict(dict(author="Kutzelnigg, Werner"))
-            self.assertTrue(len(docs) == 1)
+            self.assertEqual(len(docs), 1)
             doc = docs[0]
-            self.assertTrue(doc is not None)
-            self.assertTrue(len(doc.get_files()) == number_of_files)
+            self.assertIsNot(doc, None)
+            self.assertEqual(len(doc.get_files()), number_of_files)
 
 
 class TestCli(tests.cli.TestCli):
@@ -172,11 +172,11 @@ class TestCli(tests.cli.TestCli):
             "-b",
             "--set", "title", "Principia"
         ])
-        self.assertTrue(result.exit_code == 0)
+        self.assertEqual(result.exit_code, 0)
         db = papis.database.get()
         docs = db.query_dict(dict(author="Bertrand Russell"))
-        self.assertTrue(len(docs) == 1)
-        self.assertTrue(len(docs[0].get_files()) == 0)
+        self.assertEqual(len(docs), 1)
+        self.assertEqual(len(docs[0].get_files()), 0)
 
     def test_link(self):
         pdf = create_random_pdf()
@@ -186,15 +186,15 @@ class TestCli(tests.cli.TestCli):
             "-b",
             "--link", pdf
         ])
-        self.assertTrue(result is not None)
-        # self.assertTrue(result.exit_code == 0)
+        self.assertIsNot(result, None)
+        # self.assertEqual(result.exit_code, 0)
 
         db = papis.database.get()
         docs = db.query_dict(dict(author="Plato"))
-        self.assertTrue(len(docs) == 1)
+        self.assertEqual(len(docs), 1)
 
         doc = docs[0]
-        self.assertTrue(len(doc.get_files()) == 1)
+        self.assertEqual(len(doc.get_files()), 1)
         self.assertTrue(os.path.islink(doc.get_files()[0]))
 
     @patch("papis.utils.open_file", lambda x: None)
@@ -211,13 +211,16 @@ class TestCli(tests.cli.TestCli):
             "-b",
             "--folder-name", "the_apology", pdf
         ])
-        self.assertTrue(result.exit_code == 0)
+        self.assertEqual(result.exit_code, 0)
+
         db = papis.database.get()
         docs = db.query_dict(dict(author="Aristoteles"))
-        self.assertTrue(len(docs) == 1)
+        self.assertEqual(len(docs), 1)
+
         doc = docs[0]
         assert os.path.basename(doc.get_main_folder()) == "the-apology"
         assert len(doc.get_files()) == 1
+
         gotpdf = doc.get_files()[0]
         assert len(re.split(r"[.]pdf", pdf)) == 2
         assert len(re.split(r"[.]pdf", gotpdf)) == 2
@@ -227,9 +230,9 @@ class TestCli(tests.cli.TestCli):
         ])
         # FIXME: this is not working I don't know why
         #        I get <Result UnsupportedOperation('fileno')>
-        # self.assertTrue(result.exit_code == 0)
+        # self.assertEqual(result.exit_code, 0)
         # docs = db.query_dict(dict(author="Aristoteles"))
-        # self.assertTrue(len(docs) == 2)
+        # self.assertEqual(len(docs), 2)
 
     @patch("papis.utils.open_file", lambda x: None)
     @patch("papis.tui.utils.confirm", lambda x: True)
@@ -252,10 +255,10 @@ class TestCli(tests.cli.TestCli):
             f.write(bibstring)
 
         pdf = create_random_pdf()
-        self.assertTrue(get_document_extension(pdf) == "pdf")
+        self.assertEqual(get_document_extension(pdf), "pdf")
 
         result = self.invoke([pdf, "--from", "bibtex", bibfile])
-        self.assertTrue(result is not None)
+        self.assertIsNot(result, None)
 
         db = papis.database.get()
         docs = db.query_dict(
@@ -264,14 +267,14 @@ class TestCli(tests.cli.TestCli):
                 title="Elektrodynamik bewegter"
             )
         )
-        self.assertTrue(len(docs) == 1)
+        self.assertEqual(len(docs), 1)
         doc = docs[0]
-        self.assertTrue(len(doc.get_files()) == 1)
+        self.assertEqual(len(doc.get_files()), 1)
         # This is the original pdf file, it should still be there
         self.assertTrue(os.path.exists(pdf))
-        # and it should still be a pdf
-        self.assertTrue(get_document_extension(pdf) == "pdf")
-        self.assertTrue(get_document_extension(doc.get_files()[0]) == "pdf")
+        # and it should still be apdf
+        self.assertEqual(get_document_extension(pdf), "pdf")
+        self.assertEqual(get_document_extension(doc.get_files()[0]), "pdf")
         os.unlink(bibfile)
 
     @patch("papis.utils.open_file", lambda x: None)
@@ -290,23 +293,23 @@ class TestCli(tests.cli.TestCli):
             f.write(yamlstring)
 
         epub = create_random_epub()
-        self.assertTrue(get_document_extension(epub) == "epub")
+        self.assertEqual(get_document_extension(epub), "epub")
 
         result = self.invoke([
             epub, "--from", "yaml", yamlfile
         ])
-        self.assertTrue(result is not None)
+        self.assertIsNot(result, None)
 
         db = papis.database.get()
         docs = db.query_dict({"author": "Tolkien"})
-        self.assertTrue(len(docs) == 1)
+        self.assertEqual(len(docs), 1)
         doc = docs[0]
-        self.assertTrue(len(doc.get_files()) == 1)
-        self.assertTrue(get_document_extension(doc.get_files()[0]) == "epub")
+        self.assertEqual(len(doc.get_files()), 1)
+        self.assertEqual(get_document_extension(doc.get_files()[0]), "epub")
         # This is the original epub file, it should still be there
         self.assertTrue(os.path.exists(epub))
         # and it should still be an epub
-        self.assertTrue(get_document_extension(epub) == "epub")
+        self.assertEqual(get_document_extension(epub), "epub")
         os.unlink(yamlfile)
 
     # @patch(
@@ -329,15 +332,15 @@ class TestCli(tests.cli.TestCli):
     #         "--from", "doi", "10.1112/plms/s2-42.1.0",
     #         "--confirm", "--open"
     #     ])
-    #     self.assertTrue(result.exit_code == 0)
+    #     self.assertEqual(result.exit_code, 0)
     #     db = papis.database.get()
     #     docs = db.query_dict({"author": "Kant"})
-    #     self.assertTrue(len(docs) == 1)
+    #     self.assertEqual(len(docs), 1)
     #     doc = docs[0]
     #     # one file at least was retrieved
-    #     self.assertTrue(len(doc.get_files()) == 1)
+    #     self.assertEqual(len(doc.get_files()), 1)
     #     # it has the pdf ending
-    #     self.assertTrue(len(re.split(".pdf", doc.get_files()[0])) == 2)
+    #     self.assertEqual(len(re.split(".pdf", doc.get_files()[0])), 2)
 
     @patch("papis.utils.open_file", lambda x: None)
     @patch("papis.tui.utils.confirm", lambda x: True)
@@ -353,4 +356,4 @@ class TestCli(tests.cli.TestCli):
         self.assertTrue(os.path.exists(newdoc.get_info_file()))
         result = self.invoke([
             "--confirm", "--from", "lib", newdoc.get_main_folder(), "--open"])
-        self.assertTrue(result.exit_code == 0)
+        self.assertEqual(result.exit_code, 0)

--- a/tests/commands/test_addto.py
+++ b/tests/commands/test_addto.py
@@ -13,7 +13,7 @@ class Test(unittest.TestCase):
     def test_simple_add(self):
         db = papis.database.get()
         docs = db.query_dict({"author": "krishnamurti"})
-        assert len(docs) == 1
+        self.assertEqual(len(docs), 1)
         doc = docs[0]
 
         # add N files
@@ -23,4 +23,4 @@ class Test(unittest.TestCase):
         old_files = doc.get_files()
 
         run(doc, inputfiles)
-        self.assertTrue(len(doc.get_files()) == len(old_files) + nfiles)
+        self.assertEqual(len(doc.get_files()), len(old_files) + nfiles)

--- a/tests/commands/test_browse.py
+++ b/tests/commands/test_browse.py
@@ -34,25 +34,25 @@ class TestCli(tests.cli.TestCli):
         tests.setup_test_library()
 
     def test_run_function_exists(self):
-        self.assertTrue(run is not None)
+        self.assertIsNot(run, None)
 
     @patch("papis.utils.general_open", lambda *x, **y: None)
     def test_key_doi(self):
         result = self.invoke([
             "krishnamurti", "-k", "doi"
         ])
-        self.assertTrue(result.exit_code == 0)
+        self.assertEqual(result.exit_code, 0)
 
     def test_no_documents(self):
         result = self.invoke(["__no_document__"])
-        self.assertTrue(result.exit_code == 0)
+        self.assertEqual(result.exit_code, 0)
 
     @patch("papis.utils.general_open", lambda *x, **y: None)
     def test_key_doi_all(self):
         result = self.invoke([
             "-k", "doi", "--all"
         ])
-        self.assertTrue(result.exit_code == 0)
+        self.assertEqual(result.exit_code, 0)
 
     @patch("papis.utils.general_open", lambda *x, **y: None)
     @patch("papis.pick.pick_doc", lambda x: [])
@@ -60,4 +60,4 @@ class TestCli(tests.cli.TestCli):
         result = self.invoke([
             "krishnamurti", "-k", "doi"
         ])
-        self.assertTrue(result.exit_code == 0)
+        self.assertEqual(result.exit_code, 0)

--- a/tests/commands/test_check.py
+++ b/tests/commands/test_check.py
@@ -18,25 +18,25 @@ class Test(unittest.TestCase):
     def test_simple(self):
         docs = self.get_docs()
         dds = run(["doi"], docs)
-        self.assertTrue(len(dds) == len(docs))
+        self.assertEqual(len(dds), len(docs))
 
     def test_dicts(self):
         docs = self.get_docs()
         dds = run(["doi"], docs)
-        self.assertTrue(len(dds[0].keys()) == 3)
-        self.assertTrue("msg" in dds[0].keys())
-        self.assertTrue("doc" in dds[0].keys())
-        self.assertTrue("key" in dds[0].keys())
+        self.assertEqual(len(dds[0].keys()), 3)
+        self.assertIn("msg", dds[0].keys())
+        self.assertIn("doc", dds[0].keys())
+        self.assertIn("key", dds[0].keys())
 
     def test_config(self):
         keys = papis.config.get("check-keys")
-        self.assertTrue(isinstance(keys, str))
-        self.assertTrue(keys is not None)
+        self.assertIsInstance(keys, str)
+        self.assertIsNot(keys, None)
         lkeys = eval(keys)
-        self.assertTrue(isinstance(lkeys, list))
+        self.assertIsInstance(lkeys, list)
 
     def test_files(self):
         docs = self.get_docs()
         dds = run(["files"], docs)
-        self.assertTrue(len(dds) == len(docs))
+        self.assertEqual(len(dds), len(docs))
 """

--- a/tests/commands/test_config.py
+++ b/tests/commands/test_config.py
@@ -10,12 +10,9 @@ logging.basicConfig(level=logging.DEBUG)
 class TestCommand(unittest.TestCase):
 
     def test_simple(self):
-        self.assertTrue(run("editor") == papis.config.get("editor"))
-        self.assertTrue(run("settings.editor") == papis.config.get("editor"))
-        self.assertTrue(
-            run("papers.dir")
-            == papis.config.get("dir", section="papers")
-        )
+        self.assertEqual(run("editor"), papis.config.get("editor"))
+        self.assertEqual(run("settings.editor"), papis.config.get("editor"))
+        self.assertEqual(run("papers.dir"), papis.config.get("dir", section="papers"))
 
 
 class TestDefaultConfiguration(unittest.TestCase):
@@ -36,9 +33,9 @@ class TestDefaultConfiguration(unittest.TestCase):
         settings = papis.config.get_default_settings()
         self.assertTrue(settings)
 
-        self.assertTrue(isinstance(settings, dict))
+        self.assertIsInstance(settings, dict)
         for section in ["settings"]:
-            self.assertTrue(section in settings.keys())
+            self.assertIn(section, settings.keys())
 
     def test_set_lib(self):
         try:

--- a/tests/commands/test_default.py
+++ b/tests/commands/test_default.py
@@ -14,10 +14,10 @@ class TestCli(tests.cli.TestCli):
         result = self.invoke([
             "--version"
         ])
-        self.assertTrue(result.exit_code == 0)
+        self.assertEqual(result.exit_code, 0)
 
     # def test_set(self):
     #     result = self.invoke([
     #         "--set", "something", "42"
     #     ])
-    #     self.assertTrue(result.exit_code == 0)
+    #     self.assertEqual(result.exit_code, 0)

--- a/tests/commands/test_edit.py
+++ b/tests/commands/test_edit.py
@@ -17,13 +17,13 @@ class TestRun(unittest.TestCase):
         return db.get_all_documents()
 
     def test_run_function_exists(self):
-        self.assertTrue(run is not None)
+        self.assertIsNot(run, None)
 
     def test_update(self):
         docs = self.get_docs()
         doc = docs[0]
         title = doc["title"] + "test_update"
-        self.assertTrue(title is not None)
+        self.assertIsNot(title, None)
 
         # mocking
         doc["title"] = title
@@ -33,8 +33,8 @@ class TestRun(unittest.TestCase):
         run(doc)
         db = papis.database.get()
         docs = db.query_dict(dict(title=title))
-        self.assertTrue(len(docs) == 1)
-        self.assertTrue(docs[0]["title"] == title)
+        self.assertEqual(len(docs), 1)
+        self.assertEqual(docs[0]["title"], title)
 
 
 class TestCli(tests.cli.TestCli):
@@ -49,20 +49,20 @@ class TestCli(tests.cli.TestCli):
         result = self.invoke([
             "krishnamurti"
         ])
-        self.assertTrue(result.exit_code == 0)
+        self.assertEqual(result.exit_code, 0)
 
     def test_doc_not_found(self):
         result = self.invoke([
             'this document it"s not going to be found'
         ])
-        self.assertTrue(result.exit_code == 0)
+        self.assertEqual(result.exit_code, 0)
 
     def test_all(self):
         result = self.invoke([
             "krishnamurti", "--all", "-e", "ls"
         ])
-        self.assertTrue(result.exit_code == 0)
-        self.assertTrue(papis.config.get("editor") == "ls")
+        self.assertEqual(result.exit_code, 0)
+        self.assertEqual(papis.config.get("editor"), "ls")
 
     def test_config(self):
         self.assertTrue(papis.config.get("notes-name"))
@@ -71,12 +71,12 @@ class TestCli(tests.cli.TestCli):
         result = self.invoke([
             "krishnamurti", "--all", "-e", "echo", "-n"
         ])
-        self.assertTrue(result.exit_code == 0)
-        self.assertTrue(papis.config.get("editor") == "echo")
+        self.assertEqual(result.exit_code, 0)
+        self.assertEqual(papis.config.get("editor"), "echo")
 
         db = papis.database.get()
         docs = db.query_dict(dict(author="Krishnamurti"))
-        self.assertTrue(len(docs) == 1)
+        self.assertEqual(len(docs), 1)
         doc = docs[0]
         notespath = os.path.join(
             doc.get_main_folder(),

--- a/tests/commands/test_explore.py
+++ b/tests/commands/test_explore.py
@@ -20,13 +20,13 @@ class TestCli(tests.cli.TestCli):
         result = self.invoke([
             "cmd", "ls"
         ])
-        self.assertTrue(result.exit_code == 0)
+        self.assertEqual(result.exit_code, 0)
 
     def test_lib(self):
         result = self.invoke([
             "lib", "krishnamurti"
         ])
-        self.assertTrue(result.exit_code == 0)
+        self.assertEqual(result.exit_code, 0)
 
     def test_export_bibtex(self):
         with tempfile.NamedTemporaryFile(delete=False) as f:
@@ -35,7 +35,7 @@ class TestCli(tests.cli.TestCli):
         result = self.invoke([
             "lib", "krishnamurti", "export", "--format", "bibtex", "-o", path
         ])
-        self.assertTrue(result.exit_code == 0)
+        self.assertEqual(result.exit_code, 0)
         self.assertTrue(os.path.exists(path))
 
         with open(path) as fd:
@@ -59,7 +59,7 @@ class TestCli(tests.cli.TestCli):
         result = self.invoke([
             "lib", "krishnamurti", "export", "--format", "yaml", "-o", path
         ])
-        self.assertTrue(result.exit_code == 0)
+        self.assertEqual(result.exit_code, 0)
         self.assertTrue(os.path.exists(path))
 
         with open(path) as fd:
@@ -84,10 +84,10 @@ class TestCli(tests.cli.TestCli):
             "citations", "krishnamurti", "export", "--format", "json", "--out",
             path
         ])
-        self.assertTrue(result.exit_code == 0)
+        self.assertEqual(result.exit_code, 0)
 
         with open(path) as fd:
             yaml = fd.read()
 
-        self.assertTrue(yaml == "[]")
+        self.assertEqual(yaml, "[]")
         os.unlink(path)

--- a/tests/commands/test_export.py
+++ b/tests/commands/test_export.py
@@ -33,21 +33,21 @@ class TestRun(unittest.TestCase):
     def test_bibtex(self):
         docs = self.get_docs()
         string = run(docs, to_format="bibtex")
-        self.assertTrue(len(string) > 0)
+        self.assertTrue(string)
         data = papis.bibtex.bibtex_to_dict(string)
-        self.assertTrue(len(data) > 0)
+        self.assertTrue(data)
 
     def test_json(self):
         docs = self.get_docs()
         string = run(docs, to_format="json")
-        self.assertTrue(len(string) > 0)
+        self.assertTrue(string)
         data = json.loads(string)
-        self.assertTrue(len(data) > 0)
+        self.assertTrue(data)
 
     def test_yaml(self):
         docs = self.get_docs()
         string = run(docs, to_format="yaml")
-        self.assertTrue(len(string) > 0)
+        self.assertTrue(string)
 
         with tempfile.NamedTemporaryFile("w+", delete=False) as fd:
             path = fd.name
@@ -56,8 +56,8 @@ class TestRun(unittest.TestCase):
         with open(path, "r") as fd:
             data = list(yaml.load_all(fd, Loader=Loader))
 
-        self.assertTrue(data is not None)
-        self.assertTrue(len(list(data)) > 0)
+        self.assertIsNot(data, None)
+        self.assertTrue(data)
         os.unlink(path)
 
 
@@ -73,11 +73,11 @@ class TestCli(tests.cli.TestCli):
         result = self.invoke([
             "krishnamurti", "--format", "json"
         ])
-        self.assertTrue(result.exit_code == 0)
+        self.assertEqual(result.exit_code, 0)
         data = json.loads(result.stdout_bytes.decode())
-        assert isinstance(data, list)
-        assert len(data) == 1
-        assert re.match(r".*Krishnamurti.*", data[0]["author"]) is not None
+        self.assertIsInstance(data, list)
+        self.assertEqual(len(data), 1)
+        self.assertIsNot(re.match(r".*Krishnamurti.*", data[0]["author"]), None)
 
         # output stdout
         with tempfile.NamedTemporaryFile(delete=False) as f:
@@ -86,22 +86,22 @@ class TestCli(tests.cli.TestCli):
         result = self.invoke([
             "Krishnamurti", "--format", "json", "--out", outfile
         ])
-        self.assertTrue(result.exit_code == 0)
+        self.assertEqual(result.exit_code, 0)
         self.assertTrue(os.path.exists(outfile))
 
         with open(outfile) as fd:
             data = json.load(fd)
 
-        assert isinstance(data, list)
-        assert len(data) == 1
-        assert re.match(r".*Krishnamurti.*", data[0]["author"]) is not None
+        self.assertIsInstance(data, list)
+        self.assertEqual(len(data), 1)
+        self.assertIsNot(re.match(r".*Krishnamurti.*", data[0]["author"]), None)
         os.unlink(outfile)
 
     def test_yaml(self):
         result = self.invoke([
             "krishnamurti", "--format", "yaml"
         ])
-        self.assertTrue(result.exit_code == 0)
+        self.assertEqual(result.exit_code, 0)
         data = yaml.safe_load(result.stdout_bytes)
         assert re.match(r".*Krishnamurti.*", data["author"]) is not None
 
@@ -111,14 +111,14 @@ class TestCli(tests.cli.TestCli):
         result = self.invoke([
             "Krishnamurti", "--format", "yaml", "--out", outfile
         ])
-        self.assertTrue(result.exit_code == 0)
+        self.assertEqual(result.exit_code, 0)
         self.assertTrue(os.path.exists(outfile))
 
         with open(outfile) as fd:
             data = yaml.safe_load(fd.read())
 
-        assert data is not None
-        assert re.match(r".*Krishnamurti.*", data["author"]) is not None
+        self.assertIsNot(data, None)
+        self.assertIsNot(re.match(r".*Krishnamurti.*", data["author"]), None)
         os.unlink(outfile)
 
     def test_folder(self):
@@ -128,12 +128,12 @@ class TestCli(tests.cli.TestCli):
             result = self.invoke(["krishnamurti", "--folder", "--out", outdir])
             self.assertTrue(os.path.exists(outdir))
             self.assertTrue(os.path.isdir(outdir))
-            self.assertTrue(result.exit_code == 0)
-            self.assertTrue(result.stdout_bytes == b"")
+            self.assertEqual(result.exit_code, 0)
+            self.assertEqual(result.stdout_bytes, b"")
 
             doc = papis.document.from_folder(outdir)
-            self.assertTrue(doc is not None)
-            assert re.match(r".*Krishnamurti.*", doc["author"]) is not None
+            self.assertIsNot(doc, None)
+            self.assertIsNot(re.match(r".*Krishnamurti.*", doc["author"]), None)
 
     def test_folder_all(self):
         with tempfile.TemporaryDirectory() as d:
@@ -142,15 +142,15 @@ class TestCli(tests.cli.TestCli):
             result = self.invoke(["--all", "--folder", "--out", outdir])
             self.assertTrue(os.path.exists(outdir))
             self.assertTrue(os.path.isdir(outdir))
-            self.assertTrue(result.exit_code == 0)
-            self.assertTrue(result.stdout_bytes == b"")
+            self.assertEqual(result.exit_code, 0)
+            self.assertEqual(result.stdout_bytes, b"")
 
             dirs = glob.glob(os.path.join(outdir, "*"))
-            self.assertTrue(len(dirs) > 1)
+            self.assertGreater(len(dirs), 1)
             for d in dirs:
                 self.assertTrue(os.path.exists(d))
                 self.assertTrue(os.path.isdir(d))
 
     def test_no_documents(self):
         result = self.invoke(["-f", "bibtex", "__no_document__"])
-        self.assertTrue(result.exit_code == 0)
+        self.assertEqual(result.exit_code, 0)

--- a/tests/commands/test_git.py
+++ b/tests/commands/test_git.py
@@ -15,4 +15,4 @@ class TestCli(tests.cli.TestCli):
         result = self.invoke([
             "init"
         ])
-        self.assertTrue(result.exit_code == 0)
+        self.assertEqual(result.exit_code, 0)

--- a/tests/commands/test_mv.py
+++ b/tests/commands/test_mv.py
@@ -26,7 +26,7 @@ class Test(unittest.TestCase):
         self.assertTrue(os.path.exists(new_dir))
         papis.commands.mv.run(document, new_dir)
         docs = papis.database.get().query_dict(dict(title=title))
-        self.assertTrue(len(docs) == 1)
+        self.assertEqual(len(docs), 1)
         self.assertEqual(os.path.dirname(docs[0].get_main_folder()), new_dir)
         self.assertEqual(
             docs[0].get_main_folder(),

--- a/tests/commands/test_open.py
+++ b/tests/commands/test_open.py
@@ -32,21 +32,22 @@ class TestCli(tests.cli.TestCli):
         result = self.invoke([
             "doc without files"
         ])
-        self.assertTrue(result.exit_code == 0)
+        self.assertEqual(result.exit_code, 0)
 
         result = self.invoke([
             "Krishnamurti",
             "--tool", "nonexistingcommand"
         ])
-        self.assertTrue(result.exit_code != 0)
+        self.assertNotEqual(result.exit_code, 0)
 
         result = self.invoke([
             "Krishnamurti",
             "--tool", "nonexistingcommand", "--folder"
         ])
-        self.assertTrue(result.exit_code != 0)
+        self.assertNotEqual(result.exit_code, 0)
 
         result = self.invoke([
             "Krishnamurti", "--mark", "--all", "--tool", "dir"
         ])
-        # self.assertTrue(result.exit_code == 0)
+        self.assertIsNot(result, None)
+        # self.assertEqual(result.exit_code, 0)

--- a/tests/commands/test_rename.py
+++ b/tests/commands/test_rename.py
@@ -24,6 +24,6 @@ class Test(unittest.TestCase):
         new_name = "Some title with spaces too"
         run(document, new_name)
         docs = papis.database.get().query_dict(dict(title=title))
-        self.assertTrue(len(docs) == 1)
+        self.assertEqual(len(docs), 1)
         self.assertEqual(docs[0].get_main_folder_name(), new_name)
         self.assertTrue(os.path.exists(docs[0].get_main_folder()))

--- a/tests/commands/test_rm.py
+++ b/tests/commands/test_rm.py
@@ -18,12 +18,12 @@ class Test(unittest.TestCase):
         db = papis.database.get()
         docs = db.get_all_documents()
         ndocs = len(docs)
-        self.assertTrue(ndocs > 0)
+        self.assertGreater(ndocs, 0)
         doc = docs[0]
         papis.commands.rm.run(doc)
         docs = db.get_all_documents()
         ndocs_after_delete = len(docs)
-        self.assertTrue(ndocs > ndocs_after_delete)
+        self.assertGreater(ndocs, ndocs_after_delete)
 
     def test_rm_documents_file(self):
         db = papis.database.get()
@@ -40,12 +40,12 @@ class Test(unittest.TestCase):
         doc.save()
 
         papis.commands.rm.run(doc, filepath=path)
-        self.assertTrue(not os.path.exists(path))
+        self.assertFalse(os.path.exists(path))
 
         doc = db.query_dict(dict(title=title))[0]
-        self.assertTrue(doc is not None)
-        self.assertTrue(doc["title"] == title)
-        self.assertTrue(len(doc.get_files()) == 0)
+        self.assertIsNot(doc, None)
+        self.assertEqual(doc["title"], title)
+        self.assertEqual(len(doc.get_files()), 0)
 
 
 class TestCli(tests.cli.TestCli):
@@ -54,17 +54,17 @@ class TestCli(tests.cli.TestCli):
 
     def test_1_no_documents(self):
         result = self.invoke(["__no_document__"])
-        self.assertTrue(result.exit_code == 0)
+        self.assertEqual(result.exit_code, 0)
 
     @patch("papis.pick.pick_doc", lambda x: [])
     def test_2_no_doc_picked(self):
         result = self.invoke(["turing"])
-        self.assertTrue(result.exit_code == 0)
+        self.assertEqual(result.exit_code, 0)
 
     def test_3_force(self):
         db = papis.database.get()
         result = self.invoke(["krishnamurti", "--force"])
-        self.assertTrue(result.exit_code == 0)
+        self.assertEqual(result.exit_code, 0)
         docs = db.query_dict(dict(author="krish"))
         self.assertFalse(docs)
 
@@ -74,9 +74,9 @@ class TestCli(tests.cli.TestCli):
     def test_4_confirm(self):
         db = papis.database.get()
         docs = db.query_dict(dict(author="popper"))
-        self.assertTrue(len(docs) == 1)
+        self.assertEqual(len(docs), 1)
         result = self.invoke(["popper"])
-        self.assertTrue(result.exit_code == 0)
+        self.assertEqual(result.exit_code, 0)
         docs = db.query_dict(dict(author="popper"))
         self.assertTrue(docs)
 
@@ -86,9 +86,9 @@ class TestCli(tests.cli.TestCli):
     def test_5_confirm_true(self):
         db = papis.database.get()
         docs = db.query_dict(dict(author="popper"))
-        self.assertTrue(len(docs) == 1)
+        self.assertEqual(len(docs), 1)
         result = self.invoke(["popper"])
-        self.assertTrue(result.exit_code == 0)
+        self.assertEqual(result.exit_code, 0)
         docs = db.query_dict(dict(author="popper"))
         self.assertFalse(docs)
 
@@ -98,17 +98,17 @@ class TestCli(tests.cli.TestCli):
     def test_7_confirm_file_nopick(self):
         db = papis.database.get()
         docs = db.query_dict(dict(author="turing"))
-        self.assertTrue(len(docs) == 1)
+        self.assertEqual(len(docs), 1)
         nfiles = len(docs[0].get_files())
-        self.assertTrue(nfiles > 0)
+        self.assertGreater(nfiles, 0)
 
         result = self.invoke(["turing", "--file"])
-        self.assertTrue(result.exit_code == 0)
+        self.assertEqual(result.exit_code, 0)
 
         docs = db.query_dict(dict(author="turing"))
-        self.assertTrue(len(docs) == 1)
+        self.assertEqual(len(docs), 1)
         nfiles_after = len(docs[0].get_files())
-        self.assertTrue(nfiles == nfiles_after)
+        self.assertEqual(nfiles, nfiles_after)
 
     @patch("papis.tui.utils.confirm", lambda *x, **y: False)
     @patch("papis.pick.pick_doc", lambda x: [x[0]] if x else [])
@@ -116,17 +116,17 @@ class TestCli(tests.cli.TestCli):
     def test_6_confirm_file(self):
         db = papis.database.get()
         docs = db.query_dict(dict(author="turing"))
-        self.assertTrue(len(docs) == 1)
+        self.assertEqual(len(docs), 1)
         nfiles = len(docs[0].get_files())
-        self.assertTrue(nfiles > 0)
+        self.assertGreater(nfiles, 0)
 
         result = self.invoke(["turing", "--file"])
-        self.assertTrue(result.exit_code == 0)
+        self.assertEqual(result.exit_code, 0)
 
         docs = db.query_dict(dict(author="turing"))
-        self.assertTrue(len(docs) == 1)
+        self.assertEqual(len(docs), 1)
         nfiles_after = len(docs[0].get_files())
-        self.assertTrue(nfiles == nfiles_after)
+        self.assertEqual(nfiles, nfiles_after)
 
     @patch("papis.tui.utils.confirm", lambda *x, **y: True)
     @patch("papis.pick.pick_doc", lambda x: [x[0]] if x else [])
@@ -134,25 +134,25 @@ class TestCli(tests.cli.TestCli):
     def test_confirm_true_file(self):
         db = papis.database.get()
         docs = db.query_dict(dict(author="turing"))
-        self.assertTrue(len(docs) == 1)
+        self.assertEqual(len(docs), 1)
         nfiles = len(docs[0].get_files())
-        self.assertTrue(nfiles > 0)
+        self.assertGreater(nfiles, 0)
 
         result = self.invoke(["turing", "--file"])
-        self.assertTrue(result.exit_code == 0)
+        self.assertEqual(result.exit_code, 0)
 
         docs = db.query_dict(dict(author="turing"))
-        self.assertTrue(len(docs) == 1)
+        self.assertEqual(len(docs), 1)
         nfiles_after = len(docs[0].get_files())
-        self.assertTrue(nfiles == nfiles_after + 1)
+        self.assertEqual(nfiles, nfiles_after + 1)
 
     def test_rm_all(self):
         db = papis.database.get()
         docs = db.query_dict(dict(author="test_author"))
-        self.assertTrue(len(docs) == 2)
+        self.assertEqual(len(docs), 2)
 
         result = self.invoke(["test_author", "--all", "--force"])
-        self.assertTrue(result.exit_code == 0)
+        self.assertEqual(result.exit_code, 0)
 
         docs = db.query_dict(dict(author="test_author"))
-        self.assertTrue(len(docs) == 0)
+        self.assertEqual(len(docs), 0)

--- a/tests/commands/test_rm.py
+++ b/tests/commands/test_rm.py
@@ -33,7 +33,8 @@ class Test(unittest.TestCase):
         filename = "test.txt"
         path = os.path.join(doc.get_main_folder(), filename)
 
-        open(path, "w+").close()
+        with open(path, "w+"):
+            pass
         self.assertTrue(os.path.exists(path))
 
         doc["files"] = [filename]

--- a/tests/commands/test_update.py
+++ b/tests/commands/test_update.py
@@ -47,7 +47,7 @@ class TestCli(tests.cli.TestCli):
 
     def test_1_no_documents(self):
         result = self.invoke(["__no_document__"])
-        self.assertTrue(result.exit_code == 0)
+        self.assertEqual(result.exit_code, 0)
 
     def test_1_main(self):
         self.do_test_cli_function_exists()
@@ -60,7 +60,7 @@ class TestCli(tests.cli.TestCli):
             "-s", "isbn", "92130123",
             "--set", "doi", "10.213.phys.rev/213",
         ])
-        self.assertTrue(result.exit_code == 0)
+        self.assertEqual(result.exit_code, 0)
         docs = db.query_dict(dict(author="krishnamurti"))
         self.assertTrue(docs)
         self.assertEqual(docs[0]["doi"], "10.213.phys.rev/213")
@@ -73,21 +73,21 @@ class TestCli(tests.cli.TestCli):
             "-s", "doi", "",
             "--set", "isbn", "",
         ])
-        self.assertTrue(result is not None)
-        # self.assertTrue(result.exit_code == 0)
+        self.assertIsNot(result, None)
+        # self.assertEqual(result.exit_code, 0)
 
         docs = db.query_dict(dict(author="krishnamurti"))
-        self.assertTrue(len(docs) == 1)
+        self.assertEqual(len(docs), 1)
         self.assertTrue(docs[0].has("doi"))
         self.assertTrue(docs[0].has("isbn"))
-        self.assertTrue(not docs[0].get("doi"))
-        self.assertTrue(not docs[0].get("isbn"))
+        self.assertFalse(docs[0].get("doi"))
+        self.assertFalse(docs[0].get("isbn"))
 
     # def test_8_yaml(self):
     #     yamlpath = _get_resource_file("russell.yaml")
     #     result = self.invoke([
     #         "krishnamurti", "--from", "yaml", yamlpath])
-    #     self.assertTrue(result is not None)
+    #     self.assertIsNot(result, None)
 
     #     db = papis.database.get()
     #     docs = db.query_dict(dict(author="krishnamurti"))
@@ -98,7 +98,7 @@ class TestCli(tests.cli.TestCli):
     #     db = papis.database.get()
     #     bibpath = _get_resource_file("wannier.bib")
     #     result = self.invoke(["krishnamurti", "--from", "bibtex", bibpath])
-    #     self.assertTrue(result.exit_code == 0)
+    #     self.assertEqual(result.exit_code, 0)
     #     docs = db.query_dict(dict(author="krishnamurti"))
     #     self.assertTrue(docs)
     #     self.assertTrue(re.match(r".*Krishnamurti.*", docs[0]["author"]))
@@ -108,4 +108,4 @@ class TestCli(tests.cli.TestCli):
     #     result = self.invoke([
     #         "krishnamurti", "--from", "bibtex", yamlpath
     #     ])
-    #     self.assertTrue(result.exit_code == 0)
+    #     self.assertEqual(result.exit_code, 0)

--- a/tests/database/__init__.py
+++ b/tests/database/__init__.py
@@ -29,31 +29,29 @@ class DatabaseTest(unittest.TestCase):
 
     def test_get_lib(self):
         database = papis.database.get()
-        self.assertTrue(database.get_lib() == papis.config.get_lib_name())
+        self.assertEqual(database.get_lib(), papis.config.get_lib_name())
 
     def test_get_dir(self):
         database = papis.database.get()
-        self.assertTrue(
-            database.get_dirs() == papis.config.get_lib_dirs()
-        )
+        self.assertEqual(database.get_dirs(), papis.config.get_lib_dirs())
 
     def test_check_database(self):
         database = papis.database.get()
-        self.assertTrue(database is not None)
-        self.assertTrue(database.get_lib() == tests.get_test_lib_name())
+        self.assertIsNot(database, None)
+        self.assertEqual(database.get_lib(), tests.get_test_lib_name())
 
     def test_update(self):
         database = papis.database.get()
         doc = database.get_all_documents()[0]
-        self.assertTrue(doc is not None)
+        self.assertIsNot(doc, None)
         doc["title"] = "test_update test"
         doc.save()
         database.update(doc)
         docs = database.query_dict({"title": "test_update test"})
-        self.assertTrue(len(docs) == 1)
+        self.assertEqual(len(docs), 1)
         doc = docs[0]
-        self.assertTrue(doc is not None)
-        self.assertTrue(doc["title"] == "test_update test")
+        self.assertIsNot(doc, None)
+        self.assertEqual(doc["title"], "test_update test")
 
     def test_query_dict(self):
         database = papis.database.get()
@@ -64,20 +62,20 @@ class DatabaseTest(unittest.TestCase):
         docs = database.query_dict(
             {"title": doc["title"], "author": doc["author"]}
         )
-        self.assertTrue(len(docs) == 1)
+        self.assertEqual(len(docs), 1)
 
     def test_delete(self):
         database = papis.database.get()
         docs = database.get_all_documents()
 
         ndocs = len(docs)
-        self.assertTrue(ndocs > 1)
+        self.assertGreater(ndocs, 1)
 
         database.delete(docs[0])
         docs = database.get_all_documents()
 
         ndocs_after_delete = len(docs)
-        self.assertTrue(ndocs - ndocs_after_delete == 1)
+        self.assertEqual(ndocs - ndocs_after_delete, 1)
 
     def test_initialize(self):
         # trying to initialize again should do nothing
@@ -86,7 +84,7 @@ class DatabaseTest(unittest.TestCase):
     def test_get_all_documents(self):
         database = papis.database.get()
         docs = database.get_all_documents()
-        self.assertTrue(len(docs) > 0)
+        self.assertGreater(len(docs), 0)
 
     def test_add(self):
         database = papis.database.get()
@@ -125,7 +123,7 @@ class DatabaseTest(unittest.TestCase):
         )
 
     def test_backend_name(self):
-        self.assertTrue(papis.database.get().get_backend_name() is not None)
+        self.assertIsNot(papis.database.get().get_backend_name(), None)
 
     def test_backend(self):
         self.assertEqual(

--- a/tests/database/test_papis.py
+++ b/tests/database/test_papis.py
@@ -15,12 +15,12 @@ class Test(tests.database.DatabaseTest):
         tests.database.DatabaseTest.setUpClass()
 
     def test_backend_name(self):
-        self.assertTrue(papis.config.get("database-backend") == "papis")
+        self.assertEqual(papis.config.get("database-backend"), "papis")
 
     def test_query(self):
         database = papis.database.get()
         docs = database.query(".")
-        self.assertTrue(len(docs) > 0)
+        self.assertGreater(len(docs), 0)
 
     def test_cache_path(self):
         database = papis.database.get()

--- a/tests/database/test_whoosh.py
+++ b/tests/database/test_whoosh.py
@@ -12,11 +12,11 @@ class Test(tests.database.DatabaseTest):
         tests.database.DatabaseTest.setUpClass()
 
     def test_backend_name(self):
-        self.assertTrue(papis.config.get("database-backend") == "whoosh")
+        self.assertEqual(papis.config.get("database-backend"), "whoosh")
 
     def test_query(self):
         # The database is existing right now, which means that the
         # test library is in place and therefore we have some documents
         database = papis.database.get()
         docs = database.query("*")
-        self.assertTrue(len(docs) > 0)
+        self.assertGreater(len(docs), 0)


### PR DESCRIPTION
Some more reported issues:
* inexact asserts from `unittest`, e.g. https://github.com/papis/papis/security/code-scanning/504
* overwriting attributes in `Downloader` subclasses, e.g. https://github.com/papis/papis/security/code-scanning/463
* some other misc fixes here and there

