### PR TITLE
Update example scripts

### DIFF
--- a/examples/scripts/papis-abbrev
+++ b/examples/scripts/papis-abbrev
@@ -1,152 +1,219 @@
 #! /usr/bin/env python3
-# -*- coding: utf-8 -*-
-# papis-short-help: Correctly abbreviate journal titles
+# papis-short-help: Abbreviate journal titles
 # Copyright © 2017 Alejandro Gallo. GPLv3
-# Last modified: 2018-06-19
-import json
-import sys
+
+"""
+.. note::
+
+    This is just an example script and does not follow the ISO 4 standard to the
+    letter, but only implements basic abbreviations.
+
+This command abbreviates the journal title of a document according to the ISO 4
+standard. For example, calling::
+
+    papis abbrev -a Einstein
+
+will add an ``abbrev_journal_title`` key to all documents matching the query.
+For example, the following abbreviations are made::
+
+    'Journal of Fluid Mechanics'        > 'J. Fluid Mech.'
+    'ACM Transactions on Graphics'      > 'ACM Trans. On Graph.'.
+    'Annual Review of Fluid Mechanics'  > 'Annu. Rev. Fluid Mech.'.
+
+Command Options
+^^^^^^^^^^^^^^^
+
+.. papis-config:: ltwa
+    :section: abbrev
+
+    The path of the ``LTWA.json`` file containing an abbreviation list.
+
+.. papis-config:: ignore-words
+    :section: abbrev
+
+    A list of words to ignore in the abbreviation, e.g. ``"the"`` is ignored
+    by default, but other such short words may be required.
+
+.. papis-config:: ignore-acronyms
+    :section: abbrev
+
+    A list of words to always uppercase and leave unabbreviated if they appear
+    in the journal title.
+"""
+
 import os
+import json
+from typing import Dict, Optional
+
 import papis.api
-import papis.commands
-import papis.crossref
 import papis.document
+import papis.logging
 
-def usage():
-    print("Usage: papis abbrev <papis-search>")
-    print("'' --all for all entries")
+papis.logging.setup("INFO")
+logger = papis.logging.get_logger("papis.commands.abbrev")
 
-def print_no_journal():
-    print('The document does not have a full_journal_title set')
+papis.config.register_default_settings({
+    "abbrev": {
+        "ltwa": "",
+        "ignore-acronyms": [],
+        "ignore-words": [],
+    }
+})
 
-# load the json dictionary
-currdir = os.path.dirname(os.path.abspath(__file__))
+# load the LTWA dictionary
+LTWA_FILE_PATH = papis.config.getstring("ltwa", section="abbrev")
+if not LTWA_FILE_PATH:
+    SCRIPT_PATH = os.path.dirname(os.path.abspath(__file__))
+    LTWA_FILE_PATH = os.path.join(SCRIPT_PATH, "LTWA.json")
 
 try:
-    with open(os.path.join(currdir, "LTWA.json")) as json_data:
-        d = json.load(json_data)
-        json_data.close()
+    with open(LTWA_FILE_PATH) as f:
+        LTWA_ABBREVS = json.load(f)
 except FileNotFoundError:
-    print('LTWA.json not found!')
-    print('Did you forget to copy or symlink it to your .config/scripts directory?')
-    sys.exit(0)
+    LTWA_ABBREVS = {}
 
