### PR TITLE
Allow for http URLs where filepaths are required (`add --from bibtex` and `addto`)

### DIFF
--- a/papis/bibtex.py
+++ b/papis/bibtex.py
@@ -161,15 +161,15 @@ class Importer(papis.importer.Importer):
             else:
                 bib_data = bibtex_to_dict(self.uri)
         except requests.exceptions.RequestException as exc:
-            self.logger.warning("Failed to fetch '%s' (reason: %s)",
-                                self.uri, exc, exc_info=exc)
+            self.logger.warning("Failed to fetch '%s'.",
+                                self.uri, exc_info=exc)
         except Exception as exc:
             self.logger.error("Error reading BibTeX file: '%s'.",
                               self.uri, exc_info=exc)
             return
 
         if not bib_data:
-            self.logger.warning("empty or invalid bibtex at '%s'", self.uri)
+            self.logger.warning("Empty or invalid BibTeX entry at '%s'.", self.uri)
             return
 
         if len(bib_data) > 1:

--- a/papis/bibtex.py
+++ b/papis/bibtex.py
@@ -1,7 +1,6 @@
 import os
 import string
 import tempfile
-import logging
 from typing import Optional, List, FrozenSet, Dict, Any, Iterator
 
 import requests
@@ -147,7 +146,8 @@ class Importer(papis.importer.Importer):
         self.logger.info("Reading input file = '%s'.", self.uri)
         try:
             bib_data = []
-            if self.uri.startswith("http://") or self.uri.startswith("https://"):
+            if self.uri.startswith("http://") \
+                    or self.uri.startswith("https://"):
                 resp = requests.get(self.uri)
                 if resp.status_code == 200:
                     with tempfile.NamedTemporaryFile(suffix=".papis.bib",
@@ -169,7 +169,7 @@ class Importer(papis.importer.Importer):
             return
 
         if not bib_data:
-            self.logger.warning(f"empty or invalid bibtex at {self.uri}")
+            self.logger.warning("empty or invalid bibtex at '%s'", self.uri)
             return
 
         if len(bib_data) > 1:

--- a/papis/bibtex.py
+++ b/papis/bibtex.py
@@ -160,9 +160,9 @@ class Importer(papis.importer.Importer):
                                         self.uri, resp.status_code)
             else:
                 bib_data = bibtex_to_dict(self.uri)
-        except requests.exceptions.BaseHTTPError as e:
+        except requests.exceptions.RequestException as exc:
             self.logger.warning("Failed to fetch '%s' (reason: %s)",
-                                self.uri, e)
+                                self.uri, exc, exc_info=exc)
         except Exception as exc:
             self.logger.error("Error reading BibTeX file: '%s'.",
                               self.uri, exc_info=exc)

--- a/papis/bibtex.py
+++ b/papis/bibtex.py
@@ -1,7 +1,10 @@
 import os
 import string
+import tempfile
+import logging
 from typing import Optional, List, FrozenSet, Dict, Any, Iterator
 
+import requests
 import click
 
 import papis.config
@@ -143,13 +146,30 @@ class Importer(papis.importer.Importer):
     def fetch_data(self: papis.importer.Importer) -> Any:
         self.logger.info("Reading input file = '%s'.", self.uri)
         try:
-            bib_data = bibtex_to_dict(self.uri)
+            bib_data = []
+            if self.uri.startswith("http://") or self.uri.startswith("https://"):
+                resp = requests.get(self.uri)
+                if resp.status_code == 200:
+                    with tempfile.NamedTemporaryFile(suffix=".papis.bib",
+                                                     mode="w+b") as tf:
+                        tf.write(resp.content)
+                        tf.flush()
+                        bib_data = bibtex_to_dict(tf.name)
+                else:
+                    self.logger.warning("Failed to fetch '%s' (http error %d)",
+                                        self.uri, resp.status_code)
+            else:
+                bib_data = bibtex_to_dict(self.uri)
+        except requests.exceptions.BaseHTTPError as e:
+            self.logger.warning("Failed to fetch '%s' (reason: %s)",
+                                self.uri, e)
         except Exception as exc:
             self.logger.error("Error reading BibTeX file: '%s'.",
                               self.uri, exc_info=exc)
             return
 
         if not bib_data:
