### PR TITLE
Improvements to commands.config

### DIFF
--- a/doc/source/default-settings.rst
+++ b/doc/source/default-settings.rst
@@ -1,3 +1,5 @@
+.. _general-settings:
+
 General settings
 ----------------
 

--- a/papis/commands/config.py
+++ b/papis/commands/config.py
@@ -154,8 +154,8 @@ def run(
 
     if len(options) == 0:
         # NOTE: no options given -> just get all the settings
+        defaults = papis.config.get_default_settings()
         if default:
-            defaults = papis.config.get_default_settings()
             if section is None:
                 result = defaults
             elif section in defaults:
@@ -166,11 +166,23 @@ def run(
                              section, "', '".join(defaults))
         else:
             if section is None:
-                result = {
-                    sec: {k: config[sec][k] for k in config.options(sec)}
-                    for sec in config if sec != "DEFAULT"
-                    }
+                for sec in defaults:
+                    result[sec] = defaults[sec].copy()
+                    if sec in config:
+                        result.update({
+                            key: papis.config.get(key, section=sec)
+                            for key in config.options(sec) if key in result
+                            })
+            elif section in defaults:
+                result = defaults[section].copy()
+                if section in config:
+                    result.update({
+                        key: papis.config.get(key, section=section)
+                        for key in config.options(section) if key in result
+                        })
             elif section in config:
+                # NOTE: libraries are in the config but not in the defaults,
+                # so we just print whatever settings are in there.
                 result = {key: config[section][key] for key in config.options(section)}
             else:
                 logger.error("Section '%s' not found in configuration file. "

--- a/papis/commands/config.py
+++ b/papis/commands/config.py
@@ -19,7 +19,7 @@ If you wanted to see which ``dir`` the ``books`` library uses, you would do:
 
     papis -l books config dir
 
-With ``-l``, Papis selects a specific library (here, the "books" library). The 
+With ``-l``, Papis selects a specific library (here, the "books" library). The
 rest works just as above.
 
 Settings from a specific section in the configuration file can also be
@@ -32,18 +32,20 @@ example, if your ``books`` library is configured as a section, you can do:
 
 This is equivalent to the above ``papis -l books config dir`` command.
 
-For a more complex example, the :ref:`Bibtex` command has its own
-configuration settings. These can be accessed through
+The same notation can also be used to access configuration settings specific
+to Papis commands. For example, the :ref:`Bibtex` command's settings can be
+accessed with:
 
 .. code::
 
     papis config bibtex.default-read-bibfile
-    > main.bib
 
 You can find a list of all available settings in the configuration section
 at :ref:`general-settings`. Commands and other plugins can define their own
-settings, which are documented separately. To list the default values in a
-given section, use
+settings, which are documented separately.
+
+You can also use ``config`` to find out about some section's default
+settings:
 
 .. code::
 

--- a/papis/commands/config.py
+++ b/papis/commands/config.py
@@ -4,10 +4,20 @@ system.
 
 The ``config`` command returns the value used by Papis. Therefore, if you
 haven't customized some setting, it will return the default value. In contrast,
-if you have customized it, it will return the value you set.
+if you have customized it, it will return the value set in the configuration
+file. To show the list of default and overwritten configuration values in a
+section use
 
-Let's say you want to see which ``dir`` setting your default library is using.
-You can achieve this with:
+.. code::
+
+    papis config --default --section <name>
+    papis config --section <name>
+
+or call ``papis config`` without the section argument to show the settings
+available for all the known sections.
+
+We can also query specific settings. Let's say you want to see which ``dir``
+setting your default library is using. You can achieve this with:
 
 .. code::
 
@@ -23,33 +33,28 @@ With ``-l``, Papis selects a specific library (here, the "books" library). The
 rest works just as above.
 
 Settings from a specific section in the configuration file can also be
-accessed by adding a dot ``"."`` between the section and the setting name. For
-example, if your ``books`` library is configured as a section, you can do:
+accessed. To take an example, the `Bibtex`_ command's settings can be
+accessed with
 
 .. code::
 
-    papis config books.dir
+    papis config --default --section bibtex default-read-bibfile
+    papis config --section bibtex default-read-bibfile
 
-This is equivalent to the above ``papis -l books config dir`` command.
-
-The same notation can also be used to access configuration settings specific
-to Papis commands. For example, the :ref:`Bibtex` command's settings can be
-accessed with:
+For some more advanced usage, we can also query multiple settings at once. Then
+it may be useful to overwrite the selected section for several of the settings.
+This can be achieved by
 
 .. code::
 
-    papis config bibtex.default-read-bibfile
+    papis config --section sec1 key1 key2 key3 sec2.key4 sec3.key5
+
+where the keys take the format ``[<section>.]<key>`` with an optional prefix
+to specify the section override.
 
 You can find a list of all available settings in the configuration section
 at :ref:`general-settings`. Commands and other plugins can define their own
 settings, which are documented separately.
-
-You can also use ``config`` to find out about some section's default
-settings:
-
-.. code::
-
-    papis config --list-defaults bibtex
 
 Command-line Interface
 ^^^^^^^^^^^^^^^^^^^^^^
@@ -59,9 +64,10 @@ Command-line Interface
 """
 
 import logging
-from typing import Any, List, Optional
+from typing import Any, Dict, List, Optional, Tuple
 
 import click
+import colorama
 
 import papis.config
 import papis.commands
@@ -69,93 +75,170 @@ import papis.commands
 logger = logging.getLogger(__name__)
 
 
-def run(option_string: str) -> Optional[str]:
-    option = option_string.split(".")
+def format_option(key: str, value: Any) -> str:
+    return (
+        "{c.Style.BRIGHT}{key}{c.Style.NORMAL} "
+        "= {c.Fore.GREEN}{value!r}{c.Style.RESET_ALL}"
+        .format(c=colorama, key=key, value=value))
+
+
+def parse_option(
+        option: str, default_section: Optional[str]
+        ) -> Tuple[Optional[str], str]:
+    """
+    :returns: a ``(section, key)`` tuple parsed from *option*.
+    """
+
+    parts = option.split(".")
     key = section = None
-    if len(option) == 1:
-        key = option[0]
-    elif len(option) == 2:
-        section = option[0]
-        key = option[1]
+    if len(parts) == 1:
+        key = parts[0]
+        section = default_section
+    elif len(parts) == 2:
+        section = parts[0] if parts[0] else None
+        key = parts[1]
     else:
-        raise ValueError("unsupported option format: '{}'".format(option_string))
+        raise ValueError("Unsupported option format: '{}'".format(option))
 
-    logger.debug("key = %s, sec = %s", key, section)
-    return papis.config.get(key, section=section)
+    return section, key
 
 
-def _run_with_log(option_string: str) -> Optional[str]:
+def _get_option_safe(
+        option: str, default_section: Optional[str], default: bool = False,
+        ) -> Tuple[Optional[str], Optional[str]]:
+    key = option
+    value = None
+
     try:
-        return run(option_string)
+        section, key = parse_option(option, default_section)
     except ValueError:
         logger.error(
-            "options should be in a <section>.<key> or <key> format: got '%s'",
-            option_string)
-    except papis.exceptions.DefaultSettingValueMissing as exc:
-        logger.error("\n%s", str(exc).strip("\n"))
+            "Options should be in a <section>.<key> or <key> format: got '%s'",
+            option)
+        return key, value
 
-    return None
+    if default:
+        if section is None:
+            section = papis.config.get_general_settings_name()
+
+        defaults = papis.config.get_default_settings()
+        try:
+            value = defaults[section][key]
+        except KeyError:
+            logger.error(
+                "No default value for setting '%s' found in section '%s'",
+                key, section)
+    else:
+        try:
+            value = papis.config.get(key, section=section)
+        except papis.exceptions.DefaultSettingValueMissing as exc:
+            logger.error("\n%s", str(exc).strip("\n"))
+
+    return key, value
+
+
+def run(
+        options: List[str],
+        section: Optional[str] = None,
+        default: bool = False,
+        ) -> Dict[str, Any]:
+    """
+    :param options: a list of strings, each in a format ``[<section>].<key>``
+        (i.e. where the section is optional).
+    :param section: a default section to query for configuration settings.
+    :param default: if *True*, return hardcoded default values, otherwise return
+        the values from the configuration file.
+    """
+    config = papis.config.get_configuration()
+    result = {}     # type: Dict[str, Any]
+
+    if len(options) == 0:
+        # NOTE: no options given -> just get all the settings
+        if default:
+            defaults = papis.config.get_default_settings()
+            if section is None:
+                result = defaults
+            elif section in defaults:
+                result = defaults[section]
+            else:
+                logger.error("Section '%s' does not exist in defaults. "
+                             "Known sections are '%s'.",
+                             section, "', '".join(defaults))
+        else:
+            if section is None:
+                result = {
+                    sec: {k: config[sec][k] for k in config.options(sec)}
+                    for sec in config if sec != "DEFAULT"
+                    }
+            elif section in config:
+                result = {key: config[section][key] for key in config.options(section)}
+            else:
+                logger.error("Section '%s' not found in configuration file. "
+                             "Known sections are '%s'.",
+                             section, "', '".join(config.sections()))
+    else:
+        # NOTE: options given -> print only chosen options
+        for option in options:
+            key, value = _get_option_safe(option, section, default=default)
+            if value is not None:
+                assert key is not None
+                result[key] = value
+
+    return result
 
 
 @click.command("config")
 @click.help_option("--help", "-h")
 @click.argument("options", nargs=-1)
 @click.option(
-    "--json", "_json",
-    help="Print multiple settings in a JSON format",
+    "-s", "--section",
+    help="select a default section for the options",
+    default=None)
+@click.option(
+    "-d", "--default",
+    help="List default configuration setting values, instead of those in the "
+         "configuration file",
     default=False, is_flag=True)
 @click.option(
-    "--list-defaults", "list_defaults",
-    help="List all default configuration settings in the given section",
+    "--json", "json_",
+    help="Print settings in a JSON format",
     default=False, is_flag=True)
 def cli(options: List[str],
-        _json: bool,
-        list_defaults: bool) -> None:
+        section: Optional[str],
+        json_: bool,
+        default: bool) -> None:
     """Print configuration values"""
-    import colorama
-
-    logger.debug("config options: %s", options)
-
-    def format(key: str, value: Any) -> str:
-        return (
-            "{c.Style.BRIGHT}{key}{c.Style.NORMAL} "
-            "= {c.Fore.GREEN}{value!r}{c.Style.RESET_ALL}"
-            .format(c=colorama, key=key, value=value))
-
-    if not list_defaults and len(options) == 1:
+    if len(options) == 1:
         # NOTE: a single option is printed directly for a bit of backwards
         # compatiblity and easier use in shell scripts, so remove with care!
-        click.echo(_run_with_log(options[0]))
+        _, value = _get_option_safe(options[0], section, default=default)
+        if value is not None:
+            click.echo(value)
         return
 
-    json_result = {}
-    if list_defaults:
-        defaults = papis.config.get_default_settings()
-        for option in options:
-            if option not in defaults:
-                logger.error("Section '%s' has no defaults", option)
-                continue
+    result = run(options, section=section, default=default)
+    if not result:
+        return
 
-            if _json:
-                json_result[option] = defaults[option]
-            else:
-                click.echo("[{}]".format(option))
-                for key, value in defaults[option].items():
-                    click.echo(format(key, value))
-
-                if option != options[-1]:
-                    click.echo("")
-    else:
-        for option in options:
-            value = _run_with_log(option)
-            if value is None:
-                continue
-
-            if _json:
-                json_result[option] = value
-            else:
-                click.echo(format(option, value))
-
-    if _json:
+    if json_:
         import json
-        click.echo(json.dumps(json_result, indent=2))
+        click.echo(json.dumps(result, indent=2))
+    else:
+        if len(options) == 0 and section is None:
+            # NOTE: no inputs prints all of the sections
+            is_first = True
+            for section, settings in result.items():
+                if not is_first:
+                    click.echo("")
+
+                is_first = False
+                click.echo("[{}]".format(section))
+
+                for key, value in settings.items():
+                    click.echo(format_option(key, value))
+        else:
+            if section is not None and all("." not in o for o in options):
+                click.echo("[{}]".format(section))
+
+            for key, value in result.items():
+                click.echo(format_option(key, value))

--- a/papis/commands/config.py
+++ b/papis/commands/config.py
@@ -74,12 +74,19 @@ def run(option_string: str) -> Optional[str]:
         section = option[0]
         key = option[1]
     else:
-        raise ValueError("unrecognized option: {}".format(option_string))
+        logger.error(
+            "options should be in a <section>.<key> or <key> format: got '%s'",
+            option_string)
+        return None
 
     logger.debug("key = %s, sec = %s", key, section)
-    val = papis.config.get(key, section=section)
 
-    return val
+    try:
+        return papis.config.get(key, section=section)
+    except papis.exceptions.DefaultSettingValueMissing as exc:
+        logger.error("\n%s", str(exc).strip("\n"))
+
+    return None
 
 
 @click.command("config")

--- a/papis/commands/config.py
+++ b/papis/commands/config.py
@@ -103,7 +103,6 @@ def cli(options: List[str],
     import colorama
 
     logger.debug("config options: %s", options)
-    logger.info("Configuration file: '%s'", papis.config.get_config_file())
 
     def format(key: str, value: Any) -> str:
         return (
@@ -118,12 +117,19 @@ def cli(options: List[str],
                 logger.error("Section '%s' has no defaults", option)
                 continue
 
-            click.echo("")
             click.echo("[{}]".format(option))
             for key, value in defaults[option].items():
                 click.echo(format(key, value))
+
+            if option != options[-1]:
+                click.echo("")
     else:
-        for option in options:
-            value = run(option)
-            if value is not None:
-                click.echo(format(option, value))
+        if len(options) == 1:
+            # NOTE: a single option is printed directly for a bit of backwards
+            # compatiblity and easier use in shell scripts, so remove with care!
+            click.echo(run(options[0]))
+        else:
+            for option in options:
+                value = run(option)
+                if value is not None:
+                    click.echo(format(option, value))

--- a/papis/commands/config.py
+++ b/papis/commands/config.py
@@ -5,13 +5,28 @@ system.
 The ``config`` command returns the value used by Papis. Therefore, if you
 haven't customized some setting, it will return the default value. In contrast,
 if you have customized it, it will return the value set in the configuration
-file. To show the list of default and overwritten configuration values in a
-section use
+file. For example, to find out to what your "default-library" is set, do:
+
+.. code::
+    papis config default-library
+   
+The ``config`` command can also be used to query settings' default
+values. This is done by adding the ``--default`` flag. This ignores all
+settings set in your papis configuration file (note, however, that any
+setting set in a `config.py` file count as default values). Check the default
+"default-library" with:
+ 
+.. code::
+    papis config --default default-library
+   
+Settings from a specific section in the configuration file can also be
+accessed. To take an example, the `Bibtex`_ command's settings can be
+accessed with:
 
 .. code::
 
-    papis config --default --section <name>
-    papis config --section <name>
+    papis config --section bibtex
+    papis config --default --section bibtex
 
 or call ``papis config`` without the section argument to show the settings
 available for all the known sections.
@@ -32,18 +47,23 @@ If you wanted to see which ``dir`` the ``books`` library uses, you would do:
 With ``-l``, Papis selects a specific library (here, the "books" library). The
 rest works just as above.
 
-Settings from a specific section in the configuration file can also be
-accessed. To take an example, the `Bibtex`_ command's settings can be
-accessed with
+You can also query a specific setting within a section. For example like this:
 
 .. code::
 
-    papis config --default --section bibtex default-read-bibfile
     papis config --section bibtex default-read-bibfile
+    papis config --default --section bibtex default-read-bibfile
 
-For some more advanced usage, we can also query multiple settings at once. Then
-it may be useful to overwrite the selected section for several of the settings.
-This can be achieved by
+Alternatively, you can also you the ``<section.setting>`` format to query the value of
+a setting in a specific `section`:
+
+.. code::
+    papis config bibtex.default-read-bibfile
+    papis config --default bibtex.default-read-bibfile
+    
+For some more advanced usage, we can also query multiple settings at once.  Here,
+sections specified with ``<section>.<setting>`` override the section specified by
+``--setting <section>``. This can be achieved by:
 
 .. code::
 

--- a/papis/commands/config.py
+++ b/papis/commands/config.py
@@ -224,21 +224,24 @@ def cli(options: List[str],
         import json
         click.echo(json.dumps(result, indent=2))
     else:
+        lines = []
         if len(options) == 0 and section is None:
             # NOTE: no inputs prints all of the sections
             is_first = True
             for section, settings in result.items():
                 if not is_first:
-                    click.echo("")
+                    lines.append("")
 
                 is_first = False
-                click.echo("[{}]".format(section))
+                lines.append("[{}]".format(section))
 
                 for key, value in settings.items():
-                    click.echo(format_option(key, value))
+                    lines.append(format_option(key, value))
         else:
             if section is not None and all("." not in o for o in options):
-                click.echo("[{}]".format(section))
+                lines.append("[{}]".format(section))
 
             for key, value in result.items():
-                click.echo(format_option(key, value))
+                lines.append(format_option(key, value))
+
+        click.echo("\n".join(lines))

--- a/papis/commands/config.py
+++ b/papis/commands/config.py
@@ -1,34 +1,52 @@
 """
-The command config is a useful command because it allows you to check
+The ``config`` command is a useful command because it allows you to check
 the configuration settings' values that your current `papis` session
 is using.
 
 For example let's say that you want to see which ``dir`` setting your
-current library is using (i.e., the directory or the dir that appears
+default library is using (i.e., the directory or the dir that appears
 in the definition of the library in the configuration file), then you
-would simply do:
+would simply do
 
 .. code::
 
     papis config dir
 
-If you wanted to see which ``dir`` the library ``books`` has, for example
+If you wanted to see which ``dir`` the ``books`` library has, for example,
 then you would do
 
 .. code::
 
     papis -l books config dir
 
-This works as well for default settings, i.e., settings that you have not
-customized, for example the setting ``match-format``, you would check
-it with
+This works equally for any default settings, i.e. settings that have not been
+customized. For example, querying the ``match-format`` setting is done using
 
 .. code::
 
     papis config match-format
     > {doc[tags]}{doc.subfolder}{doc[title]}{doc[author]}{doc[year]}
 
-You can find a list of all available settings in the configuration section.
+Settings from a specific section in the configuration file can also be
+accessed by adding a dot ``"."`` between the section and the setting name. For
+example, if your ``books`` library is configured as a section, you could
+(equivalently) do
+
+.. code::
+
+    papis config books.dir
+
+For a more complex example, the :ref:`Bibtex` command has its own
+configuration settings. These can be accessed through
+
+.. code::
+
+    papis config bibtex.default-read-bibfile
+    > main.bib
+
+You can find a list of all available settings in the configuration section
+at :ref:`general-settings`. Commands and other plugins can define their own
+settings, which are documented separately.
 
 Command-line Interface
 ^^^^^^^^^^^^^^^^^^^^^^

--- a/papis/commands/config.py
+++ b/papis/commands/config.py
@@ -3,22 +3,24 @@ The ``config`` command allows you to query the settings used by Papis on your
 system.
 
 The ``config`` command returns the value used by Papis. Therefore, if you
-haven't customized some setting, it will return the default value. In contrast,
+have not customized some setting, it will return the default value. In contrast,
 if you have customized it, it will return the value set in the configuration
-file. For example, to find out to what your "default-library" is set, do:
+file. For example, to find out to what your "default-library" is set to, call:
 
 .. code::
+
     papis config default-library
-   
-The ``config`` command can also be used to query settings' default
-values. This is done by adding the ``--default`` flag. This ignores all
-settings set in your papis configuration file (note, however, that any
-setting set in a `config.py` file count as default values). Check the default
-"default-library" with:
- 
+
+The ``config`` command can also be used to query a settings' default
+value. This is done by adding the ``--default`` flag. This ignores all
+settings set in your Papis configuration file (note, however, that
+settings set in a ``config.py`` script can count as default values). Check the
+default "default-library" with:
+
 .. code::
+
     papis config --default default-library
-   
+
 Settings from a specific section in the configuration file can also be
 accessed. To take an example, the `Bibtex`_ command's settings can be
 accessed with:
@@ -28,24 +30,8 @@ accessed with:
     papis config --section bibtex
     papis config --default --section bibtex
 
-or call ``papis config`` without the section argument to show the settings
+or with ``papis config`` (without the section argument) to show the settings
 available for all the known sections.
-
-We can also query specific settings. Let's say you want to see which ``dir``
-setting your default library is using. You can achieve this with:
-
-.. code::
-
-    papis config dir
-
-If you wanted to see which ``dir`` the ``books`` library uses, you would do:
-
-.. code::
-
-    papis -l books config dir
-
-With ``-l``, Papis selects a specific library (here, the "books" library). The
-rest works just as above.
 
 You can also query a specific setting within a section. For example like this:
 
@@ -54,23 +40,21 @@ You can also query a specific setting within a section. For example like this:
     papis config --section bibtex default-read-bibfile
     papis config --default --section bibtex default-read-bibfile
 
-Alternatively, you can also you the ``<section.setting>`` format to query the value of
-a setting in a specific `section`:
+Alternatively, you can also use the ``<section.setting>`` format to query the
+value of a setting in a specific `section`:
 
 .. code::
+
     papis config bibtex.default-read-bibfile
     papis config --default bibtex.default-read-bibfile
-    
-For some more advanced usage, we can also query multiple settings at once.  Here,
+
+For some more advanced usage, we can also query multiple settings at once. Here,
 sections specified with ``<section>.<setting>`` override the section specified by
 ``--setting <section>``. This can be achieved by:
 
 .. code::
 
     papis config --section sec1 key1 key2 key3 sec2.key4 sec3.key5
-
-where the keys take the format ``[<section>.]<key>`` with an optional prefix
-to specify the section override.
 
 You can find a list of all available settings in the configuration section
 at :ref:`general-settings`. Commands and other plugins can define their own

--- a/papis/commands/config.py
+++ b/papis/commands/config.py
@@ -1,40 +1,36 @@
 """
-The ``config`` command is a useful command because it allows you to check
-the configuration settings' values that your current `papis` session
-is using.
+The ``config`` command allows you to query the settings used by Papis on your
+system.
 
-For example let's say that you want to see which ``dir`` setting your
-default library is using (i.e., the directory or the dir that appears
-in the definition of the library in the configuration file), then you
-would simply do
+The ``config`` command returns the value used by Papis. Therefore, if you
+haven't customized some setting, it will return the default value. In contrast,
+if you have customized it, it will return the value you set.
+
+Let's say you want to see which ``dir`` setting your default library is using.
+You can achieve this with:
 
 .. code::
 
     papis config dir
 
-If you wanted to see which ``dir`` the ``books`` library has, for example,
-then you would do
+If you wanted to see which ``dir`` the ``books`` library uses, you would do:
 
 .. code::
 
     papis -l books config dir
 
-This works equally for any default settings, i.e. settings that have not been
-customized. For example, querying the ``match-format`` setting is done using
-
-.. code::
-
-    papis config match-format
-    > {doc[tags]}{doc.subfolder}{doc[title]}{doc[author]}{doc[year]}
+With ``-l``, Papis selects a specific library (here, the "books" library). The 
+rest works just as above.
 
 Settings from a specific section in the configuration file can also be
 accessed by adding a dot ``"."`` between the section and the setting name. For
-example, if your ``books`` library is configured as a section, you could
-(equivalently) do
+example, if your ``books`` library is configured as a section, you can do:
 
 .. code::
 
     papis config books.dir
+
+This is equivalent to the above ``papis -l books config dir`` command.
 
 For a more complex example, the :ref:`Bibtex` command has its own
 configuration settings. These can be accessed through

--- a/papis/commands/config.py
+++ b/papis/commands/config.py
@@ -56,16 +56,17 @@ Command-line Interface
 """
 
 import logging
-from typing import Optional
+from typing import List, Optional
 
 import click
 
+import papis.config
 import papis.commands
+
+logger = logging.getLogger("config:run")
 
 
 def run(option_string: str) -> Optional[str]:
-    logger = logging.getLogger("config:run")
-
     option = option_string.split(".")
     key = section = None
     if len(option) == 1:
@@ -91,10 +92,12 @@ def run(option_string: str) -> Optional[str]:
 
 @click.command("config")
 @click.help_option("--help", "-h")
-@click.argument("option")
-def cli(option: str) -> None:
+@click.argument("options", nargs=-1)
+def cli(options: List[str]) -> None:
     """Print configuration values"""
-    logger = logging.getLogger("cli:config")
-    logger.debug(option)
+    logger.debug("Config options: %s", options)
 
-    click.echo(run(option))
+    for option in options:
+        value = run(option)
+        if value is not None:
+            click.echo("{} = {}".format(option, value))

--- a/papis/config.py
+++ b/papis/config.py
@@ -66,22 +66,29 @@ class Configuration(configparser.ConfigParser):
             self.logger.warning(
                 "Creating configuration folder in '%s'", self.dir_location)
             os.makedirs(self.dir_location)
+
         if not os.path.exists(self.scripts_location):
+            self.logger.warning(
+                "Creating scripts folder in '%s'", self.scripts_location)
             os.makedirs(self.scripts_location)
+
         if os.path.exists(self.file_location):
-            self.logger.debug(
-                "Reading configuration from '%s'", self.file_location)
+            self.logger.debug("Reading configuration from '%s'", self.file_location)
             self.read(self.file_location)
             self.handle_includes()
-        else:
+
+        # NOTE: if no sections were actually read, add default ones
+        if not self.sections():
             for section in self.default_info:
                 self[section] = {}
                 for field in self.default_info[section]:
                     self[section][field] = self.default_info[section][field]
+
             with open(self.file_location, "w") as configfile:
                 self.logger.info(
                     "Creating config file at '%s'", self.file_location)
                 self.write(configfile)
+
         configpy = get_configpy_file()
         if os.path.exists(configpy):
             self.logger.debug("Executing '%s'", configpy)

--- a/papis/config.py
+++ b/papis/config.py
@@ -66,7 +66,7 @@ class Configuration(configparser.ConfigParser):
             os.makedirs(self.dir_location)
 
         if not os.path.exists(self.scripts_location):
-            self.logger.warning(
+            logger.warning(
                 "Creating scripts folder in '%s'", self.scripts_location)
             os.makedirs(self.scripts_location)
 

--- a/tests/commands/test_config.py
+++ b/tests/commands/test_config.py
@@ -10,9 +10,18 @@ logging.basicConfig(level=logging.DEBUG)
 class TestCommand(unittest.TestCase):
 
     def test_simple(self):
-        self.assertEqual(run("editor"), papis.config.get("editor"))
-        self.assertEqual(run("settings.editor"), papis.config.get("editor"))
-        self.assertEqual(run("papers.dir"), papis.config.get("dir", section="papers"))
+        self.assertEqual(
+            run(["editor"]),
+            {"editor": papis.config.get("editor")}
+            )
+        self.assertEqual(
+            run(["settings.editor"]),
+            {"editor": papis.config.get("editor")}
+            )
+        self.assertEqual(
+            run(["papers.dir"]),
+            {"dir": papis.config.get("dir", section="papers")}
+            )
 
 
 class TestDefaultConfiguration(unittest.TestCase):

--- a/tests/commands/test_config.py
+++ b/tests/commands/test_config.py
@@ -46,6 +46,7 @@ def test_config_section() -> None:
     from papis.commands.config import run
     section = papis.config.get_general_settings_name()
     config = papis.config.get_configuration()
+    defaults = papis.config.get_default_settings()
 
     # checks:
     # * non-existent key in non-existent section: `editor`
@@ -70,7 +71,7 @@ def test_config_section() -> None:
     # checks:
     # * reading all the sections
     result = run([])
-    assert result == config.default_info
+    assert result == defaults
 
 
 @with_default_config

--- a/tests/commands/test_config.py
+++ b/tests/commands/test_config.py
@@ -1,57 +1,95 @@
-import os
-import unittest
-import logging
 import papis.config
-from papis.commands.config import run
 
+import logging
 logging.basicConfig(level=logging.DEBUG)
 
 
-class TestCommand(unittest.TestCase):
+def with_default_config(fn):
+    import os
+    import tempfile
+    import functools
 
-    def test_simple(self):
-        self.assertEqual(
-            run(["editor"]),
-            {"editor": papis.config.get("editor")}
-            )
-        self.assertEqual(
-            run(["settings.editor"]),
-            {"editor": papis.config.get("editor")}
-            )
-        self.assertEqual(
-            run(["papers.dir"]),
-            {"dir": papis.config.get("dir", section="papers")}
-            )
+    @functools.wraps(fn)
+    def wrapper(*args, **kwargs):
+        with tempfile.NamedTemporaryFile(mode="w", delete=False) as config:
+            pass
+
+        papis.config.set_config_file(config.name)
+        papis.config.reset_configuration()
+
+        result = fn(*args, **kwargs)
+
+        papis.config.set_config_file(None)
+        papis.config.reset_configuration()
+
+        os.unlink(config.name)
+
+        return result
+
+    return wrapper
 
 
-class TestDefaultConfiguration(unittest.TestCase):
+@with_default_config
+def test_config_single_option() -> None:
+    from papis.commands.config import run
 
-    @classmethod
-    def setUpClass(cls):
-        pass
+    assert run(["editor"]) == {"editor": papis.config.get("editor")}
+    assert run(["settings.editor"]) == {"editor": papis.config.get("editor")}
+    assert run(["papers.dir"]) == {"dir": papis.config.get("dir", section="papers")}
 
-    @classmethod
-    def tearDownClass(cls):
-        pass
 
-    def test_default_config(self):
-        """Test main default config
-        """
-        self.assertTrue(papis.config.get_default_settings)
+@with_default_config
+def test_config_section() -> None:
+    # NOTE: imported to register the `bibtex` default settings
+    import papis.commands.bibtex
 
-        settings = papis.config.get_default_settings()
-        self.assertTrue(settings)
+    from papis.commands.config import run
+    section = papis.config.get_general_settings_name()
+    config = papis.config.get_configuration()
 
-        self.assertIsInstance(settings, dict)
-        for section in ["settings"]:
-            self.assertIn(section, settings.keys())
+    # checks:
+    # * non-existent key in non-existent section: `editor`
+    # * non-overwritten keys in non-existent section: `auto-read`
+    # * overwriting the section: `.notes-name`
+    result = run(["editor", "auto-read", ".notes-name"], section="bibtex")
+    assert "editor" not in result
+    assert result == {
+        "auto-read": papis.config.get("auto-read", section="bibtex"),
+        "notes-name": papis.config.get("notes-name"),
+        }
 
-    def test_set_lib(self):
-        try:
-            lib = "non-existing-library"
-            self.assertFalse(os.path.exists(lib))
-            papis.config.set_lib(lib)
-        except Exception:
-            self.assertTrue(True)
-        else:
-            self.assertTrue(False)
+    # checks:
+    # * existing key in given section: `dir`
+    # * overwriting section: `.default-library`
+    result = run(["dir", ".default-library"], section="papers")
+    assert result == {
+        "dir": config.default_info["papers"]["dir"],
+        "default-library": config.default_info[section]["default-library"],
+        }
+
+    # checks:
+    # * reading all the sections
+    result = run([])
+    assert result == config.default_info
+
+
+@with_default_config
+def test_config_section_defaults() -> None:
+    from papis.commands.config import run
+    defaults = papis.config.get_default_settings()
+
+    # checks:
+    # * non-existent key in given section: `editor`
+    # * existing key in given section: `editmode`
+    # * overwriting the section: `.notes-name`
+    result = run(["editor", "editmode", ".notes-name"], section="tui", default=True)
+    assert "editor" not in result
+    assert result == {
+        "editmode": papis.config.get("editmode", section="tui"),
+        "notes-name": papis.config.get("notes-name"),
+        }
+
+    # checks:
+    # * reading all the sections
+    result = run([], default=True)
+    assert result == defaults

--- a/tests/downloaders/__init__.py
+++ b/tests/downloaders/__init__.py
@@ -29,13 +29,18 @@ def with_default_config(fn: Callable[..., Any]) -> Callable[..., Any]:
 
     @functools.wraps(fn)
     def wrapper(*args, **kwargs):
-        with tempfile.NamedTemporaryFile(mode="w") as config:
-            papis.config.set_config_file(config.name)
-            papis.config.reset_configuration()
+        with tempfile.NamedTemporaryFile(mode="w", delete=False) as config:
+            pass
 
-            result = fn(*args, **kwargs)
+        papis.config.set_config_file(config.name)
+        papis.config.reset_configuration()
 
-            papis.config.set_config_file(None)
+        result = fn(*args, **kwargs)
+
+        papis.config.set_config_file(None)
+        papis.config.reset_configuration()
+
+        os.unlink(config.name)
 
         return result
 

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -181,6 +181,16 @@ some-other-setting = mandragora
     os.unlink(configpath)
 
 
+def test_set_lib_non_existing() -> None:
+    lib = "non-existing-library"
+    assert not os.path.exists(lib)
+
+    with pytest.raises(
+            Exception,
+            match="Library '{}' does not seem to exist".format(lib)):
+        papis.config.set_lib_from_name(lib)
+
+
 def test_set_lib_from_path() -> None:
     with tempfile.TemporaryDirectory() as lib:
         assert os.path.exists(lib)
@@ -209,8 +219,13 @@ def test_reset_configuration() -> None:
 
 
 def test_get_default_settings() -> None:
-    assert type(papis.config.get_default_settings()) is dict
-    assert papis.config.get_default_settings()["settings"]["mvtool"] == "mv"
+    settings = papis.config.get_default_settings()
+    assert isinstance(settings, dict)
+    assert len(settings) != 0
+
+    section = papis.config.get_general_settings_name()
+    assert section in settings
+    assert settings[section]["mvtool"] == "mv"
 
 
 def test_register_default_settings() -> None:


### PR DESCRIPTION
Was trying to figure out what configs were used in my venv and fell down a little rabbit hole!

This make some updates to the ``config`` command:
* Improve the docs a bit.
* Do not show scary tracebacks on errors, but some hopefully helpful error messages.
* Allow more positional arguments to query multiple settings at once.
* Added `--default` to show all the defaults papis knows about for a given section (could be helpful to explore the settings without going into the code)
* Added a `--json` flag to print multiple options in the json format instead of the default INI-ish format.

@jghauser if you have the time to take a look at the documentation parts (phrasing and such), it would be greatly appreciated, as usual!