### PR TITLE
Improve external script logging

### DIFF
--- a/examples/scripts/papis-abbrev
+++ b/examples/scripts/papis-abbrev
@@ -49,7 +49,7 @@ import papis.api
 import papis.document
 import papis.logging
 
-papis.logging.setup("INFO")
+papis.logging.setup()
 logger = papis.logging.get_logger("papis.commands.abbrev")
 
 papis.config.register_default_settings({

--- a/examples/scripts/papis-check
+++ b/examples/scripts/papis-check
@@ -44,7 +44,7 @@ import papis.config
 import papis.document
 import papis.logging
 
-papis.logging.setup("INFO")
+papis.logging.setup()
 logger = papis.logging.get_logger("papis.commands.check")
 
 papis.config.register_default_settings({

--- a/examples/scripts/papis-ga
+++ b/examples/scripts/papis-ga
@@ -20,7 +20,7 @@ import papis.api
 import papis.document
 import papis.logging
 
-papis.logging.setup("INFO")
+papis.logging.setup()
 logger = papis.logging.get_logger("papis.commands.ga")
 
 

--- a/examples/scripts/papis-tags
+++ b/examples/scripts/papis-tags
@@ -31,7 +31,7 @@ import papis.cli
 import papis.document
 import papis.logging
 
-papis.logging.setup("INFO")
+papis.logging.setup()
 logger = papis.logging.get_logger("papis.commands.tags")
 
 TAG_COMMA_REGEX = re.compile(r"\s*,\s*")

--- a/papis/commands/default.py
+++ b/papis/commands/default.py
@@ -167,18 +167,18 @@ def generate_profile_writing_function(profiler: "cProfile.Profile",
 @click.option(
     "--color",
     type=click.Choice(["always", "auto", "no"]),
-    default="auto",
+    default=os.environ.get("PAPIS_LOG_COLOR", "auto"),
     help="Prevent the output from having color")
 @click.option(
     "--log",
     help="Logging level",
     type=click.Choice(["INFO", "DEBUG", "WARNING", "ERROR", "CRITICAL"]),
-    default="INFO")
+    default=os.environ.get("PAPIS_LOG_LEVEL", "INFO"))
 @click.option(
     "--logfile",
     help="File to dump the log",
     type=str,
-    default=None)
+    default=os.environ.get("PAPIS_LOG_FILE"))
 @click.option(
     "--np",
     help="Use number of processors for multicore functionalities in papis",


### PR DESCRIPTION
This improves the logging setup for scripts loaded through `papis.commands.external`, which before didn't pick up the settings passed to the command line.

This is done by:
* exporting some environment variables in `papis.commands.external`: `PAPIS_LOG_LEVEL`, `PAPIS_LOG_COLOR`, `PAPIS_LOG_FILE` and `PAPIS_DEBUG`.
* Having `papis.logging.setup()` take default values from the environ if they exist.
* To make everything consistent, `papis.commands.default` also takes the defaults from the environment if they exist.

Now a script just needs to add an empty `papis.logging.setup()` and it should just work™ :grin: