### PR TITLE
Remove configparser dependency

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -91,7 +91,6 @@ setup(
         "chardet>=3.0.2",
         "click>=7.0.0",
         "colorama>=0.2",
-        "configparser>=3.0.0",
         "dominate",
         "filetype>=1.0.1",
         "habanero<1.2.0; python_version<'3.6'",


### PR DESCRIPTION
`configparser` is available in the python 3 stdlib, so this is not needed anymore.