### PR TITLE
Improve importer docs

### DIFF
--- a/papis/commands/add.py
+++ b/papis/commands/add.py
@@ -560,10 +560,10 @@ def cli(files: List[str],
     """
 
     if list_importers:
-        import_mgr = papis.importer.get_import_mgr()
-        for n in import_mgr.names():
-            text = re.sub(r"[ \n]+", " ", import_mgr[n].plugin.__doc__)
-            click.echo("{name}\n\t{text}".format(name=n, text=text))
+        mgr = papis.importer.get_import_mgr()
+        click.echo("\n".join(papis.utils.dump_object_doc([
+            (name, mgr[name].plugin) for name in mgr.names()
+            ], sep="\n    ")))
 
         return
 

--- a/papis/commands/doctor.py
+++ b/papis/commands/doctor.py
@@ -480,16 +480,10 @@ def cli(query: str,
     """Check for common problems in documents"""
 
     if list_checks:
-        re_whitespace = re.compile(r"\s+")
+        click.echo("\n".join(papis.utils.dump_object_doc([
+            (name, fn.operate) for name, fn in REGISTERED_CHECKS.items()
+            ], sep="\n    ")))
 
-        for name, fn in REGISTERED_CHECKS.items():
-            if fn.operate.__doc__:
-                check_doc = [line for line in fn.operate.__doc__.split("\n\n") if line]
-            else:
-                check_doc = ["No description."]
-
-            headline = re_whitespace.sub(" ", check_doc[0].strip())
-            click.echo("{}\n    {}".format(name, headline))
         return
 
     documents = papis.cli.handle_doc_folder_query_all_sort(

--- a/papis/utils.py
+++ b/papis/utils.py
@@ -432,3 +432,23 @@ def is_relative_to(path: str, other: str) -> bool:
             return not os.path.relpath(path, start=other).startswith("..")
         except ValueError:
             return False
+
+
+def dump_object_doc(
+        objects: Iterable[Tuple[str, Any]],
+        sep: str = "\n\t") -> List[str]:
+    import colorama
+    re_whitespace = re.compile(r"\s+")
+
+    result = []
+    for name, obj in objects:
+        if obj.__doc__:
+            lines = [line for line in obj.__doc__.split("\n\n") if line]
+        else:
+            lines = ["No description."]
+
+        headline = re_whitespace.sub(" ", lines[0].strip())
+        result.append("{c.Style.BRIGHT}{name}{c.Style.RESET_ALL}{sep}{headline}"
+                      .format(c=colorama, name=name, sep=sep, headline=headline))
+
+    return result


### PR DESCRIPTION
Mainly adds more docs and improved exception messages to `papis.importer`.

Some small behavior changes:
* took the change to refactor the `list-importer` (for `add`) and `list-checks` (for `doctor`) to use the same formatting in a nice function. The main benefit of that is that it allows having multiline docs and it just extracts the first paragraph.
* added a `@cache` to the base `Importer.fetch`