### PR TITLE
Use getChild in get_logger to parent scripts

### DIFF
--- a/papis/logging.py
+++ b/papis/logging.py
@@ -107,4 +107,7 @@ def setup(level: Union[int, str],
 
 
 def get_logger(name: Optional[str] = None) -> logging.Logger:
-    return logging.getLogger(name)
+    if name is None or name.startswith("papis."):
+        return logging.getLogger(name)
+    else:
+        return logging.getLogger("papis").getChild(name)


### PR DESCRIPTION
In #465, I changed the logging setup to only apply to the `"papis"` logger and its children, which are determined from the naming scheme `papis.submodule.subsubmodule`. This doesn't work great with scripts or other packages that try to use `papis.logging` and be consistent with the rest of `papis`.

To fix that, we could
* use `logging.basicConfig` like before to set the style for all loggers in the process.
* use `getChild` like in this PR.

I prefer this because it keeps all the loggers under the `papis` umbrella. However, removing the `basicConfig` probably messed up setups that relied on `papis` to set up the formatting, so I'm definitely open to reverting to that.