### PR TITLE
commands.git: name command correctly

### DIFF
--- a/papis/commands/git.py
+++ b/papis/commands/git.py
@@ -27,5 +27,6 @@ import click
 import papis.commands.run
 
 cli = copy.deepcopy(papis.commands.run.cli)
+cli.name = "git"
 cli.help = "Run git command in a library or document folder"
 cli = click.option("--prefix", hidden=True, default="git", type=str)(cli)


### PR DESCRIPTION
Previously was still `run`, while now it's correctly set to `git`.