### PR TITLE
Improve support for DjVu files in filetype

### DIFF
--- a/papis/crossref.py
+++ b/papis/crossref.py
@@ -405,22 +405,21 @@ class Importer(papis.importer.Importer):
 
         self.logger.info("Trying to download document from '%s'", doc_url)
 
-        import filetype
         with papis.utils.get_session() as session:
             response = session.get(doc_url, allow_redirects=True)
 
-        kind = filetype.guess(response.content)
+        ext = papis.filetype.guess_content_extension(response.content)
         if not response.ok:
             self.logger.info("Could not download document. HTTP status: %s (%d)",
                              response.reason, response.status_code)
-        elif kind is None:
+        elif ext is None:
             self.logger.info("Downloaded document does not have a "
                              "recognizable (binary) mimetype: '%s'",
                              response.headers["Content-Type"])
         else:
             with tempfile.NamedTemporaryFile(
                     mode="wb+",
-                    suffix=".{}".format(kind.extension),
+                    suffix=".{}".format(ext),
                     delete=False) as f:
                 f.write(response.content)
                 self.logger.debug("Saving in '%s'", f.name)

--- a/papis/downloaders/__init__.py
+++ b/papis/downloaders/__init__.py
@@ -258,9 +258,9 @@ class Downloader(papis.importer.Importer):
         self.document_data = response.content
 
     def check_document_format(self) -> bool:
-        """Check if the downloaded document has the filetype that the
+        """Check if the downloaded document has the file type that the
         downloader expects. If the downloader does not expect any special
-        filetype, accept anything because there is no way to know if it is
+        file type, accept anything because there is no way to know if it is
         correct.
 
         :returns: True if it is of the right type, else otherwise
@@ -274,23 +274,25 @@ class Downloader(papis.importer.Importer):
         if self.expected_document_extension is None:
             return True
 
-        import filetype
-        retrieved_kind = filetype.guess(self.get_document_data())
+        data = self.get_document_data()
+        if data is None:
+            return True
 
-        if retrieved_kind is None:
+        from papis.filetype import guess_content_extension
+        extension = guess_content_extension(data)
+
+        if extension is None:
             print_warning()
             return False
 
-        self.logger.debug(
-            "Retrieved kind of document seems to be '%s'",
-            retrieved_kind.mime)
+        self.logger.debug("Retrieved kind of document seems to be '%s'", extension)
 
         if isinstance(self.expected_document_extension, list):
             expected_document_extensions = self.expected_document_extension
         else:
             expected_document_extensions = [self.expected_document_extension]
 
-        if retrieved_kind.extension in expected_document_extensions:
+        if extension in expected_document_extensions:
             return True
         else:
             print_warning()

--- a/papis/filetype.py
+++ b/papis/filetype.py
@@ -1,20 +1,51 @@
-import re
 import os
+import re
+from typing import Optional
+
+import filetype
+
+
+def guess_content_extension(content: bytes) -> Optional[str]:
+    """Guess the extension from (potential) file contents.
+
+    This method attempts to look at known file signatures to determine the file
+    type. This is not always possible, as it is hard to determine a unique type.
+
+    :param content: contents of a file.
+    :returns: an extension string (e.g. "pdf" without the dot) or *None* if the
+        file type cannot be determined.
+    """
+    kind = filetype.guess(content)
+    return str(kind.extension) if kind is not None else None
+
+
+def guess_document_extension(document_path: str) -> Optional[str]:
+    """Guess the extension of a given file at *document_path*.
+
+    :param document_path: path to an existing file.
+    :returns: an extension string (e.g. "pdf" without the dot) or *None* if the
+        file type cannot be determined.
+    """
+
+    document_path = os.path.expanduser(document_path)
+    kind = filetype.guess(document_path)
+
+    if kind is not None:
+        return str(kind.extension)
+
+    m = re.match(r"^.*\.([^.]+)$", os.path.basename(document_path))
+    return m.group(1) if m else None
 
 
 def get_document_extension(document_path: str) -> str:
-    """Get document extension
+    """Get an extension for the file at *document_path*.
 
-    :document_path: Path of the document
-    :returns: Extension (string)
+    This uses :func:`guess_document_extension` and returns a default extension
+    `"data"` if no specific type can be determined from the file.
 
