### PR TITLE
Doctor: tests, docs and formatting fixes

### DIFF
--- a/papis/commands/doctor.py
+++ b/papis/commands/doctor.py
@@ -8,45 +8,53 @@ can add yourself through the python configuration file.
 
 import os
 import re
-import json
-from typing import Optional, List, NamedTuple, Callable, Dict
 import collections
-import html
+from typing import Any, Optional, List, NamedTuple, Callable, Dict, Set
 
 import click
 
 import papis
-import papis.utils
-import papis.config
 import papis.cli
-import papis.pick
-import papis.database
+import papis.config
 import papis.strings
+import papis.database
 import papis.document
 import papis.logging
-from papis.commands.edit import run as edit_run
 
 logger = papis.logging.get_logger(__name__)
 
+# FIXME: when going to python >=3.6, these should be classes (dataclasses?) and
+# have some basic documentation for the various fields
+FixFn = Callable[[], None]
 Error = NamedTuple("Error", [("name", str),
                              ("path", str),
                              ("payload", str),
                              ("msg", str),
                              ("suggestion_cmd", str),
-                             ("fix_action", Callable[[], None]),
+                             ("fix_action", FixFn),
                              ("doc", Optional[papis.document.Document]),
                              ])
 CheckFn = Callable[[papis.document.Document], List[Error]]
 Check = NamedTuple("Check", [("name", str),
                              ("operate", CheckFn),
                              ])
+REGISTERED_CHECKS = {}  # type: Dict[str, Check]
+
+
+def error_to_dict(e: Error) -> Dict[str, Any]:
+    return {
+        "msg": e.payload,
+        "path": e.path,
+        "name": e.name,
+        "suggestion": e.suggestion_cmd}
 
 
 def register_check(name: str, check_function: CheckFn) -> None:
     """
     Register a check.
-    To be used by users in their configuration files
-    for example.
+
+    Registered checks are recognized by ``papis`` and can be used by users
+    in their configuration files, for example.
     """
     REGISTERED_CHECKS[name] = Check(name=name, operate=check_function)
 
@@ -60,42 +68,40 @@ FILES_CHECK_NAME = "files"
 
 def files_check(doc: papis.document.Document) -> List[Error]:
     """
-    It checks whether the files of a document actually exist in the
-    filesystem.
+    Check whether the files of a document actually exist in the filesystem.
+
+    :returns: a :class:`list` of errors, one for each file that does not exist.
     """
+    from papis.api import save_doc
+
     files = doc.get_files()
-    results = []  # type: List[Error]
-    folder = doc.get_main_folder()
+    folder = doc.get_main_folder() or ""
 
-    def _fix(_file: str) -> Callable[[], None]:
-        """
-        Files fixer function, it will remove the bad file.
-        Notice that for now it only works if the file name is not of
-        the form 'subdirectory/file' but only 'file'.
-        """
+    def make_fixer(filename: str) -> FixFn:
+        def fixer() -> None:
+            """
+            Files fixer function that removes non-existent files from the document.
 
-        def __fix() -> None:
-            _db = papis.database.get()
-            basename = os.path.basename(_file)
+            For now it only works if the file name is not of the form
+            ``subdirectory/filename``, but only ``filename``.
+            """
+
+            basename = os.path.basename(filename)
             if basename in doc["files"]:
+                logger.info("[FIX] Removing file from document: '%s'.", basename)
                 doc["files"].remove(basename)
-            doc.save()
-            _db.update(doc)
+                save_doc(doc)
 
-        return __fix
+        return fixer
 
-    for _f in files:
-        if not os.path.exists(_f):
-            results.append(Error(name=FILES_CHECK_NAME,
-                                 path=folder or "",
-                                 msg=("File '{}' declared but does not exist"
-                                      .format(_f)),
-                                 suggestion_cmd=("papis edit --doc-folder {}"
-                                                 .format(folder)),
-                                 fix_action=_fix(_f),
-                                 payload=_f,
-                                 doc=doc))
-    return results
+    return [Error(name=FILES_CHECK_NAME,
+                  path=folder,
+                  msg="File '{}' declared but does not exist".format(f),
+                  suggestion_cmd="papis edit --doc-folder {}".format(folder),
+                  fix_action=make_fixer(f),
+                  payload=f,
+                  doc=doc)
+            for f in files if not os.path.exists(f)]
 
 
 KEYS_EXIST_CHECK_NAME = "keys-exist"
