### PR TITLE
update: allow setting the ref

### DIFF
--- a/papis/commands/bibtex.py
+++ b/papis/commands/bibtex.py
@@ -143,7 +143,6 @@ import papis.commands.open
 import papis.commands.edit
 import papis.commands.browse
 import papis.commands.export
-from papis.commands.update import _update_with_database
 import papis.bibtex
 import papis.logging
 
@@ -306,6 +305,8 @@ def _edit(ctx: click.Context,
         papis bibtex read article.bib edit --set __proj focal-point --all
 
     """
+    from papis.api import save_doc
+
     not_found = 0
     docs = ctx.obj["documents"]
     if not docs:
@@ -318,7 +319,7 @@ def _edit(ctx: click.Context,
             if set_tuples:
                 for k, v in set_tuples:
                     located[k] = papis.format.format(v, located)
-                _update_with_database(located)
+                save_doc(located)
             else:
                 papis.commands.edit.run(located)
         except IndexError:

--- a/tests/commands/test_update.py
+++ b/tests/commands/test_update.py
@@ -105,3 +105,13 @@ class TestCli(tests.cli.TestCli):
     #         "krishnamurti", "--from", "bibtex", yamlpath
     #     ])
     #     self.assertEqual(result.exit_code, 0)
+
+    def test_update_ref(self):
+        result = self.invoke([
+            "krishnamurti", "--set", "ref", "NewRef",
+            ])
+        self.assertEqual(result.exit_code, 0)
+
+        db = papis.database.get()
+        doc, = db.query_dict({"author": "krishnamurti"})
+        assert doc["ref"] == "NewRef"


### PR DESCRIPTION
This reworks how `papis update` handles refs:
* *before*: refs could not be modified at all.
* *after*: `papis update --set ref MyCoolNewRef <query>` modifies the ref, but importers cannot modify the ref.

@alejandrogallo This seems reasonable to me. The original `data[ref] = document[ref]` line was added in #80, but I can't think of a good reason not to allow this now. Any thoughts?

Fixes #518