### PR TITLE
format: cache format-doc-name

### DIFF
--- a/papis/format.py
+++ b/papis/format.py
@@ -31,6 +31,9 @@ def escape(fmt: str) -> str:
 
 
 class Formater:
+    def __init__(self) -> None:
+        self.default_doc_name = papis.config.getstring("format-doc-name")
+
     def format(self,
                fmt: str,
                doc: FormatDocType,
@@ -69,7 +72,7 @@ class PythonFormater(Formater):
         if not isinstance(doc, papis.document.Document):
             doc = papis.document.from_data(doc)
 
-        doc_name = doc_key or papis.config.getstring("format-doc-name")
+        doc_name = doc_key or self.default_doc_name
         try:
             return fmt.format(**{doc_name: doc}, **additional)
         except Exception as exc:
@@ -85,6 +88,8 @@ class Jinja2Formater(Formater):
     """
 
     def __init__(self) -> None:
+        super().__init__()
+
         try:
             import jinja2       # noqa: F401
         except ImportError as exc:
@@ -108,7 +113,7 @@ class Jinja2Formater(Formater):
         if not isinstance(doc, papis.document.Document):
             doc = papis.document.from_data(doc)
 
-        doc_name = doc_key or papis.config.getstring("format-doc-name")
+        doc_name = doc_key or self.default_doc_name
         try:
             return str(Template(fmt).render(**{doc_name: doc}, **additional))
         except Exception as exc:


### PR DESCRIPTION
`papis.format.format` is called quite a lot (usually in loops over documents) and `papis.config.get` can be quite heavy. In some silly benchmarks, this shaved off 10ms in `papis export` and `papis list` calls.

As with all caching, this can get out of sync, but it should be fine for our use case.