### PR TITLE
Fix click command heading

### DIFF
--- a/doc/source/commands/add.rst
+++ b/doc/source/commands/add.rst
@@ -1,4 +1,5 @@
 Add
 ---
+
 .. automodule:: papis.commands.add
 

--- a/doc/source/conf.py
+++ b/doc/source/conf.py
@@ -1,8 +1,3 @@
-# -*- coding: utf-8 -*-
-#
-# papis documentation build configuration file, created by
-# sphinx-quickstart on Fri May 12 00:56:29 2017.
-#
 # This file is execfile()d with the current directory set to its
 # containing dir.
 #
@@ -12,23 +7,17 @@
 # All configuration values have a default; values that are commented out
 # serve to show the default.
 
-import re
-import sys
 import os
-
-# Find the directory with papis installed
-sys.path.append(
-    os.path.join(
-        os.path.dirname(__file__),
-        "..", ".."
-    )
-)
+import sys
 import papis
+import docutils
+
+from docutils.parsers.rst import Directive
 
 # If extensions (or modules to document with autodoc) are in another directory,
 # add these directories to sys.path here. If the directory is relative to the
 # documentation root, use os.path.abspath to make it absolute, like shown here.
-# sys.path.insert(0, os.path.abspath('.'))
+sys.path.append(os.path.join(os.path.dirname(__file__), "..", ".."))
 
 # -- General configuration ------------------------------------------------
 
@@ -39,30 +28,23 @@ import papis
 # extensions coming with Sphinx (named 'sphinx.ext.*') or your custom
 # ones.
 extensions = [
-    'sphinx.ext.autodoc',
-    'sphinx.ext.doctest',
-    'sphinx.ext.todo',
-    'sphinx.ext.coverage',
-    'sphinx.ext.ifconfig',
-    'sphinx.ext.viewcode',
-    'sphinx.ext.intersphinx',
-    'sphinx.ext.inheritance_diagram',
-    'sphinx_click.ext',
+    "sphinx.ext.autodoc",
+    "sphinx.ext.doctest",
+    "sphinx.ext.todo",
+    "sphinx.ext.coverage",
+    "sphinx.ext.ifconfig",
+    "sphinx.ext.viewcode",
+    "sphinx.ext.intersphinx",
+    "sphinx.ext.inheritance_diagram",
+    "sphinx_click.ext",
 ]
 
 intersphinx_mapping = {
     "https://docs.python.org/3/": None,
 }
 
-# Exec directive {{{ #
 
