### PR TITLE
Remove LGTM badge

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -175,14 +175,11 @@ Papis isn't the only fish in the pond. You might also be interested in:
 - `Zotero <https://www.zotero.org/>`__ (opensource)
 
 
-
-.. |Build_Status| image:: https://travis-ci.org/papis/papis.svg?branch=master
-   :target: https://travis-ci.org/papis/papis
 .. |ghbadge| image:: https://github.com/papis/papis/workflows/CI/badge.svg
    :target: https://github.com/papis/papis/actions?query=branch%3Amaster+workflow%3ACI
 .. |RTD| image:: https://readthedocs.org/projects/papis/badge/?version=latest
    :target: http://papis.readthedocs.io/en/latest/?badge=latest
-.. |CodeQL| image:: https://github.com/Nike-Inc/gimme-a-cli/workflows/CodeQL/badge.svg
+.. |CodeQL| image:: https://github.com/papis/papis/workflows/CodeQL/badge.svg
    :target: https://github.com/papis/papis/actions?query=branch%3Amaster+workflow%3ACodeQL
 
 .. |Pypi| image:: https://badge.fury.io/py/papis.svg

--- a/README.rst
+++ b/README.rst
@@ -1,7 +1,7 @@
 Papis
 =====
 
-|ghbadge| |Coveralls| |RTD| |CodeQL| |Pypi| |zenodo_badge|
+|ghbadge| |RTD| |CodeQL| |Pypi| |zenodo_badge|
 
 Papis is a powerful and highly extensible CLI document and bibliography manager.
 
@@ -180,8 +180,6 @@ Papis isn't the only fish in the pond. You might also be interested in:
    :target: https://travis-ci.org/papis/papis
 .. |ghbadge| image:: https://github.com/papis/papis/workflows/CI/badge.svg
    :target: https://github.com/papis/papis/actions?query=branch%3Amain+workflow%3ACI
-.. |Coveralls| image:: https://coveralls.io/repos/github/papis/papis/badge.svg?branch=master
-   :target: https://coveralls.io/github/papis/papis?branch=master
 .. |RTD| image:: https://readthedocs.org/projects/papis/badge/?version=latest
    :target: http://papis.readthedocs.io/en/latest/?badge=latest
 .. |CodeQL| image:: https://github.com/Nike-Inc/gimme-a-cli/workflows/CodeQL/badge.svg

--- a/README.rst
+++ b/README.rst
@@ -1,7 +1,7 @@
 Papis
 =====
 
-|ghbadge| |Coveralls| |RTD| |Code_Quality| |Pypi| |zenodo_badge|
+|ghbadge| |Coveralls| |RTD| |Pypi| |zenodo_badge|
 
 Papis is a powerful and highly extensible CLI document and bibliography manager.
 
@@ -113,10 +113,10 @@ Reviews and blog posts
 - `Blog post <https://alejandrogallo.github.io/blog/posts/getting-paper-references-with-papis/>`__ about getting a paper's references with ``papis explore``.
 - `Blog post <http://nicolasshu.com/zotero_and_papis.html>`__ about using Papis with Zotero and Syncthing.
 - GNU/Linux Switzerland `wrote about Papis <https://gnulinux.ch/papis-dokumentenverwaltung-fuer-die-kommandozeile>`__ *(in German)*.
-- The folks at OSTechNix wrote a review of `Papis 
+- The folks at OSTechNix wrote a review of `Papis
   <https://www.ostechnix.com/papis-command-line-based-document-bibliography-manager/>`__.
 - A `review of Papis <https://ubunlog.com/papis-administrador-documentos/>`__ by Ubunlog *(in Spanish)*.
-  
+
 Contributing
 ------------
 
@@ -139,7 +139,7 @@ Papis has grown over the years and there are now a number of projects that exten
 
    * - `papis-rofi <https://github.com/papis/papis-rofi/>`__
      - `Etn40ff <https://github.com/Etn40ff>`__
