### PR TITLE
Minor DocMatcher optimizations

### DIFF
--- a/papis/database/cache.py
+++ b/papis/database/cache.py
@@ -100,13 +100,7 @@ def match_document(
         doc_key: Optional[str] = None) -> Optional[Match[str]]:
     """Match a document's keys to a given search pattern.
 
-    The search pattern is matched against *doc_key*, if given, and *match_format*
-    otherwise.
-
-    :param search: A regex pattern to match the query against..
-    :param match_format: A format string (see ``papis.format.format``) to match
-        against.
-    :param doc_key: A specific key in the document to match against.
+    See ``papis.docmatcher.MatcherCallable``.
 
     >>> papis.config.set('match-format', '{doc[author]}')
     >>> document = papis.document.from_data({'author': 'einstein'})

--- a/papis/database/cache.py
+++ b/papis/database/cache.py
@@ -102,13 +102,13 @@ def match_document(
 
     See ``papis.docmatcher.MatcherCallable``.
 
-    >>> papis.config.set('match-format', '{doc[author]}')
+    >>> from papis.docmatcher import get_regex_from_search as regex
     >>> document = papis.document.from_data({'author': 'einstein'})
-    >>> match_document(document, 'e in') is None
+    >>> match_document(document, regex('e in'), '{doc[author]}') is None
     False
-    >>> match_document(document, 'ee in') is None
+    >>> match_document(document, regex('ee in'), '{doc[author]}') is None
     True
-    >>> match_document(document, 'einstein', '{doc[title]}') is None
+    >>> match_document(document, regex('einstein'), '{doc[title]}') is None
     True
     """
     match_format = match_format or papis.config.getstring("match-format")
@@ -116,6 +116,7 @@ def match_document(
         match_string = str(document[doc_key])
     else:
         match_string = papis.format.format(match_format, document)
+
     return search.match(match_string)
 
 

--- a/papis/database/cache.py
+++ b/papis/database/cache.py
@@ -113,7 +113,7 @@ def match_document(
     >>> match_document(document, 'einstein', '{doc[title]}') is None
     True
     """
-    match_format = match_format or str(papis.config.get("match-format"))
+    match_format = match_format or papis.config.getstring("match-format")
     if doc_key is not None:
         match_string = str(document[doc_key])
     else:

--- a/papis/docmatcher.py
+++ b/papis/docmatcher.py
@@ -37,6 +37,7 @@ class DocMatcher(object):
     search = ""  # type: str
     parsed_search = None  # type: pyparsing.ParseResults
     matcher = None  # type: Optional[MATCHER_TYPE]
+    match_format = papis.config.getstring("match-format")   # type: str
 
     @classmethod
     def return_if_match(
@@ -61,7 +62,7 @@ class DocMatcher(object):
         True
         """
         match = None
-        if cls.parsed_search is None:
+        if cls.parsed_search is None or cls.matcher is None:
             return match
 
         for parsed in cls.parsed_search:

--- a/papis/docmatcher.py
+++ b/papis/docmatcher.py
@@ -130,13 +130,13 @@ class DocMatcher(object):
         :returns: Parsed query
 
         >>> print(DocMatcher.parse('hello author : einstein'))
-        [['hello'], ['author', ':', 'einstein']]
+        [['hello'], ['author', 'einstein']]
         >>> print(DocMatcher.parse(''))
         []
         >>> print(\
             DocMatcher.parse(\
                 '"hello world whatever :" tags : \\\'hello ::::\\\''))
-        [['hello world whatever :'], ['tags', ':', 'hello ::::']]
+        [['hello world whatever :'], ['tags', 'hello ::::']]
         >>> print(DocMatcher.parse('hello'))
         [['hello']]
         """
@@ -152,10 +152,10 @@ def get_regex_from_search(search: str) -> Pattern[str]:
     :param search: A valid search string
     :returns: Regular expression
 
-    >>> get_regex_from_search(' ein 192     photon')
+    >>> get_regex_from_search(' ein 192     photon').pattern
     '.*ein.*192.*photon.*'
 
-    >>> get_regex_from_search('{1234}')
+    >>> get_regex_from_search('{1234}').pattern
     '.*\\{1234\\}.*'
     """
     return re.compile(

--- a/tests/test_docmatcher.py
+++ b/tests/test_docmatcher.py
@@ -28,25 +28,20 @@ def test_docmatcher():
 
 def test_parse_query():
     r = parse_query("hello   author : einstein")
-    assert r[0][0] == "hello"
-    assert r[1][0] == "author"
-    assert r[1][1] == ":"
-    assert r[1][2] == "einstein"
+    assert r[0].search == "hello"
+    assert r[1].doc_key == "author"
+    assert r[1].search == "einstein"
 
-    r = parse_query("doi : 123.123/124_123")
-    re = ["doi", ":", "123.123/124_123"]
-    for i in range(len(re)):
-        assert r[0][i] == re[i]
+    r, = parse_query("doi : 123.123/124_123")
+    assert r.doc_key == "doi"
+    assert r.search == "123.123/124_123"
 
-    r = parse_query("doi : 123.123/124_123(80)12")
-    re = ["doi", ":", "123.123/124_123(80)12"]
-    for i in range(len(re)):
-        assert r[0][i] == re[i]
+    r, = parse_query("doi : 123.123/124_123(80)12")
+    assert r.doc_key == "doi"
+    assert r.search == "123.123/124_123(80)12"
 
     r = parse_query('tt : asfd   author : "Albert einstein"')
-    assert r[0][0] == "tt"
-    assert r[0][1] == ":"
-    assert r[0][2] == "asfd"
-    assert r[1][0] == "author"
-    assert r[1][1] == ":"
-    assert r[1][2] == "Albert einstein"
+    assert r[0].doc_key == "tt"
+    assert r[0].search == "asfd"
+    assert r[1].doc_key == "author"
+    assert r[1].search == "Albert einstein"


### PR DESCRIPTION
Was profiling some more and found some places to improve in `DocMatcher`. 

The main changes are
* store `match-format` in the `DocMatcher` class and pass it to `matcher` by default, so that `papis.config.get` does not get called in `match_document` for every `document * search`.
* post-process results from `pyparsing` into a simpler list that can be used directly in `return_if_match`, to avoid the ifs.
* store the compiled regex when post-processing, instead of recompiling it in `match_document`.

All in all, this seems to have saved another whooping 10ms-ish on my machine, bringing a call to `papis list` with about 50 / 1200 documents down to about 170ms-ish. The rest of the time is spent loading up plugins / scripts / click.