### PR TITLE
Add some more helpful targets to Makefile

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -37,9 +37,8 @@ jobs:
         python-version: ${{ matrix.python-version }}
 
     - name: Install
-      run: ./tools/ci-install.sh
-      shell: bash
+      run: make ci-install
 
     - name: Run tests, mypy and linting
-      run: ./tools/ci-run-tests.sh
+      run: make ci-test
       shell: bash

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-.PHONY: bash-autocomplete update-authors
+.PHONY: bash-autocomplete update-authors tags doc test ci-install ci-tests
 
 bash-autocomplete:
 	make -C scripts/shell_completion/
@@ -10,4 +10,25 @@ update-authors:
 		AUTHORS
 
 tags:
-	ctags -V -R --language-force=python papis env
+	ctags -f tags \
+		--recurse=yes \
+		--tag-relative=yes \
+		--fields=+l \
+		--kinds-python=-i \
+		--language-force=python \
+		papis
+
+doc:
+	cd doc && make html SPHINXOPTS="-W --keep-going -n"
+	@echo ""
+	@echo -e "\e[1;32mRun '$$BROWSER doc/build/html/index.html' to see the docs\e[0m"
+	@echo ""
+
+test:
+	python -m pytest -rswx --cov=papis -v -s papis tests
+
+ci-install:
+	bash tools/ci-install.sh
+
+ci-test:
+	bash tools/ci-run-tests.sh


### PR DESCRIPTION
This adds 
* a `doc` target that should make the docs in HTML format.
* a `test` target that just runs pytest.
* a `ci-install` and `ci-test` target to install and run the tests like on the ci.

@jghauser hopefully these are helpful!