### PR TITLE
docs: add papis.downloaders to dev docs

### DIFF
--- a/doc/source/developer_reference.rst
+++ b/doc/source/developer_reference.rst
@@ -19,6 +19,12 @@ Developer API reference
 .. automodule:: papis.document
     :members:
 
+``papis.downloaders``
+^^^^^^^^^^^^^^^^^^^^^
+
+.. automodule:: papis.downloaders
+   :members:
+
 ``papis.importer``
 ^^^^^^^^^^^^^^^^^^
 

--- a/papis/downloaders/__init__.py
+++ b/papis/downloaders/__init__.py
@@ -21,12 +21,13 @@ def _extension_name() -> str:
 
 
 class Importer(papis.importer.Importer):
+    """Importer that tries to get data and files from implemented downloaders.
 
-    """Importer that tries to get data and files from implemented downloaders
+    This importer simply calls :func:`get_info_from_url` on the given URI.
     """
 
-    def __init__(self, **kwargs: Any) -> None:
-        super().__init__(name="url", **kwargs)
+    def __init__(self, uri: str = "") -> None:
+        super().__init__(uri=uri, name="url")
 
     @classmethod
     def match(cls, uri: str) -> Optional[papis.importer.Importer]:
@@ -36,27 +37,47 @@ class Importer(papis.importer.Importer):
             else None
         )
 
+    @papis.importer.cache
     def fetch(self) -> None:
         self.logger.info("Attempting to import from URL '%s'.", self.uri)
-        self.ctx = get_info_from_url(self.uri) or papis.importer.Context()
+        self.ctx = get_info_from_url(self.uri)
 
     def fetch_data(self) -> None:
-        pass
+        self.fetch()
 
     def fetch_files(self) -> None:
-        pass
+        self.fetch()
 
 
 class Downloader(papis.importer.Importer):
+    """A base class for downloader instances implementing common functionality.
 
-    """This is the base class for every downloader.
+    In general, downloaders are expected to implement a subset of the methods
+    below, depending on the generality. A simple downloader could only
+    implement :meth:`get_bibtex_url` and :meth:`get_document_url`.
+
+    .. attribute:: expected_document_extension
+
+        A single extension or a list of extensions supported by the downloader.
+        The extensions do not contain the leading dot, e.g. ``["pdf", "djvu"]``.
+
+    .. attribute:: priority
+
+        A priority given to the downloader. This is used when trying to
+        automatically determine a prefered downloader for a given URL.
+
+    .. attribute:: session
+
+        A :class:`requests.Session` that is used for all the requests made by
+        the downloader.
     """
 
     def __init__(self,
                  uri: str = "",
                  name: str = "",
                  ctx: Optional[papis.importer.Context] = None,
-                 expected_document_extension: Optional[Union[str, List[str]]] = None,
+                 expected_document_extension: Optional[
+                     Union[str, Sequence[str]]] = None,
                  cookies: Optional[Dict[str, str]] = None,
                  priority: int = 1,
                  ) -> None:
@@ -75,20 +96,65 @@ class Downloader(papis.importer.Importer):
         self.expected_document_extension = expected_document_extension
         self.priority = priority
         self.session = papis.utils.get_session()
-        self._soup = None  # type: Optional[bs4.BeautifulSoup]
+        self.cookies = cookies
 
+        # NOTE: used to cache data
+        self._soup = None  # type: Optional[bs4.BeautifulSoup]
         self.bibtex_data = None  # type: Optional[str]
         self.document_data = None  # type: Optional[bytes]
-
-        self.cookies = cookies
 
     def __del__(self) -> None:
         self.session.close()
 
-    def fetch_data(self) -> None:
+    @classmethod
+    def match(cls, url: str) -> Optional["Downloader"]:
+        """Check if the downloader can process the given URL.
+
+        For example, an importer that supports links from the arXiv can check
+        that the given URL matches using:
+
+        .. code:: python
+
+            re.match(r".*arxiv.org.*", uri)
+
+        This can then be used to instantiate and return a corresponding
+        :class:`Downloader` object.
+
+        :param url: An URL where the document information should be retrieved from.
+        :return: A downloader instance if the match to the URL is successful or
+            *None* otherwise.
         """