-try:
-    from StringIO import StringIO
-except ImportError:
-    from io import StringIO
-
-from docutils.parsers.rst import Directive
-import docutils
+# Exec directive {{{
 
 class ExecDirective(Directive):
     """Execute the specified python code and insert the output into the
@@ -70,10 +52,10 @@ class ExecDirective(Directive):
     has_content = True
 
     def run(self):
-        oldStdout, sys.stdout = sys.stdout, StringIO()
+        stdout_old, sys.stdout = sys.stdout, StringIO()
 
         tab_width = self.options.get(
-            'tab-width',
+            "tab-width",
             self.state.document.settings.tab_width
         )
         source = self.state_machine.input_lines.source(
@@ -81,7 +63,7 @@ class ExecDirective(Directive):
         )
 
         try:
-            exec('\n'.join(self.content))
+            exec("\n".join(self.content))
             text = sys.stdout.getvalue()
             lines = docutils.statemachine.string2lines(
                 text,
@@ -95,33 +77,33 @@ class ExecDirective(Directive):
                 docutils.nodes.error(
                     None,
                     docutils.nodes.paragraph(
-                        text = "Unable to execute python code at %s:%d:" % (
+                        text="Unable to execute python code at {}:{}:".format(
                             os.path.basename.basename(source), self.lineno
                         )
                     ),
-                    docutils.nodes.paragraph(text = str(sys.exc_info()[1]))
+                    docutils.nodes.paragraph(text=str(sys.exc_info()[1]))
                 )
             ]
         finally:
-            sys.stdout = oldStdout
+            sys.stdout = stdout_old
+
 
 class PapisConfig(Directive):
     has_content = True
     optional_arguments = 3
     required_arguments = 1
-    option_spec = dict(default=str, section=str, description=str)
+    option_spec = {"default": str, "section": str, "description": str}
     add_index = True
+
     def run(self):
         import papis.config
         key = self.arguments[0]
         section = self.options.get(
-            'section',
+            "section",
             papis.config.get_general_settings_name())
         default = self.options.get(
-            'default',
+            "default",
             papis.config.get_default_settings().get(section).get(key))
-        source = self.state_machine.input_lines.source(
-            self.lineno - self.state_machine.input_offset - 1)
 
         lines = []
         lines.append("")
@@ -130,45 +112,50 @@ class PapisConfig(Directive):
         lines.append("")
         lines.append("**{key}** (config-{section}-{key}_)"
                      .format(section=section, key=key))
-        if '\n' in str(default):
+
+        if "\n" in str(default):
             lines.append("    - **Default**: ")
             lines.append("        .. code::")
             lines.append("")
-            for lindef in default.split('\n'):
-                lines.append(3*"    " + lindef)
+            for lindef in default.split("\n"):
+                lines.append(3 * "    " + lindef)
         else:
             lines.append("    - **Default**: ``{value!r}``"
                          .format(value=default))
         lines.append("")
 
-        newViewList = docutils.statemachine.ViewList(lines)
-        self.content = newViewList + self.content
+        view = docutils.statemachine.ViewList(lines)
+        self.content = view + self.content
 
         node = docutils.nodes.paragraph()
         node.document = self.state.document
         self.state.nested_parse(self.content, self.content_offset, node)
+
         return node.children
 
+
 def setup(app):
-    app.add_directive('exec', ExecDirective)
-    app.add_directive('papis-config', PapisConfig)
+    app.add_directive("exec", ExecDirective)
+    app.add_directive("papis-config", PapisConfig)
+
+
 # }}} Exec directive #
 
 # Add any paths that contain templates here, relative to this directory.
-templates_path = ['_templates']
+templates_path = ["_templates"]
 
 # The suffix of source filenames.
-source_suffix = '.rst'
+source_suffix = ".rst"
 
 # The encoding of source files.
-#source_encoding = 'utf-8-sig'
+# source_encoding = 'utf-8-sig'
 
 # The master toctree document.
-master_doc = 'index'
+master_doc = "index"
 
 # General information about the project.
-project = u'papis'
-copyright = u'2017, Alejandro Gallo'
+project = u"papis"
+copyright = u"2017, Alejandro Gallo"
 
 # The version info for the project you're documenting, acts as replacement for
 # |version| and |release|, also used in various other places throughout the
@@ -182,13 +169,13 @@ release = version
 
 # The language for content autogenerated by Sphinx. Refer to documentation
 # for a list of supported languages.
-#language = None
+# language = None
 
 # There are two options for replacing |today|: either, you set today to some
 # non-false value, then it is used:
-#today = ''
+# today = ''
 # Else, today_fmt is used as the format for a strftime call.
-#today_fmt = '%B %d, %Y'
+# today_fmt = '%B %d, %Y'
 
 # List of patterns, relative to source directory, that match files and
 # directories to ignore when looking for source files.
@@ -199,58 +186,57 @@ exclude_patterns = [
 
 # The reST default role (used for this markup: `text`) to use for all
 # documents.
-#default_role = None
+# default_role = None
 
 # If true, '()' will be appended to :func: etc. cross-reference text.
-#add_function_parentheses = True
+# add_function_parentheses = True
 
 # If true, the current module name will be prepended to all description
 # unit titles (such as .. function::).
-#add_module_names = True
+# add_module_names = True
 
 # If true, sectionauthor and moduleauthor directives will be shown in the
 # output. They are ignored by default.
-#show_authors = False
+# show_authors = False
 
 # The name of the Pygments (syntax highlighting) style to use.
-pygments_style = 'sphinx'
+pygments_style = "sphinx"
 
 # A list of ignored prefixes for module index sorting.
-#modindex_common_prefix = []
+# modindex_common_prefix = []
 
 # If true, keep warnings as "system message" paragraphs in the built documents.
-#keep_warnings = False
-
+# keep_warnings = False
 
 # -- Options for HTML output ----------------------------------------------
 
 # The theme to use for HTML and HTML Help pages.  See the documentation for
 # a list of builtin themes.
-html_theme = 'sphinx_rtd_theme'
+html_theme = "sphinx_rtd_theme"
 
 # Theme options are theme-specific and customize the look and feel of a theme
 # further.  For a list of options available for each theme, see the
 # documentation.
-#html_theme_options = {}
+# html_theme_options = {}
 
 # Add any paths that contain custom themes here, relative to this directory.
-#html_theme_path = []
+# html_theme_path = []
 
 # The name for this set of Sphinx documents.  If None, it defaults to
 # "<project> v<release> documentation".
-#html_title = None
+# html_title = None
 
 # A shorter title for the navigation bar.  Default is the same as html_title.
-#html_short_title = None
+# html_short_title = None
 
 # The name of an image file (relative to this directory) to place at the top
 # of the sidebar.
-#html_logo = None
+# html_logo = None
 
 # The name of an image file (within the static path) to use as favicon of the
 # docs.  This file should be a Windows icon file (.ico) being 16x16 or 32x32
 # pixels large.
-#html_favicon = None
+# html_favicon = None
 
 # Add any paths that contain custom static files (such as style sheets) here,
 # relative to this directory. They are copied after the builtin static files,
@@ -260,141 +246,137 @@ html_theme = 'sphinx_rtd_theme'
 # Add any extra paths that contain custom files (such as robots.txt or
 # .htaccess) here, relative to this directory. These files are copied
 # directly to the root of the documentation.
-#html_extra_path = []
+# html_extra_path = []
 
 # If not '', a 'Last updated on:' timestamp is inserted at every page bottom,
 # using the given strftime format.
-#html_last_updated_fmt = '%b %d, %Y'
+# html_last_updated_fmt = '%b %d, %Y'
 
 # If true, SmartyPants will be used to convert quotes and dashes to
 # typographically correct entities.
-#html_use_smartypants = True
+# html_use_smartypants = True
 
 # Custom sidebar templates, maps document names to template names.
-#html_sidebars = {}
+# html_sidebars = {}
 
 # Additional templates that should be rendered to pages, maps page names to
 # template names.
-#html_additional_pages = {}
+# html_additional_pages = {}
 
 # If false, no module index is generated.
-#html_domain_indices = True
+# html_domain_indices = True
 
 # If false, no index is generated.
-#html_use_index = True
+# html_use_index = True
 
 # If true, the index is split into individual pages for each letter.
-#html_split_index = False
+# html_split_index = False
 
 # If true, links to the reST sources are added to the pages.
-#html_show_sourcelink = True
+# html_show_sourcelink = True
 
 # If true, "Created using Sphinx" is shown in the HTML footer. Default is True.
-#html_show_sphinx = True
+# html_show_sphinx = True
 
 # If true, "(C) Copyright ..." is shown in the HTML footer. Default is True.
-#html_show_copyright = True
+# html_show_copyright = True
 
 # If true, an OpenSearch description file will be output, and all pages will
 # contain a <link> tag referring to it.  The value of this option must be the
 # base URL from which the finished HTML is served.
-#html_use_opensearch = ''
+# html_use_opensearch = ''
 
 # This is the file name suffix for HTML files (e.g. ".xhtml").
-#html_file_suffix = None
+# html_file_suffix = None
 
 # Output file base name for HTML help builder.
-htmlhelp_basename = 'papisdoc'
-
+htmlhelp_basename = "papisdoc"
 
 # -- Options for LaTeX output ---------------------------------------------
 
 latex_elements = {
-# The paper size ('letterpaper' or 'a4paper').
-#'papersize': 'letterpaper',
+    # The paper size ('letterpaper' or 'a4paper').
+    # 'papersize': 'letterpaper',
 
-# The font size ('10pt', '11pt' or '12pt').
-#'pointsize': '10pt',
+    # The font size ('10pt', '11pt' or '12pt').
+    # 'pointsize': '10pt',
 
-# Additional stuff for the LaTeX preamble.
-#'preamble': '',
+    # Additional stuff for the LaTeX preamble.
+    # 'preamble': '',
 }
 
 # Grouping the document tree into LaTeX files. List of tuples
 # (source start file, target name, title,
 #  author, documentclass [howto, manual, or own class]).
 latex_documents = [
-  ('index', 'papis.tex', u'papis Documentation',
-   u'Alejandro Gallo', 'manual'),
+    ("index", "papis.tex", u"papis Documentation", u"Alejandro Gallo", "manual"),
 ]
 
 # The name of an image file (relative to this directory) to place at the top of
 # the title page.
-#latex_logo = None
+# latex_logo = None
 
 # For "manual" documents, if this is true, then toplevel headings are parts,
 # not chapters.
-#latex_use_parts = False
+# latex_use_parts = False
 
 # If true, show page references after internal links.
-#latex_show_pagerefs = False
+# latex_show_pagerefs = False
 
 # If true, show URL addresses after external links.
-#latex_show_urls = False
+# latex_show_urls = False
 
 # Documents to append as an appendix to all manuals.
-#latex_appendices = []
+# latex_appendices = []
 
 # If false, no module index is generated.
-#latex_domain_indices = True
-
+# latex_domain_indices = True
 
 # -- Options for manual page output ---------------------------------------
 
 # One entry per manual page. List of tuples
 # (source start file, name, description, authors, manual section).
 man_pages = [
-    ('index', 'papis', u'Papis Documentation',
-     [u'Alejandro Gallo'], 1),
-    ('configuration', 'papis-config', u'Papis Configuration',
-     [u'Alejandro Gallo'], 1),
-    ('commands/add', 'papis-add', u'add command',
-        ['Alejandro Gallo'], 1),
-    ('commands/addto', 'papis-addto', u'addto command',
-        ['Alejandro Gallo'], 1),
-    ('commands/browse', 'papis-browse', u'browse command',
-        ['Alejandro Gallo'], 1),
-    ('commands/config', 'papis-config', u'config command',
-        ['Alejandro Gallo'], 1),
-    ('commands/default', 'papis-default', u'default command',
-        ['Alejandro Gallo'], 1),
-    ('commands/edit', 'papis-edit', u'edit command',
-        ['Alejandro Gallo'], 1),
-    ('commands/explore', 'papis-explore', u'explore command',
-        ['Alejandro Gallo'], 1),
-    ('commands/export', 'papis-export', u'export command',
-        ['Alejandro Gallo'], 1),
-    ('commands/git', 'papis-git', u'git command',
-        ['Alejandro Gallo'], 1),
-    ('commands/list', 'papis-list', u'list command',
-        ['Alejandro Gallo'], 1),
-    ('commands/mv', 'papis-mv', u'mv command',
-        ['Alejandro Gallo'], 1),
-    ('commands/open', 'papis-open', u'open command',
-        ['Alejandro Gallo'], 1),
-    ('commands/rename', 'papis-rename', u'rename command',
-        ['Alejandro Gallo'], 1),
-    ('commands/rm', 'papis-rm', u'rm command',
-        ['Alejandro Gallo'], 1),
-    ('commands/run', 'papis-run', u'run command',
-        ['Alejandro Gallo'], 1),
-    ('commands/update', 'papis-update', u'update command',
-        ['Alejandro Gallo'], 1),
+    ("index", "papis", u"Papis Documentation",
+     [u"Alejandro Gallo"], 1),
+    ("configuration", "papis-config", u"Papis Configuration",
+     [u"Alejandro Gallo"], 1),
+    ("commands/add", "papis-add", u"add command",
+     ["Alejandro Gallo"], 1),
+    ("commands/addto", "papis-addto", u"addto command",
+     ["Alejandro Gallo"], 1),
+    ("commands/browse", "papis-browse", u"browse command",
+     ["Alejandro Gallo"], 1),
+    ("commands/config", "papis-config", u"config command",
+     ["Alejandro Gallo"], 1),
+    ("commands/default", "papis-default", u"default command",
+     ["Alejandro Gallo"], 1),
+    ("commands/edit", "papis-edit", u"edit command",
+     ["Alejandro Gallo"], 1),
+    ("commands/explore", "papis-explore", u"explore command",
+     ["Alejandro Gallo"], 1),
+    ("commands/export", "papis-export", u"export command",
+     ["Alejandro Gallo"], 1),
+    ("commands/git", "papis-git", u"git command",
+     ["Alejandro Gallo"], 1),
+    ("commands/list", "papis-list", u"list command",
+     ["Alejandro Gallo"], 1),
+    ("commands/mv", "papis-mv", u"mv command",
+     ["Alejandro Gallo"], 1),
+    ("commands/open", "papis-open", u"open command",
+     ["Alejandro Gallo"], 1),
+    ("commands/rename", "papis-rename", u"rename command",
+     ["Alejandro Gallo"], 1),
+    ("commands/rm", "papis-rm", u"rm command",
+     ["Alejandro Gallo"], 1),
+    ("commands/run", "papis-run", u"run command",
+     ["Alejandro Gallo"], 1),
+    ("commands/update", "papis-update", u"update command",
+     ["Alejandro Gallo"], 1),
 ]
 
 # If true, show URL addresses after external links.
-#man_show_urls = False
-
+# man_show_urls = False
 
 # -- Options for Texinfo output {{{1 ------------------------------------------
 
@@ -402,30 +384,29 @@ man_pages = [
 # (source start file, target name, title, author,
 #  dir menu entry, description, category)
 texinfo_documents = [
-  ('index', 'papis', u'papis Documentation',
-   u'Alejandro Gallo', 'papis', 'One line description of project.',
-   'Miscellaneous'),
+    ("index", "papis", u"papis Documentation",
+     u"Alejandro Gallo", "papis", "One line description of project.",
+     "Miscellaneous"),
 ]
 
 # Documents to append as an appendix to all manuals.
-#texinfo_appendices = []
+# texinfo_appendices = []
 
 # If false, no module index is generated.
-#texinfo_domain_indices = True
+# texinfo_domain_indices = True
 
 # How to display URL addresses: 'footnote', 'no', or 'inline'.
-#texinfo_show_urls = 'footnote'
+# texinfo_show_urls = 'footnote'
 
 # If true, do not generate a @detailmenu in the "Top" node's menu.
-#texinfo_no_detailmenu = False
-
+# texinfo_no_detailmenu = False
 
 # -- Options for Epub output {{{1 --------------------------------------------
 
 # Bibliographic Dublin Core info.
-epub_title = u'papis'
-epub_author = u'Alejandro Gallo'
-epub_publisher = u'Alejandro Gallo'
-epub_copyright = u'2017, Alejandro Gallo'
+epub_title = u"papis"
+epub_author = u"Alejandro Gallo"
+epub_publisher = u"Alejandro Gallo"
+epub_copyright = u"2017, Alejandro Gallo"
 # A list of files that should not be packed into the epub file.
-epub_exclude_files = ['search.html']
+epub_exclude_files = ["search.html"]

--- a/doc/source/conf.py
+++ b/doc/source/conf.py
@@ -13,6 +13,7 @@ import papis
 import docutils
 
 from docutils.parsers.rst import Directive
+from sphinx_click.ext import ClickDirective
 
 # If extensions (or modules to document with autodoc) are in another directory,
 # add these directories to sys.path here. If the directory is relative to the
@@ -45,6 +46,13 @@ intersphinx_mapping = {
 
 
 # Exec directive {{{
+
+class CustomClickDirective(ClickDirective):
+    def run(self):
+        sections = super().run()
+
+        # NOTE: just remove the title section so we can add our own
+        return sections[0].children[1:]
 
 
 class PapisConfig(Directive):
@@ -94,6 +102,7 @@ class PapisConfig(Directive):
 
 
 def setup(app):
+    app.add_directive("click", CustomClickDirective, override=True)
     app.add_directive("papis-config", PapisConfig)
 
 

--- a/doc/source/conf.py
+++ b/doc/source/conf.py
@@ -46,47 +46,6 @@ intersphinx_mapping = {
 
 # Exec directive {{{
 
-class ExecDirective(Directive):
-    """Execute the specified python code and insert the output into the
-    document"""
-    has_content = True
-
-    def run(self):
-        stdout_old, sys.stdout = sys.stdout, StringIO()
-
-        tab_width = self.options.get(
-            "tab-width",
-            self.state.document.settings.tab_width
-        )
-        source = self.state_machine.input_lines.source(
-            self.lineno - self.state_machine.input_offset - 1
-        )
-
-        try:
-            exec("\n".join(self.content))
-            text = sys.stdout.getvalue()
-            lines = docutils.statemachine.string2lines(
-                text,
-                tab_width,
-                convert_whitespace=True
-            )
-            self.state_machine.insert_input(lines, source)
-            return []
-        except Exception:
-            return [
-                docutils.nodes.error(
-                    None,
-                    docutils.nodes.paragraph(
-                        text="Unable to execute python code at {}:{}:".format(
-                            os.path.basename.basename(source), self.lineno
-                        )
-                    ),
-                    docutils.nodes.paragraph(text=str(sys.exc_info()[1]))
-                )
-            ]
-        finally:
-            sys.stdout = stdout_old
-
 
 class PapisConfig(Directive):
     has_content = True
@@ -135,7 +94,6 @@ class PapisConfig(Directive):
 
 
 def setup(app):
-    app.add_directive("exec", ExecDirective)
     app.add_directive("papis-config", PapisConfig)
 
 

--- a/papis/commands/add.py
+++ b/papis/commands/add.py
@@ -82,12 +82,13 @@ in a more effective way in python scripts,
 
 .. autofunction:: papis.commands.add.run
 
-Cli
-^^^
+Command-line Interface
+^^^^^^^^^^^^^^^^^^^^^^
+
 .. click:: papis.commands.add:cli
     :prog: papis add
-
 """
+
 import os
 import re
 import logging

--- a/papis/commands/addto.py
+++ b/papis/commands/addto.py
@@ -11,11 +11,13 @@ that you want to add to a document that matches with the query string
 
 notice that we repeat two times the flag ``-f``, this is important.
 
-Cli
-^^^
+Command-line Interface
+^^^^^^^^^^^^^^^^^^^^^^
+
 .. click:: papis.commands.addto:cli
     :prog: papis addto
 """
+
 import os
 import logging
 from typing import List, Optional

--- a/papis/commands/bibtex.py
+++ b/papis/commands/bibtex.py
@@ -1,5 +1,4 @@
 r"""
-
 This command helps to interact with ``bib`` files in your LaTeX projects.
 
 Examples
@@ -116,12 +115,13 @@ And use like such: |asciicast|
 .. |asciicast| image:: https://asciinema.org/a/8KbLQJSVYVYNXHVF3wgcxx5Cp.svg
    :target: https://asciinema.org/a/8KbLQJSVYVYNXHVF3wgcxx5Cp
 
-Cli
-^^^
+Command-line Interface
+^^^^^^^^^^^^^^^^^^^^^^
+
 .. click:: papis.commands.bibtex:cli
     :prog: papis bibtex
-
 """
+
 import os
 import re
 import logging

--- a/papis/commands/browse.py
+++ b/papis/commands/browse.py
@@ -49,11 +49,13 @@ to be a valid url, I guess at this point you'll know what you're doing.
 This is the default, it will do a search-engine search with the data of your
 paper and hopefully you'll find it.
 
-Cli
-^^^
+Command-line Interface
+^^^^^^^^^^^^^^^^^^^^^^
+
 .. click:: papis.commands.browse:cli
     :prog: papis browse
 """
