### PR TITLE
Fix link extraction in crossref

### DIFF
--- a/papis/crossref.py
+++ b/papis/crossref.py
@@ -118,7 +118,7 @@ key_conversion = [
     }]),
     KeyConversionPair("link", [{
         "key": str(papis.config.get("doc-url-key-name")),
-        "action": lambda x: x[1]["URL"]
+        "action": lambda x: _crossref_link(x)
     }]),
     KeyConversionPair("issued", [
         {"key": "year", "action": lambda x: _crossref_date_parts(x, 0)},
@@ -169,6 +169,19 @@ def _crossref_date_parts(entry: Dict[str, Any],
         return None
 
     return int(parts[i])
+
+
+def _crossref_link(entry: List[Dict[str, str]]) -> Optional[str]:
+    if len(entry) == 1:
+        return entry[0]["URL"]
+
+    links = [
+        # NOTE: using the 'similarity-checking' label here is just a heuristic,
+        # since that seemed to be the better choice in some examples
+        resource.get("URL") for resource in entry
+        if resource.get("intended-application") == "similarity-checking"]
+
+    return links[0] if links else None
 
 
 def crossref_data_to_papis_data(data: Dict[str, Any]) -> Dict[str, Any]:

--- a/papis/crossref.py
+++ b/papis/crossref.py
@@ -1,7 +1,7 @@
 import re
 import os
 import tempfile
-from typing import Set, List, Dict, Any, Optional, Tuple, TYPE_CHECKING
+from typing import Any, Dict, List, Optional, Tuple, TYPE_CHECKING
 
 import doi
 import click
@@ -21,7 +21,10 @@ logger = papis.logging.get_logger(__name__)
 
 KeyConversionPair = papis.document.KeyConversionPair
 
-_filter_names = set([
+# NOTE: the API JSON format is maintained at
+#   https://github.com/CrossRef/rest-api-doc/blob/master/api_format.md
+
+_filter_names = frozenset([
     "has_funder", "funder", "location", "prefix", "member", "from_index_date",
     "until_index_date", "from_deposit_date", "until_deposit_date",
     "from_update_date", "until_update_date", "from_created_date",
@@ -41,9 +44,9 @@ _filter_names = set([
     "content_domain", "has_content_domain", "has_crossmark_restriction",
     "has_relation", "relation_type", "relation_object", "relation_object_type",
     "public_references", "publisher_name", "affiliation",
-])  # type: Set[str]
+])
 
-_types_values = [
+_types_values = frozenset([
     "book-section", "monograph", "report", "peer-review", "book-track",
     "journal-article", "book-part", "other", "book", "journal-volume",
     "book-set", "reference-entry", "proceedings-article", "journal",
@@ -51,16 +54,16 @@ _types_values = [
     "proceedings", "standard", "reference-book", "posted-content",
     "journal-issue", "dissertation", "dataset", "book-series", "edited-book",
     "standard-series",
-]  # type: List[str]
+])
 
-_sort_values = [
+_sort_values = frozenset([
     "relevance", "score", "updated", "deposited", "indexed", "published",
     "published-print", "published-online", "issued", "is-referenced-by-count",
     "references-count",
-]  # type: List[str]
+])
 
 
-_order_values = ["asc", "desc"]  # type: List[str]
+_order_values = frozenset(["asc", "desc"])
 
 
 type_converter = {
@@ -254,10 +257,10 @@ def doi_to_data(doi_string: str) -> Dict[str, Any]:
     multiple=True)
 @click.option(
     "--order", "-o", help="Order of appearance according to sorting",
-    default="desc", type=click.Choice(_order_values), show_default=True)
+    default="desc", type=click.Choice(list(_order_values)), show_default=True)
 @click.option(
     "--sort", "-s", help="Sorting parameter", default="score",
-    type=click.Choice(_sort_values), show_default=True)
+    type=click.Choice(list(_sort_values)), show_default=True)
 def explorer(
         ctx: click.core.Context,
         query: str,

--- a/papis/crossref.py
+++ b/papis/crossref.py
@@ -121,16 +121,16 @@ key_conversion = [
         "action": lambda x: x[1]["URL"]
     }]),
     KeyConversionPair("issued", [
-        {"key": "year", "action": lambda x: x.get("date-parts")[0][0]},
-        {"key": "month", "action": lambda x: x.get("date-parts")[0][1]}
+        {"key": "year", "action": lambda x: _crossref_date_parts(x, 0)},
+        {"key": "month", "action": lambda x: _crossref_date_parts(x, 1)}
     ]),
     KeyConversionPair("published-online", [
-        {"key": "year", "action": lambda x: x.get("date-parts")[0][0]},
-        {"key": "month", "action": lambda x: x.get("date-parts")[0][1]}
+        {"key": "year", "action": lambda x: _crossref_date_parts(x, 0)},
+        {"key": "month", "action": lambda x: _crossref_date_parts(x, 1)}
     ]),
     KeyConversionPair("published-print", [
-        {"key": "year", "action": lambda x: x.get("date-parts")[0][0]},
-        {"key": "month", "action": lambda x: x.get("date-parts")[0][1]}
+        {"key": "year", "action": lambda x: _crossref_date_parts(x, 0)},
+        {"key": "month", "action": lambda x: _crossref_date_parts(x, 1)}
     ]),
     KeyConversionPair("publisher", [papis.document.EmptyKeyConversion]),
     KeyConversionPair("reference", [{
@@ -149,10 +149,26 @@ key_conversion = [
     KeyConversionPair("event", [  # Conferences
         {"key": "venue", "action": lambda x: x["location"]},
         {"key": "booktitle", "action": lambda x: x["name"]},
-        {"key": "year", "action": lambda x: x["start"]["date-parts"][0][0]},
-        {"key": "month", "action": lambda x: x["start"]["date-parts"][0][1]},
+        {"key": "year", "action": lambda x: _crossref_date_parts(x["start"], 0)},
+        {"key": "month", "action": lambda x: _crossref_date_parts(x["start"], 1)},
     ]),
 ]  # List[papis.document.KeyConversionPair]
+
+
+def _crossref_date_parts(entry: Dict[str, Any],
+                         i: int = 0) -> Optional[int]:
+    date_parts = entry.get("date-parts")
+    if date_parts is None:
+        return date_parts
+
+    assert len(date_parts) == 1
+    parts, = date_parts
+
+    # NOTE: dates can also be partial, where only the year is required
+    if not (0 <= i < len(parts)):
+        return None
+
+    return int(parts[i])
 
 
 def crossref_data_to_papis_data(data: Dict[str, Any]) -> Dict[str, Any]:

--- a/tests/resources/crossref/test_conference_out.json
+++ b/tests/resources/crossref/test_conference_out.json
@@ -27,6 +27,7 @@
   ],
   "type": "inproceedings",
   "url": "http://dx.doi.org/10.1145/3184558.3186235",
+  "doc_url": "http://dl.acm.org/ft_gateway.cfm?id=3186235&ftid=1958239&dwn=1",
   "citations": [
     {
       "unstructured": "Pieter Bonte, Femke Ongenae, and Filip De Turck. 2016. Learning Semantic Rules for Intelligent Transport Scheduling in Hospitals. In Proc. of the 5th Workshop on Data Mining and Knowledge Discovery meets Linked Open Data."

--- a/tests/test_crossref.py
+++ b/tests/test_crossref.py
@@ -1,14 +1,13 @@
 import os
+import json
+from typing import Any, Dict
+
 import pytest
 
-from unittest.mock import patch
-import json
-from papis.crossref import (
-    get_data, doi_to_data
-)
+import tests.downloaders as testlib
 
 
-def _get_test_json(filename):
+def _get_test_json(filename: str) -> Dict[str, Any]:
     resources = os.path.join(
         os.path.dirname(os.path.abspath(__file__)),
         "resources", "crossref"
@@ -18,8 +17,11 @@ def _get_test_json(filename):
         return json.load(fd)
 
 
+@testlib.with_default_config
 @pytest.mark.xfail(reason="crossref times out quite often")
-def test_get_data():
+def test_get_data() -> None:
+    from papis.crossref import get_data
+
     data = get_data(
         author="Albert Einstein",
         max_results=1,
@@ -28,34 +30,24 @@ def test_get_data():
     assert len(data) == 1
 
 
-@patch(
-    "papis.crossref._get_crossref_works",
-    lambda **x: _get_test_json("test1.json")
-)
-def test_doi_to_data_1():
-    data = doi_to_data("10.1103/physrevb.89.140501")
-    assert isinstance(data, dict)
-    result = _get_test_json("test1_out.json")
-    assert result == data
+@testlib.with_default_config
+@pytest.mark.parametrize(("doi", "basename"), [
+    ("10.1103/physrevb.89.140501", "test1"),
+    ("10.1103/physrevb.89.140501", "test_2"),
+    ("10.1145/3184558.3186235", "test_conference")
+    ])
+def test_doi_to_data(monkeypatch, doi: str, basename: str) -> None:
+    infile = "{}.json".format(basename)
+    outfile = "{}_out.json".format(basename)
 
+    import papis.crossref
 
-@patch(
-    "papis.crossref._get_crossref_works",
-    lambda **x: _get_test_json("test_2.json")
-)
-def test_doi_to_data_2():
-    data = doi_to_data("10.1103/physrevb.89.140501")
-    assert isinstance(data, dict)
-    result = _get_test_json("test_2_out.json")
-    assert result == data
+    with monkeypatch.context() as m:
+        m.setattr(papis.crossref,
+                  "_get_crossref_works",
+                  lambda **x: _get_test_json(infile))
 
+        data = papis.crossref.doi_to_data(doi)
+        result = _get_test_json(outfile)
 
-@patch(
-    "papis.crossref._get_crossref_works",
-    lambda **x: _get_test_json("test_conference.json")
-)
-def test_doi_to_data_conference():
-    data = doi_to_data("")
-    assert isinstance(data, dict)
-    result = _get_test_json("test_conference_out.json")
-    assert result == data
+        assert data == result


### PR DESCRIPTION
The extractor would previously just pick the second link in the list, even if there wasn't one. This updates it to pick the link marked as `"similarity-checking"` (seems like that's the better one). 

There's some documentation on the link format [here](https://github.com/CrossRef/rest-api-doc/blob/master/api_format.md#resource-link).

Fixes #379.