### PR TITLE
Fix being stuck in `while` loop when adding an entry

### DIFF
--- a/papis/commands/add.py
+++ b/papis/commands/add.py
@@ -305,7 +305,7 @@ def run(paths: List[str],
         temp_doc = papis.document.Document(data=data)
         temp_path = os.path.join(out_folder_path, folder_name)
         components = []     # type: List[str]
-        
+
         temp_path = os.path.normpath(temp_path)
         out_folder_path = os.path.normpath(out_folder_path)
 

--- a/papis/commands/add.py
+++ b/papis/commands/add.py
@@ -306,7 +306,7 @@ def run(paths: List[str],
         temp_path = os.path.join(out_folder_path, folder_name)
         components = []     # type: List[str]
         while (
-                temp_path != out_folder_path
+                not papis.utils.paths_are_identical(temp_path, out_folder_path)
                 and papis.utils.is_relative_to(temp_path, out_folder_path)):
             path_component = os.path.basename(temp_path)
 

--- a/papis/commands/add.py
+++ b/papis/commands/add.py
@@ -306,7 +306,7 @@ def run(paths: List[str],
         temp_path = os.path.join(out_folder_path, folder_name)
         components = []     # type: List[str]
         while (
-                not papis.utils.paths_are_identical(temp_path, out_folder_path)
+                temp_path != out_folder_path
                 and papis.utils.is_relative_to(temp_path, out_folder_path)):
             path_component = os.path.basename(temp_path)
 

--- a/papis/commands/add.py
+++ b/papis/commands/add.py
@@ -305,6 +305,10 @@ def run(paths: List[str],
         temp_doc = papis.document.Document(data=data)
         temp_path = os.path.join(out_folder_path, folder_name)
         components = []     # type: List[str]
+        
+        temp_path = os.path.normpath(temp_path)
+        out_folder_path = os.path.normpath(out_folder_path)
+
         while (
                 temp_path != out_folder_path
                 and papis.utils.is_relative_to(temp_path, out_folder_path)):

--- a/papis/utils.py
+++ b/papis/utils.py
@@ -285,7 +285,3 @@ def is_relative_to(path: str, other: str) -> bool:
             return not os.path.relpath(path, start=other).startswith("..")
         except ValueError:
             return False
-
-
-def paths_are_identical(path: str, other: str) -> bool:
-    return pathlib.Path(path) == pathlib.Path(other)

--- a/papis/utils.py
+++ b/papis/utils.py
@@ -276,7 +276,15 @@ def update_doc_from_data_interactively(
 
 
 def is_relative_to(path: str, other: str) -> bool:
-    return pathlib.Path(path).is_relative_to(other)
+    if sys.version_info >= (3, 9):
+        return pathlib.Path(path).is_relative_to(other)
+    # This should lead to the same result as the above for older versions of
+    # python.
+    else:
+        try:
+            return not os.path.relpath(path, start=other).startswith("..")
+        except ValueError:
+            return False
 
 
 def paths_are_identical(path: str, other: str) -> bool:

--- a/papis/utils.py
+++ b/papis/utils.py
@@ -277,3 +277,7 @@ def update_doc_from_data_interactively(
 
 def is_relative_to(path: str, other: str) -> bool:
     return pathlib.Path(path).is_relative_to(other)
+
+
+def paths_are_identical(path: str, other: str) -> bool:
+    return pathlib.Path(path) == pathlib.Path(other)

--- a/papis/utils.py
+++ b/papis/utils.py
@@ -2,6 +2,7 @@ import os
 import sys
 import re
 import logging
+import pathlib
 from itertools import count, product
 from typing import (Optional, List, Iterator, Any, Dict,
                     Union, Callable, TypeVar)
@@ -275,9 +276,4 @@ def update_doc_from_data_interactively(
 
 
 def is_relative_to(path: str, other: str) -> bool:
-    # TODO: switch to pathlib.Path.is_relative_to for python >=3.9
-    try:
-        os.path.relpath(path, start=other)
-        return True
-    except ValueError:
-        return False
+    return pathlib.Path(path).is_relative_to(other)


### PR DESCRIPTION
Should be a fix for #448.

Tests are not performed, as adding a trailing slash to `folder` when [creating the test library](https://github.com/papis/papis/blob/a81e575006b630a3558063cfc6878338ce3bf683/tests/__init__.py#L118) causes the tests to get stuck in the while loop without the fix, which I don't think is helpful.