-def ltwa_abbreviate(full_journal_name, d=d):
+# List of short words that are ommited in abbreviations
+ABBREV_IGNORE_WORDS = frozenset([
+    # en
+    "of", "in", "the", "and", "part",
+    # fr
+    "des", "de", "dans", "la", "l", "le", "et",
+    # de
+    "fur", "und",
+    # ru
+    "i"
+]) | frozenset(papis.config.getlist("ignore-words", section="abbrev"))
+
+# List of acronyms that should remain in uppercase in abbreviations
+ABBREV_IGNORE_ACRONYMS = frozenset([
+    "3D", "2D", "ACS", "ACI", "ACH", "MRS", "ECS",
+    "LC", "GC", "NATO", "ASI", "PLOS",
+    "AAPG", "AAPS", "AATCC", "ABB", "DDR",
+    "ACA", "ACM", "APL", "AQEIC", "DLG",
+    "ASSAY", "ASTM", "ASTRA",
+    "ESAIM", "SSRN", "SIAM",
+]) | frozenset(papis.config.getlist("ignore-acronyms", section="abbrev"))
+
+
+def ltwa_abbreviate(full_journal_name: str, d: Optional[Dict[str, str]] = None) -> str:
     """
     Abbreviates a journal name using International Standard Serial
-    Number (ISSN) guidelines.  ISSN abbreviations list last
-    updated 14/09/2017.  Available
-    http://www.issn.org/services/online-services/access-to-the-ltwa/
+    Number (ISSN) guidelines.
+
+    ISSN abbreviations list last updated 14/09/2017. Available
+    `here <http://www.issn.org/services/online-services/access-to-the-ltwa/>`__
+    for download as a CSV file.
     """
 
-    # local variables
-    ignore_list = [ # List of short words that are ommited in abbreviations
-        # en
-        'of', 'in', 'the', 'and', 'part',
-        # fr
-        'des', 'de', 'dans', 'la', 'l', 'le', 'et',
-        # de
-        'fur','und',
-        # ru
-        'i'
-    ]
-    upper_list = [ # List of acronyms that should remain in uppercase in abbreviations
-        '3D', '2D', 'ACS', 'ACI', 'ACH', 'MRS', 'ECS',
-        'LC', 'GC', 'NATO', 'ASI', 'PLOS',
-        'AAPG', 'AAPS', 'AATCC', 'ABB', 'DDR',
-        'ACA', 'ACM', 'APL', 'AQEIC', 'DLG',
-        'ASSAY', 'ASTM', 'ASTRA',
-    ]
+    if d is None:
+        d = LTWA_ABBREVS
 
     # initialize a new list
     return_list = []
     hyphenation = False
 
     # if just one word, return that word
-    if len(full_journal_name.split(' ')) <= 1:
+    words = full_journal_name.split(" ")
+    if len(words) <= 1:
         return full_journal_name
 
     # for all words in the full name...
-    for h, word in enumerate(full_journal_name.replace('-',' -').split(' ')):
-        word = word+'.' # Add a full stop to allow [:-i] to function as intended
-        hyphenation = False # Set hyphenation to False
+    words = full_journal_name.replace("-", " _").split(" ")
+    for word in words:
+        # add a full stop to allow [:-i] to function as intended
+        lower_word = "{}.".format(word.lower())
+        hyphenation = False
 
-        if '-' in word.lower():
+        if "-" in lower_word:
             # if word contains a hyphen, remove it and set 'hyphenation' to True
-            word = word.lower().replace('-','')
+            lower_word = lower_word.replace("-", "")
             hyphenation = True
-            print(word)
+            logger.debug("Processing word '%s'.", lower_word)
 
-        #...shrink the word from right to left.
-        for i in range(0, len(word.lower())):
-
-            # If it matches a json key...
-            if word.lower()[:-i] in [x.lower() for x in d.keys()]:
+        # shrink the word from right to left.
+        for i in range(len(lower_word)):
+            # If it matches a suffix / prefix
+            suffix = lower_word[:-i]
+            if suffix in d:
                 # ...add it to the list.
                 if hyphenation:
-                    return_list.append('-'+d[word.lower()[:-i]])
+                    return_list.append("-{}".format(d[suffix]))
                 else:
-                    return_list.append(d[word.lower()[:-i]])
+                    return_list.append(d[suffix])
                 break
 
-            elif word.lower()[:-1] in ignore_list:
+            elif lower_word[:-1] in ABBREV_IGNORE_WORDS:
                 # Don't add the word if in ignore list
                 break
 
             # If we get to the end of the word and it doesn't match...
