### PR TITLE
Use arxiv.py instead of arxiv2bib

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -17,29 +17,52 @@
       pypkgs = pkgs.python310Packages;
       lib = pkgs.lib;
 
-      runtime_py_deps = with pypkgs; [
-        pyyaml
-        arxiv2bib
-        beautifulsoup4
-        bibtexparser
-        chardet
-        click
-        colorama
-        dominate
-        filetype
-        habanero
-        isbnlib
-        lxml
-        prompt_toolkit
-        pygments
-        pyparsing
-        python-doi
-        python-slugify
-        requests
-        stevedore
-        tqdm
-        whoosh
-      ];
+      runtime_py_deps = let
+        # manually package arxiv.py since it is not yet in upstream nixpkgs
+        arxivpy = python.pkgs.buildPythonPackage rec {
+          pname = "arxiv";
+          version = "1.4.8";
+
+          src = python.pkgs.fetchPypi {
+            inherit pname version;
+            sha256 = "sha256-KoGOp0nqpipuJPwx1Tt2m00z/1XPxd2nx7fTCaOyk3M=";
+          };
+
+          doCheck = false;
+          checkInputs = [ ];
+          propagatedBuildInputs = [pypkgs.feedparser];
+
+          meta = with lib; {
+            homepage = "https://github.com/lukasschwab/arxiv.py";
+            description = " Python wrapper for the arXiv API ";
+            license = licenses.mit;
+          };
+        };
+      in
+        with pypkgs; [
+          pyyaml
+          arxiv2bib
+          beautifulsoup4
+          bibtexparser
+          chardet
+          click
+          colorama
+          dominate
+          filetype
+          habanero
+          isbnlib
+          lxml
+          prompt_toolkit
+          pygments
+          pyparsing
+          python-doi
+          python-slugify
+          requests
+          stevedore
+          tqdm
+          whoosh
+          arxivpy
+        ];
       develop_py_deps = with pypkgs; [
         pip
         virtualenv

--- a/flake.nix
+++ b/flake.nix
@@ -41,7 +41,6 @@
       in
         with pypkgs; [
           pyyaml
-          arxiv2bib
           beautifulsoup4
           bibtexparser
           chardet

--- a/papis/arxiv.py
+++ b/papis/arxiv.py
@@ -78,16 +78,16 @@ def arxiv_to_papis(result: "arxiv.Result") -> Dict[str, Any]:
     data["eprintclass"] = result.primary_category
 
     # NOTE: not quite sure what to do about the type? it's not mentioned explicitly
-    comment = result.comment.lower()
-    if "thesis" in comment:
-        if "phd" in comment:
-            data["type"] = "phdthesis"
-        elif "master" in comment:
-            data["type"] = "mastersthesis"
-        else:
-            data["type"] = "thesis"
-    else:
-        data["type"] = "article"
+    data["type"] = "article"
+    if result.comment is not None:
+        comment = result.comment.lower()
+        if "thesis" in comment:
+            if "phd" in comment:
+                data["type"] = "phdthesis"
+            elif "master" in comment:
+                data["type"] = "mastersthesis"
+            else:
+                data["type"] = "thesis"
 
     return data
 

--- a/papis/arxiv.py
+++ b/papis/arxiv.py
@@ -1,19 +1,24 @@
-"""The following table lists the field prefixes for all the fields
- that can be searched.
+"""
+Table: search_query field prefixes
+==================================
 
- Table:          search_query field prefixes
-============================================
- prefix          explanation
---------------------------------------------
- ti              Title
- au              Author
- abs             Abstract
- co              Comment
- jr              Journal Reference
- cat             Subject Category
- rn              Report Number
- id              Id (use id_list instead)
- all             All of the above
+The following table lists the field prefixes for all the fields
+that can be searched. See the details of query construction in the
+`arXiv API docs <https://arxiv.org/help/api/user-manual#query_details>`__.
+
+====== ========================
+Prefix Explanation
+====== ========================
+ti     Title
+au     Author
+abs    Abstract
+co     Comment
+jr     Journal Reference
+cat    Subject Category
+rn     Report Number
+id     Id (use id_list instead)
+all    All of the above
+====== ========================
 """
 import os
 import re

--- a/setup.cfg
+++ b/setup.cfg
@@ -29,7 +29,7 @@ hide_error_codes = False
 pretty = True
 files = papis
 
-[mypy-arxiv2bib.*]
+[mypy-arxiv.*]
 ignore_missing_imports = True
 
 [mypy-bibtexparser.*]

--- a/setup.py
+++ b/setup.py
@@ -81,7 +81,7 @@ setup(
     ],
     install_requires=[
         "PyYAML>=3.12",
-        "arxiv2bib>=1.0.7",
+        "arxiv>=1.0.0",
         "beautifulsoup4>=4.4.1",
         "bibtexparser>=0.6.2",
         "chardet>=3.0.2",

--- a/tests/test_arxiv.py
+++ b/tests/test_arxiv.py
@@ -1,13 +1,30 @@
 import pytest
-import papis.arxiv
 import papis.downloaders
 
 from tests.testlib import TemporaryConfiguration
 
+ARXIV_TEST_URLS = [
+    ("/URI(https://arxiv.org/abs/1305.2291v2)>>", "1305.2291v2"),
+    ("/URI(https://arxiv.org/abs/1205.0093)>>", "1205.0093"),
+    ("/URI(https://arxiv.org/abs/1205.1494)>>", "1205.1494"),
+    ("/URI(https://arxiv.org/abs/1011.2840)>>", "1011.2840"),
+    ("/URI(https://arxiv.org/abs/1110.3658)>>", "1110.3658"),
+    ("https://arxiv.org/abs/1110.3658>", "1110.3658"),
+    ("http://arxiv.org/abs/1110.3658>", "1110.3658"),
+    ("https://arxiv.com/abs/1110.3658>", "1110.3658"),
+    ("https://arxiv.org/1110.3658>", "1110.3658"),
+    ("arXiv:1701.08223v2?234", "1701.08223v2"),
+    ("https://arxiv.org/pdf/1110.3658.pdf", "1110.3658"),
+    ("http://arxiv.org/pdf/1110.3658.pdf", "1110.3658"),
+    ("https://arxiv.com/pdf/1110.3658.pdf", "1110.3658"),
+    ("http://arxiv.com/pdf/1110.3658.pdf", "1110.3658"),
+]
+
 
 @pytest.mark.xfail(reason="arxiv times out sometimes")
 def test_get_data(tmp_config: TemporaryConfiguration) -> None:
-    data = papis.arxiv.get_data(
+    from papis.arxiv import get_data
+    data = get_data(
         author="Garnet Chan",
         max_results=1,
         title="Finite Temperature"
@@ -18,45 +35,36 @@ def test_get_data(tmp_config: TemporaryConfiguration) -> None:
 
 
 def test_find_arxiv_id(tmp_config: TemporaryConfiguration) -> None:
-    test_data = [
-        ("/URI(https://arxiv.org/abs/1305.2291v2)>>", "1305.2291v2"),
-        ("/URI(https://arxiv.org/abs/1205.0093)>>", "1205.0093"),
-        ("/URI(https://arxiv.org/abs/1205.1494)>>", "1205.1494"),
-        ("/URI(https://arxiv.org/abs/1011.2840)>>", "1011.2840"),
-        ("/URI(https://arxiv.org/abs/1110.3658)>>", "1110.3658"),
-        ("https://arxiv.org/abs/1110.3658>", "1110.3658"),
-        ("http://arxiv.org/abs/1110.3658>", "1110.3658"),
-        ("https://arxiv.com/abs/1110.3658>", "1110.3658"),
-        ("https://arxiv.org/1110.3658>", "1110.3658"),
-        ("https://arxiv.org/pdf/1110.3658.pdf", "1110.3658"),
-        ("http://arxiv.org/pdf/1110.3658.pdf", "1110.3658"),
-        ("https://arxiv.com/pdf/1110.3658.pdf", "1110.3658"),
-        ("http://arxiv.com/pdf/1110.3658.pdf", "1110.3658"),
-    ]
+    from papis.arxiv import find_arxivid_in_text
 
-    for url, arxivid in test_data:
-        assert papis.arxiv.find_arxivid_in_text(url) == arxivid, \
-            f"Could not retrieve correct arxivid from {url}"
+    for url, arxivid in ARXIV_TEST_URLS:
+        assert find_arxivid_in_text(url) == arxivid, (
+            f"Could not retrieve correct arxivid from {url}")
 
 
-def test_match(tmp_config: TemporaryConfiguration) -> None:
-    down = papis.arxiv.Downloader.match("arxiv.org/sdf")
+def test_downloader_match(tmp_config: TemporaryConfiguration) -> None:
+    from papis.arxiv import Downloader, ARXIV_ABS_URL
+
+    down = Downloader.match("arxiv.org/sdf")
     assert isinstance(down, papis.arxiv.Downloader)
 
-    down = papis.arxiv.Downloader.match("arxiv.com/!@#!@$!%!@%!$chemed.6b00559")
+    down = Downloader.match("arxiv.com/!@#!@$!%!@%!$chemed.6b00559")
     assert down is None
 
-    down = papis.arxiv.Downloader.match("arXiv:1701.08223v2?234")
-    assert isinstance(down, papis.arxiv.Downloader)
-    assert down.uri == "https://arxiv.org/abs/1701.08223v2"
-    assert down.arxivid == "1701.08223v2"
+    for uri, arxivid in ARXIV_TEST_URLS[-2:]:
+        down = Downloader.match(uri)
+        assert down
+        assert down.arxivid == arxivid
+        assert down.uri == "{}/{}".format(ARXIV_ABS_URL, arxivid)
 
 
 @pytest.mark.xfail(reason="arxiv times out sometimes")
-def test_downloader_getter(tmp_config: TemporaryConfiguration) -> None:
-    import papis.bibtex
-
-    url = "https://arxiv.org/abs/1001.3032"
+@pytest.mark.parametrize("url", [
+    "https://arxiv.org/abs/1001.3032",
+    "https://arxiv.org/abs/1001.3032vunknown",
+    ])
+def test_importer_downloader_fetch(tmp_config: TemporaryConfiguration,
+                                   url: str) -> None:
     downs = papis.downloaders.get_matching_downloaders(url)
     assert len(downs) >= 1
 
@@ -64,16 +72,13 @@ def test_downloader_getter(tmp_config: TemporaryConfiguration) -> None:
     assert down.name == "arxiv"
     assert down.expected_document_extensions == ("pdf",)
 
-    bibtex = down.get_bibtex_data()
-    assert bibtex is not None
-    assert len(bibtex) > 0
-
-    bibs = papis.bibtex.bibtex_to_dict(bibtex)
-    assert len(bibs) == 1
-
     doc = down.get_document_data()
-    assert doc is not None
-    assert down.check_document_format()
+    if down.result:
+        assert doc is not None
+        assert down.check_document_format()
+    else:
+        assert down.arxivid is not None
+        assert doc is None
 
 
 def test_validate_arxivid(tmp_config: TemporaryConfiguration) -> None:
@@ -82,7 +87,7 @@ def test_validate_arxivid(tmp_config: TemporaryConfiguration) -> None:
     papis.arxiv.validate_arxivid("1206.6272v1")
     papis.arxiv.validate_arxivid("1206.6272v2")
 
-    import pytest
+    # bad
     for bad in ["1206.6272v3", "blahv2"]:
         with pytest.raises(ValueError, match="not an arxivid"):
             papis.arxiv.validate_arxivid(bad)


### PR DESCRIPTION
This switches the arxiv code to use [arxiv.py](https://github.com/lukasschwab/arxiv.py). Some benefits:
* it seems better maintained ([arxiv2bib](https://github.com/nathangrigg/arxiv2bib) was last updated in 2017),
* it allows removing our custom `bs4` based parsing,
* the API generally seems nicer.

