### PR TITLE
Add a Developer API section to the docs

### DIFF
--- a/doc/source/conf.py
+++ b/doc/source/conf.py
@@ -42,6 +42,9 @@ extensions = [
 
 intersphinx_mapping = {
     "https://docs.python.org/3/": None,
+    "https://requests.readthedocs.io/en/latest/": None,
+    "https://bibtexparser.readthedocs.io/en/master": None,
+    "https://docs.openstack.org/stevedore/latest/": None,
 }
 
 autodoc_member_order = "bysource"
@@ -65,21 +68,20 @@ class PapisConfig(Directive):
     add_index = True
 
     def run(self):
-        import papis.config
+        from papis.config import get_general_settings_name, get_default_settings
         key = self.arguments[0]
         section = self.options.get(
             "section",
-            papis.config.get_general_settings_name())
+            get_general_settings_name())
         default = self.options.get(
             "default",
-            papis.config.get_default_settings().get(section).get(key))
+            get_default_settings().get(section, {}).get(key, "<missing>"))
 
         lines = []
         lines.append("")
-        lines.append(".. _config-{section}-{key}:"
-                     .format(section=section, key=key))
+        lines.append(".. _config-{section}-{key}:".format(section=section, key=key))
         lines.append("")
-        lines.append("**{key}** (config-{section}-{key}_)"
+        lines.append("`{key} <config-{section}-{key}>`_"
                      .format(section=section, key=key))
 
         if "\n" in str(default):

--- a/doc/source/developer_reference.rst
+++ b/doc/source/developer_reference.rst
@@ -1,0 +1,32 @@
+Developer API reference
+-----------------------
+
+.. warning::
+
+   The APIs documented here are not stable and may change from one version to
+   another. This is meant to be used by developers, both of ``papis`` itself and
+   any external plugins.
+
+``papis.document``
+^^^^^^^^^^^^^^^^^^
+
+.. automodule:: papis.document
+    :members:
+
+``papis.importer``
+^^^^^^^^^^^^^^^^^^
+
+.. automodule:: papis.importer
+    :members:
+
+``papis.utils``
+^^^^^^^^^^^^^^^
+
+.. automodule:: papis.utils
+    :members:
+
+``papis.yaml``
+^^^^^^^^^^^^^^
+
+.. automodule:: papis.yaml
+    :members:

--- a/doc/source/document.rst
+++ b/doc/source/document.rst
@@ -1,5 +1,0 @@
-Document
-========
-
-.. automodule:: papis.document
-  :members:

--- a/doc/source/index.rst
+++ b/doc/source/index.rst
@@ -26,7 +26,6 @@ command-line interface (*CLI*) is heavily tailored after
    gui
    editors
    hooks
-   document
    scripting
    api
    plugins
@@ -34,6 +33,7 @@ command-line interface (*CLI*) is heavily tailored after
    scihub
    importing
    shell_completion
+   developer_reference
    faq
 
 

--- a/papis/importer.py
+++ b/papis/importer.py
@@ -5,12 +5,12 @@ import papis
 import papis.plugin
 import papis.logging
 
-
 if TYPE_CHECKING:
-    from stevedore import ExtensionManager
+    import stevedore.extension
 
 IMPORTER_PLUGIN_ID = "papis.importer"
 
+#: Invariant :class:`TypeVar` bound to the :class:`Importer` class.
 ImporterT = TypeVar("ImporterT", bound="Importer")
 
 
@@ -22,6 +22,9 @@ def cache(meth: Callable[[ImporterT], None]) -> Callable[[ImporterT], None]:
 
     :param meth: a method of an :class:`Importer`.
     """
+    from functools import wraps
+
+    @wraps(meth)
     def wrapper(self: ImporterT) -> None:
         if not self.ctx:
             meth(self)
@@ -64,15 +67,6 @@ class Importer:
     .. attribute:: ctx
 
         A :class:`Context` that stores the data retrieved by the importer.
-
-    .. automethod:: __init__
-
-    .. automethod:: match
-    .. automethod:: match_data
-
-    .. automethod:: fetch
-    .. automethod:: fetch_data
-    .. automethod:: fetch_files
     """
 
     def __init__(self,
@@ -169,8 +163,10 @@ class Importer:
         return "Importer({}, uri={})".format(self.name, self.uri)
 
 
-def get_import_mgr() -> "ExtensionManager":
-    """Retrieve the ``stevedore.ExtensionManager`` for importer plugins."""
+def get_import_mgr() -> "stevedore.extension.ExtensionManager":
+    """Retrieve the :class:`stevedore.extension.ExtensionManager` for
+    importer plugins.
+    """
     return papis.plugin.get_extension_manager(IMPORTER_PLUGIN_ID)
 
 

--- a/papis/yaml.py
+++ b/papis/yaml.py
@@ -73,8 +73,9 @@ def yaml_to_list(yaml_path: str,
                  raise_exception: bool = False) -> List[Dict[str, Any]]:
     """Read a list of YAML documents.
 
-    This is analogous to :func:`yaml_to_data`, but uses :func:`yaml.load_all` to
-    read multiple documents.
+    This is analogous to :func:`yaml_to_data`, but uses ``yaml.load_all`` to
+    read multiple documents (see
+    `PyYAML docs <https://pyyaml.org/wiki/PyYAMLDocumentation>`__).
 
     :param yaml_path: path to a file containing YAML documents.
     :param raise_exception: if *True* an exception is raised when loading the
@@ -135,6 +136,7 @@ class Importer(papis.importer.Importer):
 
     @classmethod
     def match(cls, uri: str) -> Optional[papis.importer.Importer]:
+        """Check if the *uri* points to an existing YAML file."""
         importer = Importer(uri=uri)
         if os.path.exists(uri) and not os.path.isdir(uri):
             importer.fetch()
@@ -142,6 +144,7 @@ class Importer(papis.importer.Importer):
         return None
 
     def fetch_data(self: papis.importer.Importer) -> Any:
+        """Fetch metadata from the YAML file."""
         self.ctx.data = yaml_to_data(self.uri, raise_exception=True)
         if self.ctx:
             self.logger.debug("Successfully read file: '%s'.", self.uri)


### PR DESCRIPTION
I was cleanup up some random docs lately (e.g. #532) so this adds them to the actual rendered html to make sure that everything is nice and pretty. It currently adds `papis.document`, `papis.importer`, `papis.utils` and `papis.yaml` with a big warning that these are dev docs. 

@jghauser I'm not sure where you left off with the doc re-organization, so let me know if this conflicts too much with what you had in mind. It looks something like this

![Screenshot_20230322_210600](https://user-images.githubusercontent.com/777240/227010922-258f9511-503c-42ff-916f-25ab3f15cc34.png)
