### PR TITLE
Fix issues around new configs

### DIFF
--- a/papis/api.py
+++ b/papis/api.py
@@ -58,15 +58,7 @@ def get_libraries() -> List[str]:
     >>> len(get_libraries()) >= 1
     True
     """
-    config = papis.config.get_configuration()
-
-    libs = []
-    for section in config:
-        sec = config[section]
-        if "dir" in sec or "dirs" in sec:
-            libs.append(section)
-
-    return libs
+    return papis.config.get_libs()
 
 
 def pick_doc(

--- a/tests/commands/test_add.py
+++ b/tests/commands/test_add.py
@@ -305,36 +305,6 @@ class TestCli(tests.cli.TestCli):
         self.assertEqual(get_document_extension(epub), "epub")
         os.unlink(yamlfile)
 
-    # @patch(
-    #     "papis.crossref.get_data",
-    #     lambda **x: [
-    #         {"author": "Kant", "doi": "1/1", "doc_url": "https://nourl"}])
-    # @patch(
-    #     "papis.downloaders.get_downloader",
-    #     lambda url, downloader:
-    #         tests.MockDownloader(
-    #             bibtex_data=" ",
-    #             document_data="%PDF-1.5%\n".encode()))
-    # @patch("papis.utils.open_file", lambda x: None)
-    # @patch(
-    #     "papis.utils.update_doc_from_data_interactively",
-    #     lambda ctxdata, impdata, string: ctxdata.update(impdata))
-    # @patch('papis.utils.confirm', lambda x: True)
-    # def test_from_doi(self):
-    #     result = self.invoke([
-    #         "--from", "doi", "10.1112/plms/s2-42.1.0",
-    #         "--confirm", "--open"
-    #     ])
-    #     self.assertEqual(result.exit_code, 0)
-    #     db = papis.database.get()
-    #     docs = db.query_dict({"author": "Kant"})
-    #     self.assertEqual(len(docs), 1)
-    #     doc = docs[0]
-    #     # one file at least was retrieved
-    #     self.assertEqual(len(doc.get_files()), 1)
-    #     # it has the pdf ending
-    #     self.assertEqual(len(re.split(".pdf", doc.get_files()[0])), 2)
-
     @patch("papis.utils.open_file", lambda x: None)
     @patch("papis.tui.utils.confirm", lambda x: True)
     @patch(

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -78,7 +78,7 @@ def test_get_config_file(monkeypatch) -> None:
 
 
 @pytest.mark.skipif(sys.platform != "linux", reason="uses linux paths")
-def test_get_configpy_file(monkeypatch):
+def test_get_configpy_file(monkeypatch) -> None:
     with tempfile.TemporaryDirectory() as d:
         with monkeypatch.context() as m:
             m.setenv("XDG_CONFIG_HOME", d)

--- a/tests/test_config_empty.py
+++ b/tests/test_config_empty.py
@@ -1,0 +1,62 @@
+# NOTE: these tests need to be in a new file to ensure that no papis modules
+# are loaded before the configuration file is set; some modules like
+# `papis.bibtex` have import side effects involving the config and interfere
+
+import os
+import tempfile
+import contextlib
+from typing import Iterator
+
+import papis.logging
+papis.logging.setup("DEBUG")
+
+
+@contextlib.contextmanager
+def temporary_config(text: str = "") -> Iterator[None]:
+    with tempfile.NamedTemporaryFile(mode="w", delete=False) as configfile:
+        configfile.write(text)
+
+    import papis.config
+    papis.config.set_config_file(configfile.name)
+    papis.config.reset_configuration()
+
+    try:
+        yield
+    finally:
+        papis.config.set_config_file(None)
+        papis.config.reset_configuration()
+
+        os.unlink(configfile.name)
+
+
+def test_empty_config() -> None:
+    with temporary_config():
+        import papis.config
+        from papis.defaults import settings
+
+        config = papis.config.get_configuration()
+        assert papis.config.get_general_settings_name() in config
+        assert papis.config.get_libs() == ["papers"]
+        assert papis.config.get("picktool") == settings["picktool"]
+
+
+def test_config_with_no_general_settings() -> None:
+    with temporary_config("[papers]\ndir = /some/directory/probably"):
+        import papis.config
+        from papis.defaults import settings
+
+        config = papis.config.get_configuration()
+        assert papis.config.get_general_settings_name() in config
+        assert papis.config.get_libs() == ["papers"]
+        assert papis.config.get("picktool") == settings["picktool"]
+
+
+def test_config_different_default_library() -> None:
+    with temporary_config("[books]\ndir = /some/directory/probably"):
+        import papis.config
+        from papis.defaults import settings
+
+        config = papis.config.get_configuration()
+        assert papis.config.get_general_settings_name() in config
+        assert papis.config.get_libs() == ["books"]
+        assert papis.config.get("picktool") == settings["picktool"]


### PR DESCRIPTION
This (hopefully) ensures that the config is properly set up in the following situations:

* no config file exists => add some default sections and libraries in there.
* no `[settings]` section exist => add one and make a best guess at a `default-library`.
* add some warnings for these scenarios so the user isn't totally surprised.

Fixes #496.