+
 import logging
 from typing import Optional
 

--- a/papis/commands/config.py
+++ b/papis/commands/config.py
@@ -30,11 +30,13 @@ it with
 
 You can find a list of all available settings in the configuration section.
 
-Cli
-^^^
+Command-line Interface
+^^^^^^^^^^^^^^^^^^^^^^
+
 .. click:: papis.commands.config:cli
     :prog: papis config
 """
+
 import logging
 from typing import Optional
 

--- a/papis/commands/default.py
+++ b/papis/commands/default.py
@@ -1,5 +1,4 @@
 """
-
 Examples
 ^^^^^^^^
 
@@ -19,13 +18,13 @@ Examples
 
         papis --pick-lib open 'einstein relativity'
 
-Cli
-^^^
+Command-line Interface
+^^^^^^^^^^^^^^^^^^^^^^
+
 .. click:: papis.commands.default:run
     :prog: papis
-    :commands: []
-
 """
+
 import os
 import sys
 import logging

--- a/papis/commands/edit.py
+++ b/papis/commands/edit.py
@@ -1,12 +1,13 @@
 """This command edits the information of the documents.
 The editor used is defined by the ``editor`` configuration setting.
 
+Command-line Interface
+^^^^^^^^^^^^^^^^^^^^^^
 
