### PR TITLE
flake8: select chosen plugins only

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -1,4 +1,5 @@
 [flake8]
+select = B, E, N, Q
 ignore = E123,W503,B019,N818
 exclude =
     doc


### PR DESCRIPTION
This ensures that only the flake8 checks defined in `setup.py` are checked even when there are others installed on the system (I have flake8-isort and this was very annoying).