### PR TITLE
parse_meta_authors: improve author parsing

### DIFF
--- a/papis/downloaders/base.py
+++ b/papis/downloaders/base.py
@@ -120,29 +120,35 @@ def parse_meta_headers(soup: "bs4.BeautifulSoup") -> Dict[str, Any]:
 
 
 def parse_meta_authors(soup: "bs4.BeautifulSoup") -> List[Dict[str, Any]]:
-    author_list = []  # type: List[Dict[str, Any]]
+    # find author tags
     authors = soup.find_all(name="meta", attrs={"name": "citation_author"})
     if not authors:
         authors = soup.find_all(
             name="meta", attrs={"name": re.compile("dc.creator", re.I)})
+
+    if not authors:
+        return []
+
+    # find affiliation tags
     affs = soup.find_all(
         name="meta",
         attrs={"name": "citation_author_institution"})
 
-    if affs and authors:
-        tuples = zip(authors, affs)  # type: Iterator[Tuple[Any, Any]]
-    elif authors:
-        tuples = ((a, None) for a in authors)
+    if affs and len(authors) == len(affs):
+        authors_and_affs = zip(authors, affs)  # type: Iterator[Tuple[Any, Any]]
     else:
-        return []
+        authors_and_affs = ((a, None) for a in authors)
 
-    for t in tuples:
-        fullname = t[0].get("content")
-        affiliation = [{"name": t[1].get("content")}] if t[1] else []
-        fullnames = re.split(r"\s+", fullname)
+    # convert to papis author format
+    author_list = []  # type: List[Dict[str, Any]]
+    for author, aff in authors_and_affs:
+        fullname, = papis.document.split_authors_name([author.get("content")])
+        affiliation = [{"name": aff.get("content")}] if aff else []
+
         author_list.append({
-            "given": fullnames[0],
-            "family": " ".join(fullnames[1:]),
+            "given": fullname["given"],
+            "family": fullname["family"],
             "affiliation": affiliation,
             })
+
     return author_list

--- a/papis/downloaders/springer.py
+++ b/papis/downloaders/springer.py
@@ -28,7 +28,13 @@ class Downloader(papis.downloaders.Downloader):
 
     def get_data(self) -> Dict[str, Any]:
         soup = self._get_soup()
-        return papis.downloaders.base.parse_meta_headers(soup)
+        data = papis.downloaders.base.parse_meta_headers(soup)
+
+        if "publication_date" in data:
+            dates = data["publication_date"].split("/")
+            data["year"] = dates[0]
+
+        return data
 
     def get_bibtex_url(self) -> Optional[str]:
         if "doi" in self.ctx.data:

--- a/tests/downloaders/resources/APS_PhysRevLett.122.145901_Out.json
+++ b/tests/downloaders/resources/APS_PhysRevLett.122.145901_Out.json
@@ -3,65 +3,37 @@
   "author": "Nomura, T. and Zhang, X.-X. and Zherlitsyn, S. and Wosnitza, J. and Tokura, Y. and Nagaosa, N. and Seki, S.",
   "author_list": [
     {
-      "affiliation": [
-        {
-          "name": "Hochfeld-Magnetlabor Dresden (HLD-EMFL), Helmholtz-Zentrum Dresden-Rossendorf, 01328 Dresden, Germany"
-        }
-      ],
+      "affiliation": [],
       "family": "Nomura",
       "given": "T."
     },
     {
-      "affiliation": [
-        {
-          "name": "Department of Applied Physics, The University of Tokyo, Tokyo 113-8656, Japan"
-        }
-      ],
+      "affiliation": [],
       "family": "Zhang",
       "given": "X.-X."
     },
     {
-      "affiliation": [
-        {
-          "name": "Quantum Matter Institute, University of British Columbia, Vancouver BC V6T 1Z4, Canada"
-        }
-      ],
+      "affiliation": [],
       "family": "Zherlitsyn",
       "given": "S."
     },
     {
-      "affiliation": [
-        {
-          "name": "Hochfeld-Magnetlabor Dresden (HLD-EMFL), Helmholtz-Zentrum Dresden-Rossendorf, 01328 Dresden, Germany"
-        }
-      ],
+      "affiliation": [],
       "family": "Wosnitza",
       "given": "J."
     },
     {
-      "affiliation": [
-        {
-          "name": "Hochfeld-Magnetlabor Dresden (HLD-EMFL), Helmholtz-Zentrum Dresden-Rossendorf, 01328 Dresden, Germany"
-        }
-      ],
+      "affiliation": [],
       "family": "Tokura",
       "given": "Y."
     },
     {
-      "affiliation": [
-        {
-          "name": "Institut für Festkörper-und Materialphysik, TU-Dresden, 01062 Dresden, Germany"
-        }
-      ],
+      "affiliation": [],
       "family": "Nagaosa",
       "given": "N."
     },
     {
-      "affiliation": [
-        {
-          "name": "Department of Applied Physics, The University of Tokyo, Tokyo 113-8656, Japan"
-        }
-      ],
+      "affiliation": [],
       "family": "Seki",
       "given": "S."
     }

--- a/tests/downloaders/resources/APS_PhysRevX.12.041027_Out.json
+++ b/tests/downloaders/resources/APS_PhysRevX.12.041027_Out.json
@@ -1,6 +1,6 @@
 {
   "abstract": "Turbulent dynamos efficiently generate folded magnetic fields that, at small plasma resistivity and viscosity, are disrupted by resistive tearing and plasmoid formation.",
-  "author": "K. Galishnikova, Alisa and W. Kunz, Matthew and A. Schekochihin, Alexander",
+  "author": "Galishnikova, Alisa K. and Kunz, Matthew W. and Schekochihin, Alexander A.",
   "author_list": [
     {
       "affiliation": [
@@ -8,8 +8,8 @@
           "name": "Department of Astrophysical Sciences, Princeton University, 4 Ivy Lane, Princeton, New Jersey 08544, USA"
         }
       ],
-      "family": "K. Galishnikova",
-      "given": "Alisa"
+      "family": "Galishnikova",
+      "given": "Alisa K."
     },
     {
       "affiliation": [
@@ -17,8 +17,8 @@
           "name": "Department of Astrophysical Sciences, Princeton University, 4 Ivy Lane, Princeton, New Jersey 08544, USA and Princeton Plasma Physics Laboratory, P.O. Box 451, Princeton, New Jersey 08543, USA"
         }
       ],
-      "family": "W. Kunz",
-      "given": "Matthew"
+      "family": "Kunz",
+      "given": "Matthew W."
     },
     {
       "affiliation": [
@@ -26,8 +26,8 @@
           "name": "The Rudolf Peierls Centre for Theoretical Physics, University of Oxford, Clarendon Laboratory, Parks Road, Oxford, OX1 3PU, United Kingdom and Merton College, Oxford OX1 4JD, United Kingdom"
         }
       ],
-      "family": "A. Schekochihin",
-      "given": "Alexander"
+      "family": "Schekochihin",
+      "given": "Alexander A."
     }
   ],
   "doi": "10.1103/PhysRevX.12.041027",

