### PR TITLE
Add config option for isbnlib service

### DIFF
--- a/doc/source/default-settings.rst
+++ b/doc/source/default-settings.rst
@@ -462,6 +462,12 @@ Downloaders
     To know more you can checkout this
     `link <http://docs.python-requests.org/en/master/user/advanced/#proxies>`__.
 
+.. papis-config:: isbn-service
+
+    Sets the ISBN service used by the ISBN importer. Available plugins are
+    documented
+    `here <https://isbnlib.readthedocs.io/en/latest/devs.html#plugins>`__.
+
 Databases
 ---------
 

--- a/papis/defaults.py
+++ b/papis/defaults.py
@@ -135,6 +135,7 @@ settings = {
     "mark-opener-format": get_default_opener(),
 
     "file-browser": get_default_opener(),
+    "bibtex-unicode": False,
     "bibtex-journal-key": "journal",
     "bibtex-export-zotero-file": False,
     "bibtex-ignore-keys": "[]",
@@ -152,10 +153,14 @@ settings = {
         "[<ansiyellow>{doc.html_escape[tags]}</ansiyellow>]"
     ),
 
+    "formater": "python",
+    "time-stamp": True,
     "info-allow-unicode": True,
     "ref-format": "{doc[title]:.15} {doc[author]:.6} {doc[year]}",
     "multiple-authors-separator": " and ",
     "multiple-authors-format": "{au[family]}, {au[given]}",
+    "document-description-format": "{doc[title]} - {doc[author]}",
+    "unique-document-keys": "['doi','ref','isbn','isbn10','url','doc_url']",
 
     "whoosh-schema-fields": "['doi']",
     "whoosh-schema-prototype":
@@ -165,16 +170,6 @@ settings = {
     '"year": TEXT(stored=True),\n'
     '"tags": TEXT(stored=True),\n'
     "}",
-
-    "unique-document-keys": "['doi','ref','isbn','isbn10','url','doc_url']",
-
-    "downloader-proxy": None,
-    "bibtex-unicode": False,
-
-    "time-stamp": True,
-
-    "document-description-format": "{doc[title]} - {doc[author]}",
-    "formater": "python",
 
     # fzf options
     "fzf-binary": "fzf",
@@ -190,5 +185,9 @@ settings = {
                           "{c.Fore.YELLOW}"
                           "«{doc[year]:4}»"
                           "{c.Style.RESET_ALL}"
-                          ":{doc[tags]}")
+                          ":{doc[tags]}"),
+
+    # importer / downloader options
+    "downloader-proxy": None,
+    "isbn-service": "openl",
 }  # type: Dict[str, Any]

--- a/papis/isbn.py
+++ b/papis/isbn.py
@@ -2,6 +2,7 @@
 from typing import Dict, Any, List, Optional
 
 import click
+from isbnlib.registry import services as isbn_services
 
 import papis.config
 import papis.document
@@ -9,6 +10,8 @@ import papis.importer
 import papis.logging
 
 logger = papis.logging.get_logger(__name__)
+
+ISBN_SERVICE_NAMES = list(isbn_services)
 
 
 def get_data(query: str = "",
@@ -18,10 +21,9 @@ def get_data(query: str = "",
     if service is None:
         service = papis.config.get("isbn-service")
 
-    import isbnlib.registry
-    if service not in isbnlib.registry.services:
+    if service not in ISBN_SERVICE_NAMES:
         logger.error("ISBN service '%s' is not known. Available services: '%s'.",
-                     service, "', '".join(isbnlib.registry.services))
+                     service, "', '".join(ISBN_SERVICE_NAMES))
         return []
 
     import isbnlib
@@ -63,8 +65,8 @@ def data_to_papis(data: Dict[str, Any]) -> Dict[str, Any]:
 @click.help_option("--help", "-h")
 @click.option("--query", "-q", default=None)
 @click.option("--service", "-s",
-              default="goob",
-              type=click.Choice(["wiki", "goob", "openl"]))
+              default=ISBN_SERVICE_NAMES[0],
+              type=click.Choice(ISBN_SERVICE_NAMES))
 def explorer(ctx: click.core.Context, query: str, service: str) -> None:
     """
     Look for documents using isbnlib


### PR DESCRIPTION
This adds a new config option `isbn-service` to allow changing the service on import, e.g.
```
papis --set isbn-service goob add --from isbn 'S-OME-ISBN-CODE'
```
which defaults to `openl` at the moment.