-Cli
-^^^
 .. click:: papis.commands.edit:cli
     :prog: papis edit
 """
+
 import os
 import logging
 from typing import Optional

--- a/papis/commands/exec.py
+++ b/papis/commands/exec.py
@@ -9,8 +9,8 @@ This command tries to mend this issue by allowing the user to write a
 python script and run it using the correct environment where papis is
 installed.
 
-CLI Examples
-^^^^^^^^^^^^
+Examples
+^^^^^^^^
 
     - Run the code in the file ``my-script.py`` and pass it the
       arguments arg1 and arg2
@@ -25,11 +25,13 @@ CLI Examples
 
         papis exec my-script.py -- -h
 
-Cli
-^^^
+Command-line Interface
+^^^^^^^^^^^^^^^^^^^^^^
+
 .. click:: papis.commands.exec:cli
     :prog: papis exec
 """
+
 import sys
 from typing import List
 

--- a/papis/commands/explore.py
+++ b/papis/commands/explore.py
@@ -79,12 +79,14 @@ picked document gets fed into the ``papis scihub`` command which tries to
 download the document using ``scihub``, and also this very document is tried to
 be opened by firefox (in case the document does have a ``url``).
 
-Cli
-^^^
+Command-line Interface
+^^^^^^^^^^^^^^^^^^^^^^
+
 .. click:: papis.commands.explore:cli
     :prog: papis explore
     :nested: full
 """
+
 import os
 import logging
 from typing import List, Optional, Union, Any, Dict, TYPE_CHECKING

--- a/papis/commands/export.py
+++ b/papis/commands/export.py
@@ -40,11 +40,13 @@ or export all of them
     party apps.
 
 
-Cli
-^^^
+Command-line Interface
+^^^^^^^^^^^^^^^^^^^^^^
+
 .. click:: papis.commands.export:cli
     :prog: papis export
 """
