### PR TITLE
Do not generate refs in importers and downloaders

### DIFF
--- a/papis/bibtex.py
+++ b/papis/bibtex.py
@@ -145,14 +145,19 @@ class Importer(papis.importer.Importer):
         self.logger.info("Reading input file = '%s'", self.uri)
         try:
             bib_data = bibtex_to_dict(self.uri)
-            if len(bib_data) > 1:
-                self.logger.warning(
-                    "The bibtex file contains more than one entry, "
-                    "only taking the first entry")
-            if bib_data:
-                self.ctx.data = bib_data[0]
         except Exception as e:
-            self.logger.debug(e)
+            self.logger.error(e)
+            return
+
+        if not bib_data:
+            return
+
+        if len(bib_data) > 1:
+            self.logger.warning(
+                "The bibtex file contains %d entries, only taking the first entry",
+                len(bib_data))
+
+        self.ctx.data = bib_data[0]
 
 
 @click.command("bibtex")
@@ -188,7 +193,6 @@ def bibtexparser_entry_to_papis(entry: Dict[str, str]) -> Dict[str, str]:
 
     _k = papis.document.KeyConversionPair
     key_conversion = [
-        _k("ID", [{"key": "ref", "action": None}]),
         _k("ENTRYTYPE", [{"key": "type", "action": None}]),
         _k("link", [{"key": "url", "action": None}]),
         _k("author", [{
@@ -209,7 +213,7 @@ def bibtex_to_dict(bibtex: str) -> List[Dict[str, str]]:
 
     .. code:: python
 
-        { type: "article ...", "ref": "example1960etAl", author:" ..."}
+        { "type": "article", "author": "...", "title": "...", ...}
 
     :param bibtex: Bibtex file path or bibtex information in string format.
     :returns: Dictionary with bibtex information with keys that bibtex

--- a/papis/downloaders/__init__.py
+++ b/papis/downloaders/__init__.py
@@ -118,8 +118,14 @@ class Downloader(papis.importer.Importer):
             if bib_rawdata:
                 datalist = papis.bibtex.bibtex_to_dict(bib_rawdata)
                 if datalist:
-                    self.logger.info("Merging data from bibtex")
+                    if len(datalist) > 1:
+                        self.logger.warning(
+                            "'%s' found %d BibTeX entries. Picking first one.",
+                            self.name, len(datalist))
+
+                    self.logger.info("Merging data from BibTeX")
                     self.ctx.data.update(datalist[0])
+
         # try getting doi
         try:
             doi = self.get_doi()

--- a/papis/pubmed.py
+++ b/papis/pubmed.py
@@ -36,7 +36,6 @@ key_conversion = [
     KeyConversionPair("container-title", [{"key": "journal", "action": None}]),
     KeyConversionPair("PMID", [
         {"key": "pmid", "action": None},
-        {"key": "ref", "action": lambda x: "pmid{}".format(x)}
         ]),
     KeyConversionPair("ISSN", [{"key": "issn", "action": None}]),
     KeyConversionPair("DOI", [{"key": "doi", "action": None}]),

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,6 +1,6 @@
 [flake8]
-select = B, E, N, Q
-ignore = E123,W503,B019,N818
+select = B, D, E, F, N, Q, W
+extend-ignore = B019, E123, N818, W503
 exclude =
     doc
     build


### PR DESCRIPTION
This goes through the downloaders and importers and removes any automatic `ref` conversions, which would interfere with the automatic ref construction in `commands.add`.

Fixes #376.