@@ -103,96 +109,122 @@ KEYS_EXIST_CHECK_NAME = "keys-exist"
 
 def keys_check(doc: papis.document.Document) -> List[Error]:
     """
-    It checks whether the keys provided in the configuration
-    option ``doctor-keys-check`` exit in the document.
+    Checks whether the keys provided in the configuration
+    option ``doctor-keys-check`` exit in the document and are non-empty.
+
+    :returns: a :class:`list` of errors, one for each key that does not exist.
     """
     keys = papis.config.getlist("doctor-keys-exist-keys")
-    folder = doc.get_main_folder()
-    results = []  # type: List[Error]
-    for k in keys:
-        if k not in doc or len(doc[k]) == 0:
-            results.append(Error(name=KEYS_EXIST_CHECK_NAME,
-                                 path=folder or "",
-                                 msg=("Key '{}' does not exist"
-                                      .format(k)),
-                                 suggestion_cmd=("papis edit --doc-folder {}"
-                                                 .format(folder)),
-                                 fix_action=lambda: None,
-                                 payload=k,
-                                 doc=doc))
-    return results
+    folder = doc.get_main_folder() or ""
 
+    return [Error(name=KEYS_EXIST_CHECK_NAME,
+                  path=folder,
+                  msg="Key '{}' does not exist.".format(k),
+                  suggestion_cmd="papis edit --doc-folder {}".format(folder),
+                  fix_action=lambda: None,
+                  payload=k,
+                  doc=doc)
+            for k in keys if k not in doc]
+
+
+REFS_BAD_SYMBOL_REGEX = re.compile(r"[ ,{}\[\]@#`']")
 
 REFS_CHECK_NAME = "refs"
 
 
 def refs_check(doc: papis.document.Document) -> List[Error]:
     """
-    It checks that a ref exists and if not it
-    tries to create one according to the ref-format configuration
-    if the user chooses to fix it.
-    """
-    folder = doc.get_main_folder()
-    bad_symbols = re.compile(r"[ ,{}\[\]@#`']")
+    Checks that a ref exists and if not it tries to create one according to
+    the ``ref-format`` configuration option.
 
-    def _fix() -> None:
+    :returns: an error if the reference does not exist or contains invalid
+        characters (as required by BibTeX).
+    """
+    from papis.api import save_doc
+
+    folder = doc.get_main_folder() or ""
+
+    def create_ref_fixer() -> None:
         ref = papis.bibtex.create_reference(doc, force=True)
-        _db = papis.database.get()
-        logger.info("Setting ref '%s' in '%s'",
+        logger.info("[FIX] Setting ref to '%s': '%s'.",
                     ref,
                     papis.document.describe(doc))
-        doc["ref"] = ref
-        doc.save()
-        _db.update(doc)
 
-    if not doc["ref"] or not str(doc["ref"]).strip():
+        doc["ref"] = ref
+        save_doc(doc)
+
+    def clean_ref_fixer() -> None:
+        ref = REFS_BAD_SYMBOL_REGEX.sub("", doc["ref"]).strip()
+        if not ref:
+            create_ref_fixer()
+        else:
+            logger.info("[FIX] Cleaning ref from '%s' to '%s': '%s'.",
+                        doc["ref"], ref,
+                        papis.document.describe(doc))
+
+            doc["ref"] = ref
+
+    ref = doc.get("ref")
+    ref = str(ref).strip() if ref is not None else ref
+
+    if not ref:
         return [Error(name=REFS_CHECK_NAME,
-                      path=folder or "",
+                      path=folder,
                       msg="Reference missing.",
                       suggestion_cmd=("papis edit --doc-folder {}"
                                       .format(folder)),
-                      fix_action=_fix,
-                      payload="",
+                      fix_action=create_ref_fixer,
+                      payload="ref",
                       doc=doc)]
-    m = bad_symbols.findall(str(doc["ref"]))
+
+    m = REFS_BAD_SYMBOL_REGEX.findall(ref)
     if m:
         return [Error(name=REFS_CHECK_NAME,
-                      path=folder or "",
-                      msg=("Bad characters ({}) found in reference."
-                           .format(set(m))),
-                      suggestion_cmd=("papis edit --doc-folder {}"
-                                      .format(folder)),
-                      fix_action=_fix,
-                      payload="",
+                      path=folder,
+                      msg="Bad characters ({}) found in reference.".format(set(m)),
+                      suggestion_cmd="papis edit --doc-folder {}".format(folder),
+                      fix_action=clean_ref_fixer,
+                      payload="ref",
                       doc=doc)]
+
     return []
 
 
-DUPLICATED_KEYS_SEEN \
-    = collections.defaultdict(list)  # type: Dict[str, List[str]]
+DUPLICATED_KEYS_SEEN = collections.defaultdict(set)  # type: Dict[str, Set[str]]
 DUPLICATED_KEYS_NAME = "duplicated-keys"
 
 
 def duplicated_keys_check(doc: papis.document.Document) -> List[Error]:
     """
-    Check for duplicated keys in `doctor-duplicated-keys-check`
+    Check for duplicated keys in the list given by the
+    ``doctor-duplicated-keys-check`` configuration option.
+
+    :returns: a :class:`list` of errors, one for each key with a value that already
+        exist in the documents from the current query.
     """
     keys = papis.config.getlist("doctor-duplicated-keys-keys")
-    folder = doc.get_main_folder()
+    folder = doc.get_main_folder() or ""
+
     results = []  # type: List[Error]
     for key in keys:
-        if str(doc[key]) in DUPLICATED_KEYS_SEEN[key]:
-            results.append(Error(name=DUPLICATED_KEYS_NAME,
-                                 msg=("Key '{}' is duplicated ({})."
-                                      .format(key, doc[key])),
-                                 suggestion_cmd=("papis edit {}:'{}'"
-                                                 .format(key, doc[key])),
-                                 payload=key,
-                                 fix_action=lambda: None,
-                                 path=folder or "",
-                                 doc=doc))
-        else:
-            DUPLICATED_KEYS_SEEN[key].append(str(doc[key]))
+        value = doc.get(key)
+        if value is None:
+            continue
+
+        value = str(value)
+        seen = DUPLICATED_KEYS_SEEN[key]
+        if value not in seen:
+            seen.update({value})
+            continue
+
+        results.append(Error(name=DUPLICATED_KEYS_NAME,
+                             path=folder,
+                             msg="Key '{}' is duplicated ({}).".format(key, value),
+                             suggestion_cmd="papis edit {}:'{}'".format(key, value),
+                             fix_action=lambda: None,
+                             payload=key,
+                             doc=doc))
+
     return results
 
 
@@ -201,46 +233,76 @@ BIBTEX_TYPE_CHECK_NAME = "bibtex-type"
 
 def bibtex_type_check(doc: papis.document.Document) -> List[Error]:
     """
-    Check that the types are compatible with bibtex or biblatex
-    type descriptors.
+    Check that the document type is compatible with BibTeX or BibLaTeX type
+    descriptors.
+
+    :returns: an error if the types are not compatible.
     """
-    types = papis.bibtex.bibtex_types
-    folder = doc.get_main_folder()
-    results = []
-    if doc["type"] not in types:
-        results.append(Error(name=BIBTEX_TYPE_CHECK_NAME,
-                             path=folder or "",
-                             msg=("Document type '{}' is not"
-                                  " a valid bibtex type"
-                                  .format(doc["type"])),
-                             suggestion_cmd=("papis edit --doc-folder {}"
-                                             .format(folder)),
-                             fix_action=lambda: None,
-                             payload=doc["type"],
-                             doc=doc))
-    return results
+    import papis.bibtex
+    folder = doc.get_main_folder() or ""
+    bib_type = doc.get("type")
+
+    if bib_type is None:
+        return [Error(name=BIBTEX_TYPE_CHECK_NAME,
+                      path=folder,
+                      msg="Document does not define a type.",
+                      suggestion_cmd="papis edit --doc-folder {}".format(folder),
+                      fix_action=lambda: None,
+                      payload="type",
+                      doc=doc)]
+
+    if bib_type not in papis.bibtex.bibtex_types:
+        return [Error(name=BIBTEX_TYPE_CHECK_NAME,
+                      path=folder,
+                      msg=("Document type '{}' is not a valid BibTeX type."
+                           .format(bib_type)),
+                      suggestion_cmd="papis edit --doc-folder {}".format(folder),
+                      fix_action=lambda: None,
+                      payload=bib_type,
+                      doc=doc)]
+
+    return []
 
 
-KEY_TYPE_CHECK_NAME = "key-type-check"
+KEY_TYPE_CHECK_NAME = "key-type"
 
 
 def key_type_check(doc: papis.document.Document) -> List[Error]:
     """
-    Check the type of some keys.
+    Check document keys have expected types.
+
+    The ``doctor-key-type-check-keys`` configuration entry defines a mapping
+    of keys and their expected types.
+
+    :returns: a :class:`list` of errors, one for each key does not have the
+        expected type (if it exists).
     """
+    folder = doc.get_main_folder() or ""
+
     results = []
-    folder = doc.get_main_folder()
-    keys = [eval(tup) for tup in
-            papis.config.getlist("doctor-key-type-check-keys")]
-    for key, typstr in keys:
-        typ = eval(typstr)
-        if doc.has(key) and not isinstance(doc[key], typ):
+    for value in papis.config.getlist("doctor-key-type-check-keys"):
+        try:
+            key, cls_name = eval(value)
+        except Exception as exc:
+            logger.error("Invalid (key, type) pair: '%s'.",
+                         value, exc_info=exc)
+            continue
+
+        try:
+            cls = eval(cls_name)
+        except Exception as exc:
+            logger.error("Invalid type for key '%s': '%s'.",
+                         key, cls_name, exc_info=exc)
+            continue
+
+        doc_value = doc.get(key)
+        if doc_value is not None and not isinstance(doc_value, cls):
             results.append(Error(name=KEY_TYPE_CHECK_NAME,
-                                 path=folder or "",
-                                 msg=("Key '{}'({}) should be of type '{}'"
+                                 path=folder,
+                                 msg=("Key '{}' ({}) should be of type '{}'"
                                       " but found '{}'"
-                                      .format(key, doc[key],
-                                              typ, type(doc[key]))),
+                                      .format(key, doc_value,
+                                              cls, type(doc_value).__name__)),
                                  suggestion_cmd=("papis edit --doc-folder {}"
                                                  .format(folder)),
                                  fix_action=lambda: None,
@@ -249,48 +311,53 @@ def key_type_check(doc: papis.document.Document) -> List[Error]:
     return results
 
 
-HTML_CODE_REGEX = re.compile(r"&[a-z_A-Z0-9]+;")
+# NOTE: https://www.w3schools.com/html/html_symbols.asp
+HTML_CODES_REGEX = re.compile(r"&([a-z0-9]+|#[0-9]{1,6}|#x[0-9a-fA-F]{1,6});")
 HTML_CODES_CHECK_NAME = "html-codes"
 
 
 def html_codes_check(doc: papis.document.Document) -> List[Error]:
     """