+
 import os
 import logging
 from typing import List, Optional

--- a/papis/commands/list.py
+++ b/papis/commands/list.py
@@ -1,8 +1,8 @@
 """
 This command is to list contents of a library.
 
-CLI Examples
-^^^^^^^^^^^^
+Examples
+^^^^^^^^
 
 - List all document files associated will all entries:
 
@@ -41,8 +41,9 @@ CLI Examples
         src="https://asciinema.org/a/QZTBZ3tFfyk9WQuJ9WWB2UpSw.js"
         id="asciicast-QZTBZ3tFfyk9WQuJ9WWB2UpSw" async></script>
 
-Cli
-^^^
+Command-line Interface
+^^^^^^^^^^^^^^^^^^^^^^
+
 .. click:: papis.commands.list:cli
     :prog: papis list
 """

--- a/papis/commands/merge.py
+++ b/papis/commands/merge.py
@@ -6,11 +6,13 @@ pass the ``--pick`` flag to pick twice for the documents.
 
 TODO: Write more documentation
 
-Cli
-^^^
+Command-line Interface
+^^^^^^^^^^^^^^^^^^^^^^
+
 .. click:: papis.commands.merge:cli
     :prog: papis open
 """
+
 import os
 import logging
 from typing import Optional, List, Dict, Any

--- a/papis/commands/mv.py
+++ b/papis/commands/mv.py
@@ -1,10 +1,11 @@
 """