-            elif i == len(word.lower()[:-1]):
+            elif i == len(lower_word[:-1]):
                 # ...add the full word to the list.
                 if hyphenation:
-                    return_list.append('-'+word.lower()[:-1])
+                    return_list.append("-{}".format(lower_word[:-1]))
                 else:
-                    return_list.append(word.lower()[:-1])
+                    return_list.append(lower_word[:-1])
 
-    # concatenate the list to a string,
-    # capitalising the first letter of each word...
+    # concatenate the list to a string, capitalising the first letter of each word
     for j, word in enumerate(return_list):
-        # ...unless it is an acronym.
-        if word.upper().replace('-','') in upper_list:
-            return_list[j] = return_list[j].upper()
+        if word.upper().replace("-", "") in ABBREV_IGNORE_ACRONYMS:
+            return_list[j] = word.upper()
         else:
-            return_list[j] = return_list[j].title()
-    return " ".join(return_list).replace(' -','-')
+            return_list[j] = word.capitalize()
+
+    return " ".join(return_list).replace(" -", "-")
 
 
-if len(sys.argv) < 2:
-    search = ""
-else:
-    search = sys.argv[1]
-    if search in ['-h', '--help']:
-        usage()
-        sys.exit(0)
+def run(query: str, all_: bool = True) -> int:
+    if not LTWA_ABBREVS:
+        logger.error("'LTWA.json' not found at '%s'!", LTWA_FILE_PATH)
+        logger.error("Did you forget to copy or symlink it to your config directory?")
+        return 1
 
-add_flags = sys.argv[2:]
+    documents = papis.api.get_documents_in_lib(
+        papis.api.get_lib_name(),
+        search=query
+    )
 
-documents = papis.api.get_documents_in_lib(
-    papis.api.get_lib_name(),
-    search=search
-)
-
-if '--all' in add_flags:
-    doc = documents
-else:
-    doc = [papis.api.pick_doc(
-        documents
-    )]
-
-for item in doc:
-    if 'full_journal_title' not in item.keys():
-        print_no_journal()
+    if all_:
+        picked_documents = documents
     else:
-        full_journal_title = item['full_journal_title']
+        picked_documents = list(papis.api.pick_doc(documents))
 
-        # Get the data from the picked document
-        data = papis.document.to_dict(item)
+    for doc in picked_documents:
+        if "journal" not in doc:
+            logger.info("The document does not have a 'journal' set.")
+        else:
+            full_journal_title = doc["journal"]
 
-        # Set the new abbrev_journal_title
-        data['abbrev_journal_title'] = ltwa_abbreviate(full_journal_title)
-        print(data['ref'],'|', full_journal_title, 'abbreviated to', data['abbrev_journal_title'])
+            # Get the data from the picked document
+            data = papis.document.to_dict(doc)
 
-        # Update the data and save
-        item.update(data, force=True)
-        item.save()
-sys.exit(0)
+            # Set the new abbrev_journal_title
+            data["abbrev_journal_title"] = ltwa_abbreviate(full_journal_title)
+            logger.info("%s: Abbreviated '%s' to '%s'.",
+                        data["ref"],
+                        full_journal_title,
+                        data["abbrev_journal_title"])
+
+            # Update the data and save
+            doc.update(data)
+            doc.save()
+
+    return 0
+
+
+if __name__ == "__main__":
+    import argparse
+
+    parser = argparse.ArgumentParser()
+    parser.add_argument(
+        "query",
+        default=papis.config.get("default-query-string"),
+        help="A query to run over the documents")
+    parser.add_argument(
+        "-a", "--all", dest="all_", action="store_true",
+        help="Apply command to all documents returned by the query")
+    args = parser.parse_args()
+
+    raise SystemExit(run(args.query, all_=args.all_))