-        Try first to get data by hand with the get_data command.
-        Then commplement with bibtex data.
+        raise NotImplementedError(
+            "Matching URI not implemented for '{}.{}'"
+            .format(cls.__module__, cls.__name__))
+
+    @papis.importer.cache
+    def fetch(self) -> None:
+        """Fetch metadata and files for the given :attr:`~papis.importer.Importer.uri`.
+
+        This method calls :meth:`Downloader.fetch_data` and
+        :meth:`Downloader.fetch_files` to get all the information available for
+        the document. It is recommended to implement the two methods separately,
+        if possible, for maximum flexibility.
+
+        The imported data is stored in :attr:`~papis.importer.Importer.ctx` and
+        it is not queried again on subsequent calls to this function.
+        """
+        self.fetch_data()
+        self.fetch_files()
+
+    def fetch_data(self) -> None:
+        """Fetch metadata for the given URL.
+
+        The imported metadata is stored in :attr:`~papis.importer.Importer.ctx`.
+        To fetch the metadata, the following steps are followed
+
+        * Call :meth:`get_data` to import any scraped metadata.
+        * Call :meth:`get_bibtex_data` to import any metadata from BibTeX
+          files available remotely.
+
+        Note that previous steps overwrite any information, i.e. the BibTeX
+        data will take priority.
         """
         # Try with get_data
         try:
@@ -128,6 +194,12 @@ class Downloader(papis.importer.Importer):
                 self.ctx.data["doi"] = doi
 
     def fetch_files(self) -> None:
+        """Fetch files from the given :attr:`~papis.importer.Importer.uri`.
+
+        The imported files are stored in :attr:`~papis.importer.Importer.ctx`.
+        The file is downloaded with :meth:`download_document` and stored as
+        a temporary file.
+        """
         # get documents
         try:
             self.download_document()
@@ -143,22 +215,18 @@ class Downloader(papis.importer.Importer):
                     self.logger.info("Saving downloaded file in '%s'.", f.name)
                     self.ctx.files.append(f.name)
 
-    def fetch(self) -> None:
-        self.fetch_data()
-        self.fetch_files()
-
-    @classmethod
-    def match(cls, url: str) -> Optional["Downloader"]:
-        raise NotImplementedError(
-            "Matching URI not implemented for '{}.{}'"
-            .format(cls.__module__, cls.__name__))
-
     def _get_body(self) -> bytes:
-        """Get body of the uri, this is also important for unittesting"""
+        """Download the content (body) at the given URL.
+
+        This method is mainly available for unittesting, i.e. so that it can get
+        monkeypatched and return known data.
+        """
         return self.session.get(self.uri, cookies=self.cookies).content
 
     def _get_soup(self) -> "bs4.BeautifulSoup":
-        """Get body of the uri, this is also important for unittesting"""
+        """Create an instance of :class:`bs4.BeautifulSoup` that parses
+        the results from :meth:`_get_body`.
+        """
         if self._soup:
             return self._soup
 
@@ -170,34 +238,31 @@ class Downloader(papis.importer.Importer):
         return self._soup
 
     def __str__(self) -> str:
-        return "Downloader({0}, uri={1})".format(self.name, self.uri)
+        return "Downloader({}, uri={})".format(self.name, self.uri)
 
     def get_bibtex_url(self) -> Optional[str]:
-        """It returns the urls that is to be access to download
-        the bibtex information. It has to be implemented for every
-        downloader, or otherwise it will raise an exception.
-
-        :returns: Bibtex url
+        """
+        :returns: an URL to a valid BibTeX file that can be used to extract
+            metadata about the document.
         """
         raise NotImplementedError(
             "Getting a BibTeX URL not implemented for the '{}' downloader".
             format(self.name))
 
     def get_bibtex_data(self) -> Optional[str]:
-        """Get the bibtex_data data if it has been downloaded already
-        and if not download it and return the data in utf-8 format.
+        """Get BibTeX data available at :meth:`get_bibtex_url`, if any.
 
-        :returns: Bibtex data in utf-8 format
+        :returns: a string containing the BibTeX data, which can be parsed.
         """
         if not self.bibtex_data:
             self.download_bibtex()
+
         return self.bibtex_data
 
     def download_bibtex(self) -> None:
-        """Bibtex downloader, it should try to download bibtex information from
-        the url provided by ``get_bibtex_url``.
+        """Download and store that BibTeX data from :meth:`get_bibtex_url`.
 
