### PR TITLE
docs: Fix missing whitespaces in CLI help texts

### DIFF
--- a/papis/commands/add.py
+++ b/papis/commands/add.py
@@ -525,7 +525,7 @@ def run(paths: List[str],
     default=lambda: True if papis.config.get("add-edit") else False)
 @click.option(
     "--link/--no-link",
-    help="Instead of copying the file to the library, create a link to"
+    help="Instead of copying the file to the library, create a link to "
          "its original location",
     default=False)
 @papis.cli.git_option(help="Git add and commit the new document")

--- a/papis/commands/bibtex.py
+++ b/papis/commands/bibtex.py
@@ -288,7 +288,7 @@ def _open(ctx: click.Context) -> None:
 @cli.command("edit")
 @click.help_option("-h", "--help")
 @click.option("-s", "--set", "set_tuples",
-              help="Update document's information with key value."
+              help="Update document's information with key value. "
               "The value can be a papis format.",
               multiple=True,
               type=(str, str),)

--- a/papis/commands/merge.py
+++ b/papis/commands/merge.py
@@ -65,7 +65,7 @@ def run(keep: papis.document.Document,
 @papis.cli.sort_option()
 @click.option("-s",
               "--second",
-              help="Keep the second document after merge and erase the first,"
+              help="Keep the second document after merge and erase the first, "
                    "the default is keep the first",
               default=False,
               is_flag=True)

--- a/papis/commands/update.py
+++ b/papis/commands/update.py
@@ -109,7 +109,7 @@ def run(document: papis.document.Document,
               multiple=True,
               default=(),)
 @click.option("-s", "--set", "set_tuples",
-              help="Update document's information with key value."
+              help="Update document's information with key value. "
                    "The value can be a papis format.",
               multiple=True,
               type=(str, str),)


### PR DESCRIPTION
Found this typo in `papis add --help`:
```
--link / --no-link        Instead of copying the file to the library, create
                            a link toits original location
```

This missing whitespace is a result of code formatting to keep line width.

A quick regex search resulted in some more strings added the same way.