### PR TITLE
Use a consistent naming scheme for loggers

### DIFF
--- a/papis/__init__.py
+++ b/papis/__init__.py
@@ -1,20 +1,4 @@
-import os
-
-# Information
 __license__ = "GPLv3"
 __version__ = "0.12"
 __author__ = __maintainer__ = "Alejandro Gallo"
 __email__ = "aamsgallo@gmail.com"
-
-
-if os.environ.get("PAPIS_DEBUG"):
-    import logging
-    log_format = (
-        "%(relativeCreated)d-"
-        + "%(levelname)s"
-        + ":"
-        + "%(name)s"
-        + ":"
-        + "%(message)s"
-    )
-    logging.basicConfig(format=log_format, level=logging.DEBUG)

--- a/papis/api.py
+++ b/papis/api.py
@@ -11,7 +11,7 @@ import papis.config
 import papis.pick
 import papis.database
 
-logger = logging.getLogger("api")
+logger = logging.getLogger(__name__)
 
 
 def get_lib_name() -> str:

--- a/papis/api.py
+++ b/papis/api.py
@@ -2,16 +2,17 @@
 This module describes which functions are intended to be used by users to
 create papis scripts.
 """
+
 from typing import Any, Dict, List, Optional
-import logging
 
 import papis.utils
 import papis.commands
 import papis.config
 import papis.pick
 import papis.database
+import papis.logging
 
-logger = logging.getLogger(__name__)
+logger = papis.logging.get_logger(__name__)
 
 
 def get_lib_name() -> str:

--- a/papis/arxiv.py
+++ b/papis/arxiv.py
@@ -18,7 +18,6 @@
 import os
 import re
 import sys
-import logging
 from typing import Optional, List, Dict, Any
 
 import click
@@ -26,9 +25,9 @@ import click
 import papis.filetype
 import papis.downloaders.base
 import papis.config
+import papis.logging
 
-
-logger = logging.getLogger(__name__)
+logger = papis.logging.get_logger(__name__)
 
 ARXIV_API_URL = "http://arxiv.org/api/query"
 ARXIV_ABS_URL = "https://arxiv.org/abs"

--- a/papis/arxiv.py
+++ b/papis/arxiv.py
@@ -28,7 +28,7 @@ import papis.downloaders.base
 import papis.config
 
 
-logger = logging.getLogger("arxiv")
+logger = logging.getLogger(__name__)
 
 ARXIV_API_URL = "http://arxiv.org/api/query"
 ARXIV_ABS_URL = "https://arxiv.org/abs"
@@ -212,7 +212,6 @@ def explorer(
         papis explore arxiv -a '"John Smith"' pick
 
     """
