### PR TITLE
Initial working implementation of papis_id

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,26 @@
+VERSION v0.13
+=============
+
+## NEW `papis_id` special key in `info.yaml`
+
+In order to make plugin writing easier we have decided to introduce
+a `papis_id` key in the document's info files.
+
+**Important**: When you update to this new version,
+clear the cache of the database backend that you're using
+
+```sh
+papis --cc
+```
+
+## NEW `papis doctor` command
+
+## Major improvements to the web application
+
+## Project's README improvement
+
+## Improvements to `bibtex` export
+
 VERSION v0.12
 =============
 

--- a/doc/source/index.rst
+++ b/doc/source/index.rst
@@ -19,6 +19,7 @@ command-line interface (*CLI*) is heavily tailored after
    info_file
    library_structure
    database_structure
+   papis_id
    commands
    web-application
    gui

--- a/doc/source/papis_id.rst
+++ b/doc/source/papis_id.rst
@@ -1,0 +1,1 @@
+.. automodule:: papis.id

--- a/papis/commands/add.py
+++ b/papis/commands/add.py
@@ -114,6 +114,7 @@ import papis.downloaders
 import papis.git
 import papis.format
 import papis.citations
+import papis.id
 
 logger = logging.getLogger("add")  # type: logging.Logger
 
@@ -133,6 +134,7 @@ class FromFolderImporter(papis.importer.Importer):
         self.logger.info("Importing from folder '%s'", self.uri)
 
         doc = papis.document.from_folder(self.uri)
+        del doc[papis.id.key_name()]
         self.ctx.data = papis.document.to_dict(doc)
         self.ctx.files = doc.get_files()
 