-        It sets the ``bibtex_data`` attribute if it succeeds.
+        Use :meth:`get_bibtex_data` to access the metadata from the BibTeX URL.
         """
         url = self.get_bibtex_url()
         if not url:
@@ -207,51 +272,48 @@ class Downloader(papis.importer.Importer):
         response = self.session.get(url, cookies=self.cookies)
         self.bibtex_data = response.content.decode()
 
-    def get_document_url(self) -> Optional[str]:
-        """It returns the urls that is to be access to download
-        the document information. It has to be implemented for every
-        downloader, or otherwise it will raise an exception.
-
-        :returns: Document url
-        """
-        raise NotImplementedError(
-            "Getting a document URL not implemented for the '{}' downloader"
-            .format(self.name))
-
     def get_data(self) -> Dict[str, Any]:
-        """A general data retriever, for instance when data needn't need
-        to come from a bibtex
+        """Retrieve general metadata from the given URL.
+
+        This function is meant to be as general as possible and should not
+        contain data imported from BibTeX (use :meth:`get_bibtex_data` instead).
+        For example, this can be used for web scrapping or calling other website
+        APIs to gather metadata about the document.
         """
         raise NotImplementedError(
             "Getting data is not implemented for the '{}' downloader"
             .format(self.name))
 
     def get_doi(self) -> Optional[str]:
-        """It returns the doi of the document, if it is retrievable.
-        It has to be implemented for every downloader, or otherwise it will
-        raise an exception.
-
-        :returns: Document doi
+        """
+        :returns: a DOI for the document, if any.
         """
         raise NotImplementedError(
             "Getting the DOI not implemented for the '{}' downloader"
             .format(self.name))
 
-    def get_document_data(self) -> Optional[bytes]:
-        """Get the document_data data if it has been downloaded already
-        and if not download it and return the data in binary format.
+    def get_document_url(self) -> Optional[str]:
+        """
+        :returns: a URL to a file that should be downloaded.
+        """
+        raise NotImplementedError(
+            "Getting a document URL not implemented for the '{}' downloader"
+            .format(self.name))
 
-        :returns: Document data in binary format
+    def get_document_data(self) -> Optional[bytes]:
+        """Get data for the downloaded file that is given by :meth:`get_document_url`.
+
+        :returns: the bytes (stored in memory) for the downloaded file.
         """
         if not self.document_data:
             self.download_document()
+
         return self.document_data
 
     def download_document(self) -> None:
-        """Document downloader, it should try to download document information
-        from the url provided by ``get_document_url``.
+        """Download and store the file that is given by :meth:`get_document_url`.
 