--- a/examples/scripts/papis-check
+++ b/examples/scripts/papis-check
@@ -1,58 +1,63 @@
 #! /usr/bin/env python3
-# -*- coding: utf-8 -*-
-# papis-short-help: Look-up citations of documents
+# papis-short-help: Check document keys
 # Copyright © 2018 Alejandro Gallo. GPLv3
+
 """
+.. note::
+
+    This is just an example script and more comprehensive checks are implemented
+    by ``papis doctor``.
+
 This command checks for several attributes in every document.
 
-For example if you want to check that every document of your library has valid
-files related to it you can just do
-
-::
+For example, if you want to check that every document in your library has valid
+files attached to it, you can just do::
 
     papis check --key files
 
-this will check that every info file has the key files and that every file
-listed exists.
+This will check that every ``info.yml`` file has the key ``"files"`` and that
+every file listed exists on the filesystem.
 
-You can also define more complicated ones, e.g., if you want to check that
-every document has files, a valid author and title you would just hit
-
-::
+You can also define more complicated checks, e.g., if you want to check that
+every document has files, a valid author and title::
 
     papis check --key files --key author --key title
 
-.. _check-command-options:
+Command Options
+^^^^^^^^^^^^^^^
 
-Check command options
-^^^^^^^^^^^^^^^^^^^^^
+.. papis-config:: keys
+    :section: check
 
-.. papis-config:: check-keys
-
-    Python list key values to be checked by default by the command
+    A list of key values to be checked by default by the command
     ``check``. E.g: ``check-keys = ["author", "doi"]``.
-    It is important that it is a valid python list.
-
 """
-import papis.api
-import papis.config
-import papis.cli
+
+import os
+from typing import Any, Dict, List, Sequence
+
 import click
-import logging
 
+import papis.api
+import papis.cli
+import papis.config
+import papis.document
+import papis.logging
 
