### PR TITLE
Add config option for --reverse

### DIFF
--- a/doc/source/conf.py
+++ b/doc/source/conf.py
@@ -45,6 +45,7 @@ intersphinx_mapping = {
     "https://requests.readthedocs.io/en/latest/": None,
     "https://bibtexparser.readthedocs.io/en/master": None,
     "https://docs.openstack.org/stevedore/latest/": None,
+    "https://click.palletsprojects.com/en/latest/": None,
 }
 
 autodoc_member_order = "bysource"

--- a/doc/source/default-settings.rst
+++ b/doc/source/default-settings.rst
@@ -771,6 +771,13 @@ Other
   if you want your documents by default to be sorted by ``year``, you
   would set ``sort-field = year``.
 
+.. papis-config:: sort-reverse
+
+    Augments ``sort-field`` by allowing the documents to be sorted in
+    reverse order. For example, when sorting by year, this allows sorting
+    ascendingly or descendingly. This is a boolean option that can be set to
+    ``True`` or ``False``.
+
 .. papis-config:: time-stamp
 
   Whether or not to add a timestamp to a document when is being added to

--- a/doc/source/developer_reference.rst
+++ b/doc/source/developer_reference.rst
@@ -7,6 +7,12 @@ Developer API reference
    another. This is meant to be used by developers, both of ``papis`` itself and
    any external plugins.
 
+``papis.cli``
+^^^^^^^^^^^^^
+
+.. automodule:: papis.cli
+    :members:
+
 ``papis.document``
 ^^^^^^^^^^^^^^^^^^
 

--- a/papis/cli.py
+++ b/papis/cli.py
@@ -43,6 +43,7 @@ def sort_option(**attrs: Any) -> DecoratorCallable:
         reverse = click.option(
             "--reverse", "sort_reverse",
             help="Reverse sort order",
+            default=lambda: papis.config.getboolean("sort-reverse"),
             is_flag=True)
 
         return sort(reverse(f))

--- a/papis/defaults.py
+++ b/papis/defaults.py
@@ -18,6 +18,7 @@ settings = {
     "database-backend": "papis",
     "default-query-string": ".",
     "sort-field": None,
+    "sort-reverse": False,
 
     "opentool": get_default_opener(),
     "dir-umask": 0o755,


### PR DESCRIPTION
The second commit adds the new configuration option. 
The first commit is just a bunch of documentation fixes for `papis.cli`.

Fixes #542.