### PR TITLE
Improve logging and error messages

### DIFF
--- a/papis/arxiv.py
+++ b/papis/arxiv.py
@@ -107,7 +107,8 @@ def validate_arxivid(arxivid: str) -> None:
 
     if not response.ok:
         raise ValueError(
-            "HTTP {}: '{}' not an arxivid".format(response.status_code, arxivid)
+            "HTTP ({} {}): '{}' not an arxivid".format(
+                response.status_code, response.reason, arxivid)
             )
 
 

--- a/papis/citations.py
+++ b/papis/citations.py
@@ -37,7 +37,7 @@ def fetch_citations(doc: Document) -> List[Dict[str, Any]]:
     metadata_citations = get_metadata_citations(doc)
     if not metadata_citations:
         if "doi" in doc:
-            logger.debug("trying with doi '%s'", doc["doi"])
+            logger.debug("Trying fetching citations with DOI '%s'.", doc["doi"])
             data = papis.crossref.doi_to_data(doc["doi"])
             metadata_citations = get_metadata_citations(data)
             if not metadata_citations:
@@ -50,14 +50,14 @@ def fetch_citations(doc: Document) -> List[Dict[str, Any]]:
 
     dois = [str(d.get("doi")).lower() for d in metadata_citations
             if "doi" in d]
-    logger.info("%d citations found to query", len(dois))
+    logger.info("Found %d citations.", len(dois))
 
     dois_with_data = [
     ]  # type: List[Dict[str, Any]]
     found_in_lib_dois = [
     ]  # type: List[Dict[str, Any]]
 
-    logger.info("Checking which citations are already in the library")
+    logger.info("Checking which citations are already in the library.")
     dois_with_data = get_citations_from_database(dois)
 
     for data in dois_with_data:
@@ -65,8 +65,8 @@ def fetch_citations(doc: Document) -> List[Dict[str, Any]]:
         if doi:
             dois.remove(doi)
 
-    logger.info("Found %d DOIs in library", len(found_in_lib_dois))
-    logger.info("Fetching %d citations from crossref", len(dois))
+    logger.info("Found %d DOIs in library.", len(found_in_lib_dois))
+    logger.info("Fetching %d citations from Crossref.", len(dois))
 
     with tqdm.tqdm(iterable=dois) as progress:
         for doi in progress:

