### PR TITLE
Skip multiprocessing if PAPIS_NP is zero

### DIFF
--- a/papis/utils.py
+++ b/papis/utils.py
@@ -62,9 +62,10 @@ def parmap(f: Callable[[A], B],
     # FIXME: load singleton plugins here instead of on all the processes
     _ = papis.format.get_formater()
 
-    if has_multiprocessing() and sys.platform != "darwin":
-        np = np or os.cpu_count()
-        np = int(os.environ.get("PAPIS_NP", str(np)))
+    if np is None:
+        np = int(os.environ.get("PAPIS_NP", str(os.cpu_count())))
+
+    if np and HAS_MULTIPROCESSING and sys.platform != "darwin":
         with Pool(np) as pool:
             return list(pool.map(f, xs))
     else:


### PR DESCRIPTION
This also allows to skip using multiprocessing altogether. For my usual queries with about < 100 documents, using multiprocessing tends do be slower.

```
> PAPIS_NP=0 hyperfine -- 'papis -l papers export --format bibtex -a einstein'   
Time (mean ± σ):     197.7 ms ±   2.3 ms    [User: 172.9 ms, System: 24.2 ms]
Range (min … max):   196.1 ms … 205.2 ms    14 runs
```
vs
```
> PAPIS_NP=8 hyperfine -- 'papis -l papers export --format bibtex -a einstein'  
Time (mean ± σ):     249.5 ms ±   4.7 ms    [User: 280.6 ms, System: 99.8 ms]
Range (min … max):   244.1 ms … 259.7 ms    11 runs
```

EDIT: Note also that creating a `Pool(n)` with `n < 1` raises an exception.