+Command-line Interface
+^^^^^^^^^^^^^^^^^^^^^^
 
-Cli
-^^^
 .. click:: papis.commands.mv:cli
     :prog: papis mv
 """
+
 import os
 import logging
 from typing import Optional

--- a/papis/commands/open.py
+++ b/papis/commands/open.py
@@ -66,11 +66,13 @@ Examples
         papis open --mark bohm
 
 
-Cli
-^^^
+Command-line Interface
+^^^^^^^^^^^^^^^^^^^^^^
+
 .. click:: papis.commands.open:cli
     :prog: papis open
 """
+
 import os
 import logging
 from typing import Optional

--- a/papis/commands/rename.py
+++ b/papis/commands/rename.py
@@ -1,10 +1,11 @@
 """
+Command-line Interface
+^^^^^^^^^^^^^^^^^^^^^^
 
-Cli
-^^^
 .. click:: papis.commands.rename:cli
     :prog: papis rename
 """
+
 import os
 import logging
 from typing import Optional

--- a/papis/commands/rm.py
+++ b/papis/commands/rm.py
@@ -1,10 +1,11 @@
 """
+Command-line Interface
+^^^^^^^^^^^^^^^^^^^^^^
 
-Cli
-^^^
 .. click:: papis.commands.rm:cli
     :prog: papis rm
 """
