### PR TITLE
format: only unescape newlines and tabs

### DIFF
--- a/papis/format.py
+++ b/papis/format.py
@@ -19,15 +19,8 @@ class InvalidFormaterError(ValueError):
 InvalidFormatterValue = InvalidFormaterError
 
 
-def escape(fmt: str) -> str:
-    # NOTE: this escapes '\n' and '\t' characters in the string so that they
-    # get printed properly when doing the 'fmt.format' below
-
-    import codecs
-    try:
-        return codecs.decode(fmt, "unicode-escape")
-    except ValueError:
-        return fmt
+def unescape(fmt: str) -> str:
+    return fmt.replace("\\n", "\n").replace("\\t", "\t").replace("\\r", "\r")
 
 
 class Formater:
@@ -68,7 +61,7 @@ class PythonFormater(Formater):
         if additional is None:
             additional = {}
 
-        fmt = escape(fmt)
+        fmt = unescape(fmt)
         if not isinstance(doc, papis.document.Document):
             doc = papis.document.from_data(doc)
 
@@ -109,7 +102,7 @@ class Jinja2Formater(Formater):
 
         from jinja2 import Template
 
-        fmt = escape(fmt)
+        fmt = unescape(fmt)
         if not isinstance(doc, papis.document.Document):
             doc = papis.document.from_data(doc)
 

--- a/tests/test_format.py
+++ b/tests/test_format.py
@@ -19,8 +19,8 @@ def test_python_formater(monkeypatch):
             papis.format.format("{doc[author]}: {doc[title]}", document)
             == "Fulano: A New Hope")
         assert (
-            papis.format.format("{doc[author]}:\\n\\t{doc[title]}", document)
-            == "Fulano:\n\tA New Hope")
+            papis.format.format("{doc[author]}:\\n\\t»{doc[title]}", document)
+            == "Fulano:\n\t»A New Hope")
         assert (
             papis.format.format(
                 "{doc[author]}: {doc[title]} - {doc[blahblah]}",


### PR DESCRIPTION
#491 seems to have been broken because it messed around with other unicode as well. This attempts to do the dumb thing and just replace `\\n` with `\n`.