-        It sets the ``document_data`` attribute if it succeeds.
+        Use :meth:`get_document_data` to access the file binary contents.
         """
         url = self.get_document_url()
         if not url:
@@ -262,12 +324,13 @@ class Downloader(papis.importer.Importer):
         self.document_data = response.content
 
     def check_document_format(self) -> bool:
-        """Check if the downloaded document has the file type that the
-        downloader expects. If the downloader does not expect any special
-        file type, accept anything because there is no way to know if it is
-        correct.
+        """Check if the document downloaded by :meth:`download_document` has
+        a file type supported by the downloader.
 
-        :returns: True if it is of the right type, else otherwise
+        If the downloader has no prefered type, then all files are accepted.
+
+        :returns: *True* if the document has a supported file type and *False*
+            otherwise.
         """
         def print_warning() -> None:
             self.logger.error(
@@ -304,18 +367,16 @@ class Downloader(papis.importer.Importer):
 
 
 def get_available_downloaders() -> List[Type[Downloader]]:
-    """Get all declared downloader classes
-    """
-    _ret = papis.plugin.get_available_plugins(
-        _extension_name())  # type: List[Type[Downloader]]
+    """Get all declared downloader classes."""
+    _ret = papis.plugin.get_available_plugins(_extension_name())
     return _ret
 
 
-def get_matching_downloaders(url: str) -> Sequence[Downloader]:
-    """Get matching downloaders for the *url*.
+def get_matching_downloaders(url: str) -> List[Downloader]:
+    """Get downloaders matching the given *url*.
 
-    :param url: URL to be matched against.
-    :returns: A list of downloaders (sorted by priority).
+    :param url: a URL to match.
+    :returns: a list of downloaders (sorted by priority).
     """
     available_downloaders = get_available_downloaders()
     logger.debug("Found available downloaders: '%s'.",
@@ -327,17 +388,18 @@ def get_matching_downloaders(url: str) -> Sequence[Downloader]:
                if d is not None]  # List[Downloader]
 
     logger.debug("Found downloaders matching query '%s': '%s'.",
-                 url,
-                 "', '".join([d.name for d in matches]))
+                 url, "', '".join([d.name for d in matches]))
 
-    return sorted(matches, key=lambda k: k.priority, reverse=True)
+    return sorted(matches, key=lambda d: d.priority, reverse=True)
 
 
 def get_downloader_by_name(name: str) -> Type[Downloader]:
-    """Get a downloader by its name
+    """Get a specific downloader by its name.
 
-    :param name: Name of the downloader
-    :returns: A downloader class
+    :param name: the name of the downloader. Note that this is the name of
+        the entry point used to define the downloader. In general, this should
+        be the same as its name, but this is not enforced.
+    :returns: a downloader class.
     """
     downloader_class = papis.plugin.get_extension_manager(
         _extension_name())[name].plugin  # type: Type[Downloader]
@@ -348,11 +410,11 @@ def get_info_from_url(
         url: str,
         expected_doc_format: Optional[str] = None
         ) -> papis.importer.Context:
-    """Get information directly from url
+    """Get information directly from the given *url*.
 
-    :param url: Url of the resource
-    :param expected_doc_format: override the doc format of the document
-    :returns: Context object
+    :param url: the URL of a resource.
+    :param expected_doc_format: an expected document file type, that is used to
+        override the file type defined by the chosen downloader.
     """
 
     downloaders = get_matching_downloaders(url)

--- a/papis/importer.py
+++ b/papis/importer.py
@@ -66,7 +66,8 @@ class Importer:
 
     .. attribute:: ctx
 
-        A :class:`Context` that stores the data retrieved by the importer.
+        A :class:`~papis.importer.Context` that stores the data retrieved by
+        the importer.
     """
 
     def __init__(self,
@@ -94,7 +95,7 @@ class Importer:
             re.match(r".*arxiv.org.*", uri)
 
         This can then be used to instantiate and return a corresponding
-        :class:`Importer` object.
+        :class:`~papis.importer.Importer` object.
 
         :param uri: An URI where the document information should be retrieved from.
         :return: An importer instance if the match to the URI is successful or
@@ -123,15 +124,15 @@ class Importer:
 
     @cache
     def fetch(self) -> None:
-        """Fetch metadata and files for the given :attr:`Importer.uri`.
+        """Fetch metadata and files for the given :attr:`~papis.importer.Importer.uri`.
 
         This method calls :meth:`Importer.fetch_data` and :meth:`Importer.fetch_files`
         to get all the information available for the document. It is recommended
         to implement the two methods separately, if possible, for maximum
         flexibility.
 
-        The imported data is stored in :attr:`Importer.ctx` and it is not
-        queried again on subsequent calls to this function.
+        The imported data is stored in :attr:`~papis.importer.Importer.ctx` and
+        it is not queried again on subsequent calls to this function.
         """
         from contextlib import suppress
 
@@ -142,18 +143,18 @@ class Importer:
             self.fetch_files()
 
     def fetch_data(self) -> None:
-        """Fetch metadata from the given :attr:`Importer.uri`.
+        """Fetch metadata from the given :attr:`~papis.importer.Importer.uri`.
 
-        The imported metadata is stored in :attr:`Importer.ctx`.
+        The imported metadata is stored in :attr:`~papis.importer.Importer.ctx`.
         """
         raise NotImplementedError(
             "Fetching metadata is not implemented for '{}.{}'"
             .format(type(self).__module__, type(self).__name__))
 
     def fetch_files(self) -> None:
-        """Fetch files from the given :attr:`Importer.uri`.
+        """Fetch files from the given :attr:`~papis.importer.Importer.uri`.
 
-        The imported files are stored in :attr:`Importer.ctx`.
+        The imported files are stored in :attr:`~papis.importer.Importer.ctx`.
         """
         raise NotImplementedError(
             "Fetching files is not implemented for '{}.{}'"


### PR DESCRIPTION
This adds the base `papis.downloaders.Downloader` class to the developer docs. It also improves the formatting and wording in some existing docs, but not much.