--- a/papis/id.py
+++ b/papis/id.py
@@ -76,3 +76,22 @@ def key_name() -> str:
     Reserved key name for databases and documents.
     """
     return "papis_id"
+
+
+def has_id(doc: Dict[str, Any]) -> bool:
+    """
+    Checks if a dictionary is potentially an identified papis
+    document.
+    """
+    return key_name() in doc
+
+
+def get(doc: Dict[str, Any]) -> str:
+    """
+    Get the id from a document.
+    """
+    if not has_id(doc):
+        raise ValueError("No '{}' found in '{}'"
+                         .format(key_name(),
+                                 papis.document.describe(doc)))
+    return str(doc[key_name()])

--- a/papis/id.py
+++ b/papis/id.py
@@ -1,0 +1,78 @@
+"""
+The ``papis_id`` key
+--------------------
+
+Every papis document should have a ``papis_id`` key created at random by
+the papis database.
+
+If you manually add a document into your library, you will have to clear
+the library cache
+
+.. code:: sh
+
+    papis --cc
+
+in order to trigger a database building the next time that you issue
+a papis command. When the library scans the document added manually,
+it will create a ``papis_id`` key automatically and **it will edit** your
+``info.yaml`` file accordingly.
+We stress again that the database will **edit** the ``info.yaml`` file,
+without committing the changes (in the case that you are using a git
+repository), so that you can inspect the changes manually.
+
+Please note that if you add a document manually with an existing
+``papis_id`` to your library, papis will not check if there is an
+id clash. A clash of ids has a very low probability.
+Please refer to the ``papis-doctor`` help for checking for clashes.
+
+Use of ``papis_id`` in scripts
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+Since the ``papis_id`` key is a unique identifier, it is quite
+useful for scripts that do not depend on the actual path
+to the document in your system.
+
+For instance you can get the ``papis_id`` of a document
+in ``bash`` like such
+
+.. code:: sh
+
+    id=$(papis list --format "{doc[papis_id]}")
+
+and subsequently use the ``id`` variable to trigger other commands,
+for instance you can open the file attached to the document like
+such
+
+.. code:: sh
+
+    papis open papis_id:${id}
+
+"""
+from typing import Optional, Dict, Any
+import hashlib
+import random
+
+import papis.document
+
+
+def compute_an_id(doc: papis.document.Document,
+                  separator: Optional[str] = None) -> str:
+    """
+    Get a random id seeded in part by the input document.
+    Note: this is a non-deterministic function if separator is None.
+    For a determined value of separator, the result is deterministic.
+    """
+    separator = separator if separator is not None else str(random.random())
+    string = separator.join([
+        str(doc),
+        str(doc.get_files()),
+        str(doc.get_info_file()),
+    ])
+    return hashlib.md5(string.encode()).hexdigest()
+
+
+def key_name() -> str:
+    """
+    Reserved key name for databases and documents.
+    """
+    return "papis_id"

--- a/papis/web/paths.py
+++ b/papis/web/paths.py
@@ -1,8 +1,25 @@
-from typing import Dict, Any
+from typing import Dict, Any, Optional
+
+import papis.id
 
 
-def _ref(doc: Dict[str, Any]) -> str:
-    return "ref:{ref}".format(ref=doc["ref"])
+def _ref(doc: Dict[str, Any]) -> Optional[str]:
+    if papis.id.has_id(doc):
+        return papis.id.get(doc)
+    return None
+
+
+def format_if_has_id(doc: Dict[str, Any],
+                     fmt: str,
+                     *args: Any,
+                     **kwargs: Any) -> str:
+    """
+    Formats the strig fmt only if doc has the papis_id key, since th
+    path requires it.
+    """
+    if papis.id.has_id(doc):
+        return fmt.format(*args, **kwargs)
+    return ""
 
 
 def query_path(libname: str) -> str:
@@ -16,41 +33,40 @@ def fetch_citations_server_path(libname: str, doc: Dict[str, Any]) -> str:
     """
     Path for fetching citations for papers
     """
-    if "ref" not in doc:
-        return "#"
-    return ("/library/{libname}/document/fetch-citations/{ref}"
-            .format(ref=_ref(doc), libname=libname))
+    return format_if_has_id(doc,
+                            "/library/{libname}/document/fetch-citations/{ref}",
+                            ref=_ref(doc),
+                            libname=libname)
 
 
 def update_notes(libname: str, doc: Dict[str, Any]) -> str:
     """
     Path for updating the notes of the paper
     """
-    if "ref" not in doc:
-        return "#"
-    return ("/library/{libname}/document/notes/{ref}"
-            .format(ref=_ref(doc), libname=libname))
+    return format_if_has_id(doc,
+                            "/library/{libname}/document/notes/{ref}",
+                            ref=_ref(doc),
+                            libname=libname)
 
 
 def update_info(libname: str, doc: Dict[str, Any]) -> str:
     """
     Path for updating the info yaml file itself
     """
-    if "ref" not in doc:
-        return "#"
-    return ("/library/{libname}/document/info/{ref}"
-            .format(ref=_ref(doc), libname=libname))
+    return format_if_has_id(doc,
+                            "/library/{libname}/document/info/{ref}",
+                            ref=_ref(doc),
+                            libname=libname)
 
 
 def doc_server_path(libname: str, doc: Dict[str, Any]) -> str:
     """
     The server path for a document, it might change in the future
     """
-    # TODO: probably we should quote the ref (and later unquote)?
-    if "ref" not in doc:
-        return "#"
-    return "/library/{libname}/document/{ref}".format(ref=_ref(doc),
-                                                      libname=libname)
+    return format_if_has_id(doc,
+                            "/library/{libname}/document/{ref}",
+                            ref=_ref(doc),
+                            libname=libname)
 
 
 def file_server_path(localpath: str,

--- a/papis/web/timeline.py
+++ b/papis/web/timeline.py
@@ -20,10 +20,13 @@ def widget(documents: Sequence[Dict[str, Any]],
     """
     t.div(id=_id, style="width: 100%; height: 300px;")
 
-    def _make_text(d: Dict[str, Any]) -> str:
-        _text = papis.document.describe(d)
-        _href = wp.doc_server_path(libname, d)
-        return r"<a href='{}'>{}</a>".format(_href, _text)
+    def _make_text(_d: Dict[str, Any]) -> str:
+        _text = papis.document.describe(_d)
+        _href = wp.doc_server_path(libname, _d)
+        if _href:
+            return (r"<a href='{}'>{}<i class='fa fa-check'></i></a>"
+                    .format(_href, _text))
+        return _text
 
     json_data = [{"text": {"text": _make_text(d)},
                   "start_date": {"year": d["year"],


### PR DESCRIPTION
This is already working, I will probably update the webapplication to use this
as a test, and implement a couple of tests.

I think the changes were quite minimal and they are not noticeable in the runtime.
Also the unique id is the same for both databases (namely `papis_id`) and
the only part of papis that knows about it (`papis.id` module) (and probably will know at all in teh future)
is database, so that @jghauser in principle can now use

`papis open papis_id:lalalaalalaala`

in both databases interchangeably.
In python, there is the handy

```
db.find_by_id("lalalaalalala")
```
that throws if two documents match this id.