+            self.logger.warning(f"empty or invalid bibtex at {self.uri}")
             return
 
         if len(bib_data) > 1:

--- a/papis/commands/addto.py
+++ b/papis/commands/addto.py
@@ -137,12 +137,12 @@ def run(document: papis.document.Document,
               help="File name for the document (papis format)",
               default=None)
 @papis.cli.doc_folder_option()
-def cli(query: str, 
-        git: bool, 
-        files: List[str], 
+def cli(query: str,
+        git: bool,
+        files: List[str],
         urls: List[str],
-        file_name: Optional[str], 
-        sort_field: Optional[str], 
+        file_name: Optional[str],
+        sort_field: Optional[str],
         doc_folder: str,
         sort_reverse: bool) -> None:
     """Add files to an existing document"""

--- a/papis/commands/addto.py
+++ b/papis/commands/addto.py
@@ -23,8 +23,7 @@ import tempfile
 from typing import List, Optional
 
 import click
-import requests
-
+import papis.api
 import papis.cli
 import papis.commands.add
 import papis.config
@@ -34,13 +33,7 @@ import papis.logging
 import papis.pick
 import papis.strings
 import papis.utils
-import papis.api
-import papis.cli
-import papis.git
-import papis.config
-import papis.document
-import papis.logging
-import papis.strings
+import requests
 from papis.exceptions import DocumentFolderNotFound
 
 logger = papis.logging.get_logger(__name__)
@@ -75,9 +68,11 @@ def run(document: papis.document.Document,
                     logger.warning("Failed to fetch '%s' (http error %d)",
                                    in_file_path, resp.status_code)
                     continue
-            except requests.exceptions.BaseHTTPError as e:
+            except requests.exceptions.RequestException as exc:
                 logger.warning("Failed to fetch '%s' (reason: %s)",
-                               in_file_path, exc_info=e)
+                               in_file_path,
+                               exc,
+                               exc_info=exc)
                 continue
             except Exception as e:
                 logger.error(str(e), exc_info=e)

--- a/papis/commands/addto.py
+++ b/papis/commands/addto.py
@@ -137,8 +137,13 @@ def run(document: papis.document.Document,
               help="File name for the document (papis format)",
               default=None)
 @papis.cli.doc_folder_option()
-def cli(query: str, git: bool, files: List[str], urls: List[str],
-        file_name: Optional[str], sort_field: Optional[str], doc_folder: str,
+def cli(query: str, 
+        git: bool, 
+        files: List[str], 
+        urls: List[str],
+        file_name: Optional[str], 
+        sort_field: Optional[str], 
+        doc_folder: str,
         sort_reverse: bool) -> None:
     """Add files to an existing document"""
     documents = papis.cli.handle_doc_folder_query_sort(

--- a/papis/commands/addto.py
+++ b/papis/commands/addto.py
@@ -74,14 +74,13 @@ def run(document: papis.document.Document,
                 else:
                     logger.warning("Failed to fetch '%s' (http error %d)",
                                    in_file_path, resp.status_code)
-                    in_file_path = None
+                    continue
             except requests.exceptions.BaseHTTPError as e:
                 logger.warning("Failed to fetch '%s' (reason: %s)",
-                               in_file_path, e)
-                in_file_path = None
+                               in_file_path, exc_info=e)
+                continue
             except Exception as e:
-                logger.error(e)
-                in_file_path = None
+                logger.error(str(e), exc_info=e)
                 return
 
         if not os.path.exists(in_file_path):

--- a/papis/commands/addto.py
+++ b/papis/commands/addto.py
@@ -69,13 +69,12 @@ def run(document: papis.document.Document,
                                    in_file_path, resp.status_code)
                     continue
             except requests.exceptions.RequestException as exc:
-                logger.warning("Failed to fetch '%s' (reason: %s)",
+                logger.warning("Failed to fetch '%s'.",
                                in_file_path,
-                               exc,
                                exc_info=exc)
                 continue
             except Exception as e:
-                logger.error(str(e), exc_info=e)
+                logger.error("Failed to fetch '%s'.", in_file_path, exc_info=e)
                 return
 
         if not os.path.exists(in_file_path):


### PR DESCRIPTION
Allows for two usecases:
* `papis addto -u https://example.com/paper.pdf paper`
* `papis add --from bibtex https://example.com/paper.bib`