### PR TITLE
Add needed typing_extensions dependency

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -108,6 +108,7 @@ setup(
         "lxml>=4.3.5; python_version>'3.6'",
         "python-slugify>=1.2.6 ; python_version>'3.4'",
         "dominate",
+        "typing_extensions",
     ],
     python_requires=">=3.5",
     extras_require={


### PR DESCRIPTION
Installing `papis` from master to a venv and running it raises an error due to a missing `typing_extensions` library. I've added it to `setup.py` so it gets installed with `papis` through `pip`. Open to feedback!