-    Checks that the keys in "doctor-html-code-keys" do not contain
-    any html codes like &amp; etc.
+    Checks that the keys in ``doctor-html-code-keys`` configuration options do
+    not contain any HTML codes like ``&amp;`` etc.
+
+    :returns: a :class:`list` of errors, one for each key that contains HTML codes.
     """
+    from html import unescape
+    from papis.api import save_doc
+
     results = []
-    folder = doc.get_main_folder()
+    folder = doc.get_main_folder() or ""
 
-    def _fix(key: str) -> Callable[[], None]:
-
-        def __fix() -> None:
-            db = papis.database.get()
-            val = html.unescape(doc[key])
-            logger.info("Setting '%s' to '%s'", key, val)
+    def make_fixer(key: str) -> FixFn:
+        def fixer() -> None:
+            val = unescape(doc[key])
             doc[key] = val
-            doc.save()
-            db.update(doc)
+            logger.info("[FIX] Setting '%s' to '%s'.", key, val)
+            save_doc(doc)
 
-        return __fix
+        return fixer
 
     for key in papis.config.getlist("doctor-html-codes-keys"):
-        if doc[key]:
-            m = HTML_CODE_REGEX.findall(str(doc[key]))
-            if m:
-                results.append(Error(name=HTML_CODES_CHECK_NAME,
-                                     path=folder or "",
-                                     msg=("Field '{}' contains html codes {}"
-                                          .format(key, m)),
-                                     suggestion_cmd=("papis edit "
-                                                     "--doc-folder {}"
-                                                     .format(folder)),
-                                     fix_action=_fix(key),
-                                     payload=key,
-                                     doc=doc))
+        value = doc.get(key)
+        if value is None:
+            continue
+
+        m = HTML_CODES_REGEX.findall(str(value))
+        if m:
+            results.append(Error(name=HTML_CODES_CHECK_NAME,
+                                 path=folder,
+                                 msg=("Field '{}' contains HTML codes {}"
+                                      .format(key, m)),
+                                 suggestion_cmd=(
+                                     "papis edit --doc-folder {}".format(folder)),
+                                 fix_action=make_fixer(key),
+                                 payload=key,
+                                 doc=doc))
+
     return results
 
 
-REGISTERED_CHECKS = {}  # type: Dict[str, Check]
 register_check(FILES_CHECK_NAME, files_check)
 register_check(KEYS_EXIST_CHECK_NAME, keys_check)
 register_check(DUPLICATED_KEYS_NAME, duplicated_keys_check)
@@ -302,13 +369,17 @@ register_check(KEY_TYPE_CHECK_NAME, key_type_check)
 
 def run(doc: papis.document.Document, checks: List[str]) -> List[Error]:
     """
