### PR TITLE
Split fetch_data and fetch_files in importers

### DIFF
--- a/papis/arxiv.py
+++ b/papis/arxiv.py
@@ -298,9 +298,13 @@ class Importer(papis.importer.Importer):
     def arxivid(self) -> Optional[str]:
         return self.downloader.arxivid
 
-    def fetch(self) -> None:
-        self.downloader.fetch()
-        self.ctx = self.downloader.ctx
+    def fetch_data(self) -> None:
+        self.downloader.fetch_data()
+        self.ctx.data = self.downloader.ctx.data.copy()
+
+    def fetch_files(self) -> None:
+        self.downloader.fetch_files()
+        self.ctx.files = self.downloader.ctx.files.copy()
 
 
 class ArxividFromPdfImporter(papis.importer.Importer):

--- a/papis/arxiv.py
+++ b/papis/arxiv.py
@@ -221,7 +221,7 @@ class Downloader(papis.downloaders.Downloader):
 
     def __init__(self, url: str) -> None:
         super().__init__(uri=url, name="arxiv", expected_document_extension="pdf")
-        self.arxivid = None  # type: Optional[str]
+        self._arxivid = None  # type: Optional[str]
 
     @classmethod
     def match(cls, url: str) -> Optional[papis.downloaders.Downloader]:
@@ -229,40 +229,35 @@ class Downloader(papis.downloaders.Downloader):
         if arxivid:
             url = "{}/{}".format(ARXIV_ABS_URL, arxivid)
             down = Downloader(url)
-            down.arxivid = arxivid
+            down._arxivid = arxivid
             return down
         else:
             return None
 
-    def _get_identifier(self) -> Optional[str]:
-        """Get arxiv identifier
-        :returns: Identifier
-        """
-        if not self.arxivid:
-            self.arxivid = find_arxivid_in_text(self.uri)
-        return self.arxivid
+    @property
+    def arxivid(self) -> Optional[str]:
+        if self._arxivid is None:
+            self._arxivid = find_arxivid_in_text(self.uri)
+            self.logger.debug("Found the arxivid '%s'.", self._arxivid)
 
-    def get_bibtex_url(self) -> Optional[str]:
-        return self._get_identifier()
+        return self._arxivid
 
     def download_bibtex(self) -> None:
-        arxivid = self.get_bibtex_url()
+        arxivid = self.arxivid
         if not arxivid:
             return None
 
         import arxiv2bib
 
-        self.logger.debug("arxivid = '%s'", arxivid)
         bibtex_cli = arxiv2bib.Cli([arxivid])
         bibtex_cli.run()
         self.bibtex_data = "".join(bibtex_cli.output).replace("\n", " ")
 
     def get_document_url(self) -> Optional[str]:
-        arxivid = self._get_identifier()
+        arxivid = self.arxivid
         if not arxivid:
             return None
 
-        self.logger.debug("arxivid = '%s'", arxivid)
         pdf_url = "{}/{}.pdf".format(ARXIV_PDF_URL, arxivid)
         self.logger.debug("pdf_url = '%s'", pdf_url)
 
@@ -284,6 +279,7 @@ class Importer(papis.importer.Importer):
 
         super().__init__(name="arxiv", uri=uri)
         self.downloader = Downloader(uri)
+        self.downloader._arxivid = aid
 
     @classmethod
     def match(cls, uri: str) -> Optional[papis.importer.Importer]:
@@ -297,6 +293,10 @@ class Importer(papis.importer.Importer):
             return None
         else:
             return Importer(uri="{}/{}".format(ARXIV_ABS_URL, uri))
+
+    @property
+    def arxivid(self) -> Optional[str]:
+        return self.downloader.arxivid
 
     def fetch(self) -> None:
         self.downloader.fetch()

--- a/papis/bibtex.py
+++ b/papis/bibtex.py
@@ -140,8 +140,7 @@ class Importer(papis.importer.Importer):
         importer.fetch()
         return importer if importer.ctx else None
 
-    @papis.importer.cache
-    def fetch(self: papis.importer.Importer) -> Any:
+    def fetch_data(self: papis.importer.Importer) -> Any:
         self.logger.info("Reading input file = '%s'", self.uri)
         try:
             bib_data = bibtex_to_dict(self.uri)

--- a/papis/dblp.py
+++ b/papis/dblp.py
@@ -208,7 +208,7 @@ class Importer(papis.importer.Importer):
         else:
             return None
 
-    def fetch(self) -> None:
+    def fetch_data(self) -> None:
         # uri: https://dblp.org/rec/conf/iccg/EncarnacaoAFFGM93.html
         # bib: https://dblp.org/rec/conf/iccg/EncarnacaoAFFGM93.bib
         if is_valid_dblp_key(self.uri):

--- a/papis/isbn.py
+++ b/papis/isbn.py
@@ -99,7 +99,7 @@ class Importer(papis.importer.Importer):
             return None
         return Importer(uri=uri)
 
-    def fetch(self) -> None:
+    def fetch_data(self) -> None:
         import isbnlib
         try:
             data = get_data(self.uri)

--- a/papis/pubmed.py
+++ b/papis/pubmed.py
@@ -102,5 +102,5 @@ class Importer(papis.importer.Importer):
 
         return None
 
-    def fetch(self) -> None:
+    def fetch_data(self) -> None:
         self.ctx.data = get_data(self.uri)

--- a/papis/yaml.py
+++ b/papis/yaml.py
@@ -128,8 +128,7 @@ class Importer(papis.importer.Importer):
             return importer if importer.ctx.data else None
         return None
 
-    @papis.importer.cache
-    def fetch(self: papis.importer.Importer) -> Any:
+    def fetch_data(self: papis.importer.Importer) -> Any:
         self.ctx.data = yaml_to_data(self.uri, raise_exception=True)
         if self.ctx:
             self.logger.debug("Successfully read file: '%s'.", self.uri)

--- a/tests/test_arxiv.py
+++ b/tests/test_arxiv.py
@@ -38,7 +38,7 @@ def test_match():
     down = Downloader.match("arXiv:1701.08223v2?234")
     assert down
     assert down.uri == "https://arxiv.org/abs/1701.08223v2"
-    assert down._get_identifier() == "1701.08223v2"
+    assert down.arxivid == "1701.08223v2"
 
 
 def test_downloader_getter():
@@ -49,7 +49,6 @@ def test_downloader_getter():
     assert down.name == "arxiv"
     assert down.expected_document_extension == "pdf"
     # assert(down.get_doi() == '10.1021/ed044p128')
-    assert len(down.get_bibtex_url()) > 0
     assert len(down.get_bibtex_data()) > 0
     bibs = papis.bibtex.bibtex_to_dict(down.get_bibtex_data())
     assert len(bibs) == 1


### PR DESCRIPTION
This updates remote importers to use `fetch_data` and `fetch_files` separately, so that #505 can properly skip downloading files when preferred. It's pretty much just a refactor.

* `arxiv`: the main `Importer` now has a split `fetch`.
* `crossref`: the main `Importer` also has a split `fetch`.
* `bibtex`, `dblp`, `isbn`, `pudmed`, `yaml`: just rename `fetch` to `fetch_data`.