### PR TITLE
papis.document: remove check in from_data

### DIFF
--- a/papis/document.py
+++ b/papis/document.py
@@ -357,10 +357,7 @@ def from_data(data: Union[Document, Dict[str, Any]]) -> Document:
     :param data: A dictionary to be copied to a new document. If this is already
         a document, a (deep) copy is performed.
     """
-    if isinstance(data, Document):
-        return Document(folder=data.get_main_folder(), data=data)
-    else:
-        return Document(data=data)
+    return Document(data=data)
 
 
 def sort(docs: List[Document], key: str, reverse: bool) -> List[Document]:

--- a/papis/format.py
+++ b/papis/format.py
@@ -66,7 +66,8 @@ class PythonFormater(Formater):
             additional = {}
 
         fmt = escape(fmt)
-        doc = papis.document.from_data(doc)
+        if not isinstance(doc, papis.document.Document):
+            doc = papis.document.from_data(doc)
 
         doc_name = doc_key or papis.config.getstring("format-doc-name")
         try:
@@ -104,7 +105,8 @@ class Jinja2Formater(Formater):
         from jinja2 import Template
 
         fmt = escape(fmt)
-        doc = papis.document.from_data(doc)
+        if not isinstance(doc, papis.document.Document):
+            doc = papis.document.from_data(doc)
 
         doc_name = doc_key or papis.config.getstring("format-doc-name")
         try:


### PR DESCRIPTION
I added a check here in #491 which seems to have made everything twice as slow for some reason (guess `from_data` is used a lot). Oops!

Before this PR
```
Benchmark 1: papis -l papers list -a einstein
Time (mean ± σ):     508.0 ms ±  16.1 ms    [User: 2808.0 ms, System: 409.1 ms]
Range (min … max):   485.7 ms … 543.9 ms    10 runs
```
and after
```
Benchmark 1: papis -l papers list -a einstein
Time (mean ± σ):     261.2 ms ±  12.0 ms    [User: 286.3 ms, System: 144.4 ms]
Range (min … max):   248.8 ms … 291.8 ms    11 runs
```