-    Runner for doctor. It runs all the checks given by the check
-    argument, and it gets the check from the global REGISTERED_CHECKS
-    dictionary.
+    Runner for ``papis doctor``.
+
+    It runs all the checks given by the *checks* argument that have been
+    registered through :func:`register_check`.
     """
+    assert all(check in REGISTERED_CHECKS for check in checks)
+
     results = []  # type: List[Error]
     for check in checks:
         results.extend(REGISTERED_CHECKS[check].operate(doc))
+
     return results
 
 
@@ -320,7 +391,7 @@ def run(doc: papis.document.Document, checks: List[str]) -> List[Error]:
               default=lambda: papis.config.getlist("doctor-default-checks"),
               multiple=True,
               type=click.Choice(registered_checks_names()),
-              help=("Checks to run on every document."))
+              help="Checks to run on every document.")
 @click.option("--json", "_json",
               default=False, is_flag=True,
               help="Output the results in json format")
@@ -338,6 +409,9 @@ def run(doc: papis.document.Document, checks: List[str]) -> List[Error]:
               help="Edit every file with the edit command.")
 @papis.cli.all_option()
 @papis.cli.doc_folder_option()
+@click.option("--list-checks", "list_checks",
+              default=False, is_flag=True,
+              help="List available checks and their descriptions")
 def cli(query: str,
         doc_folder: str,
         sort_field: Optional[str],
@@ -348,47 +422,61 @@ def cli(query: str,
         explain: bool,
         _checks: List[str],
         _json: bool,
-        suggest: bool) -> None:
+        suggest: bool,
+        list_checks: bool) -> None:
     """Check for common problems in documents"""
 
-    documents = papis.cli.handle_doc_folder_query_all_sort(query,
-                                                           doc_folder,
-                                                           sort_field,
-                                                           sort_reverse,
-                                                           _all)
+    if list_checks:
+        re_whitespace = re.compile(r"\s+")
+
+        for name, fn in REGISTERED_CHECKS.items():
+            if fn.operate.__doc__:
+                check_doc = [line for line in fn.operate.__doc__.split("\n\n") if line]
+            else:
+                check_doc = ["No description."]
+
+            headline = re_whitespace.sub(" ", check_doc[0].strip())
+            print("{}\n    {}".format(name, headline))
+        return
+
+    documents = papis.cli.handle_doc_folder_query_all_sort(
+        query, doc_folder, sort_field, sort_reverse, _all)
+
     if not documents:
         logger.warning(papis.strings.no_documents_retrieved_message)
         return
 
-    logger.debug("Running checks: %s", _checks)
+    logger.debug("Running checks: '%s'.", "', '".join(_checks))
 
     errors = []  # type: List[Error]
     for doc in documents:
-        errors += run(doc, _checks)
+        errors.extend(run(doc, _checks))
 
     if errors:
-        logger.warning("%s errors found", len(errors))
+        logger.warning("Found %s errors.", len(errors))
+    else:
+        logger.info("No errors found!")
 
     if _json:
-        print(json.dumps(list(map(lambda e:
-                                  dict(msg=e.payload,
-                                       path=e.path,
-                                       name=e.name,
-                                       suggestion=e.suggestion_cmd),
-                                  errors))))
+        import json
+
+        print(json.dumps(list(map(error_to_dict, errors))))
         return
+
+    from papis.commands.edit import run as edit_run
 
     for error in errors:
         print("{e.name}\t{e.payload}\t{e.path}".format(e=error))
+
         if explain:
-            print("\tReason: {}"
-                  .format(error.msg))
+            print("\tReason: {}".format(error.msg))
+
         if suggest:
-            print("\tSuggestion: {}"
-                  .format(error.suggestion_cmd))
+            print("\tSuggestion: {}".format(error.suggestion_cmd))
+
         if fix:
-            logger.warning("Fixing...")
             error.fix_action()
+
         if edit and error.doc:
             input("Press any key to edit...")
             edit_run(error.doc)

--- a/tests/test_doctor.py
+++ b/tests/test_doctor.py
@@ -1,0 +1,178 @@
+import os
+import tempfile
+
+import papis.api
+import papis.document
+import papis.logging
+
+papis.logging.setup("DEBUG")
+
+
+def test_files_check(monkeypatch) -> None:
+    from papis.commands.doctor import files_check
+
+    with monkeypatch.context() as m:
+        m.setattr(papis.api, "save_doc", lambda _: None)
+
+        with tempfile.NamedTemporaryFile("w") as tmp:
+            folder = os.path.dirname(tmp.name)
+            doc = papis.document.from_data({
+                "files": [os.path.basename(tmp.name), "non-existent-file"],
+                })
+
+            # check: without folder
+            errors = files_check(doc)
+            assert not errors
+
+            # check: non-existent file
+            doc.set_folder(folder)
+            error, = files_check(doc)
+            assert error.payload == os.path.join(folder, "non-existent-file")
+
+            error.fix_action()
+            assert "non-existent-file" not in doc["files"]
+
+
+def test_keys_check() -> None:
+    from papis.commands.doctor import keys_check
+
+    doc = papis.document.from_data({
+        "title": "DNA sequencing with chain-terminating inhibitors",
+        "author": "Sanger, F. and Nicklen, S. and Coulson, A. R.",
+        })
+
+    error, = keys_check(doc)
+    assert error.payload == "ref"
+
+
+def test_refs_check(monkeypatch) -> None:
+    from papis.commands.doctor import refs_check
+
+    with monkeypatch.context() as m:
+        m.setattr(papis.api, "save_doc", lambda _: None)
+        doc = papis.document.from_data({
+            "title": "DNA sequencing with chain-terminating inhibitors",
+            "author": "Sanger, F. and Nicklen, S. and Coulson, A. R.",
+            })
+
+        # check: missing ref
+        error, = refs_check(doc)
+        assert error.msg == "Reference missing."
+
+        error.fix_action()
+        assert "ref" in doc
+        assert doc["ref"] == "DnaSequencingSanger"
+
+        # check: empty ref
+        doc["ref"] = "    "
+        error, = refs_check(doc)
+        assert error.msg == "Reference missing."
+
+        # check: ref with invalid symbols
+        doc["ref"] = "[myref]"
+        error, = refs_check(doc)
+        assert "Bad characters" in error.msg
+
+        error.fix_action()
+        assert doc["ref"] == "myref"
+
+
+def test_duplicated_keys_check() -> None:
+    from papis.commands.doctor import duplicated_keys_check
+
+    docs = [
+        papis.document.from_data({"ref": "ref1"}),
+        papis.document.from_data({"ref": "ref2"}),
+        papis.document.from_data({"ref": "ref1"}),
+    ]
+
+    errors = duplicated_keys_check(docs[0])
+    assert not errors
+
+    errors = duplicated_keys_check(docs[1])
+    assert not errors
+
+    error, = duplicated_keys_check(docs[2])
+    assert error.payload == "ref"
+
+
+def test_bibtex_type_check() -> None:
+    import papis.bibtex
+    from papis.commands.doctor import bibtex_type_check
+
+    doc = papis.document.from_data({
+        "title": "DNA sequencing with chain-terminating inhibitors",
+        "author": "Sanger, F. and Nicklen, S. and Coulson, A. R.",
+        })
+
+    error, = bibtex_type_check(doc)
+    assert error.payload == "type"
+    assert "does not define a type" in error.msg
+
+    doc["type"] = "blog"
+    error, = bibtex_type_check(doc)
+    assert error.payload == "blog"
+    assert "not a valid BibTeX type" in error.msg
+
+    for bib_type in papis.bibtex.bibtex_types:
+        doc["type"] = bib_type
+        errors = bibtex_type_check(doc)
+        assert not errors
+
+
+def test_key_type_check() -> None:
+    from papis.commands.doctor import key_type_check
+
+    doc = papis.document.from_data({
+        "author_list": [{"given": "F.", "family": "Sanger"}],
+        "year": [2023],
+        })
+
+    # check: invalid setting parsing
+    papis.config.set("doctor-key-type-check-keys", ["('year', Unknown)"])
+    errors = key_type_check(doc)
+    assert not errors
+
+    papis.config.set("doctor-key-type-check-keys", ["('year', 'int', 'str')"])
+    errors = key_type_check(doc)
+    assert not errors
+
+    papis.config.set("doctor-key-type-check-keys", ["('year', 'Unknown')"])
+    errors = key_type_check(doc)
+    assert not errors
+
+    # check: incorrect type
+    papis.config.set("doctor-key-type-check-keys", ["('year', 'int')"])
+    error, = key_type_check(doc)
+    assert error.payload == "year"
+
+    # check: correct type
+    papis.config.set("doctor-key-type-check-keys", ["('author_list', 'list')"])
+    errors = key_type_check(doc)
+    assert not errors
+
+
+def test_html_codes_check(monkeypatch) -> None:
+    from papis.commands.doctor import html_codes_check
+
+    with monkeypatch.context() as m:
+        m.setattr(papis.api, "save_doc", lambda _: None)
+
+        doc = papis.document.from_data({
+            "title": "DNA sequencing with chain-terminating inhibitors",
+            "author": "Sanger, F. and Nicklen, S. and Coulson, A. R.",
+            })
+        errors = html_codes_check(doc)
+        assert not errors
+
+        for amp in ("&amp;", "&#38;", "&#x26;"):
+            doc["title"] = (
+                "DNA sequencing with chain-terminating inhibitors {} stuff"
+                .format(amp))
+
+            error, = html_codes_check(doc)
+            assert error.payload == "title"
+
+            error.fix_action()
+            assert (doc["title"]
+                    == "DNA sequencing with chain-terminating inhibitors & stuff")


### PR DESCRIPTION
Went a bit over the `papis doctor` code to add tests and updated some more things. Some of the more noticeable changes are:

* `files`: use a list comprehension; use `papis.api.save_doc`.
* `keys-exist`: use a list comprehension.
* `refs`: separate creating and fixing refs (to have better log messages); make the regex global (created once for all docs)
* `duplicated-keys`: use a set instead of a list (faster `x in set`); better handling of `None` (i.e. keys not existing on a document)
* `bibtex-type`: separated type not defined and type unknown (for better messages).
* `key-type-check`: renamed to `key-type`; made all the `eval` hopefully a bit safer.
* `html-codes`: updated regexp from W3Schools; added log message 
* added a `--list-checks` command line option that also prints out the description of the checks (from the function docs).