-    logger = logging.getLogger("explore:arxiv")
     logger.info("Looking up...")
 
     data = get_data(

--- a/papis/base.py
+++ b/papis/base.py
@@ -10,7 +10,7 @@ from typing import Optional, Dict, Any, List, Callable, NamedTuple
 
 import click
 
-logger = logging.getLogger("base")
+logger = logging.getLogger(__name__)
 
 
 def get_data(query: str = "", hits: int = 20) -> List[Dict[str, Any]]:
@@ -22,8 +22,7 @@ def get_data(query: str = "", hits: int = 20) -> List[Dict[str, Any]]:
     logger.warning("BASE engine in papis is experimental")
 
     if hits > 125:
-        logger.error(
-            "BASE only allows a maximum of 125 hits, got %d hits", hits)
+        logger.error("BASE only allows a maximum of 125 hits, got %d hits", hits)
         hits = 125
 
     dict_params = {
@@ -110,7 +109,6 @@ def explorer(ctx: click.core.Context, query: str) -> None:
 
     """
     import papis.document
-    logger = logging.getLogger("explore:base")
     logger.info("Looking up...")
 
     data = get_data(query=query)

--- a/papis/base.py
+++ b/papis/base.py
@@ -5,12 +5,14 @@ For description refer to
 https://www.base-search.net/about/download/base_interface.pdf
 
 """
-import logging
+
 from typing import Optional, Dict, Any, List, Callable, NamedTuple
 
 import click
 
-logger = logging.getLogger(__name__)
+import papis.logging
+
+logger = papis.logging.get_logger(__name__)
 
 
 def get_data(query: str = "", hits: int = 20) -> List[Dict[str, Any]]:

--- a/papis/bibtex.py
+++ b/papis/bibtex.py
@@ -1,6 +1,5 @@
 import os
 import string
-import logging
 from typing import Optional, List, FrozenSet, Dict, Any, Iterator
 
 import click
@@ -10,8 +9,9 @@ import papis.importer
 import papis.filetype
 import papis.document
 import papis.format
+import papis.logging
 
-logger = logging.getLogger(__name__)
+logger = papis.logging.get_logger(__name__)
 
 # NOTE: see the BibLaTeX docs for an up to date list of types and keys:
 #   https://ctan.org/pkg/biblatex?lang=en
@@ -215,15 +215,16 @@ def bibtex_to_dict(bibtex: str) -> List[Dict[str, str]]:
     :returns: Dictionary with bibtex information with keys that bibtex
         formally recognizes.
     """
-    # bibtexparser has too many debug messages to be useful
-    logging.getLogger("bibtexparser.bparser").setLevel(logging.WARNING)
-
     from bibtexparser.bparser import BibTexParser
     parser = BibTexParser(
         common_strings=True,
         ignore_nonstandard_types=False,
         homogenize_fields=False,
         interpolate_strings=True)
+
+    # bibtexparser has too many debug messages to be useful
+    import logging
+    logging.getLogger("bibtexparser.bparser").setLevel(logging.WARNING)
 
     if os.path.exists(bibtex):
         with open(bibtex) as fd:

--- a/papis/bibtex.py
+++ b/papis/bibtex.py
@@ -11,7 +11,7 @@ import papis.filetype
 import papis.document
 import papis.format
 
-logger = logging.getLogger("bibtex")  # type: logging.Logger
+logger = logging.getLogger(__name__)
 
 # NOTE: see the BibLaTeX docs for an up to date list of types and keys:
 #   https://ctan.org/pkg/biblatex?lang=en
@@ -168,7 +168,6 @@ def explorer(ctx: click.core.Context, bibfile: str) -> None:
     papis explore bibtex lib.bib pick
 
     """
-    logger = logging.getLogger("explore:bibtex")
     logger.info("Reading in bibtex file '%s'", bibfile)
 
     docs = [
@@ -216,16 +215,16 @@ def bibtex_to_dict(bibtex: str) -> List[Dict[str, str]]:
     :returns: Dictionary with bibtex information with keys that bibtex
         formally recognizes.
     """
-    from bibtexparser.bparser import BibTexParser
+    # bibtexparser has too many debug messages to be useful
+    logging.getLogger("bibtexparser.bparser").setLevel(logging.WARNING)
 
+    from bibtexparser.bparser import BibTexParser
     parser = BibTexParser(
         common_strings=True,
         ignore_nonstandard_types=False,
         homogenize_fields=False,
         interpolate_strings=True)
 
-    # bibtexparser has too many debug messages to be useful
-    logging.getLogger("bibtexparser.bparser").setLevel(logging.WARNING)
     if os.path.exists(bibtex):
         with open(bibtex) as fd:
             logger.debug("Reading in file '%s'", bibtex)

--- a/papis/citations.py
+++ b/papis/citations.py
@@ -1,6 +1,5 @@
-from typing import Dict, Any, List, Optional, Sequence, Tuple
-import logging
 import os
+from typing import Dict, Any, List, Optional, Sequence, Tuple
 
 import tqdm
 import colorama
@@ -10,9 +9,10 @@ import papis.database
 import papis.crossref
 import papis.yaml
 import papis.utils
+import papis.logging
 from papis.document import Document, to_dict
 
-logger = logging.getLogger(__name__)
+logger = papis.logging.get_logger(__name__)
 
 Citation = Dict[str, Any]
 Citations = Sequence[Citation]

--- a/papis/citations.py
+++ b/papis/citations.py
@@ -12,10 +12,10 @@ import papis.yaml
 import papis.utils
 from papis.document import Document, to_dict
 
+logger = logging.getLogger(__name__)
 
 Citation = Dict[str, Any]
 Citations = Sequence[Citation]
-LOGGER = logging.getLogger("citations")
 
 
 def get_metadata_citations(doc: Dict[str, Any]) -> List[Dict[str, Any]]:
@@ -37,7 +37,7 @@ def fetch_citations(doc: Document) -> List[Dict[str, Any]]:
     metadata_citations = get_metadata_citations(doc)
     if not metadata_citations:
         if doc.has("doi"):
-            LOGGER.debug("trying with doi '%s'", doc["doi"])
+            logger.debug("trying with doi '%s'", doc["doi"])
             data = papis.crossref.doi_to_data(doc["doi"])
             metadata_citations = get_metadata_citations(data)
             if not metadata_citations:
@@ -50,14 +50,14 @@ def fetch_citations(doc: Document) -> List[Dict[str, Any]]:
 
     dois = [str(d.get("doi")).lower() for d in metadata_citations
             if "doi" in d]
-    LOGGER.info("%d citations found to query", len(dois))
+    logger.info("%d citations found to query", len(dois))
 
     dois_with_data = [
     ]  # type: List[Dict[str, Any]]
     found_in_lib_dois = [
     ]  # type: List[Dict[str, Any]]
 
-    LOGGER.info("Checking which citations are already in the library")
+    logger.info("Checking which citations are already in the library")
     dois_with_data = get_citations_from_database(dois)
 
     for data in dois_with_data:
@@ -65,8 +65,8 @@ def fetch_citations(doc: Document) -> List[Dict[str, Any]]:
         if doi:
             dois.remove(doi)
 
-    LOGGER.info("Found %d DOIs in library", len(found_in_lib_dois))
-    LOGGER.info("Fetching %d citations from crossref", len(dois))
+    logger.info("Found %d DOIs in library", len(found_in_lib_dois))
+    logger.info("Fetching %d citations from crossref", len(dois))
 
     with tqdm.tqdm(iterable=dois) as progress:
         for doi in progress:

--- a/papis/commands/add.py
+++ b/papis/commands/add.py
@@ -95,7 +95,6 @@ Command-line Interface
 
 import os
 import re
-import logging
 from typing import List, Any, Optional, Dict, Tuple
 
 import click
@@ -115,8 +114,9 @@ import papis.git
 import papis.format
 import papis.citations
 import papis.id
+import papis.logging
 
-logger = logging.getLogger(__name__)
+logger = papis.logging.get_logger(__name__)
 
 
 class FromFolderImporter(papis.importer.Importer):

--- a/papis/commands/add.py
+++ b/papis/commands/add.py
@@ -116,7 +116,7 @@ import papis.format
 import papis.citations
 import papis.id
 
-logger = logging.getLogger("add")  # type: logging.Logger
+logger = logging.getLogger(__name__)
 
 
 class FromFolderImporter(papis.importer.Importer):
@@ -277,7 +277,6 @@ def run(paths: List[str],
         data = {}
 
     import tempfile
-    logger = logging.getLogger("add:run")
 
     # The real paths of the documents to be added
     in_documents_paths = paths
@@ -537,8 +536,6 @@ def cli(files: List[str],
                 name=n,
                 text=re.sub(r"[ \n]+", " ", import_mgr[n].plugin.__doc__)))
         return
-
-    logger = logging.getLogger("cli:add")
 
     data = {}
     for data_set in set_list:

--- a/papis/commands/addto.py
+++ b/papis/commands/addto.py
@@ -33,12 +33,12 @@ import papis.commands.add
 import papis.cli
 import papis.strings
 
+logger = logging.getLogger(__name__)
+
 
 def run(document: papis.document.Document,
         filepaths: List[str],
         git: bool = False) -> None:
-    logger = logging.getLogger("addto")
-
     from string import ascii_lowercase
     g = papis.utils.create_identifier(ascii_lowercase)
     string_append = ""
@@ -124,8 +124,6 @@ def cli(query: str,
         doc_folder: str,
         sort_reverse: bool) -> None:
     """Add files to an existing document"""
-    logger = logging.getLogger("cli:addto")
-
     if doc_folder:
         documents = [papis.document.from_folder(doc_folder)]
     else:

--- a/papis/commands/addto.py
+++ b/papis/commands/addto.py
@@ -19,7 +19,6 @@ Command-line Interface
 """
 
 import os
-import logging
 from typing import List, Optional
 
 import click
@@ -32,8 +31,9 @@ import papis.config
 import papis.commands.add
 import papis.cli
 import papis.strings
+import papis.logging
 
-logger = logging.getLogger(__name__)
+logger = papis.logging.get_logger(__name__)
 
 
 def run(document: papis.document.Document,

--- a/papis/commands/bibtex.py
+++ b/papis/commands/bibtex.py
@@ -147,8 +147,7 @@ import papis.commands.export
 from papis.commands.update import _update_with_database
 import papis.bibtex
 
-
-logger = logging.getLogger("papis:bibtex")
+logger = logging.getLogger(__name__)
 
 
 config.register_default_settings({"bibtex": {

--- a/papis/commands/bibtex.py
+++ b/papis/commands/bibtex.py
@@ -124,7 +124,6 @@ Command-line Interface
 
 import os
 import re
-import logging
 
 from typing import List, Optional, Tuple
 import click
@@ -146,8 +145,9 @@ import papis.commands.browse
 import papis.commands.export
 from papis.commands.update import _update_with_database
 import papis.bibtex
+import papis.logging
 
-logger = logging.getLogger(__name__)
+logger = papis.logging.get_logger(__name__)
 
 
 config.register_default_settings({"bibtex": {
@@ -550,7 +550,7 @@ def _import(ctx: click.Context, out: Optional[str], _all: bool) -> None:
         docs = papis.api.pick_doc(docs)
 
     if out is not None:
-        logging.info("Setting lib name to %s", out)
+        logger.info("Setting lib name to %s", out)
         if not os.path.exists(out):
             os.makedirs(out)
         config.set_lib_from_name(out)

--- a/papis/commands/browse.py
+++ b/papis/commands/browse.py
@@ -70,8 +70,7 @@ import papis.database
 import papis.strings
 import papis.document
 
-
-logger = logging.getLogger("browse")
+logger = logging.getLogger(__name__)
 
 
 def run(document: papis.document.Document,
@@ -137,9 +136,6 @@ def cli(query: str,
         sort_field: Optional[str],
         sort_reverse: bool) -> None:
     """Open document's url in a browser"""
-
-    logger = logging.getLogger("cli:browse")
-
     documents = papis.cli.handle_doc_folder_query_all_sort(query,
                                                            doc_folder,
                                                            sort_field,

--- a/papis/commands/browse.py
+++ b/papis/commands/browse.py
@@ -56,7 +56,6 @@ Command-line Interface
     :prog: papis browse
 """
 
-import logging
 from typing import Optional
 
 import click
@@ -69,8 +68,9 @@ import papis.pick
 import papis.database
 import papis.strings
 import papis.document
+import papis.logging
 
-logger = logging.getLogger(__name__)
+logger = papis.logging.get_logger(__name__)
 
 
 def run(document: papis.document.Document,

--- a/papis/commands/citations.py
+++ b/papis/commands/citations.py
@@ -4,19 +4,19 @@ See ../../doc/source/commands/citations.rst
 papis citations --fetch-citations
 """
 from typing import Optional
-import logging
 
 import click
 
 import papis.cli
 import papis.document
+import papis.logging
 from papis.citations import (has_citations,
                              has_cited_by,
                              update_and_save_citations_from_database_from_doc,
                              fetch_and_save_citations,
                              fetch_and_save_cited_by_from_database)
 
-logger = logging.getLogger(__name__)
+logger = papis.logging.get_logger(__name__)
 
 
 @click.command("citations")

--- a/papis/commands/citations.py
+++ b/papis/commands/citations.py
@@ -16,6 +16,8 @@ from papis.citations import (has_citations,
                              fetch_and_save_citations,
                              fetch_and_save_cited_by_from_database)
 
+logger = logging.getLogger(__name__)
+
 
 @click.command("citations")
 @click.help_option("--help", "-h")
@@ -52,10 +54,7 @@ def cli(query: str,
         fetch_citations: bool,
         fetch_cited_by: bool,
         update_from_database: bool) -> None:
-    """Check for common problems in documents"""
-
-    logger = logging.getLogger("cli:citations")
-
+    """Handle document citations"""
     documents = papis.cli.handle_doc_folder_query_all_sort(query,
                                                            doc_folder,
                                                            sort_field,

--- a/papis/commands/config.py
+++ b/papis/commands/config.py
@@ -37,14 +37,14 @@ Command-line Interface
     :prog: papis config
 """
 
-import logging
 from typing import Optional
 
 import click
 
 import papis.commands
+import papis.logging
 
-logger = logging.getLogger(__name__)
+logger = papis.logging.get_logger(__name__)
 
 
 def run(option_string: str) -> Optional[str]:

--- a/papis/commands/config.py
+++ b/papis/commands/config.py
@@ -44,9 +44,10 @@ import click
 
 import papis.commands
 
+logger = logging.getLogger(__name__)
+
 
 def run(option_string: str) -> Optional[str]:
-    logger = logging.getLogger("config:run")
 
     option = option_string.split(".")
     key = section = None
@@ -69,7 +70,6 @@ def run(option_string: str) -> Optional[str]:
 @click.argument("option")
 def cli(option: str) -> None:
     """Print configuration values"""
-    logger = logging.getLogger("cli:config")
     logger.debug(option)
 
     click.echo(run(option))

--- a/papis/commands/default.py
+++ b/papis/commands/default.py
@@ -66,6 +66,9 @@ class ColoramaFormatter(logging.Formatter):
                 record.levelname,
                 colorama.Style.RESET_ALL)
 
+        if record.name.startswith("papis."):
+            record.name = record.name[6:]
+
         return super().format(record)
 
 
@@ -252,19 +255,19 @@ def run(verbose: bool,
     else:
         colorama.init()
 
-    log_format = (colorama.Fore.YELLOW
+    log_format = ("["
                   + "%(levelname)s"
-                  + ":"
+                  + "] "
                   + colorama.Fore.GREEN
                   + "%(name)s"
                   + colorama.Style.RESET_ALL
-                  + ":"
+                  + ": "
                   + "%(message)s"
                   )
 
     if verbose:
         log = "DEBUG"
-        log_format = "%(relativeCreated)d-{}".format(log_format)
+        log_format = "[%(relativeCreated)d] {}".format(log_format)
 
     if logfile is None:
         handler = logging.StreamHandler()       # type: logging.Handler

--- a/papis/commands/default.py
+++ b/papis/commands/default.py
@@ -32,6 +32,7 @@ from typing import Optional, Tuple, List, Callable, TYPE_CHECKING
 
 import click
 import click.core
+import colorama
 
 import papis
 import papis.api
@@ -45,12 +46,25 @@ if TYPE_CHECKING:
 
 logger = logging.getLogger(__name__)
 
+LEVEL_TO_COLOR = {
+    "CRITICAL": colorama.Style.BRIGHT + colorama.Fore.RED,
+    "ERROR": colorama.Style.BRIGHT + colorama.Fore.RED,
+    "WARNING": colorama.Style.BRIGHT + colorama.Fore.YELLOW,
+    "INFO": colorama.Fore.CYAN,
+    "DEBUG": colorama.Fore.WHITE,
+}
+
 
 class ColoramaFormatter(logging.Formatter):
     def format(self, record: logging.LogRecord) -> str:
         if isinstance(record.msg, str):
-            import colorama
             record.msg = record.msg.format(c=colorama)
+
+        if record.levelname in LEVEL_TO_COLOR:
+            record.levelname = "{}{}{}".format(
+                LEVEL_TO_COLOR[record.levelname],
+                record.levelname,
+                colorama.Style.RESET_ALL)
 
         return super().format(record)
 
@@ -92,7 +106,6 @@ class MultiCommand(click.core.MultiCommand):
             matches = list(map(
                 str, difflib.get_close_matches(name, self.scripts, n=2)))
 
-            import colorama
             self.logger.error(
                 "{c.Fore.RED}{c.Style.BRIGHT}{c.Back.BLACK}"
                 "Command '{name}' is unknown! Did you mean '{matches}'?"
@@ -233,7 +246,6 @@ def run(verbose: bool,
         import atexit
         atexit.register(generate_profile_writing_function(profiler, profile))
 
-    import colorama
     if _disable_color(color):
         # Turn off colorama (strip escape sequences from the output)
         colorama.init(strip=True)

--- a/papis/commands/default.py
+++ b/papis/commands/default.py
@@ -30,7 +30,6 @@ from typing import Optional, Tuple, List, Callable, TYPE_CHECKING
 
 import click
 import click.core
-import colorama
 
 import papis
 import papis.api
@@ -74,6 +73,7 @@ class MultiCommand(click.core.MultiCommand):
         >>> cmd.name, cmd.help
         ('add', 'Add...')
         >>> mc.get_command(None, 'this command does not exist')
+        Command ... is unknown!
         """
         try:
             script = self.scripts[name]
@@ -82,12 +82,11 @@ class MultiCommand(click.core.MultiCommand):
             matches = list(map(
                 str, difflib.get_close_matches(name, self.scripts, n=2)))
 
-            print(
-                "{c.Fore.RED}{c.Style.BRIGHT}{c.Back.BLACK}"
-                "Command '{name}' is unknown! Did you mean '{matches}'?"
-                "{c.Style.RESET_ALL}"
-                .format(c=colorama, name=name, matches="' or '".join(matches))
-                )
+            if matches:
+                print("Command '{name}' is unknown! Did you mean '{matches}'?"
+                      .format(name=name, matches="' or '".join(matches)))
+            else:
+                print("Command '{name}' is unknown!".format(name=name))
 
             # return the match if there was only one match
             if len(matches) == 1:
@@ -136,7 +135,7 @@ def generate_profile_writing_function(profiler: "cProfile.Profile",
     "-v",
     "--verbose",
     help="Make the output verbose (equivalent to --log DEBUG)",
-    default=False,
+    default="PAPIS_DEBUG" in os.environ,
     is_flag=True)
 @click.option(
     "--profile",

--- a/papis/commands/default.py
+++ b/papis/commands/default.py
@@ -43,6 +43,8 @@ import papis.cli
 if TYPE_CHECKING:
     import cProfile
 
+logger = logging.getLogger(__name__)
+
 
 class ColoramaFormatter(logging.Formatter):
     def format(self, record: logging.LogRecord) -> str:
@@ -259,7 +261,6 @@ def run(verbose: bool,
         handler = logging.FileHandler(logfile, mode="a")
 
     logging.basicConfig(level=getattr(logging, log), handlers=[handler])
-    logger = logging.getLogger("default")
 
     # NOTE: order of the configurations is intentional based on priority
     #

--- a/papis/commands/doctor.py
+++ b/papis/commands/doctor.py
@@ -26,6 +26,7 @@ import papis.strings
 import papis.document
 from papis.commands.edit import run as edit_run
 
+logger = logging.getLogger(__name__)
 
 Error = NamedTuple("Error", [("name", str),
                              ("path", str),
@@ -39,8 +40,6 @@ CheckFn = Callable[[papis.document.Document], List[Error]]
 Check = NamedTuple("Check", [("name", str),
                              ("operate", CheckFn),
                              ])
-
-logger = logging.getLogger("doctor")
 
 
 def register_check(name: str, check_function: CheckFn) -> None:

--- a/papis/commands/doctor.py
+++ b/papis/commands/doctor.py
@@ -6,7 +6,6 @@ There are many checks implemented and some others that you
 can add yourself through the python configuration file.
 """
 
-import logging
 import os
 import re
 import json
@@ -24,9 +23,10 @@ import papis.pick
 import papis.database
 import papis.strings
 import papis.document
+import papis.logging
 from papis.commands.edit import run as edit_run
 
-logger = logging.getLogger(__name__)
+logger = papis.logging.get_logger(__name__)
 
 Error = NamedTuple("Error", [("name", str),
                              ("path", str),

--- a/papis/commands/edit.py
+++ b/papis/commands/edit.py
@@ -7,7 +7,6 @@ Command-line Interface
 .. click:: papis.commands.edit:cli
     :prog: papis edit
 """
-import logging
 from typing import Optional
 
 import click
@@ -25,8 +24,9 @@ import papis.strings
 import papis.git
 import papis.format
 import papis.notes
+import papis.logging
 
-logger = logging.getLogger(__name__)
+logger = papis.logging.get_logger(__name__)
 
 
 def run(document: papis.document.Document,

--- a/papis/commands/edit.py
+++ b/papis/commands/edit.py
@@ -26,11 +26,12 @@ import papis.git
 import papis.format
 import papis.notes
 
+logger = logging.getLogger(__name__)
+
 
 def run(document: papis.document.Document,
         wait: bool = True,
         git: bool = False) -> None:
-    logger = logging.getLogger("run:edit")
     info_file_path = document.get_info_file()
     if not info_file_path:
         raise Exception(papis.strings.no_folder_attached_to_document)
@@ -56,7 +57,6 @@ def run(document: papis.document.Document,
 
 def edit_notes(document: papis.document.Document,
                git: bool = False) -> None:
-    logger = logging.getLogger("edit:notes")
     logger.debug("Editing notes")
     notes_path = papis.notes.notes_path_ensured(document)
     papis.api.edit_file(notes_path)
@@ -98,9 +98,6 @@ def cli(query: str,
         sort_field: Optional[str],
         sort_reverse: bool) -> None:
     """Edit document information from a given library"""
-
-    logger = logging.getLogger("cli:edit")
-
     documents = papis.cli.handle_doc_folder_query_all_sort(query,
                                                            doc_folder,
                                                            sort_field,

--- a/papis/commands/explore.py
+++ b/papis/commands/explore.py
@@ -111,6 +111,8 @@ import papis.citations
 if TYPE_CHECKING:
     from stevedore import ExtensionManager
 
+logger = logging.getLogger(__name__)
+
 
 def _extension_name() -> str:
     return "papis.explorer"
@@ -143,7 +145,6 @@ def lib(ctx: click.Context, query: str,
         papis lib -l books einstein pick
 
     """
-    logger = logging.getLogger("explore:lib")
 
     if doc_folder:
         ctx.obj["documents"] += [papis.document.from_folder(doc_folder)]
@@ -206,8 +207,6 @@ def citations(ctx: click.Context, query: str, doc_folder: str,
         papis explore citations 'einstein' export --format yaml einstein.yaml
 
     """
-    logger = logging.getLogger("explore:citations")
-
     if doc_folder is not None:
         documents = [papis.document.from_folder(doc_folder)]
     else:
@@ -257,7 +256,6 @@ def cmd(ctx: click.Context, command: str) -> None:
 
     """
     from subprocess import call
-    logger = logging.getLogger("explore:cmd")
     docs = ctx.obj["documents"]
     for doc in docs:
         fcommand = papis.format.format(command, doc)

--- a/papis/commands/explore.py
+++ b/papis/commands/explore.py
@@ -87,7 +87,6 @@ Command-line Interface
     :nested: full
 """
 
-import logging
 from typing import List, Optional, TYPE_CHECKING
 import shlex
 
@@ -107,11 +106,12 @@ import papis.format
 import papis.crossref
 import papis.plugin
 import papis.citations
+import papis.logging
 
 if TYPE_CHECKING:
     from stevedore import ExtensionManager
 
-logger = logging.getLogger(__name__)
+logger = papis.logging.get_logger(__name__)
 
 
 def _extension_name() -> str:

--- a/papis/commands/export.py
+++ b/papis/commands/export.py
@@ -48,7 +48,6 @@ Command-line Interface
 """
 
 import os
-import logging
 from typing import List, Optional
 
 import click
@@ -61,8 +60,9 @@ import papis.api
 import papis.database
 import papis.strings
 import papis.plugin
+import papis.logging
 
-logger = logging.getLogger(__name__)
+logger = papis.logging.get_logger(__name__)
 
 
 def available_formats() -> List[str]:

--- a/papis/commands/export.py
+++ b/papis/commands/export.py
@@ -62,7 +62,7 @@ import papis.database
 import papis.strings
 import papis.plugin
 
-logger = logging.getLogger("cli:export")
+logger = logging.getLogger(__name__)
 
 
 def available_formats() -> List[str]:
@@ -186,7 +186,6 @@ def explorer(ctx: click.Context, fmt: str, out: str) -> None:
     papis explore crossref -m 200 -a 'Schrodinger' export --yaml lib.yaml
 
     """
-    logger = logging.getLogger("explore:yaml")
     docs = ctx.obj["documents"]
 
     outstring = run(docs, to_format=fmt)

--- a/papis/commands/external.py
+++ b/papis/commands/external.py
@@ -13,8 +13,7 @@ import click
 import papis.config
 import papis.commands
 
-
-logger = logging.getLogger("external")
+logger = logging.getLogger(__name__)
 
 
 def get_command_help(path: str) -> str:

--- a/papis/commands/external.py
+++ b/papis/commands/external.py
@@ -5,15 +5,15 @@ to be called by papis.
 """
 import os
 import re
-import logging
 from typing import List
 
 import click
 
 import papis.config
 import papis.commands
+import papis.logging
 
-logger = logging.getLogger(__name__)
+logger = papis.logging.get_logger(__name__)
 
 
 def get_command_help(path: str) -> str:

--- a/papis/commands/list.py
+++ b/papis/commands/list.py
@@ -49,7 +49,6 @@ Command-line Interface
 """
 
 import os
-import logging
 from typing import List, Optional, Union, Sequence
 
 import click
@@ -64,8 +63,9 @@ import papis.downloaders
 import papis.cli
 import papis.pick
 import papis.format
+import papis.logging
 
-logger = logging.getLogger(__name__)
+logger = papis.logging.get_logger(__name__)
 
 
 def run(

--- a/papis/commands/list.py
+++ b/papis/commands/list.py
@@ -65,7 +65,7 @@ import papis.cli
 import papis.pick
 import papis.format
 
-logger = logging.getLogger("list")
+logger = logging.getLogger(__name__)
 
 
 def run(
@@ -183,8 +183,6 @@ def cli(
         libraries: bool,
         sort_field: Optional[str], sort_reverse: bool) -> None:
     """List documents' properties"""
-
-    logger = logging.getLogger("cli:list")
     documents = []  # type: List[papis.document.Document]
 
     if (not libraries and not downloaders

--- a/papis/commands/merge.py
+++ b/papis/commands/merge.py
@@ -14,7 +14,6 @@ Command-line Interface
 """
 
 import os
-import logging
 from typing import Optional, List, Dict, Any
 
 import click
@@ -31,8 +30,9 @@ import papis.format
 import papis.strings
 import papis.commands.rm
 import papis.commands.update
+import papis.logging
 
-logger = logging.getLogger(__name__)
+logger = papis.logging.get_logger(__name__)
 
 
 def run(keep: papis.document.Document,

--- a/papis/commands/merge.py
+++ b/papis/commands/merge.py
@@ -32,6 +32,8 @@ import papis.strings
 import papis.commands.rm
 import papis.commands.update
 
+logger = logging.getLogger(__name__)
+
 
 def run(keep: papis.document.Document,
         erase: papis.document.Document,
@@ -40,7 +42,6 @@ def run(keep: papis.document.Document,
         keep_both: bool,
         git: bool = False) -> None:
 
-    logger = logging.getLogger("merge:run")
     files_to_move = set(files) - set(keep.get_files())
     for f in files_to_move:
         to_folder = keep.get_main_folder()
@@ -94,8 +95,6 @@ def cli(query: str,
         sort_reverse: bool,
         pick: bool) -> None:
     """Merge two documents from a given library"""
-    logger = logging.getLogger("cli:merge")
-
     documents = papis.database.get().query(query)
 
     if sort_field:

--- a/papis/commands/mv.py
+++ b/papis/commands/mv.py
@@ -20,11 +20,12 @@ import papis.cli
 import papis.pick
 import papis.strings
 
+logger = logging.getLogger(__name__)
+
 
 def run(document: papis.document.Document,
         new_folder_path: str,
         git: bool = False) -> None:
-    logger = logging.getLogger("mv:run")
 
     folder = document.get_main_folder()
     if not folder:
@@ -61,8 +62,6 @@ def cli(query: str,
     # Leave this imports here for performance
     import prompt_toolkit
     import prompt_toolkit.completion
-
-    logger = logging.getLogger("cli:mv")
 
     documents = papis.cli.handle_doc_folder_query_sort(query,
                                                        doc_folder,

--- a/papis/commands/mv.py
+++ b/papis/commands/mv.py
@@ -7,7 +7,6 @@ Command-line Interface
 """
 
 import os
-import logging
 from typing import Optional
 
 import click
@@ -19,8 +18,9 @@ import papis.document
 import papis.cli
 import papis.pick
 import papis.strings
+import papis.logging
 
-logger = logging.getLogger(__name__)
+logger = papis.logging.get_logger(__name__)
 
 
 def run(document: papis.document.Document,

--- a/papis/commands/open.py
+++ b/papis/commands/open.py
@@ -90,12 +90,13 @@ import papis.document
 import papis.format
 import papis.strings
 
+logger = logging.getLogger(__name__)
+
 
 def run(document: papis.document.Document,
         opener: Optional[str] = None,
         folder: bool = False,
         mark: bool = False) -> None:
-    logger = logging.getLogger("open:run")
     if opener is not None:
         papis.config.set("opentool", opener)
 
@@ -171,7 +172,6 @@ def cli(query: str, doc_folder: str, tool: str, folder: bool,
     """Open document from a given library"""
     if tool:
         papis.config.set("opentool", tool)
-    logger = logging.getLogger("cli:run")
 
     documents = papis.cli.handle_doc_folder_query_all_sort(query,
                                                            doc_folder,

--- a/papis/commands/open.py
+++ b/papis/commands/open.py
@@ -74,7 +74,6 @@ Command-line Interface
 """
 
 import os
-import logging
 from typing import Optional
 
 import click
@@ -89,8 +88,9 @@ import papis.database
 import papis.document
 import papis.format
 import papis.strings
+import papis.logging
 
-logger = logging.getLogger(__name__)
+logger = papis.logging.get_logger(__name__)
 
 
 def run(document: papis.document.Document,

--- a/papis/commands/rename.py
+++ b/papis/commands/rename.py
@@ -7,7 +7,6 @@ Command-line Interface
 """
 
 import os
-import logging
 from typing import Optional
 
 import click
@@ -19,8 +18,9 @@ import papis.git
 import papis.pick
 import papis.document
 import papis.tui.utils
+import papis.logging
 
-logger = logging.getLogger(__name__)
+logger = papis.logging.get_logger(__name__)
 
 
 def run(document: papis.document.Document,

--- a/papis/commands/rename.py
+++ b/papis/commands/rename.py
@@ -20,11 +20,12 @@ import papis.pick
 import papis.document
 import papis.tui.utils
 
+logger = logging.getLogger(__name__)
+
 
 def run(document: papis.document.Document,
         new_name: str, git: bool = False) -> None:
     db = papis.database.get()
-    logger = logging.getLogger("rename:run")
     folder = document.get_main_folder()
 
     if not folder:
@@ -68,8 +69,6 @@ def cli(query: str,
         doc_folder: str,
         sort_reverse: bool) -> None:
     """Rename entry"""
-    logger = logging.getLogger("cli:rename")
-
     documents = papis.cli.handle_doc_folder_query_sort(query,
                                                        doc_folder,
                                                        sort_field,

--- a/papis/commands/rm.py
+++ b/papis/commands/rm.py
@@ -7,7 +7,6 @@ Command-line Interface
 """
 
 import os
-import logging
 from typing import Optional
 
 import click
@@ -19,8 +18,9 @@ import papis.cli
 import papis.strings
 import papis.database
 import papis.git
+import papis.logging
 
-logger = logging.getLogger(__name__)
+logger = papis.logging.get_logger(__name__)
 
 
 def run(document: papis.document.Document,

--- a/papis/commands/rm.py
+++ b/papis/commands/rm.py
@@ -20,6 +20,8 @@ import papis.strings
 import papis.database
 import papis.git
 
+logger = logging.getLogger(__name__)
+
 
 def run(document: papis.document.Document,
         filepath: Optional[str] = None,
@@ -101,7 +103,6 @@ def cli(query: str,
     """
     Delete a document, a file, or a notes-file
     """
-    logger = logging.getLogger("cli:rm")
 
     documents = papis.cli.handle_doc_folder_query_all_sort(query,
                                                            doc_folder,

--- a/papis/commands/run.py
+++ b/papis/commands/run.py
@@ -64,7 +64,7 @@ import papis.config
 import papis.document
 import papis.database
 
-logger = logging.getLogger("run")
+logger = logging.getLogger(__name__)
 
 
 def run(folder: str, command: Optional[List[str]] = None) -> int:

--- a/papis/commands/run.py
+++ b/papis/commands/run.py
@@ -53,7 +53,6 @@ Command-line Interface
 """
 
 import os
-import logging
 from typing import List, Optional
 
 import click
@@ -63,8 +62,9 @@ import papis.cli
 import papis.config
 import papis.document
 import papis.database
+import papis.logging
 
-logger = logging.getLogger(__name__)
+logger = papis.logging.get_logger(__name__)
 
 
 def run(folder: str, command: Optional[List[str]] = None) -> int:

--- a/papis/commands/serve.py
+++ b/papis/commands/serve.py
@@ -1,7 +1,6 @@
 import re
 import os
 import json
-import logging
 import http.server
 import urllib.parse
 from typing import Any, List, Optional, Tuple, Callable, Dict  # noqa: ignore
@@ -23,6 +22,7 @@ import papis.commands.doctor
 import papis.crossref
 import papis.notes
 import papis.citations
+import papis.logging
 
 import papis.web.static
 import papis.web.libraries
@@ -32,7 +32,7 @@ import papis.web.search
 import papis.web.pdfjs
 
 
-logger = logging.getLogger(__name__)
+logger = papis.logging.get_logger(__name__)
 
 USE_GIT = False  # type: bool
 TAGS_LIST = {}  # type: Dict[str, Optional[Dict[str, int]]]

--- a/papis/commands/serve.py
+++ b/papis/commands/serve.py
@@ -32,7 +32,7 @@ import papis.web.search
 import papis.web.pdfjs
 
 
-logger = logging.getLogger("papis:server")
+logger = logging.getLogger(__name__)
 
 USE_GIT = False  # type: bool
 TAGS_LIST = {}  # type: Dict[str, Optional[Dict[str, int]]]

--- a/papis/commands/update.py
+++ b/papis/commands/update.py
@@ -41,7 +41,6 @@ Command-line Interface
     :prog: papis update
 """
 
-import logging
 from typing import List, Dict, Tuple, Optional, Any
 
 import click
@@ -57,8 +56,9 @@ import papis.format
 import papis.cli
 import papis.importer
 import papis.git
+import papis.logging
 
-logger = logging.getLogger(__name__)
+logger = papis.logging.get_logger(__name__)
 
 
 def _update_with_database(document: papis.document.Document) -> None:

--- a/papis/commands/update.py
+++ b/papis/commands/update.py
@@ -58,6 +58,8 @@ import papis.cli
 import papis.importer
 import papis.git
 
+logger = logging.getLogger(__name__)
+
 
 def _update_with_database(document: papis.document.Document) -> None:
     document.save()
@@ -120,7 +122,6 @@ def cli(query: str,
         sort_reverse: bool,
         set_tuples: List[Tuple[str, str]],) -> None:
     """Update a document from a given library."""
-    logger = logging.getLogger("cli:update")
 
     documents = papis.cli.handle_doc_folder_query_all_sort(query,
                                                            doc_folder,

--- a/papis/config.py
+++ b/papis/config.py
@@ -1,12 +1,12 @@
 import os
-import logging
 import configparser
 from typing import Dict, Any, List, Optional, Callable  # noqa: ignore
 
 import papis.exceptions
 import papis.library
+import papis.logging
 
-logger = logging.getLogger(__name__)
+logger = papis.logging.get_logger(__name__)
 
 PapisConfigType = Dict[str, Dict[str, Any]]
 

--- a/papis/config.py
+++ b/papis/config.py
@@ -6,10 +6,9 @@ from typing import Dict, Any, List, Optional, Callable  # noqa: ignore
 import papis.exceptions
 import papis.library
 
+logger = logging.getLogger(__name__)
 
 PapisConfigType = Dict[str, Dict[str, Any]]
-
-logger = logging.getLogger("config")
 
 _CURRENT_LIBRARY = None  #: Current library in use
 _CONFIGURATION = None  # type: Optional[Configuration]
@@ -38,7 +37,6 @@ class Configuration(configparser.ConfigParser):
         self.dir_location = get_config_folder()
         self.scripts_location = get_scripts_folder()
         self.file_location = get_config_file()
-        self.logger = logging.getLogger("Configuration")
         self.default_info = {
             "papers": {
                 "dir": "~/Documents/papers"
@@ -52,25 +50,24 @@ class Configuration(configparser.ConfigParser):
     def handle_includes(self) -> None:
         if "include" in self:
             for name in self["include"]:
-                self.logger.debug("Including '%s'", name)
+                logger.debug("Including '%s'", name)
                 fullpath = os.path.expanduser(self.get("include", name))
                 if os.path.exists(fullpath):
                     self.read(fullpath)
                 else:
-                    self.logger.warning(
+                    logger.warning(
                         "'%s' not included because it does not exist",
                         fullpath)
 
     def initialize(self) -> None:
         if not os.path.exists(self.dir_location):
-            self.logger.warning(
+            logger.warning(
                 "Creating configuration folder in '%s'", self.dir_location)
             os.makedirs(self.dir_location)
         if not os.path.exists(self.scripts_location):
             os.makedirs(self.scripts_location)
         if os.path.exists(self.file_location):
-            self.logger.debug(
-                "Reading configuration from '%s'", self.file_location)
+            logger.debug("Reading configuration from '%s'", self.file_location)
             self.read(self.file_location)
             self.handle_includes()
         else:
@@ -79,12 +76,11 @@ class Configuration(configparser.ConfigParser):
                 for field in self.default_info[section]:
                     self[section][field] = self.default_info[section][field]
             with open(self.file_location, "w") as configfile:
-                self.logger.info(
-                    "Creating config file at '%s'", self.file_location)
+                logger.info("Creating config file at '%s'", self.file_location)
                 self.write(configfile)
         configpy = get_configpy_file()
         if os.path.exists(configpy):
-            self.logger.debug("Executing '%s'", configpy)
+            logger.debug("Executing '%s'", configpy)
             with open(configpy) as fd:
                 exec(fd.read())
 

--- a/papis/crossref.py
+++ b/papis/crossref.py
@@ -1,6 +1,5 @@
 import re
 import os
-import logging
 import tempfile
 from typing import Set, List, Dict, Any, Optional, Tuple, TYPE_CHECKING
 
@@ -13,11 +12,12 @@ import papis.filetype
 import papis.document
 import papis.importer
 import papis.downloaders.base
+import papis.logging
 
 if TYPE_CHECKING:
     import habanero
 
-logger = logging.getLogger(__name__)
+logger = papis.logging.get_logger(__name__)
 
 KeyConversionPair = papis.document.KeyConversionPair
 

--- a/papis/crossref.py
+++ b/papis/crossref.py
@@ -17,8 +17,8 @@ import papis.downloaders.base
 if TYPE_CHECKING:
     import habanero
 
+logger = logging.getLogger(__name__)
 
-logger = logging.getLogger("crossref")  # type: logging.Logger
 KeyConversionPair = papis.document.KeyConversionPair
 
 _filter_names = set([
@@ -275,7 +275,6 @@ def explorer(
     papis explore crossref -a 'Albert einstein' pick export --bibtex lib.bib
 
     """
-    logger = logging.getLogger("explore:crossref")
     logger.info("Looking up...")
 
     data = get_data(

--- a/papis/database/__init__.py
+++ b/papis/database/__init__.py
@@ -1,10 +1,10 @@
-import logging
 from typing import Optional, Dict
 
 from .base import Database
 from papis.library import Library
+import papis.logging
 
-logger = logging.getLogger(__name__)
+logger = papis.logging.get_logger(__name__)
 
 DATABASES = {}  # type: Dict[Library, Database]
 

--- a/papis/database/__init__.py
+++ b/papis/database/__init__.py
@@ -4,7 +4,7 @@ from typing import Optional, Dict
 from .base import Database
 from papis.library import Library
 
-logger = logging.getLogger("database")
+logger = logging.getLogger(__name__)
 
 DATABASES = {}  # type: Dict[Library, Database]
 

--- a/papis/database/cache.py
+++ b/papis/database/cache.py
@@ -1,7 +1,6 @@
 import os
 import re
 import sys
-import logging
 from typing import List, Optional, Match, Dict, Tuple
 
 import papis.utils
@@ -10,9 +9,9 @@ import papis.document
 import papis.config
 import papis.format
 import papis.database.base
+import papis.logging
 
-
-logger = logging.getLogger(__name__)
+logger = papis.logging.get_logger(__name__)
 
 
 def get_cache_file_name(directory: str) -> str:

--- a/papis/database/whoosh.py
+++ b/papis/database/whoosh.py
@@ -40,12 +40,12 @@ you will not be able to parse the publisher through a search.
 
 """
 import os
-import logging
 from typing import List, Dict, Optional, Any, KeysView, TYPE_CHECKING
 
 import papis.config
 import papis.strings
 import papis.document
+import papis.logging
 import papis.database.base
 import papis.database.cache
 from papis.utils import get_cache_home, get_folders, folders_to_documents
@@ -55,7 +55,7 @@ if TYPE_CHECKING:
     from whoosh.fields import Schema, FieldType
     from whoosh.writing import IndexWriter
 
-logger = logging.getLogger(__name__)
+logger = papis.logging.get_logger(__name__)
 
 
 class Database(papis.database.base.Database):

--- a/papis/dissemin.py
+++ b/papis/dissemin.py
@@ -6,7 +6,7 @@ import click
 import papis.config
 import papis.document
 
-logger = logging.getLogger("dissemin")
+logger = logging.getLogger(__name__)
 
 
 def dissemin_authors_to_papis_authors(data: Dict[str, Any]) -> Dict[str, Any]:
@@ -84,7 +84,6 @@ def explorer(ctx: click.core.Context, query: str) -> None:
     papis explore dissemin -q 'Albert einstein' pick cmd 'firefox {doc[url]}'
 
     """
-    logger = logging.getLogger("explore:dissemin")
     logger.info("Looking up...")
 
     data = get_data(query=query)

--- a/papis/dissemin.py
+++ b/papis/dissemin.py
@@ -1,12 +1,12 @@
-import logging
 from typing import List, Dict, Any
 
 import click
 
 import papis.config
 import papis.document
+import papis.logging
 
-logger = logging.getLogger(__name__)
+logger = papis.logging.get_logger(__name__)
 
 
 def dissemin_authors_to_papis_authors(data: Dict[str, Any]) -> Dict[str, Any]:

--- a/papis/docmatcher.py
+++ b/papis/docmatcher.py
@@ -1,13 +1,13 @@
-import logging
 from typing import Optional, Any, Callable, TYPE_CHECKING
 
 import papis.config
 import papis.document
+import papis.logging
 
 if TYPE_CHECKING:
     import pyparsing
 
-logger = logging.getLogger(__name__)
+logger = papis.logging.get_logger(__name__)
 
 MATCHER_TYPE = Callable[[papis.document.Document, str, Optional[str]], Any]
 

--- a/papis/docmatcher.py
+++ b/papis/docmatcher.py
@@ -4,9 +4,12 @@ from typing import Optional, Any, Callable, TYPE_CHECKING
 import papis.config
 import papis.document
 
-MATCHER_TYPE = Callable[[papis.document.Document, str, Optional[str]], Any]
 if TYPE_CHECKING:
     import pyparsing
+
+logger = logging.getLogger(__name__)
+
+MATCHER_TYPE = Callable[[papis.document.Document, str, Optional[str]], Any]
 
 
 class DocMatcher(object):
@@ -31,7 +34,6 @@ class DocMatcher(object):
     search = ""  # type: str
     parsed_search = None  # type: pyparsing.ParseResults
     doc_format = "{%s[DOC_KEY]}" % (papis.config.getstring("format-doc-name"))
-    logger = logging.getLogger("DocMatcher")
     matcher = None  # type: Optional[MATCHER_TYPE]
 
     @classmethod
@@ -120,7 +122,6 @@ class DocMatcher(object):
 
 def parse_query(query_string: str) -> "pyparsing.ParseResults":
     import pyparsing
-    logger = logging.getLogger("parse_query")
     logger.debug("Parsing query: '%s'", query_string)
 
     papis_key_word = pyparsing.Word(pyparsing.alphanums + "-._/")

--- a/papis/document.py
+++ b/papis/document.py
@@ -11,7 +11,7 @@ from typing_extensions import TypedDict
 import papis.config
 import papis
 
-logger = logging.getLogger("document")  # type: logging.Logger
+logger = logging.getLogger(__name__)
 
 KeyConversion = TypedDict(
     "KeyConversion", {"key": Optional[str],

--- a/papis/document.py
+++ b/papis/document.py
@@ -2,16 +2,16 @@
 """
 import os
 import re
-import logging
 from typing import (
     List, Dict, Any, Optional, Union, NamedTuple, Callable, Tuple)
 
 from typing_extensions import TypedDict
 
-import papis.config
 import papis
+import papis.config
+import papis.logging
 
-logger = logging.getLogger(__name__)
+logger = papis.logging.get_logger(__name__)
 
 KeyConversion = TypedDict(
     "KeyConversion", {"key": Optional[str],

--- a/papis/downloaders/__init__.py
+++ b/papis/downloaders/__init__.py
@@ -14,7 +14,7 @@ import papis.utils
 if TYPE_CHECKING:
     import bs4
 
-logger = logging.getLogger("downloader")
+logger = logging.getLogger(__name__)
 
 
 def _extension_name() -> str:
@@ -71,7 +71,7 @@ class Downloader(papis.importer.Importer):
             uri=uri,
             ctx=ctx,
             name=name or os.path.basename(__file__))
-        self.logger = logging.getLogger("downloader:{}".format(self.name))
+        self.logger = logging.getLogger("downloader.{}".format(self.name))
         self.logger.debug("uri '%s'", uri)
 
         self.expected_document_extension = expected_document_extension

--- a/papis/downloaders/__init__.py
+++ b/papis/downloaders/__init__.py
@@ -1,7 +1,6 @@
 import os
 import re
 import sys
-import logging
 from typing import List, Optional, Any, Sequence, Type, Dict, Union, TYPE_CHECKING
 
 import papis.bibtex
@@ -10,11 +9,12 @@ import papis.document
 import papis.importer
 import papis.plugin
 import papis.utils
+import papis.logging
 
 if TYPE_CHECKING:
     import bs4
 
-logger = logging.getLogger(__name__)
+logger = papis.logging.get_logger(__name__)
 
 
 def _extension_name() -> str:
@@ -71,7 +71,7 @@ class Downloader(papis.importer.Importer):
             uri=uri,
             ctx=ctx,
             name=name or os.path.basename(__file__))
-        self.logger = logging.getLogger("downloader.{}".format(self.name))
+        self.logger = papis.logging.get_logger("papis.downloader.{}".format(self.name))
         self.logger.debug("uri '%s'", uri)
 
         self.expected_document_extension = expected_document_extension

--- a/papis/format.py
+++ b/papis/format.py
@@ -6,9 +6,9 @@ import papis.plugin
 import papis.document
 from papis.document import Document
 
+logger = logging.getLogger(__name__)
 
 FormatDocType = Union[Document, Dict[str, Any]]
-logger = logging.getLogger("format")
 _FORMATER = None  # type: Optional[Formater]
 
 

--- a/papis/format.py
+++ b/papis/format.py
@@ -1,12 +1,12 @@
-import logging
 from typing import Optional, Union, Any, Dict
 
 import papis.config
 import papis.plugin
 import papis.document
+import papis.logging
 from papis.document import Document
 
-logger = logging.getLogger(__name__)
+logger = papis.logging.get_logger(__name__)
 
 FormatDocType = Union[Document, Dict[str, Any]]
 _FORMATER = None  # type: Optional[Formater]

--- a/papis/git.py
+++ b/papis/git.py
@@ -1,10 +1,11 @@
 """This module serves as an lightweight interface for git related functions.
 """
 import os
-import logging
 from typing import List
 
-logger = logging.getLogger(__name__)
+import papis.logging
+
+logger = papis.logging.get_logger(__name__)
 
 
 def _issue_git_command(path: str, cmd: str) -> None:

--- a/papis/git.py
+++ b/papis/git.py
@@ -4,7 +4,7 @@ import os
 import logging
 from typing import List
 
-logger = logging.getLogger("git")
+logger = logging.getLogger(__name__)
 
 
 def _issue_git_command(path: str, cmd: str) -> None:

--- a/papis/hooks.py
+++ b/papis/hooks.py
@@ -1,13 +1,12 @@
 from typing import List, Dict, Any, Callable, TYPE_CHECKING
 
-import logging
-
 import papis.plugin
+import papis.logging
 
 if TYPE_CHECKING:
     from stevedore import ExtensionManager
 
-logger = logging.getLogger(__name__)
+logger = papis.logging.get_logger(__name__)
 
 NON_STEVEDORE_HOOKS = {}  # type: Dict[str, List[Callable[[Any], None]]]
 

--- a/papis/hooks.py
+++ b/papis/hooks.py
@@ -7,8 +7,8 @@ import papis.plugin
 if TYPE_CHECKING:
     from stevedore import ExtensionManager
 
+logger = logging.getLogger(__name__)
 
-logger = logging.getLogger("hooks")
 NON_STEVEDORE_HOOKS = {}  # type: Dict[str, List[Callable[[Any], None]]]
 
 

--- a/papis/importer.py
+++ b/papis/importer.py
@@ -32,7 +32,7 @@ class Importer:
         self.ctx = ctx or Context()  # type: Context
         self.uri = uri  # type: str
         self.name = name or os.path.basename(__file__)  # type: str
-        self.logger = logging.getLogger("importer:{}".format(self.name))
+        self.logger = logging.getLogger("importer.{}".format(self.name))
 
     @classmethod
     def match(cls, uri: str) -> Optional["Importer"]:

--- a/papis/importer.py
+++ b/papis/importer.py
@@ -1,9 +1,9 @@
 import os.path
-import logging
 from typing import Optional, List, Dict, Any, Callable, Type, TYPE_CHECKING
 
 import papis
 import papis.plugin
+import papis.logging
 
 
 if TYPE_CHECKING:
@@ -32,7 +32,7 @@ class Importer:
         self.ctx = ctx or Context()  # type: Context
         self.uri = uri  # type: str
         self.name = name or os.path.basename(__file__)  # type: str
-        self.logger = logging.getLogger("importer.{}".format(self.name))
+        self.logger = papis.logging.get_logger("papis.importer.{}".format(self.name))
 
     @classmethod
     def match(cls, uri: str) -> Optional["Importer"]:

--- a/papis/isbn.py
+++ b/papis/isbn.py
@@ -7,7 +7,7 @@ import click
 import papis.document
 import papis.importer
 
-logger = logging.getLogger("papis:isbnlib")
+logger = logging.getLogger(__name__)
 
 
 def get_data(query: str = "",
@@ -66,7 +66,6 @@ def explorer(ctx: click.core.Context, query: str, service: str) -> None:
     papis explore isbn -q 'Albert einstein' pick cmd 'firefox {doc[url]}'
 
     """
-    logger = logging.getLogger("explore:isbn")
     logger.info("Looking up...")
 
     data = get_data(query=query, service=service)

--- a/papis/isbn.py
+++ b/papis/isbn.py
@@ -1,13 +1,13 @@
 # See https://github.com/xlcnd/isbnlib for details
-import logging
 from typing import Dict, Any, List, Optional
 
 import click
 
 import papis.document
 import papis.importer
+import papis.logging
 
-logger = logging.getLogger(__name__)
+logger = papis.logging.get_logger(__name__)
 
 
 def get_data(query: str = "",

--- a/papis/isbnplus.py
+++ b/papis/isbnplus.py
@@ -70,7 +70,7 @@ import bs4
 import papis.config
 import papis.document
 
-logger = logging.getLogger("isbnplus")
+logger = logging.getLogger(__name__)
 
 ISBNPLUS_KEY = "98a765346bc0ffee6ede527499b6a4ee"  # type: str
 ISBNPLUS_APPID = "4846a7d1"  # type: str
@@ -166,14 +166,13 @@ def explorer(ctx: click.core.Context,
     papis explore isbnplus -q 'Albert einstein' pick cmd 'firefox {doc[url]}'
 
     """
-    _logger = logging.getLogger("explore:isbnplus")
-    _logger.info("Looking up...")
+    logger.info("Looking up...")
     try:
         data = get_data(query=query, author=author, title=title)
     except Exception as ex:
-        _logger.error(ex)
+        logger.error(ex)
         data = []
     docs = [papis.document.from_data(data=d) for d in data]
     ctx.obj["documents"] += docs
 
-    _logger.info("%s documents found", len(docs))
+    logger.info("%s documents found", len(docs))

--- a/papis/isbnplus.py
+++ b/papis/isbnplus.py
@@ -59,18 +59,18 @@ An example of successful returns:
     </book>
     ...
 """
-import logging
-from typing import List, Dict, Any
 import urllib.parse
 import urllib.request
+from typing import List, Dict, Any
 
 import click
 import bs4
 
 import papis.config
 import papis.document
+import papis.logging
 
-logger = logging.getLogger(__name__)
+logger = papis.logging.get_logger(__name__)
 
 ISBNPLUS_KEY = "98a765346bc0ffee6ede527499b6a4ee"  # type: str
 ISBNPLUS_APPID = "4846a7d1"  # type: str

--- a/papis/json.py
+++ b/papis/json.py
@@ -1,11 +1,11 @@
-import logging
 from typing import List
 
 import click
 
 import papis.document
+import papis.logging
 
-logger = logging.getLogger(__name__)
+logger = papis.logging.get_logger(__name__)
 
 
 def exporter(documents: List[papis.document.Document]) -> str:

--- a/papis/json.py
+++ b/papis/json.py
@@ -5,6 +5,8 @@ import click
 
 import papis.document
 
+logger = logging.getLogger(__name__)
+
 
 def exporter(documents: List[papis.document.Document]) -> str:
     import json
@@ -24,7 +26,6 @@ def explorer(ctx: click.Context, jsonfile: str) -> None:
     papis explore json lib.json pick
 
     """
-    logger = logging.getLogger("explore:json")
     logger.info("Reading in json file '%s'", jsonfile)
 
     import json

--- a/papis/logging.py
+++ b/papis/logging.py
@@ -1,0 +1,110 @@
+"""
+Logging
+-------
+
+Helper functions to set up logging used by ``papis``.
+
+.. autofunction:: setup
+.. autofunction:: get_logger
+"""
+
+import os
+import sys
+import logging
+from typing import Optional, Union
+
+import colorama
+
+
+LEVEL_TO_COLOR = {
+    "CRITICAL": colorama.Style.BRIGHT + colorama.Fore.RED,
+    "ERROR": colorama.Style.BRIGHT + colorama.Fore.RED,
+    "WARNING": colorama.Style.BRIGHT + colorama.Fore.YELLOW,
+    "INFO": colorama.Fore.CYAN,
+    "DEBUG": colorama.Fore.WHITE,
+}
+
+
+class ColoramaFormatter(logging.Formatter):
+    def format(self, record: logging.LogRecord) -> str:
+        if isinstance(record.msg, str):
+            record.msg = record.msg.format(c=colorama)
+
+        if record.levelname in LEVEL_TO_COLOR:
+            record.levelname = "{}{}{}".format(
+                LEVEL_TO_COLOR[record.levelname],
+                record.levelname,
+                colorama.Style.RESET_ALL)
+
+        if record.name.startswith("papis."):
+            record.name = record.name[6:]
+
+        return super().format(record)
+
+
+def _disable_color(color: str = "auto") -> bool:
+    return (
+        color == "no"
+        or (color == "auto" and not sys.stdout.isatty())
+        # NOTE: https://no-color.org/
+        or (color == "auto" and "NO_COLOR" in os.environ)
+        )
+
+
+def setup(level: Union[int, str],
+          color: str = "auto",
+          logfile: Optional[str] = None,
+          verbose: bool = False) -> None:
+    """
+    :param level: default logging level (see
+        :ref:`Logging Levels <logging:logging-levels>`).
+    :param color: flag to control logging colors. It should be one of
+        ``("always", "auto", "no")``.
+    :param logfile: a path for a file in which to write log messages.
+    :param verbose: make logger verbose (including debug information)
+        regardless of the *level*.
+    """
+
+    if color not in ("always", "auto", "no"):
+        raise ValueError("Unknown 'color' value: '{}'".format(color))
+
+    if _disable_color(color):
+        # Turn off colorama (strip escape sequences from the output)
+        colorama.init(strip=True)
+    else:
+        colorama.init()
+
+    if isinstance(level, str):
+        try:
+            level = getattr(logging, level)
+        except AttributeError:
+            raise ValueError("Unknown logger level: '{}'.".format(level))
+    else:
+        if logging.getLevelName(level).startswith("Level"):
+            raise ValueError("Unknown logger level: '{}'.".format(level))
+
+    log_format = (
+        "{c.Fore.GREEN}%(name)s{c.Style.RESET_ALL}: %(message)s"
+        .format(c=colorama))
+
+    if verbose:
+        level = logging.DEBUG
+        log_format = "[%(relativeCreated)d %(levelname)s] {}".format(log_format)
+    else:
+        log_format = "[%(levelname)s] {}".format(log_format)
+
+    if logfile is None:
+        handler = logging.StreamHandler()       # type: logging.Handler
+        handler.setFormatter(ColoramaFormatter(log_format))
+    else:
+        handler = logging.FileHandler(logfile, mode="a")
+
+    # NOTE: only set the properties on the root 'papis' logger and have
+    # sub-loggers inherit them, so that we don't override other packages
+    logger = logging.getLogger("papis")
+    logger.setLevel(level)
+    logger.addHandler(handler)
+
+
+def get_logger(name: Optional[str] = None) -> logging.Logger:
+    return logging.getLogger(name)

--- a/papis/pick.py
+++ b/papis/pick.py
@@ -1,5 +1,4 @@
 import os
-import logging
 import functools
 from abc import ABC, abstractmethod
 from typing import Callable, TypeVar, Generic, Sequence, Type
@@ -7,8 +6,9 @@ from typing import Callable, TypeVar, Generic, Sequence, Type
 import papis.config
 import papis.document
 import papis.plugin
+import papis.logging
 
-logger = logging.getLogger(__name__)
+logger = papis.logging.get_logger(__name__)
 
 T = TypeVar("T")
 Option = TypeVar("Option")

--- a/papis/pick.py
+++ b/papis/pick.py
@@ -8,7 +8,8 @@ import papis.config
 import papis.document
 import papis.plugin
 
-logger = logging.getLogger("pick")
+logger = logging.getLogger(__name__)
+
 T = TypeVar("T")
 Option = TypeVar("Option")
 

--- a/papis/plugin.py
+++ b/papis/plugin.py
@@ -61,8 +61,7 @@ from typing import List, Dict, Any, TYPE_CHECKING
 if TYPE_CHECKING:
     from stevedore import ExtensionManager
 
-logger = logging.getLogger("papis:plugin")
-
+logger = logging.getLogger(__name__)
 
 MANAGERS = {}  # type: Dict[str, ExtensionManager]
 
@@ -74,7 +73,6 @@ def stevedore_error_handler(manager: "ExtensionManager",
 
 
 def _load_extensions(namespace: str) -> None:
-    global MANAGERS
     logger.debug("Creating manager for %s", namespace)
 
     from stevedore import ExtensionManager

--- a/papis/plugin.py
+++ b/papis/plugin.py
@@ -55,13 +55,15 @@ The ``extension_manager`` will be able to access the provided functions
 in the package if they have been declared in the entry points of
 the ``setup.py`` script of the named package.
 """
-import logging
+
 from typing import List, Dict, Any, TYPE_CHECKING
+
+import papis.logging
 
 if TYPE_CHECKING:
     from stevedore import ExtensionManager
 
-logger = logging.getLogger(__name__)
+logger = papis.logging.get_logger(__name__)
 
 MANAGERS = {}  # type: Dict[str, ExtensionManager]
 

--- a/papis/tui/widgets/list.py
+++ b/papis/tui/widgets/list.py
@@ -1,6 +1,5 @@
 import os
 import re
-import logging
 import functools
 from typing import (
     Optional, Any, List, Generic, Sequence,
@@ -17,8 +16,9 @@ from prompt_toolkit.layout.containers import (
 from prompt_toolkit.filters import has_focus
 
 import papis.utils
+import papis.logging
 
-logger = logging.getLogger(__name__)
+logger = papis.logging.get_logger(__name__)
 
 Option = TypeVar("Option")
 

--- a/papis/tui/widgets/list.py
+++ b/papis/tui/widgets/list.py
@@ -18,10 +18,9 @@ from prompt_toolkit.filters import has_focus
 
 import papis.utils
 
+logger = logging.getLogger(__name__)
 
 Option = TypeVar("Option")
-
-logger = logging.getLogger("tui:widget:list")
 
 
 def match_against_regex(

--- a/papis/utils.py
+++ b/papis/utils.py
@@ -22,7 +22,7 @@ import papis.document
 import papis.database
 import papis.defaults
 
-logger = logging.getLogger("utils")
+logger = logging.getLogger(__name__)
 
 A = TypeVar("A")
 B = TypeVar("B")
@@ -195,8 +195,6 @@ def folders_to_documents(folders: List[str]) -> List[papis.document.Document]:
     :param folders: List of folder paths.
     :returns: List of document objects.
     """
-    logger = logging.getLogger("utils:folders_to_documents")
-
     import time
     begin_t = time.time()
     result = parmap(papis.document.from_folder, folders)
@@ -229,8 +227,6 @@ def get_cache_home() -> str:
 
 def get_matching_importer_or_downloader(matching_string: str
                                         ) -> List[papis.importer.Importer]:
-    logger = logging.getLogger("utils:matcher")
-
     importers = []  # type: List[papis.importer.Importer]
     _imps = papis.importer.get_importers()
     _downs = papis.downloaders.get_available_downloaders()
@@ -247,8 +243,7 @@ def get_matching_importer_or_downloader(matching_string: str
             continue
         if importer:
             logger.info(
-                "%s {c.Back.BLACK}{c.Fore.GREEN}"
-                "matches %s{c.Style.RESET_ALL}",
+                "%s {c.Back.BLACK}{c.Fore.GREEN}matches %s{c.Style.RESET_ALL}",
                 matching_string, importer.name)
             try:
                 importer.fetch()

--- a/papis/utils.py
+++ b/papis/utils.py
@@ -1,7 +1,6 @@
 import os
 import sys
 import re
-import logging
 import pathlib
 from itertools import count, product
 from typing import (Optional, List, Iterator, Any, Dict,
@@ -21,8 +20,9 @@ import papis.downloaders
 import papis.document
 import papis.database
 import papis.defaults
+import papis.logging
 
-logger = logging.getLogger(__name__)
+logger = papis.logging.get_logger(__name__)
 
 A = TypeVar("A")
 B = TypeVar("B")

--- a/papis/yaml.py
+++ b/papis/yaml.py
@@ -1,4 +1,3 @@
-import logging
 import os
 from typing import Optional, List, Dict, Any, Sequence
 
@@ -9,6 +8,7 @@ import papis.utils
 import papis.config
 import papis.importer
 import papis.document
+import papis.logging
 
 # NOTE: try to use the CLoader when possible, as it's a lot faster than the
 # python version, at least at the time of writing
@@ -17,7 +17,7 @@ try:
 except ImportError:
     from yaml import SafeLoader as Loader  # type: ignore[assignment]
 
-logger = logging.getLogger(__name__)
+logger = papis.logging.get_logger(__name__)
 
 YAML_LOADER = Loader
 

--- a/papis/yaml.py
+++ b/papis/yaml.py
@@ -17,7 +17,8 @@ try:
 except ImportError:
     from yaml import SafeLoader as Loader  # type: ignore[assignment]
 
-logger = logging.getLogger("yaml")
+logger = logging.getLogger(__name__)
+
 YAML_LOADER = Loader
 
 
@@ -102,15 +103,14 @@ def explorer(ctx: click.Context, yamlfile: str) -> None:
     papis explore yaml lib.yaml pick
 
     """
-    _logger = logging.getLogger("explore:yaml")
-    _logger.info("Reading in yaml file '%s'", yamlfile)
+    logger.info("Reading in yaml file '%s'", yamlfile)
 
     with open(yamlfile) as fd:
         docs = [papis.document.from_data(d)
                 for d in yaml.load_all(fd, Loader=Loader)]
     ctx.obj["documents"] += docs
 
-    _logger.info("%d documents found", len(docs))
+    logger.info("%d documents found", len(docs))
 
 
 class Importer(papis.importer.Importer):

--- a/setup.cfg
+++ b/setup.cfg
@@ -12,6 +12,7 @@ multiline-quotes = double
 addopts = --doctest-modules
           --ignore=papis/downloaders/thesesfr.py
           --cov=papis
+doctest_optionflags = NORMALIZE_WHITESPACE ELLIPSIS
 norecursedirs = .git doc build dist
 python_files = *.py
 

--- a/tests/commands/test_config.py
+++ b/tests/commands/test_config.py
@@ -1,10 +1,11 @@
 import os
 import unittest
-import logging
+
 import papis.config
+import papis.logging
 from papis.commands.config import run
 
-logging.basicConfig(level=logging.DEBUG)
+papis.logging.setup("DEBUG")
 
 
 class TestCommand(unittest.TestCase):

--- a/tests/downloaders/test_acs.py
+++ b/tests/downloaders/test_acs.py
@@ -1,13 +1,13 @@
 import os
 import pytest
 
+import papis.logging
 import papis.downloaders
 from papis.downloaders.acs import Downloader
 
 import tests.downloaders as testlib
 
-import logging
-logging.basicConfig(level=logging.DEBUG)
+papis.logging.setup("DEBUG")
 
 ACS_URLS = (
     "https://pubs.acs.org/doi/abs/10.1021/jp003647e",

--- a/tests/downloaders/test_annualreviews.py
+++ b/tests/downloaders/test_annualreviews.py
@@ -1,13 +1,13 @@
 import os
 import pytest
 
+import papis.logging
 import papis.downloaders
 from papis.downloaders.annualreviews import Downloader
 
 import tests.downloaders as testlib
 
-import logging
-logging.basicConfig(level=logging.DEBUG)
+papis.logging.setup("DEBUG")
 
 ANNUAL_REVIEWS_URLS = (
     "https://www.annualreviews.org/doi/10.1146/annurev-conmatphys-031214-014726",

--- a/tests/downloaders/test_aps.py
+++ b/tests/downloaders/test_aps.py
@@ -1,13 +1,13 @@
 import os
 import pytest
 
+import papis.logging
 import papis.downloaders
 from papis.downloaders.aps import Downloader
 
 import tests.downloaders as testlib
 
-import logging
-logging.basicConfig(level=logging.DEBUG)
+papis.logging.setup("DEBUG")
 
 APS_URLS = (
     "https://journals.aps.org/prl/abstract/10.1103/PhysRevLett.122.145901",

--- a/tests/downloaders/test_citeseerx.py
+++ b/tests/downloaders/test_citeseerx.py
@@ -2,13 +2,13 @@ import os
 import pytest
 from typing import Callable
 
+import papis.logging
 import papis.downloaders
 from papis.downloaders.citeseerx import Downloader
 
 import tests.downloaders as testlib
 
-import logging
-logging.basicConfig(level=logging.DEBUG)
+papis.logging.setup("DEBUG")
 
 CITESEERX_URLS = (
     "https://citeseerx.ist.psu.edu/doc_view/pid/497490d0d3ab2724e58b03765055f7a134ce89d3",  # noqa: E501

--- a/tests/downloaders/test_fallback.py
+++ b/tests/downloaders/test_fallback.py
@@ -1,12 +1,12 @@
 import pytest
 
+import papis.logging
 import papis.downloaders
 from papis.downloaders.fallback import Downloader
 
 import tests.downloaders as testlib
 
-import logging
-logging.basicConfig(level=logging.DEBUG)
+papis.logging.setup("DEBUG")
 
 
 FALLBACK_URLS = (

--- a/tests/downloaders/test_hal.py
+++ b/tests/downloaders/test_hal.py
@@ -1,13 +1,13 @@
 import os
 import pytest
 
+import papis.logging
 import papis.downloaders
 from papis.downloaders.hal import Downloader
 
 import tests.downloaders as testlib
 
-import logging
-logging.basicConfig(level=logging.DEBUG)
+papis.logging.setup("DEBUG")
 
 HAL_URLS = (
     "https://hal.archives-ouvertes.fr/jpa-00235190",

--- a/tests/downloaders/test_iopscience.py
+++ b/tests/downloaders/test_iopscience.py
@@ -1,13 +1,13 @@
 import os
 import pytest
 
+import papis.logging
 import papis.downloaders
 from papis.downloaders.iopscience import Downloader
 
 import tests.downloaders as testlib
 
-import logging
-logging.basicConfig(level=logging.DEBUG)
+papis.logging.setup("DEBUG")
 
 IOPSCIENCE_URLS = (
     "https://iopscience.iop.org/article/10.1088/0026-1394/12/4/002",

--- a/tests/downloaders/test_project_euclid.py
+++ b/tests/downloaders/test_project_euclid.py
@@ -1,13 +1,13 @@
 import os
 import pytest
 
+import papis.logging
 import papis.downloaders
 from papis.downloaders.projecteuclid import Downloader
 
 import tests.downloaders as testlib
 
-import logging
-logging.basicConfig(level=logging.DEBUG)
+papis.logging.setup("DEBUG")
 
 PROJECT_EUCLID_URLS = (
     "https://projecteuclid.org/journals/advances-in-differential-equations/volume-19/"

--- a/tests/downloaders/test_sciencedirect.py
+++ b/tests/downloaders/test_sciencedirect.py
@@ -1,13 +1,13 @@
 import os
 import pytest
 
+import papis.logging
 import papis.downloaders
 from papis.downloaders.sciencedirect import Downloader
 
 import tests.downloaders as testlib
 
-import logging
-logging.basicConfig(level=logging.DEBUG)
+papis.logging.setup("DEBUG")
 
 SCIENCE_DIRECT_URLS = (
     "https://www.sciencedirect.com/science/article/abs/pii/S0009261497040141",

--- a/tests/downloaders/test_springer.py
+++ b/tests/downloaders/test_springer.py
@@ -1,13 +1,13 @@
 import os
 import pytest
 
+import papis.logging
 import papis.downloaders
 from papis.downloaders.springer import Downloader
 
 import tests.downloaders as testlib
 
-import logging
-logging.basicConfig(level=logging.DEBUG)
+papis.logging.setup("DEBUG")
 
 SPRINGER_LINK_URLS = (
     "https://link.springer.com/article/10.1007/s10924-010-0192-1",

--- a/tests/downloaders/test_tandfonline.py
+++ b/tests/downloaders/test_tandfonline.py
@@ -1,13 +1,13 @@
 import os
 import pytest
 
+import papis.logging
 import papis.downloaders
 from papis.downloaders.tandfonline import Downloader
 
 import tests.downloaders as testlib
 
-import logging
-logging.basicConfig(level=logging.DEBUG)
+papis.logging.setup("DEBUG")
 
 TANDFONLINE_URLS = (
     "https://www.tandfonline.com/doi/full/10.1080/00268976.2013.788745",

--- a/tests/test_bibtex.py
+++ b/tests/test_bibtex.py
@@ -5,9 +5,9 @@ import pytest
 import papis
 import papis.bibtex
 import papis.document
+import papis.logging
 
-import logging
-logging.basicConfig(level=logging.DEBUG)
+papis.logging.setup("DEBUG")
 
 BIBTEX_RESOURCES = os.path.join(os.path.dirname(__file__), "resources", "bibtex")
 


### PR DESCRIPTION
This makes a few changes to how the logging is setup. To summarize a bit:

* adds a new `papis.logging` module that should contain all the logging colors and formatting.
* names all the loggers `__name__`, i.e. based on the module they're in.
* changes the log format to `[LEVEL] submodule.submodule: Some message`. Note that `"papis."` is removed from `__name__` in the actual output.
* adds color coding to the log level in the format, i.e. ERROR is red, INFO is cyan, etc.

All the uses in the source and tests are updated to use this. I've checked a few of the commands in real-life usage and it seems to be working fine, but more testing is definitely welcome!