--- a/papis/commands/add.py
+++ b/papis/commands/add.py
@@ -301,7 +301,7 @@ def run(paths: List[str],
 
     for p in in_documents_paths:
         if not os.path.exists(p):
-            raise IOError("Document {} not found".format(p))
+            raise FileNotFoundError("File '{}' not found".format(p))
 
     in_documents_names = [
         papis.utils.clean_document_name(doc_path)
@@ -364,7 +364,9 @@ def run(paths: List[str],
         out_folder_path = os.path.join(out_folder_path, out_folder_name)
 
     if not papis.utils.is_relative_to(out_folder_path, base_path):
-        raise ValueError("formatting produced path outside of library")
+        raise ValueError(
+            "Formatting produced a path outside of library: '{}' not relative to '{}'"
+            .format(base_path, out_folder_path))
 
     if os.path.exists(out_folder_path):
         out_folder_path = ensure_new_folder(out_folder_path)

--- a/papis/commands/addto.py
+++ b/papis/commands/addto.py
@@ -64,14 +64,14 @@ def run(document: papis.document.Document,
         if len(os.path.abspath(out_file_path)) >= 255:
             logger.warning(
                 "Length of absolute path is > 255 characters. "
-                "This may cause some issues with some pdf viewers")
+                "This may cause some issues with some PDF viewers.")
 
         if os.path.exists(out_file_path):
-            logger.warning("%s already exists, ignoring...", out_file_path)
+            logger.warning("File '%s' already exists. Skipping...", out_file_path)
             continue
 
         import shutil
-        logger.info("[CP] '%s' to '%s'", in_file_path, out_file_path)
+        logger.info("[CP] '%s' to '%s'.", in_file_path, out_file_path)
         shutil.copy(in_file_path, out_file_path)
 
     if "files" not in document:

--- a/papis/commands/addto.py
+++ b/papis/commands/addto.py
@@ -30,6 +30,7 @@ import papis.config
 import papis.document
 import papis.logging
 import papis.strings
+from papis.exceptions import DocumentFolderNotFound
 
 logger = papis.logging.get_logger(__name__)
 
@@ -39,8 +40,7 @@ def run(document: papis.document.Document,
         git: bool = False) -> None:
     doc_folder = document.get_main_folder()
     if not doc_folder or not os.path.exists(doc_folder):
-        raise Exception("Document does not have a folder attached: '{}'."
-                        .format(papis.document.describe(document)))
+        raise DocumentFolderNotFound(papis.document.describe(document))
 
     from papis.utils import create_identifier
     suffix = create_identifier(skip=len(document.get_files()))

--- a/papis/commands/addto.py
+++ b/papis/commands/addto.py
@@ -38,8 +38,9 @@ def run(document: papis.document.Document,
         filepaths: List[str],
         git: bool = False) -> None:
     doc_folder = document.get_main_folder()
-    if not doc_folder:
-        raise Exception("Document does not have a folder attached")
+    if not doc_folder or not os.path.exists(doc_folder):
+        raise Exception("Document does not have a folder attached: '{}'."
+                        .format(papis.document.describe(document)))
 
     from papis.utils import create_identifier
     suffix = create_identifier(skip=len(document.get_files()))
@@ -49,7 +50,7 @@ def run(document: papis.document.Document,
 
     for in_file_path in filepaths:
         if not os.path.exists(in_file_path):
-            raise Exception("{} not found".format(in_file_path))
+            raise FileNotFoundError("File '{}' not found".format(in_file_path))
 
         # Rename the file in the staging area
         new_filename = get_file_name(

--- a/papis/commands/browse.py
+++ b/papis/commands/browse.py
@@ -110,7 +110,7 @@ def run(document: papis.document.Document,
                    + urllib.parse.urlencode(params))
 
     if browse:
-        logger.info("Opening url '%s'", url)
+        logger.info("Opening URL '%s'.", url)
         papis.utils.general_open(url, "browser", wait=False)
     else:
         click.echo(url)
@@ -149,7 +149,7 @@ def cli(query: str,
     if key:
         papis.config.set("browse-key", key)
 
-    logger.info("Using key '%s'", papis.config.get("browse-key"))
+    logger.info("Using key '%s'.", papis.config.get("browse-key"))
 
     for document in documents:
         run(document, browse=not _print)

--- a/papis/commands/browse.py
+++ b/papis/commands/browse.py
@@ -91,23 +91,21 @@ def run(document: papis.document.Document,
                    .format(document["doi"]))
         elif "isbn" == key:
             url = "https://isbnsearch.org/isbn/{}".format(document["isbn"])
-        else:
+        elif key != "search-engine":
             url = document[key]
+    except KeyError as exc:
+        logger.error("Failed to construct URL for key '%s'.", key, exc_info=exc)
 
-        if not url:
-            raise KeyError()
-
-    except KeyError:
-        if not url or key == "search-engine":
-            import urllib.parse
-            params = {
-                "q": papis.format.format(
-                    papis.config.getstring("browse-query-format"),
-                    document)
-            }
-            url = (papis.config.getstring("search-engine")
-                   + "/?"
-                   + urllib.parse.urlencode(params))
+    if not url or key == "search-engine":
+        import urllib.parse
+        params = {
+            "q": papis.format.format(
+                papis.config.getstring("browse-query-format"),
+                document)
+        }
+        url = (papis.config.getstring("search-engine")
+               + "/?"
+               + urllib.parse.urlencode(params))
 
     if browse:
         logger.info("Opening URL '%s'.", url)

--- a/papis/commands/citations.py
+++ b/papis/commands/citations.py
@@ -66,20 +66,20 @@ def cli(query: str,
         _has_cited_by_p = has_cited_by(document)
         if fetch_citations:
             if _has_citations_p and force or not _has_citations_p:
-                logger.info("[%d/%d] fetching citations for %s",
+                logger.info("[%d/%d] Fetching citations for '%s'.",
                             i + 1, len(documents),
                             papis.document.describe(document))
                 fetch_and_save_citations(document)
         if update_from_database:
             if _has_citations_p:
-                logger.info("[%d/%d] updating citations from library for %s",
+                logger.info("[%d/%d] Updating citations from library for '%s'.",
                             i + 1, len(documents),
                             papis.document.describe(document))
                 update_and_save_citations_from_database_from_doc(document)
         if fetch_cited_by:
             if _has_cited_by_p and force or not _has_cited_by_p:
-                logger.info("[%d/%d] fetching cited-by "
-                            "references from library for %s",
-                            i + 1, len(documents),
-                            papis.document.describe(document))
+                logger.info(
+                    "[%d/%d] Fetching cited-by references from library for '%s'",
+                    i + 1, len(documents),
+                    papis.document.describe(document))
                 fetch_and_save_cited_by_from_database(document)

--- a/papis/commands/config.py
+++ b/papis/commands/config.py
@@ -117,7 +117,7 @@ def _get_option_safe(
         section, key = parse_option(option, default_section)
     except ValueError:
         logger.error(
-            "Options should be in a <section>.<key> or <key> format: got '%s'",
+            "Options should be in a <section>.<key> or <key> format: got '%s'.",
             option)
         return key, value
 
@@ -130,13 +130,14 @@ def _get_option_safe(
             value = defaults[section][key]
         except KeyError:
             logger.error(
-                "No default value for setting '%s' found in section '%s'",
+                "No default value for setting '%s' found in section '%s'.",
                 key, section)
     else:
         try:
             value = papis.config.get(key, section=section)
         except papis.exceptions.DefaultSettingValueMissing as exc:
-            logger.error("\n%s", str(exc).strip("\n"))
+            logger.error("No value for setting '%s' found in section '%s'.",
+                         key, section, exc_info=exc)
 
     return key, value
 

--- a/papis/commands/default.py
+++ b/papis/commands/default.py
@@ -248,7 +248,7 @@ def run(verbose: bool,
 
     # read in configuration from command-line
     for pair in set_list:
-        logger.debug("Setting '%s' to '%s'", *pair)
+        logger.debug("Setting '%s' to '%s'.", *pair)
         papis.config.set(pair[0], pair[1])
 
     if clear_cache:

--- a/papis/commands/default.py
+++ b/papis/commands/default.py
@@ -232,8 +232,8 @@ def run(verbose: bool,
 
     if not library.paths:
         raise RuntimeError(
-            "Library '{}' does not have any existing folders attached to it, "
-            "please define and create the paths"
+            "Library '{}' does not have any existing folders attached to it. "
+            "Please define and create the paths in the configuration file"
             .format(lib))
 
     # Now the library should be set, let us check if there is a

--- a/papis/commands/edit.py
+++ b/papis/commands/edit.py
@@ -42,7 +42,7 @@ def run(document: papis.document.Document,
 
     # If nothing changed there is nothing else to be done
     if _old_dict == _new_dict:
-        logger.debug("old and new are equal, doing nothing")
+        logger.debug("No changes made to the document.")
         return
 
     papis.database.get().update(document)
@@ -57,7 +57,7 @@ def run(document: papis.document.Document,
 
 def edit_notes(document: papis.document.Document,
                git: bool = False) -> None:
-    logger.debug("Editing notes")
+    logger.debug("Editing notes.")
     notes_path = papis.notes.notes_path_ensured(document)
     papis.api.edit_file(notes_path)
     if git:

--- a/papis/commands/edit.py
+++ b/papis/commands/edit.py
@@ -25,6 +25,7 @@ import papis.git
 import papis.format
 import papis.notes
 import papis.logging
+from papis.exceptions import DocumentFolderNotFound
 
 logger = papis.logging.get_logger(__name__)
 
@@ -34,7 +35,8 @@ def run(document: papis.document.Document,
         git: bool = False) -> None:
     info_file_path = document.get_info_file()
     if not info_file_path:
-        raise Exception(papis.strings.no_folder_attached_to_document)
+        raise DocumentFolderNotFound(papis.document.describe(document))
+
     _old_dict = papis.document.to_dict(document)
     papis.utils.general_open(info_file_path, "editor", wait=wait)
     document.load()

--- a/papis/commands/explore.py
+++ b/papis/commands/explore.py
@@ -150,7 +150,7 @@ def lib(ctx: click.Context, query: str,
         ctx.obj["documents"] += [papis.document.from_folder(doc_folder)]
     db = papis.database.get(library_name=library)
     docs = db.query(query)
-    logger.info("%d documents found", len(docs))
+    logger.info("Found %d documents.", len(docs))
 
     ctx.obj["documents"] += docs
     assert isinstance(ctx.obj["documents"], list)
@@ -220,13 +220,13 @@ def citations(ctx: click.Context, query: str, doc_folder: str,
         return
 
     for document in documents:
-        logger.debug("exploring %s", papis.document.describe(document))
+        logger.debug("Exploring document '%s'.", papis.document.describe(document))
         if cited_by:
             _citations = papis.citations.get_cited_by(document)
         else:
             _citations = papis.citations.get_citations(document)
 
-        logger.debug("got %s citations", len(_citations))
+        logger.debug("Found %d citations.", len(_citations))
 
         ctx.obj["documents"].extend(_citations)
 
@@ -260,7 +260,7 @@ def cmd(ctx: click.Context, command: str) -> None:
     for doc in docs:
         fcommand = papis.format.format(command, doc)
         splitted_command = shlex.split(fcommand)
-        logger.info("Calling '%s'", splitted_command)
+        logger.info("Calling command '%s'.", splitted_command)
         call(splitted_command)
 
 

--- a/papis/commands/export.py
+++ b/papis/commands/export.py
@@ -61,6 +61,7 @@ import papis.database
 import papis.strings
 import papis.plugin
 import papis.logging
+from papis.exceptions import DocumentFolderNotFound
 
 logger = papis.logging.get_logger(__name__)
 
@@ -154,7 +155,7 @@ def cli(query: str,
             _doc_folder_name = document.get_main_folder_name()
             outdir = out or _doc_folder_name
             if not _doc_folder or not _doc_folder_name or not outdir:
-                raise Exception(papis.strings.no_folder_attached_to_document)
+                raise DocumentFolderNotFound(papis.document.describe(document))
             if not len(documents) == 1:
                 outdir = os.path.join(out, _doc_folder_name)
             logger.info(

--- a/papis/commands/export.py
+++ b/papis/commands/export.py
@@ -128,7 +128,7 @@ def cli(query: str,
         return
 
     if fmt and folder:
-        logger.warning("Only --folder flag will be considered (--fmt ignored)")
+        logger.warning("Only --folder flag will be considered (--fmt ignored).")
 
     # Get the local folder of the document so that third-party apps
     # can actually go to the folder without checking with papis
@@ -139,11 +139,11 @@ def cli(query: str,
 
     if ret_string is not None and not folder:
         if out is not None:
-            logger.info("Dumping to '%s'", out)
+            logger.info("Dumping to '%s'.", out)
             with open(out, "a+") as fd:
                 fd.write(ret_string)
         else:
-            logger.info("Dumping to stdout")
+            logger.info("Dumping to STDOUT.")
             click.echo(ret_string)
         return
 
@@ -158,7 +158,7 @@ def cli(query: str,
             if not len(documents) == 1:
                 outdir = os.path.join(out, _doc_folder_name)
             logger.info(
-                "Exporting doc '%s' to '%s'",
+                "Exporting document '%s' to '%s'.",
                 papis.document.describe(document), outdir)
             shutil.copytree(_doc_folder, outdir)
 
@@ -192,7 +192,7 @@ def explorer(ctx: click.Context, fmt: str, out: str) -> None:
     if out is not None:
         with open(out, "a+") as fd:
             logger.info(
-                "Writing %d documents in %s into '%s'", len(docs), fmt, out)
+                "Writing %d documents in '%s' format to '%s'.", len(docs), fmt, out)
             fd.write(outstring)
     else:
         click.echo(outstring)

--- a/papis/commands/external.py
+++ b/papis/commands/external.py
@@ -67,7 +67,7 @@ def external_cli(ctx: click.core.Context, flags: List[str]) -> None:
     script = ctx.obj  # type: papis.commands.Script
     path = script.path
     if not path:
-        raise Exception("Path for script {} not found".format(script))
+        raise FileNotFoundError("Path for script '{}' not found".format(script))
 
     cmd = [path] + list(flags)
     logger.debug("Calling external command '%s'.", cmd)

--- a/papis/commands/external.py
+++ b/papis/commands/external.py
@@ -70,7 +70,7 @@ def external_cli(ctx: click.core.Context, flags: List[str]) -> None:
         raise Exception("Path for script {} not found".format(script))
 
     cmd = [path] + list(flags)
-    logger.debug("Calling '%s'", cmd)
+    logger.debug("Calling external command '%s'.", cmd)
 
     params = ctx.parent.params if ctx.parent else {}
     environ = os.environ.copy()

--- a/papis/commands/list.py
+++ b/papis/commands/list.py
@@ -100,7 +100,7 @@ def run(documents: List[papis.document.Document],
 
     if template is not None:
         if not os.path.exists(template):
-            logger.error("Template file '%s' not found", template)
+            logger.error("Template file '%s' not found.", template)
             return []
         with open(template) as fd:
             fmt = fd.read()

--- a/papis/commands/merge.py
+++ b/papis/commands/merge.py
@@ -47,16 +47,16 @@ def run(keep: papis.document.Document,
         to_folder = keep.get_main_folder()
         if to_folder:
             import shutil
-            logger.info("Moving %s", f)
+            logger.info("Moving '%s' to '%s'.", f, to_folder)
             shutil.copy(f, to_folder)
             keep["files"] += [os.path.basename(f)]
     papis.commands.update.run(keep, data, git=git)
 
     if not keep_both:
-        logger.info("Removing '%s'", erase)
+        logger.info("Removing '%s'.", papis.document.describe(erase))
         papis.commands.rm.run(erase, git=git)
     else:
-        logger.info("Keeping both documents")
+        logger.info("Keeping both documents.")
 
 
 @click.command("merge")
@@ -141,7 +141,6 @@ def cli(query: str,
         files += [doc.get_files()[i] for i in indices]
 
     if not papis.tui.utils.confirm("Are you sure you want to merge?"):
-        logger.info("Exiting safely")
         return
 
     keep = b if second else a
@@ -158,7 +157,7 @@ def cli(query: str,
             keep["files"] += [os.path.basename(f)]
         keep.update(data_a)
         keep.save()
-        logger.info("Saving the new document in '%s'", out)
+        logger.info("Saving the new document in '%s'.", out)
         return
 
     run(keep, erase, data_a, files, keep_both, git)

--- a/papis/commands/mv.py
+++ b/papis/commands/mv.py
@@ -33,7 +33,7 @@ def run(document: papis.document.Document,
     cmd = ["git", "-C", folder] if git else []
     cmd += ["mv", folder, new_folder_path]
     db = papis.database.get()
-    logger.debug(cmd)
+    logger.debug("Running command '%s'.", cmd)
 
     import subprocess
     subprocess.call(cmd)
@@ -41,7 +41,7 @@ def run(document: papis.document.Document,
     new_document_folder = os.path.join(
         new_folder_path,
         os.path.basename(folder))
-    logger.debug("New document folder: '%s'", new_document_folder)
+    logger.debug("New document folder: '%s'.", new_document_folder)
 
     document.set_folder(new_document_folder)
     db.add(document)
@@ -93,14 +93,14 @@ def cli(query: str,
                 completer=completer,
                 complete_while_typing=True
             ))
-    except Exception as e:
-        logger.error(e)
+    except Exception as exc:
+        logger.error("Failed to choose directory.", exc_info=exc)
         return
 
-    logger.info("new folder is '%s'", new_folder)
+    logger.info("New document folder: '%s'.", new_folder)
 
     if not os.path.exists(new_folder):
-        logger.info("Creating path %s", new_folder)
+        logger.info("Creating path '%s'.", new_folder)
         os.makedirs(new_folder, mode=papis.config.getint("dir-umask") or 0o666)
 
     run(document, new_folder, git=git)

--- a/papis/commands/mv.py
+++ b/papis/commands/mv.py
@@ -19,6 +19,7 @@ import papis.cli
 import papis.pick
 import papis.strings
 import papis.logging
+from papis.exceptions import DocumentFolderNotFound
 
 logger = papis.logging.get_logger(__name__)
 
@@ -29,7 +30,8 @@ def run(document: papis.document.Document,
 
     folder = document.get_main_folder()
     if not folder:
-        raise Exception(papis.strings.no_folder_attached_to_document)
+        raise DocumentFolderNotFound(papis.document.describe(document))
+
     cmd = ["git", "-C", folder] if git else []
     cmd += ["mv", folder, new_folder_path]
     db = papis.database.get()

--- a/papis/commands/open.py
+++ b/papis/commands/open.py
@@ -89,6 +89,7 @@ import papis.document
 import papis.format
 import papis.strings
 import papis.logging
+from papis.exceptions import DocumentFolderNotFound
 
 logger = papis.logging.get_logger(__name__)
 
@@ -102,7 +103,7 @@ def run(document: papis.document.Document,
 
     _doc_folder = document.get_main_folder()
     if _doc_folder is None:
-        raise Exception(papis.strings.no_folder_attached_to_document)
+        raise DocumentFolderNotFound(papis.document.describe(document))
 
     if folder:
         # Open directory
@@ -116,11 +117,11 @@ def run(document: papis.document.Document,
                 _mark_name = papis.config.getstring("mark-format-name")
                 _mark_opener = papis.config.getstring("mark-opener-format")
                 if not _mark_fmt:
-                    raise Exception(
+                    raise ValueError(
                         "No mark header format given. Set 'mark-header-format' in "
                         "the configuration file")
                 if not _mark_name:
-                    raise Exception(
+                    raise ValueError(
                         "No mark name format given. Set 'mark-format-name' "
                         "in the configuration file")
                 mark_dict = papis.api.pick(
@@ -131,7 +132,7 @@ def run(document: papis.document.Document,
                         _mark_fmt, x, doc_key=_mark_name))
                 if mark_dict:
                     if not _mark_opener:
-                        raise Exception(
+                        raise ValueError(
                             "No mark opener format given. Set 'mark-opener-format' "
                             "in the configuration file")
                     opener = papis.format.format(

--- a/papis/commands/open.py
+++ b/papis/commands/open.py
@@ -117,11 +117,12 @@ def run(document: papis.document.Document,
                 _mark_opener = papis.config.getstring("mark-opener-format")
                 if not _mark_fmt:
                     raise Exception(
-                        "No mark header format. Set 'mark-header-format' in "
-                        "the configuration file.")
+                        "No mark header format given. Set 'mark-header-format' in "
+                        "the configuration file")
                 if not _mark_name:
-                    raise Exception("No mark name format. Set 'mark-format-name' "
-                                    "in the configuration file.")
+                    raise Exception(
+                        "No mark name format given. Set 'mark-format-name' "
+                        "in the configuration file")
                 mark_dict = papis.api.pick(
                     marks,
                     header_filter=lambda x: papis.format.format(
@@ -130,7 +131,9 @@ def run(document: papis.document.Document,
                         _mark_fmt, x, doc_key=_mark_name))
                 if mark_dict:
                     if not _mark_opener:
-                        raise Exception("mark-opener-format not set")
+                        raise Exception(
+                            "No mark opener format given. Set 'mark-opener-format' "
+                            "in the configuration file")
                     opener = papis.format.format(
                         _mark_opener,
                         papis.document.from_data(mark_dict[0]),

--- a/papis/commands/open.py
+++ b/papis/commands/open.py
@@ -109,17 +109,19 @@ def run(document: papis.document.Document,
         papis.api.open_dir(_doc_folder)
     else:
         if mark:
-            logger.debug("Getting document's marks")
+            logger.debug("Getting document's marks.")
             marks = document[papis.config.getstring("mark-key-name")]
             if marks:
-                logger.info("Picking marks")
                 _mark_fmt = papis.config.getstring("mark-header-format")
                 _mark_name = papis.config.getstring("mark-format-name")
                 _mark_opener = papis.config.getstring("mark-opener-format")
                 if not _mark_fmt:
-                    raise Exception("No mark header format")
+                    raise Exception(
+                        "No mark header format. Set 'mark-header-format' in "
+                        "the configuration file.")
                 if not _mark_name:
-                    raise Exception("No mark name format")
+                    raise Exception("No mark name format. Set 'mark-format-name' "
+                                    "in the configuration file.")
                 mark_dict = papis.api.pick(
                     marks,
                     header_filter=lambda x: papis.format.format(
@@ -133,11 +135,12 @@ def run(document: papis.document.Document,
                         _mark_opener,
                         papis.document.from_data(mark_dict[0]),
                         doc_key=_mark_name)
-                    logger.info("Setting opener to '%s'", opener)
+                    logger.info("Setting opener to '%s'.", opener)
                     papis.config.set("opentool", opener)
         files = document.get_files()
         if not files:
-            logger.error("The document chosen has no files attached")
+            logger.error("The chosen document has no files attached: '%s'.",
+                         papis.document.describe(document))
             return
         files_to_open = papis.api.pick(files, header_filter=os.path.basename)
         for file_to_open in files_to_open:

--- a/papis/commands/rename.py
+++ b/papis/commands/rename.py
@@ -19,6 +19,7 @@ import papis.pick
 import papis.document
 import papis.tui.utils
 import papis.logging
+from papis.exceptions import DocumentFolderNotFound
 
 logger = papis.logging.get_logger(__name__)
 
@@ -29,7 +30,7 @@ def run(document: papis.document.Document,
     folder = document.get_main_folder()
 
     if not folder:
-        raise Exception(papis.strings.no_folder_attached_to_document)
+        raise DocumentFolderNotFound(papis.document.describe(document))
 
     subfolder = os.path.dirname(folder)
 

--- a/papis/commands/rename.py
+++ b/papis/commands/rename.py
@@ -36,23 +36,23 @@ def run(document: papis.document.Document,
     new_folder_path = os.path.join(subfolder, new_name)
 
     if os.path.exists(new_folder_path):
-        logger.warning("Path '%s' already exists", new_folder_path)
+        logger.warning("Path '%s' already exists.", new_folder_path)
         return
 
     cmd = ["git", "-C", folder] if git else []
     cmd += ["mv", folder, new_folder_path]
 
     import subprocess
-    logger.debug(cmd)
+    logger.debug("Running command '%s'.", cmd)
     subprocess.call(cmd)
 
     if git:
         papis.git.commit(
             new_folder_path,
-            "Rename from {} to '{}'".format(folder, new_name))
+            "Rename from '{}' to '{}'".format(folder, new_name))
 
     db.delete(document)
-    logger.debug("New document folder: '%s'", new_folder_path)
+    logger.debug("New document folder: '%s'.", new_folder_path)
     document.set_folder(new_folder_path)
     db.add(document)
 

--- a/papis/commands/rm.py
+++ b/papis/commands/rm.py
@@ -124,7 +124,7 @@ def cli(query: str,
                 if not papis.tui.utils.confirm(
                         "Are you sure?", bottom_toolbar=tbar):
                     continue
-            logger.info("Removing '%s'...", filepath)
+            logger.info("Removing file '%s' from document.", filepath)
             run(document, filepath=filepath, git=git)
 
     if _notes:
@@ -140,14 +140,13 @@ def cli(query: str,
                 if not papis.tui.utils.confirm(
                         "Are you sure?", bottom_toolbar=tbar):
                     continue
-            logger.info("Removing '%s'...", notespath)
+            logger.info("Removing notes: '%s'.", notespath)
             run(document, notespath=notespath, git=git)
 
     if not (_file or _notes):
         for document in documents:
             if not force:
-                logger.warning("Folder to be removed: '%s'",
-                               document.get_main_folder())
+                logger.warning("Removing folder: '%s'.", document.get_main_folder())
                 logger.warning("The following document will be removed:")
                 papis.tui.utils.text_area(
                     text=papis.document.dump(document),
@@ -156,5 +155,5 @@ def cli(query: str,
                         "Do you want to remove the document?"):
                     continue
 
-            logger.warning("Removing ...")
             run(document, git=git)
+            logger.warning("Document removed: '%s'.", papis.document.describe(document))

--- a/papis/commands/rm.py
+++ b/papis/commands/rm.py
@@ -19,6 +19,7 @@ import papis.strings
 import papis.database
 import papis.git
 import papis.logging
+from papis.exceptions import DocumentFolderNotFound
 
 logger = papis.logging.get_logger(__name__)
 
@@ -32,7 +33,7 @@ def run(document: papis.document.Document,
     db = papis.database.get()
     _doc_folder = document.get_main_folder()
     if not _doc_folder:
-        raise Exception(papis.strings.no_folder_attached_to_document)
+        raise DocumentFolderNotFound(papis.document.describe(document))
 
     if filepath is not None:
         os.remove(filepath)

--- a/papis/commands/run.py
+++ b/papis/commands/run.py
@@ -71,10 +71,11 @@ def run(folder: str, command: Optional[List[str]] = None) -> int:
     if command is None:
         command = []
 
-    logger.debug("Changing directory to '%s'", folder)
+    logger.debug("Changing directory to '%s'.", folder)
     os.chdir(os.path.expanduser(folder))
     commandstr = " ".join(command)
-    logger.debug("Command: %s", commandstr)
+
+    logger.debug("Running command '%s'.", commandstr)
     return os.system(commandstr)
 
 

--- a/papis/commands/serve.py
+++ b/papis/commands/serve.py
@@ -280,7 +280,7 @@ class PapisRequestHandler(http.server.BaseHTTPRequestHandler):
                 self.wfile.write(f.read())
             self.wfile.flush()
         else:
-            raise Exception("File {} does not exist".format(path))
+            raise FileNotFoundError("File '{}' does not exist".format(path))
 
     def process_routes(self,
                        routes: List[Tuple[str, Any]]) -> None:
@@ -311,8 +311,9 @@ class PapisRequestHandler(http.server.BaseHTTPRequestHandler):
         db = papis.database.get(libname)
         doc = db.find_by_id(papis_id)
         if not doc:
-            raise Exception("Document with ref %s not "
-                            "found in the database" % papis_id)
+            raise ValueError(
+                "Document with ref '{}' not found in the database".format(papis_id)
+                )
         return doc
 
     def _get_form(self, method: str = "POST") -> cgi.FieldStorage:
@@ -404,7 +405,8 @@ class PapisRequestHandler(http.server.BaseHTTPRequestHandler):
                 self.wfile.write(f.read())
                 self.wfile.flush()
             return
-        raise Exception("File {} does not exist".format(path))
+
+        raise FileNotFoundError("File '{}' does not exist".format(path))
 
     def do_POST(self) -> None:              # noqa: N802
         """

--- a/papis/commands/serve.py
+++ b/papis/commands/serve.py
@@ -197,9 +197,9 @@ class PapisRequestHandler(http.server.BaseHTTPRequestHandler):
         self._redirect_back()
 
     def get_libraries(self) -> None:
-        logger.info("getting libraries")
+        logger.info("Getting libraries.")
         libs = papis.api.get_libraries()
-        logger.debug("%s", libs)
+        logger.debug("Found libraries: '%s'.", "', '".join(libs))
 
         self._ok()
         self._header_json()
@@ -207,7 +207,7 @@ class PapisRequestHandler(http.server.BaseHTTPRequestHandler):
         self._send_json(libs)
 
     def get_library(self, libname: str) -> None:
-        logger.info(libname)
+        logger.info("Getting library '%s'.", libname)
         lib = papis.config.get_lib_from_name(libname)
 
         self._ok()
@@ -223,7 +223,7 @@ class PapisRequestHandler(http.server.BaseHTTPRequestHandler):
     def get_query(self, libname: str, query: str) -> None:
         self._handle_lib(libname)
         cleaned_query = urllib.parse.unquote(query)
-        logger.info("Querying in lib %s for <%s>", libname, cleaned_query)
+        logger.info("Querying in library '%s' for '%s'.", libname, cleaned_query)
         docs = papis.api.get_documents_in_lib(libname, cleaned_query)
         self.serve_documents(docs)
 
@@ -232,7 +232,7 @@ class PapisRequestHandler(http.server.BaseHTTPRequestHandler):
         Serve a list of documents and set the files attribute to
         the full paths so that the user can reach them.
         """
-        logger.info("serving %s documents", len(docs))
+        logger.info("Serving %s documents.", len(docs))
 
         # get absolute paths for files
         for d in docs:
@@ -343,18 +343,18 @@ class PapisRequestHandler(http.server.BaseHTTPRequestHandler):
         new_info = form.getvalue("value")
         info_path = doc.get_info_file()
 
-        logger.info("checking syntax of the yaml")
+        logger.info("Checking syntax of the info file: '%s'.", info_path)
         with tempfile.NamedTemporaryFile(mode="w+", delete=False) as fdr:
             fdr.write(new_info)
         try:
             papis.yaml.yaml_to_data(fdr.name, raise_exception=True)
         except ValueError as e:
-            self._send_json_error(404, "Error in yaml: {}".format(e))
+            self._send_json_error(404, "Error in info file: {}".format(e))
             os.unlink(fdr.name)
             return
         else:
             os.unlink(fdr.name)
-            logger.info("info text seems ok")
+            logger.info("Info file is valid.")
             with open(info_path, "w+") as _fdr:
                 _fdr.write(new_info)
             doc.load()
@@ -489,11 +489,11 @@ def cli(address: str, port: int, git: bool) -> None:
     if not papis.web.pdfjs.detect_pdfjs():
         logger.warning(papis.web.pdfjs.error_message())
 
-    logger.info("starting server in address http://%s:%s",
+    logger.info("Starting server in address 'http://%s:%s'.",
                 address or "localhost",
                 port)
-    logger.info("press Ctrl-C to exit")
-    logger.info("THIS COMMAND IS EXPERIMENTAL, "
-                "expect bugs, feedback appreciated")
+    logger.info("Press <Ctrl-C> to exit.")
+    logger.info("THIS COMMAND IS EXPERIMENTAL, expect bugs. Feedback appreciated!")
+
     httpd = http.server.HTTPServer(server_address, PapisRequestHandler)
     httpd.serve_forever()

--- a/papis/commands/update.py
+++ b/papis/commands/update.py
@@ -135,8 +135,7 @@ def cli(query: str,
     for document in documents:
         ctx = papis.importer.Context()
 
-        logger.info("Updating "
-                    "{c.Back.WHITE}{c.Fore.BLACK}%s{c.Style.RESET_ALL}",
+        logger.info("Updating {c.Back.WHITE}{c.Fore.BLACK}%s{c.Style.RESET_ALL}.",
                     papis.document.describe(document))
 
         ctx.data.update(document)
@@ -167,8 +166,8 @@ def cli(query: str,
                             importer.fetch()
                 except NotImplementedError:
                     continue
-                except Exception as e:
-                    logger.exception(e)
+                except Exception as exc:
+                    logger.exception("Failed to match document data.", exc_info=exc)
                 else:
                     if importer and importer.ctx:
                         matching_importers.append(importer)

--- a/papis/commands/update.py
+++ b/papis/commands/update.py
@@ -57,6 +57,7 @@ import papis.cli
 import papis.importer
 import papis.git
 import papis.logging
+from papis.exceptions import DocumentFolderNotFound
 
 logger = papis.logging.get_logger(__name__)
 
@@ -80,7 +81,7 @@ def run(document: papis.document.Document,
     folder = document.get_main_folder()
     info = document.get_info_file()
     if not folder or not info:
-        raise Exception(papis.strings.no_folder_attached_to_document)
+        raise DocumentFolderNotFound(papis.document.describe(document))
     if git:
         papis.git.add_and_commit_resource(
             folder, info,

--- a/papis/commands/update.py
+++ b/papis/commands/update.py
@@ -84,7 +84,7 @@ def run(document: papis.document.Document,
     if git:
         papis.git.add_and_commit_resource(
             folder, info,
-            "Update information for '{0}'".format(
+            "Update information for '{}'".format(
                 papis.document.describe(document)))
 
 

--- a/papis/config.py
+++ b/papis/config.py
@@ -342,7 +342,12 @@ def getint(key: str, section: Optional[str] = None) -> Optional[int]:
     >>> getint('something')
     42
     """
-    return general_get(key, section=section, data_type=int)
+    try:
+        return general_get(key, section=section, data_type=int)
+    except ValueError:
+        value = general_get(key, section=section)
+        raise ValueError("Key '{}' should be an integer: '{}' is of type '{}'"
+                         .format(key, value, type(key).__name__))
 
 
 def getfloat(key: str, section: Optional[str] = None) -> Optional[float]:
@@ -351,7 +356,12 @@ def getfloat(key: str, section: Optional[str] = None) -> Optional[float]:
     >>> getfloat('something')
     0.42
     """
-    return general_get(key, section=section, data_type=float)
+    try:
+        return general_get(key, section=section, data_type=float)
+    except ValueError:
+        value = general_get(key, section=section)
+        raise ValueError("Key '{}' should be a float: '{}' is of type '{}'"
+                         .format(key, value, type(key).__name__))
 
 
 def getboolean(key: str, section: Optional[str] = None) -> Optional[bool]:
@@ -360,7 +370,12 @@ def getboolean(key: str, section: Optional[str] = None) -> Optional[bool]:
     >>> getboolean('add-open')
     True
     """
-    return general_get(key, section=section, data_type=bool)
+    try:
+        return general_get(key, section=section, data_type=bool)
+    except ValueError:
+        value = general_get(key, section=section)
+        raise ValueError("Key '{}' should be a boolean: '{}' is of type '{}'"
+                         .format(key, value, type(key).__name__))
 
 
 def getstring(key: str, section: Optional[str] = None) -> str:
@@ -371,8 +386,9 @@ def getstring(key: str, section: Optional[str] = None) -> str:
     """
     result = general_get(key, section=section, data_type=str)
     if not isinstance(result, str):
-        raise ValueError("Key '{}' should be a string, not a '{}'"
-                         .format(key, type(key).__name__))
+        raise ValueError("Key '{}' should be a string: '{}' is of type '{}'"
+                         .format(key, result, type(key).__name__))
+
     return str(result)
 
 

--- a/papis/config.py
+++ b/papis/config.py
@@ -50,20 +50,19 @@ class Configuration(configparser.ConfigParser):
     def handle_includes(self) -> None:
         if "include" in self:
             for name in self["include"]:
-                logger.debug("Including '%s'", name)
                 fullpath = os.path.expanduser(self.get("include", name))
                 if os.path.exists(fullpath):
+                    logger.debug("Including file '%s'.", name)
                     self.read(fullpath)
                 else:
                     logger.warning(
-                        "'%s' not included because it does not exist",
+                        "'%s' not included because it does not exist.",
                         fullpath)
 
     def initialize(self) -> None:
         # ensure all configuration directories exist
         if not os.path.exists(self.dir_location):
-            logger.warning(
-                "Creating configuration folder in '%s'", self.dir_location)
+            logger.warning("Creating configuration folder in '%s'.", self.dir_location)
             os.makedirs(self.dir_location)
 
         if not os.path.exists(self.scripts_location):
@@ -73,7 +72,7 @@ class Configuration(configparser.ConfigParser):
 
         # load settings
         if os.path.exists(self.file_location):
-            logger.debug("Reading configuration from '%s'", self.file_location)
+            logger.debug("Reading configuration from '%s'.", self.file_location)
             try:
                 self.read(self.file_location)
                 self.handle_includes()
@@ -93,7 +92,7 @@ class Configuration(configparser.ConfigParser):
                     self[section][field] = self.default_info[section][field]
 
             with open(self.file_location, "w") as configfile:
-                logger.info("Creating config file at '%s'", self.file_location)
+                logger.info("Creating configuration file at '%s'.", self.file_location)
                 self.write(configfile)
 
         # ensure the general section and default-library exist in the config
@@ -114,7 +113,7 @@ class Configuration(configparser.ConfigParser):
         # evaluate the python config
         configpy = get_configpy_file()
         if os.path.exists(configpy):
-            logger.debug("Executing '%s'", configpy)
+            logger.debug("Executing configuration script '%s'.", configpy)
             with open(configpy) as fd:
                 exec(fd.read())
 
@@ -224,7 +223,7 @@ def get_config_file() -> str:
         config_file = _OVERRIDE_VARS["file"]
     else:
         config_file = os.path.join(get_config_folder(), "config")
-    logger.debug("Getting config file '%s'", config_file)
+    logger.debug("Getting config file '%s'.", config_file)
     return config_file
 
 
@@ -239,7 +238,7 @@ def set_config_file(filepath: str) -> None:
     """Override the main configuration file path
     """
     global _OVERRIDE_VARS
-    logger.debug("Setting config file to '%s'", filepath)
+    logger.debug("Setting config file to '%s'.", filepath)
     _OVERRIDE_VARS["file"] = filepath
 
 
@@ -408,7 +407,7 @@ def get_configuration() -> Configuration:
     """
     global _CONFIGURATION
     if _CONFIGURATION is None:
-        logger.debug("Creating configuration")
+        logger.debug("Creating configuration.")
         _CONFIGURATION = Configuration()
         # Handle local configuration file, and merge it if it exists
         local_config_file = papis.config.get("local-config-file")
@@ -427,7 +426,7 @@ def merge_configuration_from_path(path: Optional[str],
     """
     if path is None or not os.path.exists(path):
         return
-    logger.debug("Merging configuration from '%s'", path)
+    logger.debug("Merging configuration from '%s'.", path)
     configuration.read(path)
     configuration.handle_includes()
 
@@ -457,9 +456,7 @@ def get_lib_from_name(libname: str) -> papis.library.Library:
     if libname not in config:
         if os.path.isdir(libname):
             # Check if the path exists, then use this path as a new library
-            logger.warning(
-                "Since the path '%s' exists, interpreting it as a library",
-                libname)
+            logger.warning("Setting path '%s' as the main library folder.", libname)
             library_obj = papis.library.from_paths([libname])
             name = library_obj.path_format()
             # the configuration object can only store strings
@@ -553,5 +550,5 @@ def reset_configuration() -> Configuration:
     """
     global _CONFIGURATION
     _CONFIGURATION = None
-    logger.debug("Resetting configuration")
+    logger.debug("Resetting configuration.")
     return get_configuration()

--- a/papis/config.py
+++ b/papis/config.py
@@ -465,14 +465,14 @@ def get_lib_from_name(libname: str) -> papis.library.Library:
             # the configuration object can only store strings
             config[name] = {"dirs": str(library_obj.paths)}
         else:
-            raise Exception("Library '{0}' does not seem to exist"
-                            "\n\n"
-                            "To add a library simply write the following"
-                            " in your configuration file located at '{cpath}'"
-                            "\n\n"
-                            "\t[{0}]\n"
-                            "\tdir = path/to/your/{0}/folder"
-                            .format(libname, cpath=get_config_file()))
+            raise RuntimeError("Library '{0}' does not seem to exist"
+                               "\n\n"
+                               "To add a library simply write the following"
+                               " in your configuration file located at '{cpath}'"
+                               "\n\n"
+                               "\t[{0}]\n"
+                               "\tdir = path/to/your/{0}/folder"
+                               .format(libname, cpath=get_config_file()))
     else:
         try:
             paths = [os.path.expanduser(config[libname]["dir"])]
@@ -480,7 +480,7 @@ def get_lib_from_name(libname: str) -> papis.library.Library:
             try:
                 paths = eval(os.path.expanduser(config[libname].get("dirs")))
             except Exception as e:
-                raise Exception(
+                raise RuntimeError(
                     "To define a library you have to set either 'dir' or 'dirs' "
                     "in the configuration file.\n"
                     "\t'dir' must be a path to an existing folder.\n"

--- a/papis/config.py
+++ b/papis/config.py
@@ -371,7 +371,8 @@ def getstring(key: str, section: Optional[str] = None) -> str:
     """
     result = general_get(key, section=section, data_type=str)
     if not isinstance(result, str):
-        raise ValueError("Key {0} should be a string".format(key))
+        raise ValueError("Key '{}' should be a string, not a '{}'"
+                         .format(key, type(key).__name__))
     return str(result)
 
 
@@ -387,14 +388,16 @@ def getlist(key: str, section: Optional[str] = None) -> List[str]:
         return list(map(str, rawvalue))
     try:
         rawvalue = eval(rawvalue)
-    except Exception as e:
+    except Exception:
         raise SyntaxError(
-            "The key '{0}' must be a valid python object\n\t{1}"
-            .format(key, e))
+            "The key '{}' must be a valid Python object: {}"
+            .format(key, rawvalue))
     else:
         if not isinstance(rawvalue, list):
             raise SyntaxError(
-                "The key '{0}' must be a valid python list".format(key))
+                "The key '{}' must be a valid Python list. Got: {} (type {!r})"
+                .format(key, rawvalue, type(rawvalue).__name__))
+
         return list(map(str, rawvalue))
 
 
@@ -477,13 +480,12 @@ def get_lib_from_name(libname: str) -> papis.library.Library:
             try:
                 paths = eval(os.path.expanduser(config[libname].get("dirs")))
             except Exception as e:
-                raise Exception("To define a library you have to set either"
-                                " dir or dirs in the configuration file.\n"
-                                "\tdir must be a path to a single folder.\n"
-                                "\tdirs must be a python list of "
-                                "paths to folders.\n\n"
-                                "Error: ({0})"
-                                .format(e))
+                raise Exception(
+                    "To define a library you have to set either 'dir' or 'dirs' "
+                    "in the configuration file.\n"
+                    "\t'dir' must be a path to an existing folder.\n"
+                    "\t'dirs' must be a python list of paths.\n\n"
+                    "Error: {}".format(e))
         library_obj = papis.library.Library(libname, paths)
     return library_obj
 

--- a/papis/crossref.py
+++ b/papis/crossref.py
@@ -216,10 +216,11 @@ def get_data(
         filters = {}
 
     if filters:
-        if not set(filters) & _filter_names == set(filters):
-            raise Exception(
-                "Filter keys must be one of {0}"
-                .format(",".join(_filter_names))
+        unknown_filters = set(filters) - _filter_names
+        if unknown_filters:
+            raise ValueError(
+                "Unknown filters '{}'. Filter keys must be one of '{}'"
+                .format("', '".join(unknown_filters), "', '".join(_filter_names))
             )
     data = {
         "query": query,
@@ -268,7 +269,8 @@ def doi_to_data(doi_string: str) -> Dict[str, Any]:
     results = get_data(dois=[doi_string])
     if results:
         return results[0]
-    raise ValueError("Couldn't get data for doi ({})".format(doi_string))
+    raise ValueError(
+        "Could not retrieve data for DOI '{}' from Crossref".format(doi_string))
 
 
 @click.command("crossref")

--- a/papis/database/__init__.py
+++ b/papis/database/__init__.py
@@ -33,7 +33,7 @@ def _instantiate_database(backend_name: str, library: Library) -> Database:
         import papis.database.whoosh
         return papis.database.whoosh.Database(library)
     else:
-        raise Exception("No valid database type: {}".format(backend_name))
+        raise ValueError("Invalid database backend: '{}'".format(backend_name))
 
 
 def get_all_query_string() -> str:

--- a/papis/database/base.py
+++ b/papis/database/base.py
@@ -48,7 +48,8 @@ class Database(ABC):
         :param document: Document to be matched
         :param query_string: Query string
         """
-        raise NotImplementedError("Match not defined for this class")
+        raise NotImplementedError(
+            "Match not defined for backend '{}'".format(self.get_backend_name()))
 
     @abstractmethod
     def clear(self) -> None:
@@ -88,9 +89,8 @@ class Database(ABC):
         if len(results) > 1:
             raise ValueError("More than one document matches the unique id '{}'"
                              .format(identifier))
-        if results:
-            return results[0]
-        return None
+
+        return results[0] if results else None
 
     @staticmethod
     def get_id_key() -> str:

--- a/papis/database/cache.py
+++ b/papis/database/cache.py
@@ -247,6 +247,8 @@ class Database(papis.database.base.Database):
             lambda d: d[1].get_main_folder() == document.get_main_folder(),
             enumerate(self.get_documents())))
         if not result:
-            raise Exception(
-                "The document passed could not be found in the library")
+            raise ValueError(
+                "The document passed could not be found in the library: '{}'"
+                .format(papis.document.describe(document)))
+
         return result

--- a/papis/database/whoosh.py
+++ b/papis/database/whoosh.py
@@ -79,17 +79,17 @@ class Database(papis.database.base.Database):
     def clear(self) -> None:
         import shutil
         if self.index_exists():
-            logger.warning("Clearing the database")
+            logger.warning("Clearing the database.")
             shutil.rmtree(self.index_dir)
 
     def add(self, document: papis.document.Document) -> None:
         schema_keys = self.get_schema_init_fields().keys()
 
-        logger.debug("Adding document...")
+        logger.debug("Adding document: '%s'.", papis.document.describe(document))
         writer = self.get_writer()
         self.add_document_with_writer(document, writer, schema_keys)
 
-        logger.debug("Committing document..")
+        logger.debug("Committing document: '%s'.", papis.document.describe(document))
         writer.commit()
 
     def update(self, document: papis.document.Document) -> None:
@@ -101,12 +101,12 @@ class Database(papis.database.base.Database):
     def delete(self, document: papis.document.Document) -> None:
         writer = self.get_writer()
 
-        logger.debug("Deleting document..")
+        logger.debug("Deleting document: '%s'.", papis.document.describe(document))
         writer.delete_by_term(
             Database.get_id_key(),
             self.get_id_value(document))
 
-        logger.debug("Committing deletion..")
+        logger.debug("Committing document: '%s'.", papis.document.describe(document))
         writer.commit()
 
     def query_dict(self,
@@ -116,7 +116,7 @@ class Database(papis.database.base.Database):
         return self.query(query_string)
 
     def query(self, query_string: str) -> List[papis.document.Document]:
-        logger.debug("Querying '%s'...", query_string)
+        logger.debug("Querying database for '%s'.", query_string)
 
         import whoosh.qparser
         index = self.get_index()
@@ -126,7 +126,7 @@ class Database(papis.database.base.Database):
         query = qp.parse(query_string)
         with index.searcher() as searcher:
             results = searcher.search(query, limit=None)
-            logger.debug(results)
+            logger.debug("Found %d results: %s", len(results), results)
             documents = [
                 papis.document.from_folder(r.get("papis-folder"))
                 for r in results]
@@ -158,9 +158,9 @@ class Database(papis.database.base.Database):
         """Create a brand new index, notice that if an index already
         exists it will delete it and create a new one.
         """
-        logger.debug("Creating index...")
+        logger.debug("Creating index.")
         if not os.path.exists(self.index_dir):
-            logger.debug("Creating index directory '%s'", self.index_dir)
+            logger.debug("Creating index directory '%s'.", self.index_dir)
             os.makedirs(self.index_dir)
 
         import whoosh.index
@@ -231,7 +231,7 @@ class Database(papis.database.base.Database):
             # aren't the same, then we have to rebuild the
             # database.
             if user_field_names != db_field_names:
-                logger.debug("Rebuilding database because field names do not match")
+                logger.debug("Rebuilding database because field names do not match.")
                 self.rebuild()
             else:
                 # Otherwise, verify that the fields are
@@ -241,14 +241,14 @@ class Database(papis.database.base.Database):
                 for field in user_field_names:
                     if user_fields[field] != db_fields[field]:
                         logger.debug(
-                            "Rebuilding database because field types do not match")
+                            "Rebuilding database because field types do not match.")
 
                         self.rebuild()
                         rebuilt_db = True
                         break
 
                 if not rebuilt_db:
-                    logger.debug("Initialized index found for library")
+                    logger.debug("Initialized index found for library.")
                     return
         self.create_index()
         self.do_indexing()
@@ -277,7 +277,7 @@ class Database(papis.database.base.Database):
     def create_schema(self) -> "Schema":
         """Creates and returns whoosh schema to be applied to the library
         """
-        logger.debug("Creating schema...")
+        logger.debug("Creating schema.")
         fields = self.get_schema_init_fields()
 
         from whoosh.fields import Schema

--- a/papis/database/whoosh.py
+++ b/papis/database/whoosh.py
@@ -49,6 +49,7 @@ import papis.logging
 import papis.database.base
 import papis.database.cache
 from papis.utils import get_cache_home, get_folders, folders_to_documents
+from papis.exceptions import DocumentFolderNotFound
 
 if TYPE_CHECKING:
     from whoosh.index import Index
@@ -150,7 +151,7 @@ class Database(papis.database.base.Database):
     def _get_doc_folder(self, document: papis.document.Document) -> str:
         _folder = document.get_main_folder()
         if _folder is None:
-            raise Exception(papis.strings.no_folder_attached_to_document)
+            raise DocumentFolderNotFound(papis.document.describe(document))
         else:
             return _folder
 

--- a/papis/dblp.py
+++ b/papis/dblp.py
@@ -138,7 +138,7 @@ def get_data(query: str = "", max_results: int = 30) -> List[Dict[str, Any]]:
     hits = result["hits"].get("hit")
 
     if hits is None:
-        logger.error("Could not retrieve results from DBLP. Error: '%s'",
+        logger.error("Could not retrieve results from DBLP. Error: '%s'.",
                      result["status"]["text"])
         return []
 
@@ -183,13 +183,13 @@ def explorer(
 
         papis explore dblp -a 'Albert einstein' pick export --bibtex lib.bib
     """
-    logger.info("Looking up...")
+    logger.info("Looking up DBLP documents...")
 
     data = get_data(query=query, max_results=max_results)
     docs = [papis.document.from_data(data=d) for d in data]
     ctx.obj["documents"] += docs
 
-    logger.info("%s documents found", len(docs))
+    logger.info("Found %d documents.", len(docs))
 
 
 class Importer(papis.importer.Importer):
@@ -220,7 +220,7 @@ class Importer(papis.importer.Importer):
             response = session.get(url)
 
         if not response.ok:
-            logger.error("Could not get BibTeX entry for '%s'", self.uri)
+            logger.error("Could not get BibTeX entry for '%s'.", self.uri)
             return
 
         entries = papis.bibtex.bibtex_to_dict(response.content.decode())

--- a/papis/dissemin.py
+++ b/papis/dissemin.py
@@ -57,7 +57,7 @@ def get_data(query: str = "") -> List[Dict[str, Any]]:
         response = session.get(DISSEMIN_API_URL, params={"q": query})
 
     if not response.ok:
-        logger.error("An HTTP error (%d %s) was encountered for query: '%s'",
+        logger.error("An HTTP error (%d %s) was encountered for query: '%s'.",
                      response.status_code, response.reason, query)
         return []
 
@@ -78,10 +78,10 @@ def explorer(ctx: click.core.Context, query: str) -> None:
     papis explore dissemin -q 'Albert einstein' pick cmd 'firefox {doc[url]}'
 
     """
-    logger.info("Looking up...")
+    logger.info("Looking up Dissemin documents...")
 
     data = get_data(query=query)
     docs = [papis.document.from_data(data=d) for d in data]
     ctx.obj["documents"] += docs
 
-    logger.info("%s documents found", len(docs))
+    logger.info("Found %s documents.", len(docs))

--- a/papis/docmatcher.py
+++ b/papis/docmatcher.py
@@ -165,7 +165,7 @@ def get_regex_from_search(search: str) -> Pattern[str]:
 
 def parse_query(query_string: str) -> List[ParseResult]:
     import pyparsing
-    logger.debug("Parsing query: '%s'", query_string)
+    logger.debug("Parsing query: '%s'.", query_string)
 
     papis_key_word = pyparsing.Word(pyparsing.alphanums + "-._/")
     papis_value_word = pyparsing.Word(pyparsing.alphanums + "-._/()")
@@ -190,7 +190,7 @@ def parse_query(query_string: str) -> List[ParseResult]:
         )
     )
     parsed = papis_query.parseString(query_string)
-    logger.debug("Parsed query: '%s'", parsed)
+    logger.debug("Parsed query: '%s'.", parsed)
 
     # convert pyparsing results to our format
     results = []

--- a/papis/document.py
+++ b/papis/document.py
@@ -118,9 +118,9 @@ def keyconversion_to_data(conversions: Sequence[KeyConversionPair],
             if action:
                 try:
                     new_value = action(papis_value)
-                except Exception as ex:
-                    logger.debug("Error while trying to parse '%s' (%s)",
-                                 papis_key, ex)
+                except Exception as exc:
+                    logger.debug("Error while trying to parse '%s' (%s).",
+                                 papis_key, exc_info=exc)
                     new_value = None
             else:
                 new_value = papis_value
@@ -340,10 +340,10 @@ class Document(Dict[str, Any]):
 
         try:
             data = papis.yaml.yaml_to_data(info_file, raise_exception=True)
-        except Exception as ex:
+        except Exception as exc:
             logger.error(
-                "Error reading info file in '%s'. Please check it!\n%s",
-                info_file, ex)
+                "Error reading info file at '%s'. Please check it!",
+                self.get_info_file(), exc_info=exc)
         else:
             self.update(data)
 
@@ -507,7 +507,7 @@ def sort(docs: Sequence[Document], key: str, reverse: bool = False) -> List[Docu
             -priority.value if reverse else priority.value,
             date, int_value, str_value)
 
-    logger.debug("Sorting %d documents", len(docs))
+    logger.debug("Sorting %d documents.", len(docs))
     return sorted(docs, key=document_sort_key, reverse=reverse)
 
 

--- a/papis/document.py
+++ b/papis/document.py
@@ -167,8 +167,8 @@ def author_list_to_author(data: Dict[str, Any]) -> str:
 
     if separator is None or fmt is None:
         raise Exception(
-            "You have to define 'multiple-author-separator'"
-            " and 'multiple-author-format'")
+            "Cannot join the author list if the settings 'multiple-authors-separator' "
+            "and 'multiple-authors-format' are not present in the configuration")
 
     return separator.join([
         fmt.format(au=author) for author in data["author_list"]
@@ -442,7 +442,7 @@ def move(document: Document, path: str) -> None:
     >>> move(doc, newfolder)
     Traceback (most recent call last):
     ...
-    Exception: There is already...
+    FileExistsError: There is already...
     """
     folder = document.get_main_folder()
     if not folder:
@@ -451,8 +451,8 @@ def move(document: Document, path: str) -> None:
     path = os.path.expanduser(path)
     if os.path.exists(path):
         raise Exception(
-            "There is already a document in {0}, please check it,\n"
-            "a temporary papis document has been stored in {1}"
+            "There is already a document at '{}' that should be checked. A temporary"
+            "document has been stored at '{}'"
             .format(path, folder)
         )
 

--- a/papis/document.py
+++ b/papis/document.py
@@ -166,7 +166,7 @@ def author_list_to_author(data: Dict[str, Any]) -> str:
     fmt = papis.config.getstring("multiple-authors-format")
 
     if separator is None or fmt is None:
-        raise Exception(
+        raise ValueError(
             "Cannot join the author list if the settings 'multiple-authors-separator' "
             "and 'multiple-authors-format' are not present in the configuration")
 
@@ -450,7 +450,7 @@ def move(document: Document, path: str) -> None:
 
     path = os.path.expanduser(path)
     if os.path.exists(path):
-        raise Exception(
+        raise FileExistsError(
             "There is already a document at '{}' that should be checked. A temporary"
             "document has been stored at '{}'"
             .format(path, folder)

--- a/papis/downloaders/__init__.py
+++ b/papis/downloaders/__init__.py
@@ -150,7 +150,8 @@ class Downloader(papis.importer.Importer):
     @classmethod
     def match(cls, url: str) -> Optional["Downloader"]:
         raise NotImplementedError(
-            "Matching uri not implemented for this importer")
+            "Matching URI not implemented for '{}.{}'"
+            .format(cls.__module__, cls.__name__))
 
     def _get_body(self) -> bytes:
         """Get body of the uri, this is also important for unittesting"""
@@ -179,7 +180,8 @@ class Downloader(papis.importer.Importer):
         :returns: Bibtex url
         """
         raise NotImplementedError(
-            "Getting bibtex url not implemented for this downloader")
+            "Getting a BibTeX URL not implemented for the '{}' downloader".
+            format(self.name))
 
     def get_bibtex_data(self) -> Optional[str]:
         """Get the bibtex_data data if it has been downloaded already
@@ -213,14 +215,16 @@ class Downloader(papis.importer.Importer):
         :returns: Document url
         """
         raise NotImplementedError(
-            "Getting bibtex url not implemented for this downloader")
+            "Getting a document URL not implemented for the '{}' downloader"
+            .format(self.name))
 
     def get_data(self) -> Dict[str, Any]:
         """A general data retriever, for instance when data needn't need
         to come from a bibtex
         """
         raise NotImplementedError(
-            "Getting general data is not implemented for this downloader")
+            "Getting data is not implemented for the '{}' downloader"
+            .format(self.name))
 
     def get_doi(self) -> Optional[str]:
         """It returns the doi of the document, if it is retrievable.
@@ -230,7 +234,8 @@ class Downloader(papis.importer.Importer):
         :returns: Document doi
         """
         raise NotImplementedError(
-            "Getting document url not implemented for this downloader")
+            "Getting the DOI not implemented for the '{}' downloader"
+            .format(self.name))
 
     def get_document_data(self) -> Optional[bytes]:
         """Get the document_data data if it has been downloaded already

--- a/papis/downloaders/__init__.py
+++ b/papis/downloaders/__init__.py
@@ -37,7 +37,7 @@ class Importer(papis.importer.Importer):
         )
 
     def fetch(self) -> None:
-        self.logger.info("Attempting to import from url '%s'", self.uri)
+        self.logger.info("Attempting to import from URL '%s'.", self.uri)
         self.ctx = get_info_from_url(self.uri) or papis.importer.Context()
 
     def fetch_data(self) -> None:
@@ -71,7 +71,6 @@ class Downloader(papis.importer.Importer):
             ctx=ctx,
             name=name or os.path.basename(__file__))
         self.logger = papis.logging.get_logger("papis.downloader.{}".format(self.name))
-        self.logger.debug("uri '%s'", uri)
 
         self.expected_document_extension = expected_document_extension
         self.priority = priority
@@ -113,10 +112,10 @@ class Downloader(papis.importer.Importer):
                 if datalist:
                     if len(datalist) > 1:
                         self.logger.warning(
-                            "'%s' found %d BibTeX entries. Picking first one.",
+                            "'%s' found %d BibTeX entries. Picking the first one!",
                             self.name, len(datalist))
 
-                    self.logger.info("Merging data from BibTeX")
+                    self.logger.info("Merging data from BibTeX.")
                     self.ctx.data.update(datalist[0])
 
         # try getting doi
@@ -141,7 +140,7 @@ class Downloader(papis.importer.Importer):
                 with tempfile.NamedTemporaryFile(
                         mode="wb+", delete=False) as f:
                     f.write(doc_rawdata)
-                    self.logger.info("Saving downloaded file in '%s'", f.name)
+                    self.logger.info("Saving downloaded file in '%s'.", f.name)
                     self.ctx.files.append(f.name)
 
     def fetch(self) -> None:
@@ -201,7 +200,7 @@ class Downloader(papis.importer.Importer):
         url = self.get_bibtex_url()
         if not url:
             return
-        self.logger.info("Downloading bibtex from '%s'", url)
+        self.logger.info("Downloading BibTeX from '%s'.", url)
 
         response = self.session.get(url, cookies=self.cookies)
         self.bibtex_data = response.content.decode()
@@ -252,7 +251,7 @@ class Downloader(papis.importer.Importer):
         url = self.get_document_url()
         if not url:
             return
-        self.logger.info("Downloading file from '%s'", url)
+        self.logger.info("Downloading file from '%s'.", url)
 
         response = self.session.get(url, cookies=self.cookies)
         self.document_data = response.content
@@ -268,7 +267,7 @@ class Downloader(papis.importer.Importer):
         def print_warning() -> None:
             self.logger.error(
                 "The downloaded data does not seem to be of "
-                "the correct type ('%s')",
+                "the expected '%s' type.",
                 self.expected_document_extension)
 
         if self.expected_document_extension is None:
@@ -285,7 +284,7 @@ class Downloader(papis.importer.Importer):
             print_warning()
             return False
 
-        self.logger.debug("Retrieved kind of document seems to be '%s'", extension)
+        self.logger.debug("Retrieved document type seems to be '%s'.", extension)
 
         if isinstance(self.expected_document_extension, list):
             expected_document_extensions = self.expected_document_extension
@@ -314,7 +313,7 @@ def get_matching_downloaders(url: str) -> Sequence[Downloader]:
     :returns: A list of downloaders (sorted by priority).
     """
     available_downloaders = get_available_downloaders()
-    logger.debug("Available downloaders: '%s'",
+    logger.debug("Found available downloaders: '%s'.",
                  "', '".join([d.__module__ for d in available_downloaders]))
 
     matches = [d
@@ -322,7 +321,7 @@ def get_matching_downloaders(url: str) -> Sequence[Downloader]:
                for d in [maybe_downloader.match(url)]
                if d is not None]  # List[Downloader]
 
-    logger.debug("Downloaders matching '%s': '%s'",
+    logger.debug("Found downloaders matching query '%s': '%s'.",
                  url,
                  "', '".join([d.name for d in matches]))
 
@@ -353,13 +352,13 @@ def get_info_from_url(
 
     downloaders = get_matching_downloaders(url)
     if not downloaders:
-        logger.warning("No matching downloader found for '%s'", url)
+        logger.warning("No matching downloader found for '%s'.", url)
         return papis.importer.Context()
 
-    logger.debug("Found %d matching downloaders", len(downloaders))
+    logger.debug("Found %d matching downloaders.", len(downloaders))
     downloader = downloaders[0]
 
-    logger.info("Using downloader '%s'", downloader)
+    logger.info("Using downloader '%s'.", downloader)
     if downloader.expected_document_extension is None and \
             expected_doc_format is not None:
         downloader.expected_document_extension = expected_doc_format

--- a/papis/downloaders/acm.py
+++ b/papis/downloaders/acm.py
@@ -22,7 +22,7 @@ class Downloader(papis.downloaders.Downloader):
 
     def get_doi(self) -> Optional[str]:
         url = self.uri
-        self.logger.debug("Parsing DOI from '%s'", url)
+        self.logger.debug("Parsing DOI from '%s'.", url)
         mdoi = re.match(r".*/doi/(.*/[^?&%^$]*).*", url)
         if mdoi:
             doi = mdoi.group(1).replace("abs/", "").replace("full/", "")
@@ -33,5 +33,5 @@ class Downloader(papis.downloaders.Downloader):
     def get_document_url(self) -> Optional[str]:
         durl = ("https://dl.acm.org/doi/pdf/{doi}"
                 .format(doi=self.get_doi()))
-        self.logger.debug("doc url = '%s'", durl)
+        self.logger.debug("Using document URL: '%s'.", durl)
         return durl

--- a/papis/downloaders/acs.py
+++ b/papis/downloaders/acs.py
@@ -44,7 +44,7 @@ class Downloader(papis.downloaders.Downloader):
         doi = self.ctx.data.get("doi")
         if doi is not None:
             url = self.BIBTEX_URL.format(doi=doi)
-            self.logger.debug("bibtex url = %s", url)
+            self.logger.debug("Using BibTeX URL: '%s'.", url)
             return url
 
         return None

--- a/papis/downloaders/annualreviews.py
+++ b/papis/downloaders/annualreviews.py
@@ -30,7 +30,7 @@ class Downloader(papis.downloaders.Downloader):
     def get_document_url(self) -> Optional[str]:
         if "doi" in self.ctx.data:
             url = self.DOCUMENT_URL.format(doi=self.ctx.data["doi"])
-            self.logger.debug("doc url = '%s'", url)
+            self.logger.debug("Using document URL: '%s'.", url)
 
             return url
         else:
@@ -39,7 +39,7 @@ class Downloader(papis.downloaders.Downloader):
     def get_bibtex_url(self) -> Optional[str]:
         if "doi" in self.ctx.data:
             url = self.BIBTEX_URL.format(doi=self.ctx.data["doi"])
-            self.logger.debug("bibtex url = '%s'", url)
+            self.logger.debug("Using BibTeX URL: '%s'.", url)
 
             return url
         else:

--- a/papis/downloaders/aps.py
+++ b/papis/downloaders/aps.py
@@ -20,12 +20,12 @@ class Downloader(papis.downloaders.fallback.Downloader):
     def get_bibtex_url(self) -> Optional[str]:
         url = "{}?type=bibtex&download=true".format(
             self.uri.replace("/abstract", "/export"))
-        self.logger.debug("bibtex url = '%s'", url)
+        self.logger.debug("Using BibTeX URL '%s'.", url)
 
         return url
 
     def get_document_url(self) -> Optional[str]:
         url = self.uri.replace("/abstract", "/pdf")
-        self.logger.debug("pdf url = '%s'", url)
+        self.logger.debug("Using document URL: '%s'.", url)
 
         return url

--- a/papis/downloaders/citeseerx.py
+++ b/papis/downloaders/citeseerx.py
@@ -55,7 +55,7 @@ class Downloader(papis.downloaders.Downloader):
             )
 
         if not response.ok:
-            self.logger.error("Could not obtain CiteSeerX data: '%s'", response.reason)
+            self.logger.error("Could not obtain CiteSeerX data: '%s'.", response.reason)
 
         return response.content
 

--- a/papis/downloaders/fallback.py
+++ b/papis/downloaders/fallback.py
@@ -34,15 +34,13 @@ class Downloader(papis.downloaders.Downloader):
             if doi:
                 return str(doi)
 
-        self.logger.info("Trying to parse doi from url body...")
-        soup = self._get_soup()
-
         from doi import find_doi_in_text
+        soup = self._get_soup()
         return find_doi_in_text(str(soup))
 
     def get_document_url(self) -> Optional[str]:
         url = self.ctx.data.get("pdf_url")
         if url is not None:
-            self.logger.debug("Got a pdf url = '%s'", url)
+            self.logger.debug("Using document URL: '%s'.", url)
 
         return str(url)

--- a/papis/downloaders/frontiersin.py
+++ b/papis/downloaders/frontiersin.py
@@ -22,7 +22,7 @@ class Downloader(papis.downloaders.Downloader):
 
     def get_doi(self) -> Optional[str]:
         url = self.uri
-        self.logger.info("Parsing DOI from '%s'", url)
+        self.logger.debug("Parsing DOI from '%s'.", url)
         mdoi = re.match(r".*/articles/([^/]+/[^/?&%^$]+).*", url)
         if mdoi:
             doi = mdoi.group(1)
@@ -32,11 +32,11 @@ class Downloader(papis.downloaders.Downloader):
     def get_document_url(self) -> Optional[str]:
         durl = ("https://www.frontiersin.org/articles/{doi}/pdf"
                 .format(doi=self.get_doi()))
-        self.logger.debug("doc url = '%s'", durl)
+        self.logger.debug("Using document URL: '%s'.", durl)
         return durl
 
     def get_bibtex_url(self) -> Optional[str]:
         url = ("https://www.frontiersin.org/articles/{doi}/bibTex"
                .format(doi=self.get_doi()))
-        self.logger.debug("bibtex url = '%s'", url)
+        self.logger.debug("Using BibTeX URL: '%s'.", url)
         return url

--- a/papis/downloaders/get.py
+++ b/papis/downloaders/get.py
@@ -24,7 +24,7 @@ class Downloader(papis.downloaders.Downloader):
         if m:
             d = Downloader(url)
             extension = m.group(1)
-            d.logger.info("Expecting a document of type '%s'", extension)
+            d.logger.info("Expecting a document of type '%s'.", extension)
             d.expected_document_extension = extension
             return d
         else:

--- a/papis/downloaders/hal.py
+++ b/papis/downloaders/hal.py
@@ -59,7 +59,7 @@ class Downloader(papis.downloaders.fallback.Downloader):
     def get_bibtex_url(self) -> Optional[str]:
         if "pdf_url" in self.ctx.data:
             url = self.uri.replace("document", "bibtex")
-            self.logger.debug("bibtex url = '%s'", url)
+            self.logger.debug("Using BibTeX URL: '%s'.", url)
             return url
         else:
             return None

--- a/papis/downloaders/ieee.py
+++ b/papis/downloaders/ieee.py
@@ -41,7 +41,7 @@ class Downloader(papis.downloaders.Downloader):
 
     def download_bibtex(self) -> None:
         url, params = self._get_bibtex_url()
-        self.logger.debug("bibtex url = '%s'", url)
+        self.logger.debug("Using BibTeX URL: '%s'.", url)
 
         response = self.session.get(url, params=params)
         if not response.ok:
@@ -51,10 +51,9 @@ class Downloader(papis.downloaders.Downloader):
 
     def get_document_url(self) -> Optional[str]:
         identifier = self.get_identifier()
-        self.logger.debug("paper id = '%s'", identifier)
         pdf_url = "{}{}{}".format(
             "https://ieeexplore.ieee.org/",
             "stampPDF/getPDF.jsp?tp=&isnumber=&arnumber=",
             identifier)
-        self.logger.debug("pdf url = '%s'", pdf_url)
+        self.logger.debug("Using document URL: '%s'.", pdf_url)
         return pdf_url

--- a/papis/downloaders/iopscience.py
+++ b/papis/downloaders/iopscience.py
@@ -40,7 +40,7 @@ class Downloader(papis.downloaders.Downloader):
             return None
 
         url = self.DOCUMENT_URL.format(doi=doi)
-        self.logger.debug("doc url = '%s'", url)
+        self.logger.debug("Using document URL: '%s'.", url)
 
         return url
 
@@ -60,7 +60,7 @@ class Downloader(papis.downloaders.Downloader):
             return None
 
         url = self.BIBTEX_URL.format(aid=aid)
-        self.logger.debug("bibtex url = '%s'", url)
+        self.logger.debug("Using BibTeX URL: '%s'.", url)
         return url
 
     def get_data(self) -> Dict[str, Any]:

--- a/papis/downloaders/sciencedirect.py
+++ b/papis/downloaders/sciencedirect.py
@@ -61,7 +61,7 @@ class Downloader(papis.downloaders.Downloader):
 
         # get authors
         scripts = soup.find_all(name="script", attrs={"data-iso-key": "_0"})
-        self.logger.debug("Found %d scripts with 'data-iso-key=_0'", len(scripts))
+        self.logger.debug("Found %d scripts with 'data-iso-key=_0'.", len(scripts))
 
         if len(scripts) == 1:
             import json

--- a/papis/downloaders/scitationaip.py
+++ b/papis/downloaders/scitationaip.py
@@ -32,12 +32,12 @@ class Downloader(papis.downloaders.Downloader):
         # https://aip.scitation.org/doi/pdf/10.1063/1.4873138
         durl = ("https://aip.scitation.org/doi/pdf/{doi}"
                 .format(doi=self.get_doi()))
-        self.logger.debug("doc url = '%s'", durl)
+        self.logger.debug("Using document URL: '%s'.", durl)
         return durl
 
     def get_bibtex_url(self) -> Optional[str]:
         url = ("https://aip.scitation.org/action/downloadCitation"
                "?format=bibtex&cookieSet=1&doi={doi}"
                .format(doi=self.get_doi()))
-        self.logger.debug("bibtex url = '%s'", url)
+        self.logger.debug("Using BibTeX URL: '%s'.", url)
         return url

--- a/papis/downloaders/springer.py
+++ b/papis/downloaders/springer.py
@@ -39,7 +39,7 @@ class Downloader(papis.downloaders.Downloader):
     def get_bibtex_url(self) -> Optional[str]:
         if "doi" in self.ctx.data:
             url = self.BIBTEX_URL.format(doi=self.ctx.data["doi"])
-            self.logger.debug("bibtex url = '%s'", url)
+            self.logger.debug("Using BibTeX URL: '%s'.", url)
             return url
         else:
             return None
@@ -47,7 +47,7 @@ class Downloader(papis.downloaders.Downloader):
     def get_document_url(self) -> Optional[str]:
         if "doi" in self.ctx.data:
             url = self.DOCUMENT_URL.format(doi=self.ctx.data["doi"])
-            self.logger.debug("doc url = '%s'", url)
+            self.logger.debug("Using document URL: '%s'.", url)
             return url
         else:
             return None

--- a/papis/downloaders/tandfonline.py
+++ b/papis/downloaders/tandfonline.py
@@ -71,7 +71,7 @@ class Downloader(papis.downloaders.Downloader):
             return None
 
         url = self.BIBTEX_URL.format(doi=doi)
-        self.logger.debug("bibtex url = '%s'", url)
+        self.logger.debug("Using BibTeX URL: '%s'.", url)
         return url
 
     def get_document_url(self) -> Optional[str]:
@@ -80,5 +80,5 @@ class Downloader(papis.downloaders.Downloader):
             return None
 
         url = self.DOCUMENT_URL.format(doi=doi)
-        self.logger.debug("doc url = '%s'", url)
+        self.logger.debug("Using document URL: '%s'.", url)
         return url

--- a/papis/downloaders/thesesfr.py
+++ b/papis/downloaders/thesesfr.py
@@ -48,7 +48,7 @@ class Downloader(papis.downloaders.Downloader):
         ))
 
         if not a:
-            self.logger.error("No document url in theses.fr")
+            self.logger.error("No document found for '%s'.", self.uri)
             return None
 
         second_url = a[0]["href"]
@@ -60,7 +60,7 @@ class Downloader(papis.downloaders.Downloader):
         ))
 
         if not a:
-            self.logger.error("No document url in '%s'", second_url)
+            self.logger.error("No document found for '%s'.", second_url)
             return None
 
         return str(a[0]["href"])
@@ -72,5 +72,5 @@ class Downloader(papis.downloaders.Downloader):
         'https://www.theses.fr/2014TOU30305.bib'
         """
         url = "https://www.theses.fr/{id}.bib".format(id=self.get_identifier())
-        self.logger.debug("bibtex url = '%s'", url)
+        self.logger.debug("Using BibTeX URL: '%s'.", url)
         return url

--- a/papis/downloaders/worldscientific.py
+++ b/papis/downloaders/worldscientific.py
@@ -22,7 +22,7 @@ class Downloader(papis.downloaders.Downloader):
 
     def get_doi(self) -> Optional[str]:
         url = self.uri
-        self.logger.debug("Parsing DOI from '%s'", url)
+        self.logger.debug("Parsing DOI from '%s'.", url)
         mdoi = re.match(r".*/doi/(.*/[^?&%^$]*).*", url)
         if mdoi:
             doi = mdoi.group(1).replace("abs/", "").replace("full/", "")
@@ -38,11 +38,11 @@ class Downloader(papis.downloaders.Downloader):
     def get_document_url(self) -> Optional[str]:
         durl = ("https://www.worldscientific.com/doi/pdf/{doi}"
                 .format(doi=self.get_doi()))
-        self.logger.debug("doc url = '%s'", durl)
+        self.logger.debug("Using document URL: '%s'.", durl)
         return durl
 
     def get_bibtex_url(self) -> Optional[str]:
         url = "https://www.worldscientific.com/action/downloadCitation"\
               "?format=bibtex&cookieSet=1&doi=%s" % self.get_doi()
-        self.logger.debug("bibtex url = '%s'", url)
+        self.logger.debug("Using BibTeX URL: '%s'.", url)
         return url

--- a/papis/exceptions.py
+++ b/papis/exceptions.py
@@ -2,6 +2,8 @@
 readable.
 """
 
+import papis.strings
+
 
 class DefaultSettingValueMissing(Exception):
     """This exception is when a setting's value has no default value.
@@ -19,3 +21,10 @@ class DefaultSettingValueMissing(Exception):
     Don't forget to check the documentation.
         """.format(key)
         super().__init__(message)
+
+
+class DocumentFolderNotFound(FileNotFoundError):
+    def __init__(self, doc: str) -> None:
+        super().__init__("{}: '{}'".format(
+            papis.strings.no_folder_attached_to_document,
+            doc))

--- a/papis/format.py
+++ b/papis/format.py
@@ -42,7 +42,7 @@ class Formater:
 
         :returns: a string with all the replacement fields filled in.
         """
-        raise NotImplementedError
+        raise NotImplementedError(type(self).__name__)
 
 
 class PythonFormater(Formater):

--- a/papis/git.py
+++ b/papis/git.py
@@ -20,7 +20,7 @@ def _issue_git_command(path: str, cmd: str) -> None:
 
     import shlex
     split_cmd = shlex.split(cmd)
-    logger.debug(split_cmd)
+    logger.debug("Running command: %s.", split_cmd)
 
     import subprocess
     os.chdir(path)
@@ -34,8 +34,8 @@ def commit(path: str, message: str) -> None:
     :param message: Commit message
     """
 
-    logger.info("Committing '%s' with message '%s'", path, message)
-    cmd = 'git commit -m "{0}"'.format(message)
+    logger.info("Committing '%s' with message '%s'.", path, message)
+    cmd = "git commit -m '{}'".format(message)
     _issue_git_command(path, cmd)
 
 
@@ -45,8 +45,8 @@ def add(path: str, resource: str) -> None:
     :param path: Folder where a git repo exists.
     :param resource: Commit resource
     """
-    logger.info("Adding '%s'", path)
-    cmd = 'git add "{0}"'.format(resource)
+    logger.info("Adding '%s'.", path)
+    cmd = "git add '{}'".format(resource)
     _issue_git_command(path, cmd)
 
 
@@ -56,18 +56,19 @@ def remove(path: str, resource: str, recursive: bool = False) -> None:
     :param path: Folder where a git repo exists.
     :param resource: Commit resource
     """
-    logger.info("Removing '%s'", path)
+    logger.info("Removing '%s'.", path)
     # force removal always
-    cmd = 'git rm -f {r} "{0}"'.format(resource, r="-r" if recursive else "")
+    flag = "-r" if recursive else ""
+    cmd = "git rm -f {} '{}'".format(flag, resource)
     _issue_git_command(path, cmd)
 
 
 def add_and_commit_resource(path: str, resource: str, message: str) -> None:
-    """Adds and commits a resource.
+    """Adds and commits a single resource.
 
-    :param path: Folder where a git repo exists.
-    :param resource: Commit resource
-    :param message: Commit message
+    :param path: Folder where the git repository is located.
+    :param resource: name of the resource to add and commit.
+    :param message: commit message.
     """
     add(path, resource)
     commit(path, message)
@@ -76,7 +77,7 @@ def add_and_commit_resource(path: str, resource: str, message: str) -> None:
 def add_and_commit_resources(path: str,
                              resources: List[str],
                              message: str) -> None:
-    """Adds and commits a resources.
+    """Add and commit multiple resources.
     """
     for resource in resources:
         add(path, resource)

--- a/papis/hooks.py
+++ b/papis/hooks.py
@@ -21,7 +21,7 @@ def get(name: str) -> "ExtensionManager":
 
 def run(name: str, *args: Any, **kwargs: Any) -> None:
     full_name = _get_namespace(name)
-    logger.debug("Running hooks for %s", full_name)
+    logger.debug("Running hooks for '%s'.", full_name)
     for callback in papis.plugin.get_available_plugins(full_name):
         callback(*args, **kwargs)
     hooks = NON_STEVEDORE_HOOKS.get(full_name)
@@ -32,6 +32,6 @@ def run(name: str, *args: Any, **kwargs: Any) -> None:
 
 def add(name: str, fun: Callable[[Any], None]) -> None:
     full_name = _get_namespace(name)
-    logger.debug("Adding hook for %s", full_name)
+    logger.debug("Adding hook for '%s'.", full_name)
     hooks = NON_STEVEDORE_HOOKS.setdefault(full_name, [])
     hooks.append(fun)

--- a/papis/id.py
+++ b/papis/id.py
@@ -90,8 +90,10 @@ def get(doc: Dict[str, Any]) -> str:
     """
     Get the id from a document.
     """
+    key = key_name()
     if not has_id(doc):
-        raise ValueError("No '{}' found in '{}'"
-                         .format(key_name(),
-                                 papis.document.describe(doc)))
-    return str(doc[key_name()])
+        raise ValueError(
+            "Papis ID key '{}' not found in document: '{}'"
+            .format(key, papis.document.describe(doc)))
+
+    return str(doc[key])

--- a/papis/importer.py
+++ b/papis/importer.py
@@ -108,7 +108,7 @@ class Importer:
         """
 
         raise NotImplementedError(
-            "Matching URIs is not implemented for '{}.{}'"
+            "Matching URI is not implemented for '{}.{}'"
             .format(cls.__module__, cls.__name__))
 
     @classmethod
@@ -166,7 +166,7 @@ class Importer:
             .format(type(self).__module__, type(self).__name__))
 
     def __str__(self) -> str:
-        return "Importer({}, uri={})".format(self.name, self.uri)
+        return "{}({}, uri={})".format(type(self).__name__, self.name, self.uri)
 
 
 def get_import_mgr() -> "ExtensionManager":

--- a/papis/isbn.py
+++ b/papis/isbn.py
@@ -16,7 +16,7 @@ ISBN_SERVICE_NAMES = list(isbn_services)
 
 def get_data(query: str = "",
              service: Optional[str] = None) -> List[Dict[str, Any]]:
-    logger.debug("Trying to retrieve isbn from query: '%s'", query)
+    logger.debug("Trying to retrieve ISBN from query: '%s'.", query)
 
     if service is None:
         service = papis.config.get("isbn-service")
@@ -76,13 +76,13 @@ def explorer(ctx: click.core.Context, query: str, service: str) -> None:
     papis explore isbn -q 'Albert einstein' pick cmd 'firefox {doc[url]}'
 
     """
-    logger.info("Looking up...")
+    logger.info("Looking up ISBN documents...")
 
     data = get_data(query=query, service=service)
     docs = [papis.document.from_data(data=d) for d in data]
     ctx.obj["documents"] += docs
 
-    logger.info("%d documents found", len(docs))
+    logger.info("Found %d documents.", len(docs))
 
 
 class Importer(papis.importer.Importer):

--- a/papis/json.py
+++ b/papis/json.py
@@ -26,7 +26,7 @@ def explorer(ctx: click.Context, jsonfile: str) -> None:
     papis explore json lib.json pick
 
     """
-    logger.info("Reading in json file '%s'", jsonfile)
+    logger.info("Reading JSON file '%s'...", jsonfile)
 
     import json
 
@@ -34,4 +34,4 @@ def explorer(ctx: click.Context, jsonfile: str) -> None:
         docs = [papis.document.from_data(d) for d in json.load(f)]
         ctx.obj["documents"] += docs
 
-    logger.info("%s documents found", len(docs))
+    logger.info("Found %s documents.", len(docs))

--- a/papis/logging.py
+++ b/papis/logging.py
@@ -131,10 +131,10 @@ def setup(level: Optional[Union[int, str]] = None,
         try:
             level = int(getattr(logging, level))
         except AttributeError:
-            raise ValueError("Unknown logger level: '{}'.".format(level))
+            raise ValueError("Unknown logger level: '{}'".format(level))
     else:
         if logging.getLevelName(level).startswith("Level"):
-            raise ValueError("Unknown logger level: '{}'.".format(level))
+            raise ValueError("Unknown logger level: '{}'".format(level))
 
     log_format = (
         "{c.Fore.GREEN}%(name)s{c.Style.RESET_ALL}: %(message)s"

--- a/papis/pick.py
+++ b/papis/pick.py
@@ -48,10 +48,10 @@ def pick(
     try:
         picker = get_picker(name)  # type: Type[Picker[Option]]
     except KeyError:
-        logger.error("Invalid picker: %s", name)
+        entrypoints = papis.plugin.get_available_entrypoints(_extension_name())
         logger.error(
-            "Registered pickers are: %s",
-            papis.plugin.get_available_entrypoints(_extension_name()))
+            "Invalid picker: '%s'. Registered pickers are '%s'.",
+            name, "', '".join(entrypoints))
         return []
     else:
         return picker()(options,

--- a/papis/plugin.py
+++ b/papis/plugin.py
@@ -70,12 +70,12 @@ MANAGERS = {}  # type: Dict[str, ExtensionManager]
 
 def stevedore_error_handler(manager: "ExtensionManager",
                             entrypoint: str, exception: str) -> None:
-    logger.error("Error while loading entrypoint '%s'", entrypoint)
-    logger.error(exception)
+    logger.error("Error while loading entrypoint '%s': %s.", entrypoint, exception)
 
 
 def _load_extensions(namespace: str) -> None:
-    logger.debug("Creating manager for %s", namespace)
+    global MANAGERS
+    logger.debug("Creating manager for namespace '%s'.", namespace)
 
     from stevedore import ExtensionManager
     MANAGERS[namespace] = ExtensionManager(

--- a/papis/strings.py
+++ b/papis/strings.py
@@ -1,3 +1,3 @@
-no_documents_retrieved_message = "No documents retrieved."  # type: str
-no_folder_attached_to_document = "Document has no folder attached."  # type: str
+no_documents_retrieved_message = "No documents retrieved"  # type: str
+no_folder_attached_to_document = "Document has no folder attached"  # type: str
 time_format = "%Y-%m-%d-%H:%M:%S"  # type: str

--- a/papis/strings.py
+++ b/papis/strings.py
@@ -1,3 +1,3 @@
-no_documents_retrieved_message = "No documents retrieved"  # type: str
-no_folder_attached_to_document = "Document has no folder attached"  # type: str
+no_documents_retrieved_message = "No documents retrieved."  # type: str
+no_folder_attached_to_document = "Document has no folder attached."  # type: str
 time_format = "%Y-%m-%d-%H:%M:%S"  # type: str

--- a/papis/tui/widgets/command_line_prompt.py
+++ b/papis/tui/widgets/command_line_prompt.py
@@ -88,9 +88,11 @@ class CommandLinePrompt(ConditionalContainer):  # type: ignore
         cmds = list(filter(lambda c: name in c.names, self.commands))
 
         if len(cmds) > 1:
-            raise Exception("More than one command matches the input")
+            raise ValueError(
+                "More than one command matches the input: ['{}']"
+                .format("', '".join(cmd.name for cmd in cmds)))
         elif not cmds:
-            raise Exception("No command found ({0})".format(name))
+            raise ValueError("No command found for '{}'".format(name))
 
         input_cmd.pop(0)
         cmds[0].run(cmds[0], *input_cmd)

--- a/papis/tui/widgets/list.py
+++ b/papis/tui/widgets/list.py
@@ -284,7 +284,7 @@ class OptionsList(ConditionalContainer, Generic[Option]):  # type: ignore
             operator.add,
             [self.options_headers[i] for i in self.indices],
             [])  # type: List[Tuple[str, str]]
-        logger.debug("Created items in %.1f ms", 1000 * (time.time() - begin_t))
+        logger.debug("Created items in %.1f ms.", 1000 * (time.time() - begin_t))
         return internal_text
 
     def index_to_line(self, index: int) -> int:
@@ -300,7 +300,7 @@ class OptionsList(ConditionalContainer, Generic[Option]):  # type: ignore
         return self._indices_to_lines[index]
 
     def process_options(self) -> None:
-        logger.debug("Processing %d options", len(self.get_options()))
+        logger.debug("Processing %d options.", len(self.get_options()))
         self.marks = []
 
         def _get_linecount(_o: Option) -> int:
@@ -309,7 +309,7 @@ class OptionsList(ConditionalContainer, Generic[Option]):  # type: ignore
         self.options_headers_linecount = list(map(_get_linecount,
                                                   self.get_options()))
         self.max_entry_height = max(self.options_headers_linecount)
-        logger.debug("Processing headers")
+        logger.debug("Processing headers.")
         self.options_headers = []
         for _opt in self.get_options():
             prestring = self.header_filter(_opt) + "\n"
@@ -320,9 +320,9 @@ class OptionsList(ConditionalContainer, Generic[Option]):  # type: ignore
                     "Error processing html for\n %s\n %s", prestring, e)
                 htmlobject = [("fg:ansired", prestring)]
             self.options_headers += [htmlobject]
-        logger.debug("Got %d headers", len(self.options_headers))
-        logger.debug("Processing matchers")
+        logger.debug("Got %d headers.", len(self.options_headers))
+        logger.debug("Processing matchers.")
         self.options_matchers = list(
             map(self.match_filter, self.get_options()))
         self.indices = list(range(len(self.get_options())))
-        logger.debug("Got %d matchers", len(self.options_matchers))
+        logger.debug("Got %d matchers.", len(self.options_matchers))

--- a/papis/utils.py
+++ b/papis/utils.py
@@ -121,8 +121,8 @@ def general_open(file_name: str,
         opener = default_opener
 
     import shlex
-    cmd = shlex.split("{0} '{1}'".format(opener, file_name))
-    logger.debug("cmd: %s", cmd)
+    cmd = shlex.split("{} '{}'".format(opener, file_name))
+    logger.debug("Running command: '%s'.", cmd)
 
     # NOTE: Detached processes do not fail properly when the command does not
     # exist, so we check for it manually here
@@ -133,10 +133,10 @@ def general_open(file_name: str,
 
     import subprocess
     if wait:
-        logger.debug("Waiting for process to finish")
+        logger.debug("Waiting for process to finish.")
         subprocess.call(cmd)
     else:
-        logger.debug("Not waiting for process to finish")
+        logger.debug("Not waiting for process to finish.")
         popen_kwargs = {
             "shell": False,
             "stdin": None,
@@ -177,7 +177,7 @@ def get_folders(folder: str) -> List[str]:
     :param folder: root folder to look into.
     :returns: List of folders containing an ``info`` file.
     """
-    logger.debug("Indexing folders in '%s'", folder)
+    logger.debug("Indexing folders in '%s'.", folder)
     info_name = papis.config.getstring("info-name")
 
     folders = []
@@ -185,7 +185,7 @@ def get_folders(folder: str) -> List[str]:
         if os.path.exists(os.path.join(root, info_name)):
             folders.append(root)
 
-    logger.debug("%d valid folders retrieved", len(folders))
+    logger.debug("Retrieved %d valid folders.", len(folders))
 
     return folders
 
@@ -321,7 +321,7 @@ def folders_to_documents(folders: Iterable[str]) -> List[papis.document.Document
     begin_t = time.time()
     result = parmap(papis.document.from_folder, folders)
 
-    logger.debug("Done in %.1f ms", 1000 * (time.time() - begin_t))
+    logger.debug("Finished in %.1f ms.", 1000 * (time.time() - begin_t))
     return result
 
 
@@ -398,7 +398,7 @@ def get_matching_importer_or_downloader(
     for cls in all_importer_classes:
         name = "{}.{}".format(cls.__module__, cls.__name__)
         logger.debug("Trying with importer "
-                     "{c.Back.BLACK}{c.Fore.YELLOW}%s{c.Style.RESET_ALL}",
+                     "{c.Back.BLACK}{c.Fore.YELLOW}%s{c.Style.RESET_ALL}.",
                      name)
 
         try:

--- a/papis/utils.py
+++ b/papis/utils.py
@@ -277,7 +277,8 @@ def locate_document_in_lib(document: papis.document.Document,
         if docs:
             return docs[0]
 
-    raise IndexError("Document not found in library")
+    raise IndexError("Document not found in library: '{}'"
+                     .format(papis.document.describe(document)))
 
 
 def locate_document(

--- a/papis/yaml.py
+++ b/papis/yaml.py
@@ -116,14 +116,14 @@ def explorer(ctx: click.Context, yamlfile: str) -> None:
 
         papis explore yaml lib.yaml pick
     """
-    logger.info("Reading in yaml file '%s'", yamlfile)
+    logger.info("Reading YAML file '%s'...", yamlfile)
 
     with open(yamlfile) as fd:
         docs = [papis.document.from_data(d)
                 for d in yaml.load_all(fd, Loader=Loader)]
     ctx.obj["documents"] += docs
 
-    logger.info("%d documents found", len(docs))
+    logger.info("Found %d documents.", len(docs))
 
 
 class Importer(papis.importer.Importer):

--- a/papis/yaml.py
+++ b/papis/yaml.py
@@ -59,10 +59,10 @@ def yaml_to_data(yaml_path: str,
     with open(yaml_path) as fd:
         try:
             data = yaml.load(fd, Loader=Loader)
-        except Exception as e:
+        except Exception as exc:
             if raise_exception:
-                raise ValueError(e) from e
-            logger.error("YAML syntax error. %s", e)
+                raise ValueError(exc) from exc
+            logger.error("YAML syntax error.", exc_info=exc)
             return {}
         else:
             assert isinstance(data, dict)

--- a/tests/downloaders/__init__.py
+++ b/tests/downloaders/__init__.py
@@ -9,7 +9,7 @@ DOWNLOADER_RESOURCES_PATH = os.path.join(os.path.dirname(__file__), "resources")
 
 PAPIS_UPDATE_RESOURCES = os.environ.get("PAPIS_UPDATE_RESOURCES", "none").lower()
 if PAPIS_UPDATE_RESOURCES not in ("none", "remote", "local", "both"):
-    raise ValueError("unsupported value of 'PAPIS_UPDATE_RESOURCES'")
+    raise ValueError("Unsupported value of 'PAPIS_UPDATE_RESOURCES'")
 
 
 def get_resource(name: str) -> str:
@@ -102,7 +102,7 @@ def get_local_resource(
                     sort_keys=True,
                     )
             else:
-                raise ValueError("unknown file extension: '{}'".format(ext))
+                raise ValueError("Unknown file extension: '{}'".format(ext))
 
     with open(filename, "r", encoding="utf-8") as f:
         if ext == ".json":
@@ -110,4 +110,4 @@ def get_local_resource(
         elif ext == ".yml" or ext == ".yaml":
             return papis.yaml.yaml_to_data(filename)
         else:
-            raise ValueError("unknown file extension: '{}'".format(ext))
+            raise ValueError("Unknown file extension: '{}'".format(ext))

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -272,9 +272,8 @@ def test_get_list() -> None:
     except SyntaxError as e:
         assert (
             str(e) == (
-                "The key 'super-key-list' must be a valid python "
-                "object\n\tname 'asdf' is not defined"
-            )
+                "The key 'super-key-list' must be a valid Python object: "
+                "[asdf,2,3,4]")
         )
 
     papis.config.set("super-key-list", "2")
@@ -285,6 +284,7 @@ def test_get_list() -> None:
     except SyntaxError as e:
         assert (
             str(e) == (
-                "The key 'super-key-list' must be a valid python list"
+                "The key 'super-key-list' must be a valid Python list. "
+                "Got: 2 (type 'int')"
             )
         )

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -141,6 +141,41 @@ def test_get() -> None:
         papis.config.get("_unknown_key")
 
 
+def test_get_types() -> None:
+    # getint
+    papis.config.set("int_config", "1")
+    value = papis.config.getint("int_config")
+    assert isinstance(value, int)
+    assert value == 1
+
+    papis.config.set("int_config", "x")
+    with pytest.raises(ValueError,
+                       match="Key 'int_config' should be an integer"):
+        value = papis.config.getint("int_config")
+
+    # getfloat
+    papis.config.set("float_config", "3.1415")
+    value = papis.config.getfloat("float_config")
+    assert isinstance(value, float)
+    assert value == 3.1415
+
+    papis.config.set("float_config", "not1")
+    with pytest.raises(ValueError,
+                       match="Key 'float_config' should be a float"):
+        value = papis.config.getfloat("float_config")
+
+    # getboolean
+    papis.config.set("boolean_config", "True")
+    value = papis.config.getboolean("boolean_config")
+    assert isinstance(value, bool)
+    assert value
+
+    papis.config.set("boolean_config", "not1")
+    with pytest.raises(ValueError,
+                       match="Key 'boolean_config' should be a boolean"):
+        value = papis.config.getboolean("boolean_config")
+
+
 def test_get_configuration() -> None:
     settings = papis.config.get_general_settings_name()
     config = papis.config.get_configuration()

--- a/tests/tui/widgets/test_command_line_prompt.py
+++ b/tests/tui/widgets/test_command_line_prompt.py
@@ -22,7 +22,7 @@ def test_commandlineprompt():
         prompt.text = "est"
         e = prompt.trigger()
     except Exception as e:
-        assert str(e) == "No command found (est)"
+        assert str(e) == "No command found for 'est'"
     else:
         assert False        # noqa: B011
 
@@ -39,6 +39,6 @@ def test_commandlineprompt():
     try:
         prompt.trigger()
     except Exception as e:  # noqa: F841
-        assert str(e) == "More than one command matches the input"
+        assert str(e) == "More than one command matches the input: ['test', 'test']"
     else:
         assert False        # noqa: B011


### PR DESCRIPTION
Went through the logging messages an tried to improve the messages a bit. Mainly
* Made most messages into proper sentences.
* Made sentences sound more action-y, i.e. `Found 5 documents` vs `5 documents found`.
* Used better exceptions than a bare `Exception` in some places.
* Use the documented `exc_info` to add exception information to a logging message.
* The full traceback for an exception is only printed when `--log DEBUG`, otherwise a simpler message is added from the `exc_info`. It now prints
```
[ERROR] commands.list: An error has occurred! (Caught exception 'ValueError: OMG!'. Use `--log DEBUG` to see traceback)
```
and when using `--log DEBUG`
```
[ERROR] commands.list: An error has occurred!
┆ Traceback (most recent call last):
┆   File "/mnt/data/code/projects/papis/papis/papis/commands/list.py", line 228, in cli
┆     raise ValueError("OMG!")
┆ ValueError: OMG!
```
while before it was always 
```
[ERROR] commands.list: An error has occurred!
Traceback (most recent call last):
  File "/mnt/data/code/projects/papis/papis/papis/commands/list.py", line 228, in cli
    raise ValueError("OMG!")
ValueError: OMG!
```

All of this should be cosmetic changes, so hopefully no big deal. @jghauser Would appreciate your thoughts, if you have the time!