-   
+
    * - `papis-dmenu <https://github.com/papis/papis-dmenu>`__
      - you?
 
@@ -183,8 +183,6 @@ Papis isn't the only fish in the pond. You might also be interested in:
    :target: https://coveralls.io/github/papis/papis?branch=master
 .. |RTD| image:: https://readthedocs.org/projects/papis/badge/?version=latest
    :target: http://papis.readthedocs.io/en/latest/?badge=latest
-.. |Code_Quality| image:: https://img.shields.io/lgtm/grade/python/g/papis/papis.svg?logo=lgtm&logoWidth=18
-   :target: https://lgtm.com/projects/g/papis/papis/context:python
 .. |Pypi| image:: https://badge.fury.io/py/papis.svg
    :target: https://pypi.org/project/papis/
 .. |zenodo_badge| image:: https://zenodo.org/badge/82691622.svg

--- a/README.rst
+++ b/README.rst
@@ -1,7 +1,7 @@
 Papis
 =====
 
-|ghbadge| |Coveralls| |RTD| |Pypi| |zenodo_badge|
+|ghbadge| |Coveralls| |RTD| |CodeQL| |Pypi| |zenodo_badge|
 
 Papis is a powerful and highly extensible CLI document and bibliography manager.
 
@@ -179,10 +179,14 @@ Papis isn't the only fish in the pond. You might also be interested in:
 .. |Build_Status| image:: https://travis-ci.org/papis/papis.svg?branch=master
    :target: https://travis-ci.org/papis/papis
 .. |ghbadge| image:: https://github.com/papis/papis/workflows/CI/badge.svg
+   :target: https://github.com/papis/papis/actions?query=branch%3Amain+workflow%3ACI
 .. |Coveralls| image:: https://coveralls.io/repos/github/papis/papis/badge.svg?branch=master
    :target: https://coveralls.io/github/papis/papis?branch=master
 .. |RTD| image:: https://readthedocs.org/projects/papis/badge/?version=latest
    :target: http://papis.readthedocs.io/en/latest/?badge=latest
+.. |CodeQL| image:: https://github.com/Nike-Inc/gimme-a-cli/workflows/CodeQL/badge.svg
+   :target: https://github.com/papis/papis/actions?query=branch%3Amain+workflow%3ACodeQL
+
 .. |Pypi| image:: https://badge.fury.io/py/papis.svg
    :target: https://pypi.org/project/papis/
 .. |zenodo_badge| image:: https://zenodo.org/badge/82691622.svg

--- a/README.rst
+++ b/README.rst
@@ -179,11 +179,11 @@ Papis isn't the only fish in the pond. You might also be interested in:
 .. |Build_Status| image:: https://travis-ci.org/papis/papis.svg?branch=master
    :target: https://travis-ci.org/papis/papis
 .. |ghbadge| image:: https://github.com/papis/papis/workflows/CI/badge.svg
-   :target: https://github.com/papis/papis/actions?query=branch%3Amain+workflow%3ACI
+   :target: https://github.com/papis/papis/actions?query=branch%3Amaster+workflow%3ACI
 .. |RTD| image:: https://readthedocs.org/projects/papis/badge/?version=latest
    :target: http://papis.readthedocs.io/en/latest/?badge=latest
 .. |CodeQL| image:: https://github.com/Nike-Inc/gimme-a-cli/workflows/CodeQL/badge.svg
-   :target: https://github.com/papis/papis/actions?query=branch%3Amain+workflow%3ACodeQL
+   :target: https://github.com/papis/papis/actions?query=branch%3Amaster+workflow%3ACodeQL
 
 .. |Pypi| image:: https://badge.fury.io/py/papis.svg
    :target: https://pypi.org/project/papis/


### PR DESCRIPTION
LGTM went EOL on December 15th, so this removes the badge.

@alejandrogallo The `coveralls` badge also points to something that still uses the TravisCI and hasn't been updated in a long time. Can you update that or should I remove it as well?