### PR TITLE
Format: unescape newlines

### DIFF
--- a/papis/document.py
+++ b/papis/document.py
@@ -351,13 +351,16 @@ def move(document: Document, path: str) -> None:
         document.set_folder(path)
 
 
-def from_data(data: Dict[str, Any]) -> Document:
-    """Construct a document object from a data dictionary.
+def from_data(data: Union[Document, Dict[str, Any]]) -> Document:
+    """Construct a document object from a dictionary.
 
-    :param data: Data to be copied to a new document
-    :returns: A papis document
+    :param data: A dictionary to be copied to a new document. If this is already
+        a document, a (deep) copy is performed.
     """
-    return Document(data=data)
+    if isinstance(data, Document):
+        return Document(folder=data.get_main_folder(), data=data)
+    else:
+        return Document(data=data)
 
 
 def sort(docs: List[Document], key: str, reverse: bool) -> List[Document]:

--- a/papis/utils.py
+++ b/papis/utils.py
@@ -14,6 +14,7 @@ except ImportError:
     HAS_MULTIPROCESSING = False
 
 import papis.config
+import papis.format
 import papis.exceptions
 import papis.importer
 import papis.downloaders
@@ -58,6 +59,9 @@ def parmap(f: Callable[[A], B],
     todo: enable multiprocessing support for darwin (py3.6+) ...
     todo: ... see https://github.com/papis/papis/issues/323
     """
+    # FIXME: load singleton plugins here instead of on all the processes
+    _ = papis.format.get_formater()
+
     if has_multiprocessing() and sys.platform != "darwin":
         np = np or os.cpu_count()
         np = int(os.environ.get("PAPIS_NP", str(np)))


### PR DESCRIPTION
This uses `codecs.decode` to unescape newlines (and others) from the provided strings. In particular, it can now do
```
>> papis list --format '{doc[author]}\n\t{doc[title]}' -a 'einstein'  
Joshua Foer
	Moonwalking With Einstein
```
while before it would print
```
>> papis list --format '{doc[author]}\n\t{doc[title]}' -a 'einstein'  
Joshua Foer\n\tMoonwalking With Einstein
```