-options = {
-    'check': {
-        "keys": '["files"]',
+papis.logging.setup("INFO")
+logger = papis.logging.get_logger("papis.commands.check")
+
+papis.config.register_default_settings({
+    "check": {
+        "keys": ["files"],
     }
-}
-papis.config.register_default_settings(options)
+})
 
 
-def check_files(document):
-    """Check for the exsitence of the document's files
-    :returns: False if some file does not exist, True otherwise
-    :rtype:  bool
+def check_files(document: papis.document.Document) -> bool:
+    """Check for the exsitence of the document's files.
+
+    :returns: *False* if some file does not exist, *True* otherwise
 
     >>> from papis.document import from_data
     >>> doc = from_data({'title': 'Hello World'})
@@ -65,63 +70,58 @@ def check_files(document):
     for f in document.get_files():
         # document.logger.debug(f)
         if not os.path.exists(f):
-            print(
-                "** Error: %s not found in %s" % (
-                f,
-                document.get_main_folder())
-            )
+            logger.error("'%s' not found in '%s'.", f, document.get_main_folder())
             return False
         else:
             return True
 
+    return True
 
-def run(keys, documents):
+
+def run(keys: Sequence[str],
+        documents: Sequence[papis.document.Document],
+        ) -> Sequence[Dict[str, Any]]:
     result = []
     for document in documents:
         for key in keys:
             if key not in document.keys():
-                result.append(
-                    dict(doc=document, key=key, msg='not defined')
-                )
+                result.append({"doc": document, "key": key, "msg": "Undefined"})
             elif not document[key] and document[key] is not False:
-                result.append(
-                    dict(doc=document, key=key, msg='ill defined')
-                )
-            elif key == 'files':
+                result.append({"doc": document, "key": key, "msg": "Ill-defined"})
+            elif key == "files":
                 if not check_files(document):
-                    result.append(
-                        dict(doc=document, key=key, msg='problem with files')
-                    )
+                    result.append({"doc": document, "key": key, "msg": "Missing files"})
+
     return result
 
 
 @click.command()
-@click.help_option('--help', '-h')
-@papis.cli.query_option()
+@click.help_option("--help", "-h")
+@papis.cli.query_argument()
 @click.option(
     "--key", "-k",
     help="Space separated fields to check against",
-    type=str,
     multiple=True,
-    default=lambda: eval(papis.config.get('keys', section='keys'))
+    default=lambda: eval(papis.config.getstring("keys", section="check"))
 )
-def cli(query, key):
+def cli(query: str, key: List[str]) -> None:
     """Check document from a given library"""
     documents = papis.database.get().query(query)
-    logger = logging.getLogger('cli:check')
-    logger.debug(key)
     troubled_docs = run(key, documents)
+
     for doc in troubled_docs:
         print(
-            "{d[key]} - {d[msg]} - {folder}".format(
-                d=doc, folder=doc['doc'].get_main_folder()
+            "{key} - {folder}: {msg}".format(
+                key=doc["key"],
+                folder=doc["doc"].get_main_folder(),
+                msg=doc["msg"],
             )
         )
 
     if not len(troubled_docs) == 0:
-        print("Errors were detected, please fix the info files")
+        logger.error("Errors were detected, please fix the info files")
     else:
-        print("No errors detected")
+        logger.info("No errors detected")
 
 
 if __name__ == "__main__":

--- a/examples/scripts/papis-ga
+++ b/examples/scripts/papis-ga
@@ -1,41 +1,67 @@
 #! /usr/bin/env python3
-# -*- coding: utf-8 -*-
 # papis-short-help: Git add <document>
 # Copyright © 2017 Alejandro Gallo. GPLv3
-import sys
+
+"""
+.. note::
+
+    This is just an example script and this functionality is better
+    implemented by ``papis git``.
+
+Adds the files in the path of the selected documents to the ``git`` index.
+A simple usage of this command is::
+
+    papis ga -a Einstein
+"""
+
 import os
+
 import papis.api
-import papis.commands
-import subprocess
+import papis.document
+import papis.logging
+
+papis.logging.setup("INFO")
+logger = papis.logging.get_logger("papis.commands.ga")
 
 
-def usage():
-    print("Usage: papis ga <document-search>")
-
-
-def add(doc):
+def add(doc: papis.document.Document) -> None:
     path = os.path.expanduser(papis.config.get_lib_dirs()[0])
-    cmd = ['git', '-C', path, 'add'] + doc.get_files() + [doc.get_info_file()]
-    print(cmd)
+    cmd = ["git", "-C", path, "add"] + doc.get_files() + [doc.get_info_file()]
+
+    logger.info("Running command: '%s'", " ".join(cmd))
+
+    import subprocess
     subprocess.call(cmd)
 
 
-if __name__ == "__main__":
-    if len(sys.argv) < 2:
-        search = ""
-    else:
-        search = sys.argv[1]
-        if search in ['-h', '--help']:
-            usage()
-            sys.exit(0)
-
+def run(query: str, all_: bool = False) -> int:
     documents = papis.api.get_documents_in_lib(
         papis.api.get_lib_name(),
-        search=search
+        search=query
     )
 
-    doc = papis.api.pick_doc(
-        documents
-    )
+    if all_:
+        picked_documents = documents
+    else:
+        picked_documents = list(papis.api.pick_doc(documents))
 
-    add(doc)
+    for doc in picked_documents:
+        add(doc)
+
+    return 0
+
+
+if __name__ == "__main__":
+    import argparse
+
+    parser = argparse.ArgumentParser()
+    parser.add_argument(
+        "query",
+        default=papis.config.get("default-query-string"),
+        help="A query to run over the documents")
+    parser.add_argument(
+        "-a", "--all", dest="all_", action="store_true",
+        help="Apply command to all documents returned by the query")
+    args = parser.parse_args()
+
+    raise SystemExit(run(args.query, all_=args.all_))

--- a/examples/scripts/papis-mail
+++ b/examples/scripts/papis-mail
@@ -1,27 +1,28 @@
 #! /usr/bin/env bash
-# papis-short-help:  Email a paper to my friend
+# papis-short-help: Email a paper to a friend
 # Copyright © 2017 Alejandro Gallo. GPLv3
 
 if [[ $1 = "-h" ]]; then
-  echo "Email a paper to my friend"
+  echo "Email a paper to a friend"
   cat <<EOF
 Usage: papis output_folder
 EOF
   exit 0
 fi
 
-folder_name=$1
+folder_name="$1"
 zip_name="${folder_name}.zip"
 mail_agent=mutt
 
-papis -l ${PAPIS_LIB} export --folder --out ${folder_name}
+papis -l ${PAPIS_LIB} export --folder --out "${folder_name}"
 if [[ ! -e ${folder_name} ]]; then
-  echo "${folder_name} not created, exiting..."
+  echo "${folder_name} does not exist, exiting..."
   exit 1
 fi
-echo "Ziping folder (${folder_name} => ${zip_name})"
-zip -r ${zip_name} ${folder_name}
 
-${mail_agent} -a ${zip_name}
+echo "Ziping folder (${folder_name} => ${zip_name})"
+zip -r "${zip_name}" "${folder_name}"
+
+${mail_agent} -a "${zip_name}"
 
 

--- a/examples/scripts/papis-tags
+++ b/examples/scripts/papis-tags
@@ -1,17 +1,51 @@
 #! /usr/bin/env python3
-# -*- coding: utf-8 -*-
-# Last modified: 2018-11-14
+# papis-short-help: Search tags in the library
+# Copyright © 2018 Alejandro Gallo. GPLv3
+
+"""
+This commands allows searching tags and selecting documents that match.
+A simple usage of this command is just::
+
+    papis tags --no-confirm Einstein
+
+which will first compile a list of all the tags in documents that contain the
+``"Einstein"`` query. The user is then prompted to select a tag. This tag
+is then used to find all other documents in the library that are tagged with it.
+The user is then prompted to select a document and open its main folder.
+
+Papis does not impose any structure on the format of the ``"tags"`` field in
+a document. However, for this script the following formats are supported:
+
+* a list of string tags, e.g. ``["tag1", "tag2", "tag3"]
+* a comma-separated string of tags, where the tags themselves can contain spaces,
+  e.g. ``"tag name 1, tag name 2, tag name 3"``.
+* a space-separated string of tags, e.g. ``"tag-name-1 tag-name-2 tag-name-3"``.
+"""
+
+import re
+
+import click
+
 import papis.api
 import papis.cli
-from papis.commands.open import run as papis_open
-import papis.database
-import click
+import papis.document
+import papis.logging
+
+papis.logging.setup("INFO")
+logger = papis.logging.get_logger("papis.commands.tags")
+
+TAG_COMMA_REGEX = re.compile(r"\s*,\s*")
+TAG_SPACE_REGEX = re.compile(r"\W+")
 
 
 @click.command()
-@click.help_option('-h', '--help')
-@papis.cli.query_option()
-def main(query):
+@papis.cli.query_argument()
+@click.help_option("-h", "--help")
+@click.option(
+    "--confirm/--no-confirm",
+    help="Ask to confirm before adding to the collection",
+    default=lambda: True if papis.config.get("add-confirm") else False)
+def main(query: str, confirm: bool) -> None:
     """
     Search tags of the library and open a document
     """
@@ -21,38 +55,63 @@ def main(query):
     )
 
     # Create an empty tag list
-    tag_list = []
-    for item in documents:
-        if 'tags' in item.keys():
-            for tag in list([item['tags']]):
-                # if tag contains a comma, split it to a list
-                if tag.split(','):
-                    tag = tag.split(',')
-                else:
-                    continue
-                tag_list.append(tag)
+    tag_list = set()
+    for doc in documents:
+        tags = doc.get("tags")
+        if tags is None:
+            continue
+
+        if isinstance(tags, str):
+            # NOTE: tags can be either one of
+            #   tag name 1, tag name 2, tag name 3
+            #   tag-name-1 tag-name-2 tag-name-3
+            # i.e. if comma separated, spaces are allowed in
+            if "," in tags:
+                tags = TAG_COMMA_REGEX.split(tags)
+            else:
+                tags = TAG_SPACE_REGEX.split(tags)
+        elif isinstance(tags, list):
+            pass
+        else:
+            logger.error("'tags' key has unknown type '%s': '%s'",
+                         type(tags).__name__, papis.document.describe(doc))
+            continue
+
+        tag_list = tag_list | set(tags)
 
     # if no tags are found, exit gracefully
-    if tag_list == []:
-        print('The library does not have any tags set')
+    if not tag_list:
+        logger.info("The selected documents do not have any tags set.")
         return
 
-    # flatten the list, which may be a list of lists
-    # also make it lower case and strip out any preceding spaces. The list
-    # set, is then sorted to alphanumeric order.
-    flat_list = sorted(set([y.strip(' ').lower() for x in tag_list for y in x]))
-
-    # Allow the list set (no duplicates) )to be sorted into alphabetical
+    # Allow the list set (no duplicates) ) to be sorted into alphabetical
     # order and picked from
-    picked_tag = papis.api.pick(flat_list)
+    sorted_tags = sorted(list(tag_list))
+    picked_tags = papis.api.pick(sorted_tags)
+    if len(picked_tags) == 1:
+        picked_tag, = picked_tags
+    else:
+        logger.error("Picked multiple tags (selecting first one): '%s'",
+                     "', '".join(picked_tags))
+        picked_tag = picked_tags[0]
 
-    docs = papis.database.get().query_dict(dict(tags=picked_tag))
+    logger.info("Picked tag '%s'", picked_tag)
+    docs = papis.api.get_documents_in_lib(search={"tags": picked_tag})
+    docs = list(papis.api.pick_doc(docs))
 
-    doc = papis.api.pick_doc(docs)
-    if not doc:
-        return
+    from papis.tui.utils import confirm as confirm_dialog
+    for doc in docs:
+        folder = doc.get_main_folder()
+        if folder is None:
+            continue
 
-    papis_open(doc)
+        if confirm:
+            if not confirm_dialog(
+                    "Open folder for '{}'?".format(papis.document.describe(doc))
+                    ):
+                continue
+
+        papis.api.open_dir(folder, wait=False)
 
 
 if __name__ == "__main__":

--- a/papis/api.py
+++ b/papis/api.py
@@ -5,7 +5,7 @@ create papis scripts.
 .. class:: T
 """
 
-from typing import Any, Callable, Dict, List, Optional, Sequence, TypeVar
+from typing import Any, Callable, Dict, List, Optional, Sequence, TypeVar, Union
 
 import papis.utils
 import papis.config
@@ -183,16 +183,23 @@ def get_documents_in_dir(
 
 def get_documents_in_lib(
         library: Optional[str] = None,
-        search: str = "") -> List[papis.document.Document]:
+        search: Union[Dict[str, Any], str] = "") -> List[papis.document.Document]:
     """
     Get documents contained in the given library.
 
     :param library: a library name.
-    :param search: a search string used to filter the documents.
+    :param search: a search parameter used to filter the documents.
     :returns: a :class:`list` of filtered documents from *library*.
     """
     import papis.database
-    return papis.database.get(library).query(search)
+    db = papis.database.get(library)
+
+    if isinstance(search, str):
+        return db.query(search)
+    elif isinstance(search, dict):
+        return db.query_dict(search)
+    else:
+        raise TypeError("Unknown search parameter: '{}'".format(search))
 
 
 def clear_lib_cache(lib: Optional[str] = None) -> None:

--- a/setup.cfg
+++ b/setup.cfg
@@ -4,10 +4,11 @@ extend-ignore = B019, E123, N818, W503
 exclude =
     doc
     build
+    examples/scripts/papis-mail
+filename = *.py, examples*papis-*
 max-line-length = 88
 inline-quotes = double
 multiline-quotes = double
-
 
 [tool:pytest]
 addopts = --doctest-modules

--- a/tests/commands/test_add.py
+++ b/tests/commands/test_add.py
@@ -1,7 +1,6 @@
 import re
 import os
 import tempfile
-import unittest
 from unittest.mock import patch
 import tests
 import tests.cli

--- a/tests/commands/test_addto.py
+++ b/tests/commands/test_addto.py
@@ -1,5 +1,3 @@
-import unittest
-
 import papis.config
 from papis.commands.addto import run
 

--- a/tests/commands/test_edit.py
+++ b/tests/commands/test_edit.py
@@ -1,4 +1,3 @@
-import unittest
 import os
 
 import papis.config

--- a/tests/commands/test_export.py
+++ b/tests/commands/test_export.py
@@ -4,7 +4,6 @@ import glob
 
 import json
 import tempfile
-import unittest
 
 import yaml
 

--- a/tests/commands/test_list.py
+++ b/tests/commands/test_list.py
@@ -1,5 +1,4 @@
 import os
-import unittest
 
 import papis.config
 import papis.database

--- a/tests/commands/test_mv.py
+++ b/tests/commands/test_mv.py
@@ -1,5 +1,4 @@
 import os
-import unittest
 import tempfile
 
 import papis.database

--- a/tests/commands/test_open.py
+++ b/tests/commands/test_open.py
@@ -1,5 +1,3 @@
-import unittest
-
 import papis.bibtex
 import papis.config
 import papis.document

--- a/tests/commands/test_rename.py
+++ b/tests/commands/test_rename.py
@@ -1,5 +1,4 @@
 import os
-import unittest
 
 import papis.database
 from papis.commands.rename import run

--- a/tests/commands/test_rm.py
+++ b/tests/commands/test_rm.py
@@ -1,5 +1,4 @@
 import os
-import unittest
 from unittest.mock import patch
 
 import papis.config

--- a/tests/commands/test_run.py
+++ b/tests/commands/test_run.py
@@ -1,5 +1,3 @@
-import unittest
-
 from papis.commands.run import run
 import papis.config
 

--- a/tests/commands/test_update.py
+++ b/tests/commands/test_update.py
@@ -1,4 +1,3 @@
-import unittest
 import os
 
 import papis.config

--- a/tools/ci-run-tests.sh
+++ b/tools/ci-run-tests.sh
@@ -4,7 +4,7 @@ PYTHON_MINOR_VERSION=$(python -c 'import sys; print(sys.version_info.minor)')
 EXIT_STATUS=0
 
 python -m pytest papis/ tests/ --cov=papis || EXIT_STATUS=$?
-python -m flake8 papis || EXIT_STATUS=$?
+python -m flake8 papis tests examples || EXIT_STATUS=$?
 if (( "$PYTHON_MINOR_VERSION" > 6)); then
     python -m mypy --show-error-codes papis || EXIT_STATUS=$?
 fi


### PR DESCRIPTION
This cleans up the example scripts a bit to get them more in line with recent changes.

* Add flake8 checks and fix errors
* Rename `query_option` to `query_argument`
* Use `papis.logging`
* Add typing annotations and some docs to each script
* Use `argparse` in `papis-abbrev` and `papis-ga` instead of manually parsing `sys.argv`.
* A bunch of misc changes to the style, e.g. `key in doc` instead of `key in doc.keys()`.

I've tested the scripts and they seem to be working as expected for some simple examples.

cc @michaelplews: This makes some non-trivial modifications to the `papis-tags` script, so just a heads-up in case you're still using it (as the original author from `git blame`)! If you are still using it, feedback is very welcome!