### PR TITLE
commands.default: Dump raw profile data

### DIFF
--- a/papis/commands/default.py
+++ b/papis/commands/default.py
@@ -116,12 +116,7 @@ def generate_profile_writing_function(profiler: "cProfile.Profile",
                                       filename: str) -> Callable[[], None]:
     def _on_finish() -> None:
         profiler.disable()
-        profiler.create_stats()
-        with open(filename, "w") as output:
-            import pstats
-            stats = pstats.Stats(profiler, stream=output)
-            stats.sort_stats("time")
-            stats.print_stats()
+        profiler.dump_stats(filename)
 
     return _on_finish
 


### PR DESCRIPTION
Before it was writing out an ASCII file with some statistics sorted by time. Unfortunately that couldn't be loaded into e.g. `gprof2dot` to visualize it a bit better.

This dumps the raw profile data instead so that other visualization apps can be used.

cc @j-c-w It's been a while, but you added this, so any feedback is very welcome!