### PR TITLE
Fix missing newline in papis.document.dump

### DIFF
--- a/papis/document.py
+++ b/papis/document.py
@@ -274,11 +274,17 @@ def dump(document: Document) -> str:
 
     >>> doc = from_data({'title': 'Hello World'})
     >>> dump(doc)
-    'title:   Hello World\\n'
+    'title:     Hello World'
     """
-    return "".join([
-        "{}:   {}".format(key, value) for key, value in document.items()
-        ]) + "\n"
+    # NOTE: this tries to align all the values to the next multiple of 4 of the
+    # longest key length, for a minimum of visual consistency
+    width = max(len(key) for key in document)
+    width = (width // 4 + 2) * 4 - 1
+
+    return "\n".join([
+        "{:{}}{}".format("{}:".format(key), width, value)
+        for key, value in sorted(document.items())
+        ])
 
 
 def delete(document: Document) -> None:

--- a/tests/test_document.py
+++ b/tests/test_document.py
@@ -146,3 +146,22 @@ def test_sort() -> None:
     ]
     sdocs = papis.document.sort(docs, key="year", reverse=False)
     assert sdocs[0] == docs[1]
+
+
+def test_dump() -> None:
+    doc = papis.document.from_data({
+        "author": "Turing, Alan",
+        "title": "Computing machinery and intelligence",
+        "year": 1950,
+        "some-longer-key": "value",
+        })
+
+    result = papis.document.dump(doc)
+    expected_result = (
+        "author:            Turing, Alan\n"
+        "some-longer-key:   value\n"
+        "title:             Computing machinery and intelligence\n"
+        "year:              1950"
+        )
+
+    assert result == expected_result


### PR DESCRIPTION
Managed to mess up the `join` in https://github.com/papis/papis/pull/419/files#diff-682cf814342bcf093b2680414653beea5744a9aab988d8bdabbe528a6b177391. This updates `papis.document.dump` a bit:
* adds the missing new lines (fixing a bug!)
* aligns the keys / values when dumping so that it's a bit easier to follow
* adds a test so that the formatting doesn't get messed up by mistake in the future!
