### PR TITLE
commands.addto: some small cleanups

### DIFF
--- a/papis/commands/addto.py
+++ b/papis/commands/addto.py
@@ -23,15 +23,13 @@ from typing import List, Optional
 
 import click
 
-import papis.pick
-import papis.utils
-import papis.document
+import papis.api
+import papis.cli
 import papis.git
 import papis.config
-import papis.commands.add
-import papis.cli
-import papis.strings
+import papis.document
 import papis.logging
+import papis.strings
 
 logger = papis.logging.get_logger(__name__)
 
@@ -39,65 +37,55 @@ logger = papis.logging.get_logger(__name__)
 def run(document: papis.document.Document,
         filepaths: List[str],
         git: bool = False) -> None:
-    from string import ascii_lowercase
-    g = papis.utils.create_identifier(ascii_lowercase)
-    string_append = ""
-
-    _doc_folder = document.get_main_folder()
-    if not _doc_folder:
+    doc_folder = document.get_main_folder()
+    if not doc_folder:
         raise Exception("Document does not have a folder attached")
 
-    for _ in range(len(document.get_files())):
-        string_append = next(g)
+    from papis.utils import create_identifier
+    suffix = create_identifier(skip=len(document.get_files()))
 
+    from papis.commands.add import get_file_name
     new_file_list = []
-    for i in range(len(filepaths)):
-        in_file_path = filepaths[i]
 
+    for in_file_path in filepaths:
         if not os.path.exists(in_file_path):
             raise Exception("{} not found".format(in_file_path))
 
         # Rename the file in the staging area
-        new_filename = papis.utils.clean_document_name(
-            papis.commands.add.get_file_name(
-                papis.document.to_dict(document),
-                in_file_path,
-                suffix=string_append
-            )
+        new_filename = get_file_name(
+            papis.document.to_dict(document),
+            in_file_path,
+            suffix=next(suffix)
         )
+        out_file_path = os.path.join(doc_folder, new_filename)
         new_file_list.append(new_filename)
 
-        end_document_path = os.path.join(
-            _doc_folder,
-            new_filename
-        )
-        string_append = next(g)
-
         # Check if the absolute file path is > 255 characters
-        if len(os.path.abspath(end_document_path)) >= 255:
+        if len(os.path.abspath(out_file_path)) >= 255:
             logger.warning(
                 "Length of absolute path is > 255 characters. "
                 "This may cause some issues with some pdf viewers")
 
-        if os.path.exists(end_document_path):
-            logger.warning(
-                "%s already exists, ignoring...", end_document_path)
+        if os.path.exists(out_file_path):
+            logger.warning("%s already exists, ignoring...", out_file_path)
             continue
 
         import shutil
-        logger.info("[CP] '%s' to '%s'", in_file_path, end_document_path)
-        shutil.copy(in_file_path, end_document_path)
+        logger.info("[CP] '%s' to '%s'", in_file_path, out_file_path)
+        shutil.copy(in_file_path, out_file_path)
 
     if "files" not in document:
         document["files"] = []
+
     document["files"] += new_file_list
-    document.save()
-    papis.database.get().update(document)
+    papis.api.save_doc(document)
+
     if git:
+
         for r in new_file_list + [document.get_info_file()]:
-            papis.git.add(_doc_folder, r)
+            papis.git.add(doc_folder, r)
         papis.git.commit(
-            _doc_folder,
+            doc_folder,
             "Add new files to '{}'".format(papis.document.describe(document)))
 
 
@@ -128,7 +116,6 @@ def cli(query: str,
         query, doc_folder, sort_field, sort_reverse)
 
     if not documents:
-        import papis.strings
         logger.warning(papis.strings.no_documents_retrieved_message)
         return
 

--- a/papis/commands/addto.py
+++ b/papis/commands/addto.py
@@ -124,19 +124,15 @@ def cli(query: str,
         doc_folder: str,
         sort_reverse: bool) -> None:
     """Add files to an existing document"""
-    if doc_folder:
-        documents = [papis.document.from_folder(doc_folder)]
-    else:
-        documents = papis.database.get().query(query)
+    documents = papis.cli.handle_doc_folder_query_sort(
+        query, doc_folder, sort_field, sort_reverse)
 
     if not documents:
+        import papis.strings
         logger.warning(papis.strings.no_documents_retrieved_message)
         return
 
-    if sort_field:
-        documents = papis.document.sort(documents, sort_field, sort_reverse)
-
-    docs = papis.pick.pick_doc(documents)
+    docs = papis.api.pick_doc(documents)
 
     if not docs:
         return

--- a/papis/utils.py
+++ b/papis/utils.py
@@ -2,7 +2,6 @@ import os
 import sys
 import re
 import pathlib
-from itertools import count, product
 from typing import (Optional, List, Iterator, Iterable, Any, Dict,
                     Union, Callable, TypeVar, Tuple, TYPE_CHECKING)
 
@@ -152,7 +151,7 @@ def get_folders(folder: str) -> List[str]:
     return folders
 
 
-def create_identifier(input_list: str) -> Iterator[str]:
+def create_identifier(input_list: Optional[str] = None, skip: int = 0) -> Iterator[str]:
     """This creates a generator object capable of iterating over lists to
     create combinations of that list that result in unique strings.
     Ideally for use in modifying an existing string to make it unique.
@@ -166,10 +165,20 @@ def create_identifier(input_list: str) -> Iterator[str]:
     (`see here <https://stackoverflow.com/questions/14381940/>`__)
 
     :param input_list: list to iterate over
+    :param skip: number of identifiers to skip.
     """
-    for n in count(1):
-        for s in product(input_list, repeat=n):
-            yield "".join(s)
+    import string
+    from itertools import count, product, islice
+
+    def ids() -> Iterator[str]:
+        inputs = string.ascii_lowercase if input_list is None else input_list
+
+        for n in count(1):
+            for s in product(inputs, repeat=n):
+                yield "".join(s)
+
+    for i in islice(ids(), skip, None):
+        yield i
 
 
 def clean_document_name(doc_path: str) -> str:


### PR DESCRIPTION
* extend `create_identifier` to skip first `n` entries and use that in `addto`.
* use `handle_doc_folder_query_sort`.
* `add.get_file_name` already does `clean_document_name`, so `addto` doesn't need to.
* use `papis.api`.