+    :param document_path: path to an existing file.
+    :returns: an extension string.
     """
-    import filetype
-    filetype.guess(document_path)
-    kind = filetype.guess(document_path)
-    if kind is None:
-        m = re.match(r"^.*\.([^.]+)$", os.path.basename(document_path))
-        return m.group(1) if m else "data"
-    else:
-        assert isinstance(kind.extension, str)
-        return kind.extension
+
+    extension = guess_document_extension(document_path)
+    return extension if extension is not None else "data"

--- a/papis/filetype.py
+++ b/papis/filetype.py
@@ -5,6 +5,36 @@ from typing import Optional
 import filetype
 
 
+class DjVu(filetype.Type):      # type: ignore[misc]
+    """
+    Implements the DjVu type matcher.
+    """
+
+    MIME = "image/vnd.djvu"
+    EXTENSION = "djvu"
+
+    def __init__(self) -> None:
+        super().__init__(mime=self.MIME, extension=self.EXTENSION)
+
+    def match(self, buf: bytes) -> bool:
+        # https://en.wikipedia.org/wiki/List_of_file_signatures
+        # magic: AT&TFORMXXXXDJV[UM]
+        return (
+            len(buf) >= 16
+            and buf[0] == 0x41 and buf[1] == 0x54
+            and buf[2] == 0x26 and buf[3] == 0x54
+            and buf[4] == 0x46 and buf[5] == 0x4F
+            and buf[6] == 0x52 and buf[7] == 0x4D
+            # and buf[8:11] == ??
+            and buf[12] == 0x44 and buf[13] == 0x4A
+            and buf[14] == 0x56
+            and (buf[15] == 0x55 or buf[15] == 0x4D)
+            )
+
+
+filetype.add_type(DjVu())
+
+
 def guess_content_extension(content: bytes) -> Optional[str]:
     """Guess the extension from (potential) file contents.
 

--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -12,7 +12,7 @@ def create_random_pdf(suffix: str = "", prefix: str = "") -> str:
 
 
 def create_random_epub(suffix: str = "", prefix: str = "") -> str:
-    buf = bytearray(
+    buf = bytes(
         [0x50, 0x4B, 0x3, 0x4]
         + [0x00 for i in range(26)]
         + [0x6D, 0x69, 0x6D, 0x65, 0x74, 0x79, 0x70, 0x65, 0x61, 0x70,
@@ -22,7 +22,20 @@ def create_random_epub(suffix: str = "", prefix: str = "") -> str:
         )
 
     with tempfile.NamedTemporaryFile(suffix=suffix, prefix=prefix, delete=False) as fd:
-        fd.write(bytearray(buf))
+        fd.write(buf)
+
+    return fd.name
+
+
+def create_random_djvu(suffix: str = "", prefix: str = "") -> str:
+    buf = bytes(
+        [0x41, 0x54, 0x26, 0x54, 0x46, 0x4F, 0x52, 0x4D]
+        + [0x00, 0x00, 0x00, 0x00]
+        + [0x44, 0x4A, 0x56, 0x4D]
+        )
+
+    with tempfile.NamedTemporaryFile(suffix=suffix, prefix=prefix, delete=False) as fd:
+        fd.write(buf)
 
     return fd.name
 

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -117,8 +117,9 @@ def test_guess_extension():
         [tests.create_random_pdf(), "pdf"],
         [tests.create_random_file(), "data"],
         [tests.create_random_epub(), "epub"],
+        [tests.create_random_djvu(), "djvu"],
         [tests.create_random_file(suffix=".yaml"), "yaml"],
-        [tests.create_random_file(suffix=".text"), "text"],
+        [tests.create_random_file(suffix=".txt"), "txt"],
     ]
     for d in docs:
         assert get_document_extension(d[0]) == d[1]

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -111,7 +111,7 @@ def test_locate_document():
     assert found_doc is None
 
 
-def test_extension():
+def test_guess_extension():
     docs = [
         [tests.create_random_pdf(), "pdf"],
         [tests.create_random_pdf(), "pdf"],


### PR DESCRIPTION
This extends the support from `filetype` to also include DjVu files. Unfortunately upstream seems to be pretty slow (by looking at their issues / pull requests), so this should be a quicker way to go.

Added some more functions there to wrap `filetype`:
* `guess_content_extension`
* `guess_document_extension`
that work the same, but return `None` if they can't figure it out.