+
 import os
 import logging
 from typing import Optional

--- a/papis/commands/run.py
+++ b/papis/commands/run.py
@@ -1,8 +1,8 @@
 r"""
 This command is useful to issue commands in the directory of your library.
 
-CLI Examples
-^^^^^^^^^^^^
+Examples
+^^^^^^^^
 
     - List files in your directory
 
@@ -45,11 +45,13 @@ CLI Examples
           papis run -a -- sed -i "s/^note:/_note:/" info.yaml
 
 
-Cli
-^^^
+Command-line Interface
+^^^^^^^^^^^^^^^^^^^^^^
+
 .. click:: papis.commands.run:cli
     :prog: papis run
 """
+
 import os
 import logging
 from typing import List, Optional

--- a/papis/commands/update.py
+++ b/papis/commands/update.py
@@ -34,8 +34,9 @@ and add the tag of ``physics`` to all papers tagged as ``classics``
 
         papis update --all --set tags '{doc[tags]} physics' einstein
 
-Cli
-^^^
+Command-line Interface
+^^^^^^^^^^^^^^^^^^^^^^
+
 .. click:: papis.commands.update:cli
     :prog: papis update
 """


### PR DESCRIPTION
This is meant to help address a note from https://github.com/papis/papis/discussions/413#discussion-4496598 (in the Commands section).

Before, the docs looked like https://papis.readthedocs.io/en/latest/commands.html#cli. This removes a level in the sections and looks like this (i.e. remove the extra `papis add` heading)

![Screenshot_20221202_213746](https://user-images.githubusercontent.com/777240/205372860-25f3ed4e-2e03-4348-969d-061405329966.png)

@jghauser Can you take a look and see if this is more like what you had in mind? The code is quite hacky, but it seems to get the job done..