### PR TITLE
Add some help messages to the Makefile

### DIFF
--- a/HACKING.md
+++ b/HACKING.md
@@ -4,66 +4,125 @@ Guidelines for Code Modification
 Coding Style
 ------------
 
-* Use syntax compatible with Python `3.1+`.
-* Use docstrings with `sphinx` in mind
-* 4 spaces are the preferred indentation method.
-* No trailing white spaces are allowed.
-* Restrict each line of code to 80 characters.
-* Follow the PEP8 style guide: https://www.python.org/dev/peps/pep-0008/
-* Always run tests before submitting a new PR.
-  You need to install the develop packages of papis for this:
-  ```
-  pip3 install -e .[develop]
-  ```
-  You can then run the tests with the command
-  ```
-  ./tools/ci-run-tests.sh
-  ```
+* Use syntax compatible with Python `3.5+`.
+* Use docstrings with [Sphinx](https://www.sphinx-doc.org/en/master/) in mind.
+* Follow the [PEP8 style guide](https://www.python.org/dev/peps/pep-0008/)
+* Try and run tests locally before submitting a new PR.
 
+Development
+-----------
+
+For development, consider creating a new virtual environment (with any
+prefered method, e.g. [venv](https://docs.python.org/3/library/venv.html)).
+All development packages can be installed with
+```bash
+python -m pip install -e '.[develop]'
+```
+
+To run the tests, just use `pytest`. Some helpful wrappers are given in the
+`Makefile` (see `make help`), e.g. to run the tests
+```bash
+make test
+```
+which runs the full test suite and doctests for `papis`. To run the tests exactly
+as they are set up on the Github Actions CI use
+```
+make ci-install
+make ci-test
+```
+
+The docs can be generated with
+```
+make doc
+```
 
 Issues
 ------
 
-You can open issues in the github issue tracker
-https://github.com/papis/papis/issues.
-
+You can open issues in the [GitHub issue tracker](https://github.com/papis/papis/issues).
 
 Version Numbering
 -----------------
 
-Three numbers, `A.B.C`, where
+The versioning scheme generally follows semantic versioning. That is, we
+have three numbers, `A.B.C`, where:
+
 * `A` changes on a rewrite
 * `B` changes when major configuration incompatibilities occur
 * `C` changes with each release (bug fixes..)
 
+Extending Papis
+===============
 
+Adding Configuration Options
+----------------------------
 
-Common Changes
-==============
+To add a new main option:
 
-Adding options
---------------
-
-- Add a default value in `defaults.py`.
-- Document the option in `./doc/source/default-settings.rst`
+- Add a default value in `defaults.py` in the `settings` dictionary.
+- Document the option in `doc/source/default-settings.rst`. Try to answer the
+  following questions:
   - What is it?
+  - Where is it used?
   - What type should it be?
-  - Note: the default is displayed automatically, so no need to write it
-    explicitly.
+  - What values are allowed? (default values are added automatically)
 
-The setting is now accessible with `papis.config.get('myoption')`
-or through the cli interface `papis config myoption`.
+The setting is now accessible with `papis.config.get("myoption")`
+or through the command-line interface `papis config myoption`.
 
+To add a new option in a custom section (or generally with a common prefix)
 
-Adding scripts
+- Call `papis.config.register_default_settings` with a dictionary
+  `{"section": {"option1": "value", ...}}`.
+- Document the option in a similar fashion to above
+
+The setting can now be accessed with `papis.config.get("section-option1")`
+or `papis.config.get("option1", section="section")`.
+
+Adding Scripts
 --------------
 
-* You can add scripts for everyone to share to the folder
-  `examples/scripts/` in the repository. These scripts will not be shipped
-  with papis, but they are there for other users to use and modify.
+Can add scripts for everyone to share to the folder `examples/scripts` in the
+repository. These scripts will not be shipped with papis, but they are there
+for other users to use and modify.
 
+Adding Importers
+----------------
 
-Adding downloaders
+An importer is used to get data from a file or service into `papis`. For example,
+see the arXiv importers in `arxiv.py`. To add a new importer
+
+- Create a class that inherits from `papis.importer.Importer`.
+- Implement the `Importer.match` method, which is used to check if a given URI
+  can be handled by the importer.
+- Implement the `Importer.fetch` method, that gets the data. This method should
+  set the `Importer.ctx` attribute to contain the extracted information.
+- (Optional) Instead of the `fetch` method, you can also implement the `fetch_data`
+  and / or `fetch_files` methods separately.
+
+The importer is then registered with `papis` by adding it to `setup.py`. In the
+`entry_points` argument under `"papis.importer"` add
+```
+myimporter=papis.myservice:Importer
+```
+or see the existing examples.
+
+Adding Downloaders
 ------------------
 
-TODO: explain how to add new downloaders
+The difference between a downloader and an importer in `papis` is largely
+semantic. Downloaders are mostly meant to scrape websites or download files
+from a remote location. They can be implemented in a very similar way:
+
+- Create a class that inherits from `papis.downloaders.Downloader`.
+- Implement the `Downloader.match` method, which generally checks if a given
+  URI matches a website URL.
+- (Optional) Implement the `Downloader.get_data` method, which returns a dictionary.
+- (Optional) Implement the `Downloader.get_bibtex_url` method to return an URL
+  from which a BibTeX file can be downloaded. This is then parsed and merged
+  automatically.
+- (Optional) Implement the `Downloader.get_document_url` method to return an
+  URL from which a document (e.g. PDF file) can be downloaded.
+
+The downloader can then be added to the `"papis.downloader"` key in `setup.py`,
+similarly to an importer.

--- a/Makefile
+++ b/Makefile
@@ -1,15 +1,23 @@
-.PHONY: bash-autocomplete update-authors tags doc test ci-install ci-tests
+all: help
 
-bash-autocomplete:
-	make -C scripts/shell_completion/
+help: 								## Show this help
+	@echo -e "Specify a command. The choices are:\n"
+	@grep -E '^[0-9a-zA-Z_-]+:.*?## .*$$' $(MAKEFILE_LIST) | awk 'BEGIN {FS = ":.*?## "}; {printf "  \033[0;36m%-18s\033[m %s\n", $$1, $$2}'
+	@echo ""
+.PHONY: help
 
-update-authors:
+shell_completion:					## Generate shell completion scripts
+	make -C scripts/shell_completion
+.PHONY: shell_completion
+
+update-authors:						## Generate AUTHORS file from git commits
 	git shortlog -s -e -n | \
 		sed -e "s/\t/  /" | \
 		sed -e "s/^\s*//" > \
 		AUTHORS
+.PHONY: update-authors
 
-tags:
+tags:								## Generate ctags for main codebase
 	ctags -f tags \
 		--recurse=yes \
 		--tag-relative=yes \
@@ -17,18 +25,23 @@ tags:
 		--kinds-python=-i \
 		--language-force=python \
 		papis
+.PHONY: tags
 
-doc:
+doc:								## Generate the documentation in doc/
 	cd doc && make html SPHINXOPTS="-W --keep-going -n"
 	@echo ""
 	@echo -e "\e[1;32mRun '$$BROWSER doc/build/html/index.html' to see the docs\e[0m"
 	@echo ""
+.PHONY: doc
 
-test:
+test:								## Run pytest test and doctests
 	python -m pytest -rswx --cov=papis -v -s papis tests
+.PHONY: test
 
-ci-install:
+ci-install:							## Install dependencies like on the CI
 	bash tools/ci-install.sh
+.PHONY: ci-install
 
-ci-test:
+ci-test:							## Run tests like on the CI
 	bash tools/ci-run-tests.sh
+.PHONY: ci-test


### PR DESCRIPTION
Typing `make help` now prints
```
Specify a command. The choices are:

help               Show this help
shell_completion   Generate shell completion scripts
update-authors     Generate AUTHORS file from git commits
tags               Generate ctags for main codebase
doc                Generate the documentation in doc/
test               Run pytest test and doctests
ci-install         Install dependencies like on the CI
ci-test            Run tests like on the CI
```
which seems useful enough. This updates the `HACKING.md` to mention using the Makefile and some other things.