### PR TITLE
Improve to_bibtex performance

### DIFF
--- a/tests/test_bibtex.py
+++ b/tests/test_bibtex.py
@@ -133,7 +133,7 @@ def test_to_bibtex_formatting() -> None:
         + "  journal = {Nature},\n"
         + "  title = {The Theory of Everything},\n"
         + "  year = {2350},\n"
-        + "}\n"
+        + "}"
         )
 
     assert papis.bibtex.to_bibtex(doc) == expected_bibtex

--- a/tests/test_document.py
+++ b/tests/test_document.py
@@ -99,7 +99,7 @@ def test_to_bibtex() -> None:
         "  journal = {jcp},\n"
         "  title = {Hello},\n"
         "  year = {3200BCE},\n"
-        "}\n")
+        "}")
     doc["journal_abbrev"] = "j"
     assert papis.bibtex.to_bibtex(doc) == (
         "@book{HelloFernan3200bce,\n"
@@ -107,7 +107,7 @@ def test_to_bibtex() -> None:
         "  journal = {j},\n"
         "  title = {Hello},\n"
         "  year = {3200BCE},\n"
-        "}\n")
+        "}")
     del doc["title"]
 
     doc["ref"] = "hello1992"
@@ -116,7 +116,7 @@ def test_to_bibtex() -> None:
         "  author = {Fernandez, Gilgamesh},\n"
         "  journal = {j},\n"
         "  year = {3200BCE},\n"
-        "}\n")
+        "}")
 
 
 def test_to_json() -> None:


### PR DESCRIPTION
Some updates while doing #412. The main changes are:

* only do one sweep through the document keys (i.e. do the `bibtex_key_converter` directly)
* construct a `List[str]` with the bibtex lines and join at the end. Using `str += extra` is known to be quadratic.

For a few simple benchmarks (using hyperfine) trying to export ~20 and ~200 papers (library has about ~1500). Before it was
```
Benchmark 1: papis -l papers export -f bibtex -a greengard
  Time (mean ± σ):     420.5 ms ±   6.8 ms    [User: 440.8 ms, System: 194.0 ms]
  Range (min … max):   407.9 ms … 432.8 ms    10 runs

Benchmark 2: papis -l papers export -f bibtex -a optimization
  Time (mean ± σ):     525.7 ms ±   4.9 ms    [User: 562.8 ms, System: 184.5 ms]
  Range (min … max):   518.9 ms … 536.8 ms    10 runs
```
and now it is
```
Benchmark 1: papis -l papers export -f bibtex -a greengard
  Time (mean ± σ):     403.0 ms ±   3.9 ms    [User: 430.5 ms, System: 181.5 ms]
  Range (min … max):   397.6 ms … 408.9 ms    10 runs

Benchmark 1: papis -l papers export -f bibtex -a optimization
  Time (mean ± σ):     421.3 ms ±   4.5 ms    [User: 447.5 ms, System: 188.0 ms]
  Range (min … max):   414.8 ms … 426.8 ms    10 runs
```

Not much, but the new version doesn't seem to take noticeably more time when exporting more files!