### PR TITLE
Simplify mypy configuration

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -18,92 +18,43 @@ doctest_optionflags = NORMALIZE_WHITESPACE ELLIPSIS
 norecursedirs = .git doc build dist
 python_files = *.py
 
+[mypy]
+strict = True
+show_column_numbers = True
+hide_error_codes = False
+pretty = True
+files = papis
+
+[mypy-arxiv2bib.*]
+ignore_missing_imports = True
+
+[mypy-bibtexparser.*]
+ignore_missing_imports = True
+
+[mypy-colorama.*]
+ignore_missing_imports = True
+
+[mypy-dominate.*]
+ignore_missing_imports = True
+
+[mypy-filetype.*]
+ignore_missing_imports = True
+
+[mypy-habanero.*]
+ignore_missing_imports = True
+
+[mypy-isbnlib.*]
+ignore_missing_imports = True
+
+[mypy-stevedore.*]
+ignore_missing_imports = True
+
 [mypy-typing.re.*]
 ignore_missing_imports = True
 
 [mypy-whoosh.*]
 ignore_missing_imports = True
 
-[mypy-arxiv2bib.*]
-ignore_missing_imports = True
-
-[mypy-isbnlib.*]
-ignore_missing_imports = True
-
-[mypy-pyparsing.*]
-ignore_missing_imports = True
-
-[mypy-pygments.*]
-ignore_missing_imports = True
-
-[mypy-slugify.*]
-ignore_missing_imports = True
-
-[mypy-filetype.*]
-ignore_missing_imports = True
-
-[mypy-stevedore.*]
-ignore_missing_imports = True
-
-[mypy-tqdm.*]
-ignore_missing_imports = True
-
-[mypy-bs4.*]
-ignore_missing_imports = True
-
-[mypy-prompt_toolkit.*]
-ignore_missing_imports = True
-
-[mypy-colorama.*]
-ignore_missing_imports = True
-ignore_errors = True
-
-[mypy-bibtexparser.*]
-ignore_missing_imports = True
-ignore_errors = True
-
-[mypy-click.*]
-ignore_missing_imports = True
-ignore_errors = True
-
-[mypy-habanero.*]
-ignore_missing_imports = True
-ignore_errors = True
-
-[mypy-dominate.*]
-ignore_missing_imports = True
-ignore_errors = True
-
-[mypy-requests.*]
-ignore_missing_imports = True
-ignore_errors = True
-
-
-[mypy]
-# This is basically --strict
-disallow_redefinition = True
-warn_unused_configs = True
-disallow_any_generics = True
-disallow_subclassing_any = True
-disallow_untyped_calls = True
-disallow_untyped_defs = True
-disallow_incomplete_defs = True
-check_untyped_defs = True
-disallow_untyped_decorators = True
-no_implicit_optional = True
-warn_redundant_casts = True
-warn_unused_ignores = True
-warn_return_any = True
-no_implicit_reexport = True
-# export html report default
-#html_report = htmlmypy
-follow_imports = silent
-#mypy_path = stubs
-
-files = papis
-
-# Ignore errors on tui since there is the prompt-toolkit 2 and 3
-# differences.
 [mypy-papis.tui.*]
 ignore_missing_imports = True
 ignore_errors = True

--- a/setup.py
+++ b/setup.py
@@ -132,8 +132,11 @@ setup(
             "sphinx-click",
             "sphinx_rtd_theme",
             "types-PyYAML",
+            "types-Pygments",
+            "types-beautifulsoup4",
+            "types-python-slugify",
             "types-requests",
-            "types-contextvars",
+            "types-tqdm",
         ],
     },
     description=(


### PR DESCRIPTION
This tries to simplify the `mypy` configuration a bit.

* removes some unnecessary ignores modules that have typing annotations now.
* use explicit `strict = True` in the config instead of listing the options. This may not be a great idea because the enabled options are not stable.