### PR TITLE
Fix cache database query for jinja2

### DIFF
--- a/papis/database/cache.py
+++ b/papis/database/cache.py
@@ -100,13 +100,9 @@ def match_document(
         doc_key: Optional[str] = None) -> Optional[Match[str]]:
     """Main function to match document to a given search.
 
-    :param document: Papis document
-    :param search: A valid search string
-    :param match_format: Python-like format string.
-        (`see here
-        <https://docs.python.org/2/library/string.html#format-string-syntax>`__)
-    :param doc_key: Restrict the search to an optionally given document key
-    :returns: Non false if matches, true-ish if it does match.
+    :param search: A (valid) search string.
+    :param match_format: A format string (see ``papis.format.format``).
+    :param doc_key: Restrict the search to an optionally given document key.
 
     >>> papis.config.set('match-format', '{doc[author]}')
     >>> document = papis.document.from_data({'author': 'einstein'})

--- a/papis/database/cache.py
+++ b/papis/database/cache.py
@@ -96,7 +96,8 @@ def filter_documents(
 
 def match_document(
         document: papis.document.Document, search: str,
-        match_format: Optional[str] = None) -> Optional[Match[str]]:
+        match_format: Optional[str] = None,
+        doc_key: Optional[str] = None) -> Optional[Match[str]]:
     """Main function to match document to a given search.
 
     :param document: Papis document
@@ -104,6 +105,7 @@ def match_document(
     :param match_format: Python-like format string.
         (`see here
         <https://docs.python.org/2/library/string.html#format-string-syntax>`__)
+    :param doc_key: Restrict the search to an optionally given document key
     :returns: Non false if matches, true-ish if it does match.
 
     >>> papis.config.set('match-format', '{doc[author]}')
@@ -116,7 +118,10 @@ def match_document(
     True
     """
     match_format = match_format or str(papis.config.get("match-format"))
-    match_string = papis.format.format(match_format, document)
+    if doc_key is not None:
+        match_string = str(document[doc_key])
+    else:
+        match_string = papis.format.format(match_format, document)
     regex = get_regex_from_search(search)
     return re.match(regex, match_string, re.IGNORECASE)
 

--- a/papis/docmatcher.py
+++ b/papis/docmatcher.py
@@ -9,7 +9,10 @@ if TYPE_CHECKING:
 
 logger = papis.logging.get_logger(__name__)
 
-MATCHER_TYPE = Callable[[papis.document.Document, str, Optional[str]], Any]
+MATCHER_TYPE = Callable[
+    [papis.document.Document, str, Optional[str], Optional[str]],
+    Any
+]
 
 
 class DocMatcher(object):
@@ -33,7 +36,6 @@ class DocMatcher(object):
     """
     search = ""  # type: str
     parsed_search = None  # type: pyparsing.ParseResults
-    doc_format = "{%s[DOC_KEY]}" % (papis.config.getstring("format-doc-name"))
     matcher = None  # type: Optional[MATCHER_TYPE]
 
     @classmethod
@@ -65,13 +67,13 @@ class DocMatcher(object):
         for parsed in cls.parsed_search:
             if len(parsed) == 1:
                 search = parsed[0]
-                sformat = None
+                doc_key = None
             elif len(parsed) == 3:
                 search = parsed[2]
-                sformat = cls.doc_format.replace("DOC_KEY", parsed[0])
+                doc_key = parsed[0]
 
             if cls.matcher is not None:
-                match = doc if cls.matcher(doc, search, sformat) else None
+                match = doc if cls.matcher(doc, search, None, doc_key) else None
             if not match:
                 break
         return match

--- a/tests/test_docmatcher.py
+++ b/tests/test_docmatcher.py
@@ -10,7 +10,6 @@ def get_docs():
 
 
 def test_docmatcher():
-
     DocMatcher.set_search("author:einstein")
     assert DocMatcher.search == "author:einstein"
     DocMatcher.set_search("author:seitz")
@@ -21,7 +20,7 @@ def test_docmatcher():
     docs = get_docs()
     assert len(list(docs)) == 16
     for res in [(True, 16), (False, 0)]:
-        DocMatcher.set_matcher(lambda doc, search, sformat, res=res: res[0])
+        DocMatcher.set_matcher(lambda doc, search, sformat, doc_key, res=res: res[0])
         filtered = list(
             filter(lambda x: x is not None, map(DocMatcher.return_if_match, docs)))
         assert len(filtered) == res[1]


### PR DESCRIPTION
Following the discussion and ideas in https://github.com/papis/papis/pull/384, I've created a new potential fix for querying with the cache database and the `jinja2` formatter. This should work regardless of the actual formatter used.