--- a/tests/downloaders/resources/APS_RevModPhys.94.045004_Out.json
+++ b/tests/downloaders/resources/APS_RevModPhys.94.045004_Out.json
@@ -1,6 +1,6 @@
 {
   "abstract": "Understanding the structure and function of both energy and matter is a fundamental goal in science. Various spatiotemporal probes have been developed from electromagnetic waves spanning the entire range of the spectrum to neutrons and charged particles such as electrons. With the development of highly controlled, shorter electron bunches, retrieving dynamic structural information from solid-state and gas-phase samples is now possible at timescales that resolve atomic motion and length scales that resolve atomic positions in even the lightest elements. In this review advances in the generation, manipulation, and characterization of ultrashort electron beams are described.",
-  "author": "Filippetto, D. and Musumeci, P. and K. Li, R. and J. Siwick, B. and R. Otto, M. and Centurion, M. and P. F. Nunes, J.",
+  "author": "Filippetto, D. and Musumeci, P. and Li, R. K. and Siwick, B. J. and Otto, M. R. and Centurion, M. and Nunes, J. P. F.",
   "author_list": [
     {
       "affiliation": [
@@ -26,8 +26,8 @@
           "name": "Department of Engineering Physics, Tsinghua University, Beijing 100084, China and Key Laboratory of Particle and Radiation Imaging, Tsinghua University, Ministry of Education, Beijing 100084, China"
         }
       ],
-      "family": "K. Li",
-      "given": "R."
+      "family": "Li",
+      "given": "R. K."
     },
     {
       "affiliation": [
@@ -35,8 +35,8 @@
           "name": "Centre for the Physics of Materials, Department of Physics and Department of Chemistry, McGill University, Montreal, Quebec H3A 2T8, Canada"
         }
       ],
-      "family": "J. Siwick",
-      "given": "B."
+      "family": "Siwick",
+      "given": "B. J."
     },
     {
       "affiliation": [
@@ -44,8 +44,8 @@
           "name": "Centre for the Physics of Materials, Department of Physics and Department of Chemistry, McGill University, Montreal, Quebec H3A 2T8, Canada"
         }
       ],
-      "family": "R. Otto",
-      "given": "M."
+      "family": "Otto",
+      "given": "M. R."
     },
     {
       "affiliation": [
@@ -62,8 +62,8 @@
           "name": "University of Nebraska-Lincoln, 855 North 16th Street, Lincoln, Nebraska 68588, USA"
         }
       ],
-      "family": "P. F. Nunes",
-      "given": "J."
+      "family": "Nunes",
+      "given": "J. P. F."
     }
   ],
   "doi": "10.1103/RevModPhys.94.045004",

--- a/tests/downloaders/resources/SpringerLink_BF02727953_Out.json
+++ b/tests/downloaders/resources/SpringerLink_BF02727953_Out.json
@@ -1,6 +1,6 @@
 {
   "abstract": "The classical configuration space of a system of identical particles is examined. Due to the identification of points which are related by permutations of particle indices, it is essentially different, globally, from the Cartesian product of the one-particle spaces. This fact is explicity taken into account in a quantization of the theory. As a consequence, no symmetry constraints on the wave functions and the observables need to be postulated. The two possibilities, corresponding to symmetric and antisymmetric wave functions, appear in a natural way in the formalism. But this is only the case in which the particles move in three- or higher-dimensional space. In one and two dimensions a continuum of possible intermediate cases connects the boson and fermion cases. The effect of particle spin in the present formalism is discussed.",
-  "author": "J. M., Leinaas, and J., Myrheim,",
+  "author": "Leinaas, J. M. and Myrheim, J.",
   "author_list": [
     {
       "affiliation": [
@@ -8,8 +8,8 @@
           "name": "Department of Physics, University of Oslo, Oslo"
         }
       ],
-      "family": "J. M.",
-      "given": "Leinaas,"
+      "family": "Leinaas",
+      "given": "J. M."
     },
     {
       "affiliation": [
@@ -17,8 +17,8 @@
           "name": "Department of Physics, University of Oslo, Oslo"
         }
       ],
-      "family": "J.",
-      "given": "Myrheim,"
+      "family": "Myrheim",
+      "given": "J."
     }
   ],
   "date": "2007-10-23",
@@ -38,5 +38,6 @@
   "title": "On the theory of identical particles",
   "type": "OriginalPaper",
   "url": "https://link.springer.com/article/10.1007/BF02727953",
-  "volume": "37"
+  "volume": "37",
+  "year": "1977"
 }

--- a/tests/downloaders/resources/SpringerLink_s10924_010_0192_1_Out.json
+++ b/tests/downloaders/resources/SpringerLink_s10924_010_0192_1_Out.json
@@ -1,6 +1,6 @@
 {
   "abstract": "Amylose containing polysaccharides are one of the most abundant and inexpensive naturally occurring biopolymers. Therefore, they are one of the most promising candidates to produce substitute plastics, especially in packaging applications. To determine the suitability for packaging applications, cytotoxicity of a modified amylose based bioplastic was investigated using NIH 3T3 Fibroblast cells from observation of cell morphology and MTS assay. Chemical durability of the amylose based bioplastic film was also studied by ion release and pH measurement after immersing the film into water. In&nbsp;vitro cytotoxicity (Cell morphology study and MTS assay) showed that the amylose based bioplastic film has in&nbsp;vitro biocompatibility and can be used for packaging applications. The ion release and pH measurement also supported the results.",
-  "author": "Sanchita, Bandyopadhyay-Ghosh, and Robert, Jeng, and Joydeep, Mukherjee, and Mohini, Sain,",
+  "author": "Bandyopadhyay-Ghosh, Sanchita and Jeng, Robert and Mukherjee, Joydeep and Sain, Mohini",
   "author_list": [
     {
       "affiliation": [
@@ -8,8 +8,8 @@
           "name": "Centre for Biocomposites and Biomaterials Processing, University of Toronto, Toronto, Canada"
         }
       ],
-      "family": "Sanchita",
-      "given": "Bandyopadhyay-Ghosh,"
+      "family": "Bandyopadhyay-Ghosh",
+      "given": "Sanchita"
     },
     {
       "affiliation": [
@@ -17,8 +17,8 @@
           "name": "Centre for Biocomposites and Biomaterials Processing, University of Toronto, Toronto, Canada"
         }
       ],
-      "family": "Robert",
-      "given": "Jeng,"
+      "family": "Jeng",
+      "given": "Robert"
     },
     {
       "affiliation": [
@@ -26,8 +26,8 @@
           "name": "The Arthur and Sonia Labatt Brain Tumour Research Centre, The Hospital for Sick Children, University of Toronto, Toronto, Canada"
         }
       ],
-      "family": "Joydeep",
-      "given": "Mukherjee,"
+      "family": "Mukherjee",
+      "given": "Joydeep"
     },
     {
       "affiliation": [
@@ -35,8 +35,8 @@
           "name": "Centre for Biocomposites and Biomaterials Processing, University of Toronto, Toronto, Canada"
         }
       ],
-      "family": "Mohini",
-      "given": "Sain,"
+      "family": "Sain",
+      "given": "Mohini"
     }
   ],
   "date": "2010-05-05",
@@ -56,5 +56,6 @@
   "title": "In Vitro Cytotoxicity of Amylose-Based Bioplastic for Packaging Applications",
   "type": "OriginalPaper",
   "url": "https://link.springer.com/article/10.1007/s10924-010-0192-1",
-  "volume": "18"
+  "volume": "18",
+  "year": "2010"
 }


### PR DESCRIPTION
To be clearer, this fixes parsing of names like `"Smith, John"`, where previously it would split on the whitespace and take the first element as the given name and the second one as the family name. That name format showed up in the `Springer` downloader.

This PR switches to using `papis.document.split_authors_name`, which uses `bibtexparser` under the hood to do a bunch of fancier heuristics.