### PR TITLE
Add working implementation of bibtex-ignore-keys

### DIFF
--- a/doc/source/default-settings.rst
+++ b/doc/source/default-settings.rst
@@ -183,10 +183,10 @@ Bibtex options
 .. papis-config:: bibtex-ignore-keys
    :default: []
 
-  When exporting document to bibtex format, do not export the keys
+  When exporting a document to the BibTeX format, do not export the keys
   appearing in this list. This might be useful if you have some keys
-  that might have a lot of content, such as ``abstract``, or maybe you
-  have used a valid bibtex key for some other purposes, like the ``note``
+  that have a lot of content, such as ``abstract``, or maybe you
+  have used a valid BibTeX key for some other purposes, like the ``note``
   key.
 
 .. papis-config:: extra-bibtex-types

--- a/doc/source/default-settings.rst
+++ b/doc/source/default-settings.rst
@@ -180,6 +180,15 @@ Bibtex options
     [mylib]
     extra-bibtex-keys = ["tags", "doc_url"]
 
+.. papis-config:: bibtex-ignore-keys
+   :default: []
+
+  When exporting document to bibtex format, do not export the keys
+  appearing in this list. This might be useful if you have some keys
+  that might have a lot of content, such as ``abstract``, or maybe you
+  have used a valid bibtex key for some other purposes, like the ``note``
+  key.
+
 .. papis-config:: extra-bibtex-types
   :default: []
 

--- a/papis/bibtex.py
+++ b/papis/bibtex.py
@@ -115,6 +115,10 @@ bibtex_key_converter = {
     "proceedingsTitle": "booktitle"
 }  # type: Dict[str, str]
 
+bibtex_ignore_keys = (
+    frozenset(papis.config.getlist("bibtex-ignore-keys"))
+)  # type: FrozenSet[str]
+
 
 def exporter(documents: List[papis.document.Document]) -> str:
     return "\n\n".join(to_bibtex_multiple(documents))
@@ -329,6 +333,9 @@ def to_bibtex(document: papis.document.Document, *, indent: int = 2) -> str:
     for key in sorted(document):
         bib_key = bibtex_key_converter.get(key, key)
         if bib_key not in bibtex_keys:
+            continue
+
+        if bib_key in bibtex_ignore_keys:
             continue
 
         bib_value = str(document[bib_key])

--- a/papis/defaults.py
+++ b/papis/defaults.py
@@ -136,6 +136,7 @@ settings = {
     "file-browser": get_default_opener(),
     "bibtex-journal-key": "journal",
     "bibtex-export-zotero-file": False,
+    "bibtex-ignore-keys": "[]",
     "extra-bibtex-keys": "[]",
     "extra-bibtex-types": "[]",
     "default-library": "papers",


### PR DESCRIPTION
I needed a setting to not export the abstract of my big library, so that other programs
have a better time parsing it.

I think this is a useful addition to the bibtex settings, what do you people think?