### PR TITLE
Use singleton requests.Session object

### DIFF
--- a/papis/arxiv.py
+++ b/papis/arxiv.py
@@ -66,14 +66,14 @@ def get_data(
     )
     logger.debug("query = '%s'", search_query)
 
-    session = papis.utils.get_session()
-    response = session.get(
-        ARXIV_API_URL,
-        params={
-            "search_query": search_query,
-            "start": str(page),
-            "max_results": str(max_results),
-        })
+    with papis.utils.get_session() as session:
+        response = session.get(
+            ARXIV_API_URL,
+            params={
+                "search_query": search_query,
+                "start": str(page),
+                "max_results": str(max_results),
+            })
 
     import bs4
     soup = bs4.BeautifulSoup(
@@ -102,9 +102,9 @@ def get_data(
 
 
 def validate_arxivid(arxivid: str) -> None:
-    session = papis.utils.get_session()
+    with papis.utils.get_session() as session:
+        response = session.get("{}/{}".format(ARXIV_ABS_URL, arxivid))
 
-    response = session.get("{}/{}".format(ARXIV_ABS_URL, arxivid))
     if not response.ok:
         raise ValueError(
             "HTTP {}: '{}' not an arxivid".format(response.status_code, arxivid)

--- a/papis/base.py
+++ b/papis/base.py
@@ -46,16 +46,16 @@ def get_data(
                      BASE_MAX_QUERY_LENGTH, len(query))
         query = query[:BASE_MAX_QUERY_LENGTH]
 
-    session = papis.utils.get_session()
-    response = session.get(
-        BASE_API_URL,
-        params={
-            "func": "PerformSearch",
-            "query": query if query else None,
-            "format": "json",
-            "hits": str(hits),
-            "boost": "oa" if boost else None,
-        })
+    with papis.utils.get_session() as session:
+        response = session.get(
+            BASE_API_URL,
+            params={
+                "func": "PerformSearch",
+                "query": query if query else None,
+                "format": "json",
+                "hits": str(hits),
+                "boost": "oa" if boost else None,
+            })
 
     if not response.ok:
         logger.error("An HTTP error (%d %s) was encountered for query: '%s'.",

--- a/papis/config.py
+++ b/papis/config.py
@@ -1,6 +1,6 @@
 import os
 import configparser
-from typing import Dict, Any, List, Optional, Callable  # noqa: ignore
+from typing import Dict, Any, List, Optional, Callable  # noqa: F401
 
 import papis.exceptions
 import papis.library

--- a/papis/crossref.py
+++ b/papis/crossref.py
@@ -400,8 +400,7 @@ class Importer(papis.importer.Importer):
                 response = session.get(doc_url, allow_redirects=True)
                 kind = filetype.guess(response.content)
 
-                import requests
-                if response.status_code != requests.codes.ok:
+                if not response.ok:
                     self.logger.info("Could not download document. "
                                      "HTTP status: %s (%d)",
                                      response.reason, response.status_code)

--- a/papis/crossref.py
+++ b/papis/crossref.py
@@ -396,10 +396,10 @@ class Importer(papis.importer.Importer):
                     "Trying to download document from '%s'", doc_url)
 
                 import filetype
-                session = papis.utils.get_session()
-                response = session.get(doc_url, allow_redirects=True)
-                kind = filetype.guess(response.content)
+                with papis.utils.get_session() as session:
+                    response = session.get(doc_url, allow_redirects=True)
 
+                kind = filetype.guess(response.content)
                 if not response.ok:
                     self.logger.info("Could not download document. "
                                      "HTTP status: %s (%d)",

--- a/papis/crossref.py
+++ b/papis/crossref.py
@@ -395,17 +395,12 @@ class Importer(papis.importer.Importer):
                 self.logger.info(
                     "Trying to download document from '%s'", doc_url)
 
-                import requests
-                session = requests.Session()
-
-                import requests.structures
-                session.headers = requests.structures.CaseInsensitiveDict({
-                    "user-agent": papis.config.getstring("user-agent")})
-
                 import filetype
+                session = papis.utils.get_session()
                 response = session.get(doc_url, allow_redirects=True)
                 kind = filetype.guess(response.content)
 
+                import requests
                 if response.status_code != requests.codes.ok:
                     self.logger.info("Could not download document. "
                                      "HTTP status: %s (%d)",

--- a/papis/dissemin.py
+++ b/papis/dissemin.py
@@ -3,10 +3,13 @@ from typing import List, Dict, Any
 import click
 
 import papis.config
+import papis.utils
 import papis.document
 import papis.logging
 
 logger = papis.logging.get_logger(__name__)
+
+DISSEMIN_API_URL = "https://dissem.in/api/search/"
 
 
 def dissemin_authors_to_papis_authors(data: Dict[str, Any]) -> Dict[str, Any]:
@@ -50,24 +53,14 @@ def get_data(query: str = "") -> List[Dict[str, Any]]:
     Get data using the dissemin API
     https://dissem.in/api/search/?q=pregroup
     """
-    import urllib.parse
-    import urllib.request
+    session = papis.utils.get_session()
+    response = session.get(DISSEMIN_API_URL, params={"q": query})
+    if not response.ok:
+        logger.error("An HTTP error (%d %s) was encountered for query: '%s'",
+                     response.status_code, response.reason, query)
+        return []
 
-    dict_params = {"q": query}
-    params = urllib.parse.urlencode(dict_params)
-    main_url = "https://dissem.in/api/search/?"
-    req_url = main_url + params
-    logger.debug("url = '%s'", req_url)
-    url = urllib.request.Request(
-        req_url,
-        headers={
-            "User-Agent": str(papis.config.get("user-agent"))
-        }
-    )
-    jsondoc = urllib.request.urlopen(url).read().decode()
-
-    import json
-    paperlist = json.loads(jsondoc)
+    paperlist = response.json()
     return sum([dissemindoc_to_papis(d) for d in paperlist["papers"]], [])
 
 

--- a/papis/dissemin.py
+++ b/papis/dissemin.py
@@ -53,8 +53,9 @@ def get_data(query: str = "") -> List[Dict[str, Any]]:
     Get data using the dissemin API
     https://dissem.in/api/search/?q=pregroup
     """
-    session = papis.utils.get_session()
-    response = session.get(DISSEMIN_API_URL, params={"q": query})
+    with papis.utils.get_session() as session:
+        response = session.get(DISSEMIN_API_URL, params={"q": query})
+
     if not response.ok:
         logger.error("An HTTP error (%d %s) was encountered for query: '%s'",
                      response.status_code, response.reason, query)

--- a/papis/downloaders/__init__.py
+++ b/papis/downloaders/__init__.py
@@ -76,12 +76,16 @@ class Downloader(papis.importer.Importer):
 
         self.expected_document_extension = expected_document_extension
         self.priority = priority
+        self.session = papis.utils.get_session()
         self._soup = None  # type: Optional[bs4.BeautifulSoup]
 
         self.bibtex_data = None  # type: Optional[str]
         self.document_data = None  # type: Optional[bytes]
 
         self.cookies = cookies
+
+    def __del__(self) -> None:
+        self.session.close()
 
     def fetch_data(self) -> None:
         """
@@ -151,8 +155,7 @@ class Downloader(papis.importer.Importer):
 
     def _get_body(self) -> bytes:
         """Get body of the uri, this is also important for unittesting"""
-        session = papis.utils.get_session()
-        return session.get(self.uri, cookies=self.cookies).content
+        return self.session.get(self.uri, cookies=self.cookies).content
 
     def _get_soup(self) -> "bs4.BeautifulSoup":
         """Get body of the uri, this is also important for unittesting"""
@@ -200,8 +203,7 @@ class Downloader(papis.importer.Importer):
             return
         self.logger.info("Downloading bibtex from '%s'", url)
 
-        session = papis.utils.get_session()
-        response = session.get(url, cookies=self.cookies)
+        response = self.session.get(url, cookies=self.cookies)
         self.bibtex_data = response.content.decode()
 
     def get_document_url(self) -> Optional[str]:
@@ -252,8 +254,7 @@ class Downloader(papis.importer.Importer):
             return
         self.logger.info("Downloading file from '%s'", url)
 
-        session = papis.utils.get_session()
-        response = session.get(url, cookies=self.cookies)
+        response = self.session.get(url, cookies=self.cookies)
         self.document_data = response.content
 
     def check_document_format(self) -> bool:

--- a/papis/downloaders/citeseerx.py
+++ b/papis/downloaders/citeseerx.py
@@ -48,8 +48,7 @@ class Downloader(papis.downloaders.Downloader):
                 else None)
 
     def _get_raw_data(self) -> bytes:
-        session = papis.utils.get_session()
-        response = session.get(
+        response = self.session.get(
             self.API_URL,
             params={"paper_id": self.pid},
             headers={"token": "undefined", "referer": self.uri},

--- a/papis/downloaders/citeseerx.py
+++ b/papis/downloaders/citeseerx.py
@@ -2,6 +2,7 @@ import os
 import re
 from typing import Any, ClassVar, Dict, Optional
 
+import papis.utils
 import papis.document
 import papis.downloaders
 
@@ -47,7 +48,8 @@ class Downloader(papis.downloaders.Downloader):
                 else None)
 
     def _get_raw_data(self) -> bytes:
-        response = self.session.get(
+        session = papis.utils.get_session()
+        response = session.get(
             self.API_URL,
             params={"paper_id": self.pid},
             headers={"token": "undefined", "referer": self.uri},

--- a/papis/downloaders/ieee.py
+++ b/papis/downloaders/ieee.py
@@ -43,8 +43,7 @@ class Downloader(papis.downloaders.Downloader):
         url, params = self._get_bibtex_url()
         self.logger.debug("bibtex url = '%s'", url)
 
-        session = papis.utils.get_session()
-        response = session.get(url, params=params)
+        response = self.session.get(url, params=params)
         if not response.ok:
             return
 

--- a/papis/downloaders/thesesfr.py
+++ b/papis/downloaders/thesesfr.py
@@ -1,7 +1,6 @@
 import re
 from typing import Optional
 
-import papis.utils
 import papis.downloaders.base
 
 
@@ -41,8 +40,7 @@ class Downloader(papis.downloaders.Downloader):
         import bs4
 
         # TODO: Simplify this function for typing
-        session = papis.utils.get_session()
-        raw_data = session.get(self.uri).content.decode("utf-8")
+        raw_data = self.session.get(self.uri).content.decode("utf-8")
         soup = bs4.BeautifulSoup(raw_data, "html.parser")
         a = list(filter(
             lambda t: re.match(r".*en ligne.*", t.text),
@@ -54,7 +52,7 @@ class Downloader(papis.downloaders.Downloader):
             return None
 
         second_url = a[0]["href"]
-        raw_data = session.get(second_url).content.decode("utf-8")
+        raw_data = self.session.get(second_url).content.decode("utf-8")
         soup = bs4.BeautifulSoup(raw_data, "html.parser")
         a = list(filter(
             lambda t: re.match(r".*pdf$", t.get("href", "")),

--- a/papis/downloaders/thesesfr.py
+++ b/papis/downloaders/thesesfr.py
@@ -1,6 +1,7 @@
 import re
 from typing import Optional
 
+import papis.utils
 import papis.downloaders.base
 
 
@@ -40,7 +41,8 @@ class Downloader(papis.downloaders.Downloader):
         import bs4
 
         # TODO: Simplify this function for typing
-        raw_data = self.session.get(self.uri).content.decode("utf-8")
+        session = papis.utils.get_session()
+        raw_data = session.get(self.uri).content.decode("utf-8")
         soup = bs4.BeautifulSoup(raw_data, "html.parser")
         a = list(filter(
             lambda t: re.match(r".*en ligne.*", t.text),
@@ -52,7 +54,7 @@ class Downloader(papis.downloaders.Downloader):
             return None
 
         second_url = a[0]["href"]
-        raw_data = self.session.get(second_url).content.decode("utf-8")
+        raw_data = session.get(second_url).content.decode("utf-8")
         soup = bs4.BeautifulSoup(raw_data, "html.parser")
         a = list(filter(
             lambda t: re.match(r".*pdf$", t.get("href", "")),

--- a/papis/isbnplus.py
+++ b/papis/isbnplus.py
@@ -88,20 +88,21 @@ def get_data(query: str = "",
              app_key: str = ISBNPLUS_KEY
              ) -> List[Dict[str, Any]]:
     """Get documents from isbnplus"""
-    session = papis.utils.get_session()
-    response = session.get(
-        "{}/search".format(ISBNPLUS_BASEURL),
-        params={
-            "q": query if query else None,
-            "p": str(page),
-            "a": author if author else None,
-            "c": category if category else None,
-            "s": series if series else None,
-            "t": title if title else None,
-            "order": order,
-            "app_id": app_id,
-            "app_key": app_key
-        })
+    with papis.utils.get_session() as session:
+        response = session.get(
+            "{}/search".format(ISBNPLUS_BASEURL),
+            params={
+                "q": query if query else None,
+                "p": str(page),
+                "a": author if author else None,
+                "c": category if category else None,
+                "s": series if series else None,
+                "t": title if title else None,
+                "order": order,
+                "app_id": app_id,
+                "app_key": app_key
+            })
+
     if not response.ok:
         logger.error("An HTTP error (%d %s) was encountered for query: '%s'",
                      response.status_code, response.reason, query)

--- a/papis/pubmed.py
+++ b/papis/pubmed.py
@@ -1,6 +1,7 @@
 from typing import Any, Dict, List, Optional
 
 import papis
+import papis.utils
 import papis.importer
 import papis.document
 import papis.downloaders.base
@@ -84,15 +85,11 @@ def is_valid_pmid(pmid: str) -> bool:
 def get_data(query: str = "") -> Dict[str, Any]:
     # NOTE: being nice and using the project version as a user agent
     # as requested in https://api.ncbi.nlm.nih.gov/lit/ctxp
-    import requests
-    headers = requests.structures.CaseInsensitiveDict({
-        "user-agent": "papis/{}".format(papis.__version__)
-        })
-
-    session = requests.Session()
-    session.headers = headers       # type: ignore[assignment]
-    response = session.get(PUBMED_URL.format(
-        pmid=query.strip(), database=PUBMED_DATABASE))
+    session = papis.utils.get_session()
+    response = session.get(
+        PUBMED_URL.format(pmid=query.strip(), database=PUBMED_DATABASE),
+        headers={"user-agent": "papis/{}".format(papis.__version__)},
+        )
 
     import json
     return pubmed_data_to_papis_data(json.loads(response.content.decode()))

--- a/papis/pubmed.py
+++ b/papis/pubmed.py
@@ -69,19 +69,20 @@ def is_valid_pmid(pmid: str) -> bool:
     if not pmid.isdigit():
         return False
 
-    session = papis.utils.get_session()
-    response = session.get(PUBMED_URL.format(pmid=pmid, database=PUBMED_DATABASE))
+    with papis.utils.get_session() as session:
+        response = session.get(PUBMED_URL.format(pmid=pmid, database=PUBMED_DATABASE))
+
     return response.ok
 
 
 def get_data(query: str = "") -> Dict[str, Any]:
     # NOTE: being nice and using the project version as a user agent
     # as requested in https://api.ncbi.nlm.nih.gov/lit/ctxp
-    session = papis.utils.get_session()
-    response = session.get(
-        PUBMED_URL.format(pmid=query.strip(), database=PUBMED_DATABASE),
-        headers={"user-agent": "papis/{}".format(papis.__version__)},
-        )
+    with papis.utils.get_session() as session:
+        response = session.get(
+            PUBMED_URL.format(pmid=query.strip(), database=PUBMED_DATABASE),
+            headers={"user-agent": "papis/{}".format(papis.__version__)},
+            )
 
     import json
     return pubmed_data_to_papis_data(json.loads(response.content.decode()))

--- a/papis/pubmed.py
+++ b/papis/pubmed.py
@@ -69,17 +69,9 @@ def is_valid_pmid(pmid: str) -> bool:
     if not pmid.isdigit():
         return False
 
-    import urllib
-    url = PUBMED_URL.format(pmid=pmid, database=PUBMED_DATABASE)
-    request = urllib.request.Request(url)
-
-    from urllib.error import HTTPError, URLError
-    try:
-        urllib.request.urlopen(request)
-    except (HTTPError, URLError):
-        return False
-
-    return True
+    session = papis.utils.get_session()
+    response = session.get(PUBMED_URL.format(pmid=pmid, database=PUBMED_DATABASE))
+    return response.ok
 
 
 def get_data(query: str = "") -> Dict[str, Any]:

--- a/papis/utils.py
+++ b/papis/utils.py
@@ -4,7 +4,7 @@ import re
 import pathlib
 from itertools import count, product
 from typing import (Optional, List, Iterator, Any, Dict,
-                    Union, Callable, TypeVar)
+                    Union, Callable, TypeVar, TYPE_CHECKING)
 
 try:
     import multiprocessing.synchronize  # noqa: F401
@@ -24,8 +24,34 @@ import papis.logging
 
 logger = papis.logging.get_logger(__name__)
 
+if TYPE_CHECKING:
+    import requests
+
 A = TypeVar("A")
 B = TypeVar("B")
+
+_REQUESTS_SESSION = None    # type: Optional[requests.Session]
+
+
+def get_session() -> "requests.Session":
+    global _REQUESTS_SESSION
+
+    if _REQUESTS_SESSION is None:
+        import requests
+        session = requests.Session()
+        session.headers.update({
+            "User-Agent": papis.config.getstring("user-agent"),
+        })
+
+        proxy = papis.config.get("downloader-proxy")
+        if proxy is not None:
+            session.proxies = {
+                "http": proxy,
+                "https": proxy,
+            }
+        _REQUESTS_SESSION = session
+
+    return _REQUESTS_SESSION
 
 
 def has_multiprocessing() -> bool:

--- a/papis/utils.py
+++ b/papis/utils.py
@@ -30,28 +30,21 @@ if TYPE_CHECKING:
 A = TypeVar("A")
 B = TypeVar("B")
 
-_REQUESTS_SESSION = None    # type: Optional[requests.Session]
-
 
 def get_session() -> "requests.Session":
-    global _REQUESTS_SESSION
+    import requests
+    session = requests.Session()
+    session.headers.update({
+        "User-Agent": papis.config.getstring("user-agent"),
+    })
 
-    if _REQUESTS_SESSION is None:
-        import requests
-        session = requests.Session()
-        session.headers.update({
-            "User-Agent": papis.config.getstring("user-agent"),
-        })
-
-        proxy = papis.config.get("downloader-proxy")
-        if proxy is not None:
-            session.proxies = {
-                "http": proxy,
-                "https": proxy,
-            }
-        _REQUESTS_SESSION = session
-
-    return _REQUESTS_SESSION
+    proxy = papis.config.get("downloader-proxy")
+    if proxy is not None:
+        session.proxies = {
+            "http": proxy,
+            "https": proxy,
+        }
+    return session
 
 
 def has_multiprocessing() -> bool:


### PR DESCRIPTION
This adds a `papis.utils.get_session` that returns a `requests.Session` object to be used everywhere with the user-agent and proxies set by the user. This also replaced all the `urllib` usage.

Benefits: `requests` API is nicer; headers and proxies set consistently; some savings on multiple requests?
Downsides: ?