### PR TITLE
Update typing annotations

### DIFF
--- a/papis/arxiv.py
+++ b/papis/arxiv.py
@@ -222,7 +222,7 @@ class Downloader(papis.downloaders.Downloader):
 
     def __init__(self, url: str) -> None:
         super().__init__(uri=url, name="arxiv", expected_document_extension="pdf")
-        self._arxivid = None  # type: Optional[str]
+        self._arxivid: Optional[str] = None
 
     @classmethod
     def match(cls, url: str) -> Optional[papis.downloaders.Downloader]:
@@ -272,7 +272,7 @@ class Importer(papis.importer.Importer):
     def __init__(self, uri: str) -> None:
         try:
             validate_arxivid(uri)
-            aid = uri       # type: Optional[str]
+            aid: Optional[str] = uri
         except ValueError:
             aid = find_arxivid_in_text(uri)
 
@@ -314,7 +314,7 @@ class ArxividFromPdfImporter(papis.importer.Importer):
 
     def __init__(self, uri: str) -> None:
         super().__init__(name="pdf2arxivid", uri=uri)
-        self.arxivid = None  # type: Optional[str]
+        self.arxivid: Optional[str] = None
 
     @classmethod
     def match(cls, uri: str) -> Optional[papis.importer.Importer]:

--- a/papis/bibtex.py
+++ b/papis/bibtex.py
@@ -18,7 +18,7 @@ logger = papis.logging.get_logger(__name__)
 # NOTE: see the BibLaTeX docs for an up to date list of types and keys:
 #   https://ctan.org/pkg/biblatex?lang=en
 
-bibtex_types = frozenset([
+bibtex_types: FrozenSet[str] = frozenset([
     # regular types (Section 2.1.1)
     "article",
     "book", "mvbook", "inbook", "bookinbook", "suppbook", "booklet",
@@ -56,18 +56,18 @@ bibtex_types = frozenset([
     "video",
     # type aliases (Section 2.1.2)
     "conference", "electronic", "masterthesis", "phdthesis", "techreport", "www",
-]) | frozenset(papis.config.getlist("extra-bibtex-types"))  # type: FrozenSet[str]
+]) | frozenset(papis.config.getlist("extra-bibtex-types"))
 
 # Zotero translator fields, see also
 #   https://github.com/zotero/zotero-schema
 #   https://github.com/papis/papis/pull/121
-bibtex_type_converter = {
+bibtex_type_converter: Dict[str, str] = {
     "conferencePaper": "inproceedings",
     "journalArticle": "article",
     "journal": "article",
-}  # type: Dict[str, str]
+}
 
-bibtex_keys = frozenset([
+bibtex_keys: FrozenSet[str] = frozenset([
     # data fields (Section 2.2.2)
     "abstract", "addendum", "afterword", "annotation", "annotator", "author",
     "authortype", "bookauthor", "bookpagination", "booksubtitle", "booktitle",
@@ -103,23 +103,23 @@ bibtex_keys = frozenset([
     "primaryclass", "school"
     # fields that we ignore
     # type,
-]) | frozenset(papis.config.getlist("extra-bibtex-keys"))  # type: FrozenSet[str]
+]) | frozenset(papis.config.getlist("extra-bibtex-keys"))
 
 # Zotero translator fields, see also
 #   https://github.com/zotero/zotero-schema
 #   https://github.com/papis/papis/pull/121
-bibtex_key_converter = {
+bibtex_key_converter: Dict[str, str] = {
     "abstractNote": "abstract",
     "university": "school",
     "conferenceName": "eventtitle",
     "place": "location",
     "publicationTitle": "journal",
     "proceedingsTitle": "booktitle"
-}  # type: Dict[str, str]
+}
 
-bibtex_ignore_keys = (
+bibtex_ignore_keys: FrozenSet[str] = (
     frozenset(papis.config.getlist("bibtex-ignore-keys"))
-)  # type: FrozenSet[str]
+)
 
 
 def exporter(documents: List[papis.document.Document]) -> str:

--- a/papis/citations.py
+++ b/papis/citations.py
@@ -53,10 +53,8 @@ def fetch_citations(doc: papis.document.Document) -> List[Dict[str, Any]]:
             if "doi" in d]
     logger.info("Found %d citations.", len(dois))
 
-    dois_with_data = [
-    ]  # type: List[Dict[str, Any]]
-    found_in_lib_dois = [
-    ]  # type: List[Dict[str, Any]]
+    dois_with_data: List[Dict[str, Any]] = []
+    found_in_lib_dois: List[Dict[str, Any]] = []
 
     logger.info("Checking which citations are already in the library.")
     dois_with_data = get_citations_from_database(dois)
@@ -91,7 +89,7 @@ def get_citations_from_database(
     with the information of these documents.
     """
     db = papis.database.get()
-    dois_with_data = []  # type: List[Dict[str, Any]]
+    dois_with_data: List[Dict[str, Any]] = []
     with tqdm.tqdm(iterable=dois) as progress:
         for doi in progress:
             citation = db.query_dict({"doi": doi})
@@ -117,7 +115,7 @@ def update_and_save_citations_from_database_from_doc(
 
 
 def update_citations_from_database(citations: Citations) -> Citations:
-    new_citations = []  # type: List[Dict[str, Any]]
+    new_citations: List[Dict[str, Any]] = []
     dois = [str(c.get("doi")).lower() for c in citations
             if "doi" in c]
     new_data_list = get_citations_from_database(dois)
@@ -215,7 +213,7 @@ def fetch_cited_by_from_database(cit: Citation) -> Citations:
     if not doi:
         return []
 
-    result = []  # type: List[Citation]
+    result: List[Citation] = []
     db = papis.database.get()
     documents = db.get_all_documents()
 

--- a/papis/commands/__init__.py
+++ b/papis/commands/__init__.py
@@ -34,12 +34,10 @@ class AliasedGroup(click.core.Group):
         return None
 
 
-Script = NamedTuple("Script",
-                    [("command_name", str),
-                     ("path", Optional[str]),
-                     ("plugin", Union[None,
-                                      click.core.Command,
-                                      AliasedGroup])])
+class Script(NamedTuple):
+    command_name: str
+    path: Optional[str]
+    plugin: Optional[Union[click.Command, AliasedGroup]]
 
 
 def get_external_scripts() -> Dict[str, Script]:

--- a/papis/commands/add.py
+++ b/papis/commands/add.py
@@ -329,7 +329,7 @@ def run(paths: List[str],
     if folder_name:
         temp_doc = papis.document.Document(data=data)
         temp_path = os.path.join(out_folder_path, folder_name)
-        components = []     # type: List[str]
+        components: List[str] = []
 
         temp_path = os.path.normpath(temp_path)
         out_folder_path = os.path.normpath(out_folder_path)

--- a/papis/commands/config.py
+++ b/papis/commands/config.py
@@ -155,7 +155,7 @@ def run(
         the values from the configuration file.
     """
     config = papis.config.get_configuration()
-    result = {}     # type: Dict[str, Any]
+    result: Dict[str, Any] = {}
 
     if len(options) == 0:
         # NOTE: no options given -> just get all the settings

--- a/papis/commands/doctor.py
+++ b/papis/commands/doctor.py
@@ -38,7 +38,7 @@ CheckFn = Callable[[papis.document.Document], List[Error]]
 Check = NamedTuple("Check", [("name", str),
                              ("operate", CheckFn),
                              ])
-REGISTERED_CHECKS = {}  # type: Dict[str, Check]
+REGISTERED_CHECKS: Dict[str, Check] = {}
 
 
 def error_to_dict(e: Error) -> Dict[str, Any]:
@@ -190,7 +190,7 @@ def refs_check(doc: papis.document.Document) -> List[Error]:
     return []
 
 
-DUPLICATED_KEYS_SEEN = collections.defaultdict(set)  # type: Dict[str, Set[str]]
+DUPLICATED_KEYS_SEEN: Dict[str, Set[str]] = collections.defaultdict(set)
 DUPLICATED_KEYS_NAME = "duplicated-keys"
 
 
@@ -205,7 +205,7 @@ def duplicated_keys_check(doc: papis.document.Document) -> List[Error]:
     keys = papis.config.getlist("doctor-duplicated-keys-keys")
     folder = doc.get_main_folder() or ""
 
-    results = []  # type: List[Error]
+    results: List[Error] = []
     for key in keys:
         value = doc.get(key)
         if value is None:
@@ -429,7 +429,7 @@ def run(doc: papis.document.Document, checks: List[str]) -> List[Error]:
     """
     assert all(check in REGISTERED_CHECKS for check in checks)
 
-    results = []  # type: List[Error]
+    results: List[Error] = []
     for check in checks:
         results.extend(REGISTERED_CHECKS[check].operate(doc))
 
@@ -495,7 +495,7 @@ def cli(query: str,
 
     logger.debug("Running checks: '%s'.", "', '".join(_checks))
 
-    errors = []  # type: List[Error]
+    errors: List[Error] = []
     for doc in documents:
         errors.extend(run(doc, _checks))
 

--- a/papis/commands/doctor.py
+++ b/papis/commands/doctor.py
@@ -23,21 +23,35 @@ import papis.logging
 
 logger = papis.logging.get_logger(__name__)
 
-# FIXME: when going to python >=3.6, these should be classes (dataclasses?) and
-# have some basic documentation for the various fields
 FixFn = Callable[[], None]
-Error = NamedTuple("Error", [("name", str),
-                             ("path", str),
-                             ("payload", str),
-                             ("msg", str),
-                             ("suggestion_cmd", str),
-                             ("fix_action", FixFn),
-                             ("doc", Optional[papis.document.Document]),
-                             ])
-CheckFn = Callable[[papis.document.Document], List[Error]]
-Check = NamedTuple("Check", [("name", str),
-                             ("operate", CheckFn),
-                             ])
+CheckFn = Callable[[papis.document.Document], List["Error"]]
+
+
+class Error(NamedTuple):
+    #: Name of the check generating the error.
+    name: str
+    #: Path to the document that generated the error.
+    path: str
+    #: A value that caused the error.
+    payload: str
+    #: A short message describing the error that can be displayed to the user.
+    msg: str
+    #: A command to run to fix the error that can be suggested to the user.
+    suggestion_cmd: str
+    #: A callable that can autofix the error.
+    fix_action: FixFn
+    #: The document that generated the error.
+    doc: Optional[papis.document.Document]
+
+
+class Check(NamedTuple):
+    #: Name of the check
+    name: str
+    #: A callable that takes a document and returns a list of errors generated
+    #: by the current check.
+    operate: CheckFn
+
+
 REGISTERED_CHECKS: Dict[str, Check] = {}
 
 

--- a/papis/commands/external.py
+++ b/papis/commands/external.py
@@ -64,7 +64,7 @@ def get_exported_variables(ctx: Optional[Dict[str, Any]] = None) -> Dict[str, st
 @click.pass_context
 def external_cli(ctx: click.core.Context, flags: List[str]) -> None:
     """Actual papis command to call the external command"""
-    script = ctx.obj  # type: papis.commands.Script
+    script: papis.commands.Script = ctx.obj
     path = script.path
     if not path:
         raise FileNotFoundError("Path for script '{}' not found".format(script))

--- a/papis/commands/list.py
+++ b/papis/commands/list.py
@@ -208,7 +208,7 @@ def cli(query: str,
         libraries: bool,
         sort_field: Optional[str], sort_reverse: bool) -> None:
     """List documents' properties"""
-    documents = []  # type: List[papis.document.Document]
+    documents: List[papis.document.Document] = []
 
     if (not libraries and not downloaders
             and not _file and not info and not _dir):

--- a/papis/commands/merge.py
+++ b/papis/commands/merge.py
@@ -131,7 +131,7 @@ def cli(query: str,
                                                    data_b,
                                                    papis.document.describe(b))
 
-    files = []  # type: List[str]
+    files: List[str] = []
     for doc in documents:
         indices = papis.tui.utils.select_range(
             doc.get_files(),

--- a/papis/commands/serve.py
+++ b/papis/commands/serve.py
@@ -34,8 +34,8 @@ import papis.web.pdfjs
 
 logger = papis.logging.get_logger(__name__)
 
-USE_GIT = False  # type: bool
-TAGS_LIST = {}  # type: Dict[str, Optional[Dict[str, int]]]
+USE_GIT = False
+TAGS_LIST: Dict[str, Optional[Dict[str, int]]] = {}
 
 
 AnyFn = Callable[..., Any]

--- a/papis/config.py
+++ b/papis/config.py
@@ -10,14 +10,14 @@ logger = papis.logging.get_logger(__name__)
 
 PapisConfigType = Dict[str, Dict[str, Any]]
 
-_CURRENT_LIBRARY = None  #: Current library in use
-_CONFIGURATION = None  # type: Optional[Configuration]
-_DEFAULT_SETTINGS = None  # type: Optional[PapisConfigType]
-_OVERRIDE_VARS = {
+_CURRENT_LIBRARY = None
+_CONFIGURATION: Optional["Configuration"] = None
+_DEFAULT_SETTINGS: Optional[PapisConfigType] = None
+_OVERRIDE_VARS: Dict[str, Optional[str]] = {
     "folder": None,
     "file": None,
     "scripts": None
-}  # type: Dict[str, Optional[str]]
+}
 
 
 def get_general_settings_name() -> str:
@@ -34,17 +34,17 @@ class Configuration(configparser.ConfigParser):
     def __init__(self) -> None:
         super().__init__()
 
-        self.dir_location = get_config_folder()
-        self.scripts_location = get_scripts_folder()
-        self.file_location = get_config_file()
-        self.default_info = {
+        self.dir_location: str = get_config_folder()
+        self.scripts_location: str = get_scripts_folder()
+        self.file_location: str = get_config_file()
+        self.default_info: PapisConfigType = {
             "papers": {
                 "dir": "~/Documents/papers"
             },
             get_general_settings_name(): {
                 "default-library": "papers"
             }
-        }  # type: PapisConfigType
+        }
         self.initialize()
 
     def handle_includes(self) -> None:
@@ -185,7 +185,7 @@ def get_config_dirs() -> List[str]:
     """Get papis configuration directories where the configuration
     files might be stored
     """
-    dirs = []  # type: List[str]
+    dirs: List[str] = []
     # get_config_home should also be included on top of XDG_CONFIG_DIRS
     if os.environ.get("XDG_CONFIG_DIRS") is not None:
         dirs += [
@@ -273,7 +273,7 @@ def general_get(key: str, section: Optional[str] = None,
     default_settings = get_default_settings()
 
     # Check data type for setting getter method
-    method = None  # type: Optional[Callable[[Any, Any], Any]]
+    method: Callable[[Any, Any], Any]
     if data_type == int:
         method = config.getint
     elif data_type == float:
@@ -313,7 +313,7 @@ def general_get(key: str, section: Optional[str] = None,
         )
 
     # Try to get key's value from configuration
-    value = None  # type: Optional[Any]
+    value: Any = None
     for section_name, key_name in candidate_sections:
         if section_name not in config:
             continue
@@ -399,7 +399,7 @@ def getlist(key: str, section: Optional[str] = None) -> List[str]:
     :raises SyntaxError: Whenever the parsed syntax is either not a valid
         python object or a valid python list.
     """
-    rawvalue = general_get(key, section=section)  # type: Any
+    rawvalue: Any = general_get(key, section=section)
     if isinstance(rawvalue, list):
         return list(map(str, rawvalue))
     try:

--- a/papis/crossref.py
+++ b/papis/crossref.py
@@ -92,8 +92,7 @@ type_converter = {
     "report-series": "inproceedings",
     "standard-series": "incollection",
     "standard": "techreport",
-}  # type: Dict[str, str]
-
+}
 
 key_conversion = [
     KeyConversionPair("DOI", [{"key": "doi", "action": None}]),
@@ -331,7 +330,7 @@ class DoiFromPdfImporter(papis.importer.Importer):
     def __init__(self, uri: str) -> None:
         """The uri should be a filepath"""
         super().__init__(name="pdf2doi", uri=uri)
-        self._doi = None  # type: Optional[str]
+        self._doi: Optional[str] = None
 
     @classmethod
     def match(cls, uri: str) -> Optional[papis.importer.Importer]:
@@ -471,7 +470,7 @@ class Downloader(papis.downloaders.Downloader):
 
     def __init__(self, uri: str) -> None:
         super().__init__(uri=uri, name="doi")
-        self._doi = None    # type: Optional[str]
+        self._doi: Optional[str] = None
 
     @classmethod
     def match(cls, uri: str) -> Optional[papis.downloaders.Downloader]:

--- a/papis/database/__init__.py
+++ b/papis/database/__init__.py
@@ -6,7 +6,7 @@ import papis.logging
 
 logger = papis.logging.get_logger(__name__)
 
-DATABASES = {}  # type: Dict[Library, Database]
+DATABASES: Dict[Library, Database] = {}
 
 
 def get(library_name: Optional[str] = None) -> Database:

--- a/papis/database/cache.py
+++ b/papis/database/cache.py
@@ -121,7 +121,7 @@ class Database(papis.database.base.Database):
     def __init__(self, library: Optional[papis.library.Library] = None) -> None:
         super().__init__(library)
 
-        self.documents = None  # type: Optional[List[papis.document.Document]]
+        self.documents: Optional[List[papis.document.Document]] = None
         self.initialize()
 
     def get_backend_name(self) -> str:
@@ -143,9 +143,9 @@ class Database(papis.database.base.Database):
                 self.documents = pickle.load(fd)
         else:
             logger.info("Indexing library. This might take a while...")
-            folders = sum([papis.utils.get_folders(d)
-                           for d in self.get_dirs()],
-                          [])  # type: List[str]
+            folders: List[str] = sum(
+                [papis.utils.get_folders(d) for d in self.get_dirs()],
+                [])
             self.documents = papis.utils.folders_to_documents(folders)
             logger.debug("Computing 'papis_id' for each document.")
             for doc in self.documents:

--- a/papis/database/whoosh.py
+++ b/papis/database/whoosh.py
@@ -70,7 +70,7 @@ class Database(papis.database.base.Database):
                 self.cache_dir,
                 papis.database.cache.get_cache_file_name(
                     self.lib.path_format()
-                )))  # type: str
+                )))
 
         self.initialize()
 
@@ -205,8 +205,7 @@ class Database(papis.database.base.Database):
         at the time of building a brand new index.
         """
         logger.debug("Indexing the library, this might take a while...")
-        folders = sum([
-            get_folders(d) for d in self.get_dirs()], [])  # type: List[str]
+        folders: List[str] = sum([get_folders(d) for d in self.get_dirs()], [])
         documents = folders_to_documents(folders)
         schema_keys = self.get_schema_init_fields().keys()
         writer = self.get_writer()

--- a/papis/defaults.py
+++ b/papis/defaults.py
@@ -13,7 +13,7 @@ def get_default_opener() -> str:
     return "xdg-open"
 
 
-settings = {
+settings: Dict[str, Any] = {
     "local-config-file": ".papis.config",
     "database-backend": "papis",
     "default-query-string": ".",
@@ -191,4 +191,4 @@ settings = {
     # importer / downloader options
     "downloader-proxy": None,
     "isbn-service": "openl",
-}  # type: Dict[str, Any]
+}

--- a/papis/dissemin.py
+++ b/papis/dissemin.py
@@ -13,7 +13,7 @@ DISSEMIN_API_URL = "https://dissem.in/api/search/"
 
 
 def dissemin_authors_to_papis_authors(data: Dict[str, Any]) -> Dict[str, Any]:
-    new_data = {}  # type: Dict[str, Any]
+    new_data: Dict[str, Any] = {}
     if "authors" in data:
         authors = []
         for author in data["authors"]:

--- a/papis/docmatcher.py
+++ b/papis/docmatcher.py
@@ -61,10 +61,10 @@ class DocMatcher(object):
     parallelize the matching.
     """
 
-    search = ""  # type: str
-    parsed_search = None  # type: List[ParseResult]
-    matcher = None  # type: Optional[MatcherCallable]
-    match_format = papis.config.getstring("match-format")   # type: str
+    search: str = ""
+    parsed_search: Optional[List[ParseResult]] = None
+    matcher: Optional[MatcherCallable] = None
+    match_format: str = papis.config.getstring("match-format")
 
     @classmethod
     def return_if_match(

--- a/papis/docmatcher.py
+++ b/papis/docmatcher.py
@@ -8,11 +8,10 @@ import papis.logging
 logger = papis.logging.get_logger(__name__)
 
 
-_ParseResult = NamedTuple("_ParseResult", [
-    ("search", str),
-    ("pattern", Pattern[str]),
-    ("doc_key", Optional[str]),
-    ])
+class _ParseResult(NamedTuple):
+    search: str
+    pattern: Pattern[str]
+    doc_key: Optional[str]
 
 
 class ParseResult(_ParseResult):

--- a/papis/document.py
+++ b/papis/document.py
@@ -27,32 +27,25 @@ class _SortPriority(enum.IntEnum):
     Missing = 3
 
 
-#: A :class:`dict` that contains a *key* and an *action*. The *key* contains the
-#: name of a key in another dictionary and the *action* contains a callable
-#: that can pre-processes the value.
-KeyConversion = TypedDict(
-    "KeyConversion", {"key": Optional[str],
-                      "action": Optional[Callable[[Any], Any]]}
-)
+class KeyConversion(TypedDict):
+    """A :class:`dict` that contains a *key* and an *action*."""
+
+    #: Name of a key in a foreign dictionary to convert.
+    key: Optional[str]
+    #: Action to apply to the value at :attr:`key` for pre-processing.
+    action: Optional[Callable[[Any], Any]]
+
 
 #: A default :class:`KeyConversion`.
 EmptyKeyConversion = KeyConversion(key=None, action=None)
 
-KeyConversionPair = NamedTuple(
-    "KeyConversionPair",
-    [
-        ("foreign_key", str),
-        ("list", List[KeyConversion]),
-    ]
-)
-KeyConversionPair.foreign_key.__doc__ = """
-    A string denoting the foreign key (in the input data).
-"""
 
-KeyConversionPair.list.__doc__ = """
-    A :class:`list` of :class:`KeyConversion` mappings used to
-    rename and post-process the :attr:`foreign_key` and its value.
-"""
+class KeyConversionPair(NamedTuple):
+    #: A string denoting the foreign key (in the input data).
+    foreign_key: str
+    #: A :class:`list` of :class:`KeyConversion` mappings used to
+    #: rename and post-process the :attr:`foreign_key` and its value.
+    list: List[KeyConversion]
 
 
 def keyconversion_to_data(conversions: Sequence[KeyConversionPair],

--- a/papis/document.py
+++ b/papis/document.py
@@ -110,7 +110,7 @@ def keyconversion_to_data(conversions: Sequence[KeyConversionPair],
             continue
 
         for conv_data in key_pair.list:
-            papis_key = conv_data.get("key") or foreign_key  # type: str
+            papis_key: str = conv_data.get("key") or foreign_key
             papis_value = data[foreign_key]
 
             action = conv_data.get("action")
@@ -232,15 +232,15 @@ class Document(Dict[str, Any]):
         in the document for use in HTML documents.
     """
 
-    subfolder = ""          # type: str
-    _info_file_path = ""    # type: str
+    subfolder: str = ""
+    _info_file_path: str = ""
 
     def __init__(self,
                  folder: Optional[str] = None,
                  data: Optional[Dict[str, Any]] = None) -> None:
         super().__init__()
 
-        self._folder = None          # type: Optional[str]
+        self._folder: Optional[str] = None
 
         if folder is not None:
             self.set_folder(folder)

--- a/papis/downloaders/__init__.py
+++ b/papis/downloaders/__init__.py
@@ -99,9 +99,9 @@ class Downloader(papis.importer.Importer):
         self.cookies = cookies
 
         # NOTE: used to cache data
-        self._soup = None  # type: Optional[bs4.BeautifulSoup]
-        self.bibtex_data = None  # type: Optional[str]
-        self.document_data = None  # type: Optional[bytes]
+        self._soup: Optional[bs4.BeautifulSoup] = None
+        self.bibtex_data: Optional[str] = None
+        self.document_data: Optional[bytes] = None
 
     def __del__(self) -> None:
         self.session.close()
@@ -401,8 +401,9 @@ def get_downloader_by_name(name: str) -> Type[Downloader]:
         be the same as its name, but this is not enforced.
     :returns: a downloader class.
     """
-    downloader_class = papis.plugin.get_extension_manager(
-        _extension_name())[name].plugin  # type: Type[Downloader]
+    downloader_class: Type[Downloader] = (
+        papis.plugin.get_extension_manager(_extension_name())[name].plugin
+    )
     return downloader_class
 
 

--- a/papis/downloaders/acs.py
+++ b/papis/downloaders/acs.py
@@ -6,14 +6,14 @@ import papis.downloaders
 
 
 class Downloader(papis.downloaders.Downloader):
-    DOCUMENT_URL = (
+    DOCUMENT_URL: ClassVar[str] = (
         "https://pubs.acs.org/doi/pdf/{doi}"
-        )   # type: ClassVar[str]
+        )
 
-    BIBTEX_URL = (
+    BIBTEX_URL: ClassVar[str] = (
         "https://pubs.acs.org/action/downloadCitation"
         "?format=bibtex&cookieSet=1&doi={doi}"
-        )   # type: ClassVar[str]
+        )
 
     def __init__(self, url: str) -> None:
         super().__init__(

--- a/papis/downloaders/annualreviews.py
+++ b/papis/downloaders/annualreviews.py
@@ -5,13 +5,12 @@ import papis.downloaders.base
 
 
 class Downloader(papis.downloaders.Downloader):
+    DOCUMENT_URL: ClassVar[str] = "https://annualreviews.org/doi/pdf/{doi}"
 
-    DOCUMENT_URL = "https://annualreviews.org/doi/pdf/{doi}"  # type: ClassVar[str]
-
-    BIBTEX_URL = (
+    BIBTEX_URL: ClassVar[str] = (
         "https://annualreviews.org/action/downloadCitation"
         "?format=bibtex&cookieSet=1&doi={doi}"
-        )  # type: ClassVar[str]
+        )
 
     def __init__(self, url: str) -> None:
         super().__init__(

--- a/papis/downloaders/base.py
+++ b/papis/downloaders/base.py
@@ -19,7 +19,7 @@ MetaEquivalence = TypedDict(
     }
 )
 
-meta_equivalences = [
+meta_equivalences: List[MetaEquivalence] = [
     # google
     {"tag": "meta", "key": "abstract", "attrs": {"name": "description"}},
     {"tag": "meta", "key": "doi", "attrs": {"name": "doi"}},
@@ -96,11 +96,11 @@ meta_equivalences = [
             "key": "doi",
             "attrs": {"name": re.compile("dc.identifier", re.I),
                       "scheme": "doi"}},
-]  # type: List[MetaEquivalence]
+]
 
 
 def parse_meta_headers(soup: "bs4.BeautifulSoup") -> Dict[str, Any]:
-    data = {}  # type: Dict[str, Any]
+    data: Dict[str, Any] = {}
     for equiv in meta_equivalences:
         elements = soup.find_all(equiv["tag"], attrs=equiv["attrs"])
         if elements:
@@ -131,12 +131,12 @@ def parse_meta_authors(soup: "bs4.BeautifulSoup") -> List[Dict[str, Any]]:
         attrs={"name": "citation_author_institution"})
 
     if affs and len(authors) == len(affs):
-        authors_and_affs = zip(authors, affs)  # type: Iterator[Tuple[Any, Any]]
+        authors_and_affs: Iterator[Tuple[Any, Any]] = zip(authors, affs)
     else:
         authors_and_affs = ((a, None) for a in authors)
 
     # convert to papis author format
-    author_list = []  # type: List[Dict[str, Any]]
+    author_list: List[Dict[str, Any]] = []
     for author, aff in authors_and_affs:
         fullname, = papis.document.split_authors_name([author.get("content")])
         affiliation = [{"name": aff.get("content")}] if aff else []

--- a/papis/downloaders/base.py
+++ b/papis/downloaders/base.py
@@ -11,13 +11,12 @@ import papis.utils
 if TYPE_CHECKING:
     import bs4
 
-MetaEquivalence = TypedDict(
-    "MetaEquivalence", {
-        "tag": str,
-        "key": str,
-        "attrs": Dict[str, Union[str, Pattern[str]]],
-    }
-)
+
+class MetaEquivalence(TypedDict):
+    tag: str
+    key: str
+    attrs: Dict[str, Union[str, Pattern[str]]]
+
 
 meta_equivalences: List[MetaEquivalence] = [
     # google

--- a/papis/downloaders/citeseerx.py
+++ b/papis/downloaders/citeseerx.py
@@ -23,13 +23,13 @@ article_key_conversion = [
 class Downloader(papis.downloaders.Downloader):
 
     # NOTE: not sure if this API is open for the public, but it seems to work
-    API_URL = "https://citeseerx.ist.psu.edu/api/paper"  # type: ClassVar[str]
+    API_URL: ClassVar[str] = "https://citeseerx.ist.psu.edu/api/paper"
 
     # NOTE: this seems to fail with an 'Internal Server Error 500' more often
     # than not, so it may not be worth it to keep around until it stabilizes
-    DOCUMENT_URL = (
+    DOCUMENT_URL: ClassVar[str] = (
         "https://citeseerx.ist.psu.edu/document?repid=rep1&type=pdf&doi={pid}"
-        )  # type: ClassVar[str]
+        )
 
     def __init__(self, url: str) -> None:
         super().__init__(

--- a/papis/downloaders/hal.py
+++ b/papis/downloaders/hal.py
@@ -11,16 +11,16 @@ class Downloader(papis.downloaders.fallback.Downloader):
     # TODO: a list of other domains seems to be available at
     # https://hal.science/browse/portal
 
-    SUPPORTED_HAL_SCIENCE_SUBDOMAINS = (
+    SUPPORTED_HAL_SCIENCE_SUBDOMAINS: ClassVar[Tuple[str, ...]] = (
         "hal", r"shs\.hal", r"theses\.hal", r"media\.hal",
-        )   # type: ClassVar[Tuple[str, ...]]
+        )
 
-    SUPPORTED_ARCHIVES_OUVERTES_SUBDOMAINS = (
+    SUPPORTED_ARCHIVES_OUVERTES_SUBDOMAINS: ClassVar[Tuple[str, ...]] = (
         "hal", "halshs", "tel", "medihal",
         # other domains
         "hal-anr", "hal-bnf", "hal-cea", "hal-centralesupelec", "hal-cnam",
         "hal-cnrs",
-        )   # type: ClassVar[Tuple[str, ...]]
+        )
 
     def __init__(self, url: str) -> None:
         super().__init__(

--- a/papis/downloaders/iopscience.py
+++ b/papis/downloaders/iopscience.py
@@ -5,15 +5,15 @@ import papis.downloaders.base
 
 
 class Downloader(papis.downloaders.Downloader):
-    DOCUMENT_URL = (
+    DOCUMENT_URL: ClassVar[str] = (
         "https://iopscience.iop.org/article/{doi}/pdf"
-        )   # type: ClassVar[str]
+        )
 
-    BIBTEX_URL = (
+    BIBTEX_URL: ClassVar[str] = (
         "https://iopscience.iop.org/export?aid={aid}"
         "&exportFormat=iopexport_bib&exportType=abs"
         "&navsubmit=Export%2Babstract"
-        )   # type: ClassVar[str]
+        )
 
     def __init__(self, url: str) -> None:
         super().__init__(

--- a/papis/downloaders/sciencedirect.py
+++ b/papis/downloaders/sciencedirect.py
@@ -57,7 +57,7 @@ class Downloader(papis.downloaders.Downloader):
 
     def get_data(self) -> Dict[str, Any]:
         soup = self._get_soup()
-        data = {}   # type: Dict[str, Any]
+        data: Dict[str, Any] = {}
 
         # get authors
         scripts = soup.find_all(name="script", attrs={"data-iso-key": "_0"})

--- a/papis/downloaders/springer.py
+++ b/papis/downloaders/springer.py
@@ -6,14 +6,14 @@ import papis.document
 
 
 class Downloader(papis.downloaders.Downloader):
-    DOCUMENT_URL = (
+    DOCUMENT_URL: ClassVar[str] = (
         "https://link.springer.com/content/pdf/{doi}.pdf"
-        )   # type: ClassVar[str]
+        )
 
-    BIBTEX_URL = (
+    BIBTEX_URL: ClassVar[str] = (
         "https://citation-needed.springer.com/v2/"
         "references/{doi}?format=bibtex&amp;flavour=citation"
-        )   # type: ClassVar[str]
+        )
 
     def __init__(self, url: str) -> None:
         super().__init__(

--- a/papis/downloaders/tandfonline.py
+++ b/papis/downloaders/tandfonline.py
@@ -37,14 +37,14 @@ def _parse_month(date: str) -> Optional[int]:
 
 
 class Downloader(papis.downloaders.Downloader):
-    DOCUMENT_URL = (
+    DOCUMENT_URL: ClassVar[str] = (
         "https://www.tandfonline.com/doi/pdf/{doi}"
-        )   # type: ClassVar[str]
+        )
 
-    BIBTEX_URL = (
+    BIBTEX_URL: ClassVar[str] = (
         "https://www.tandfonline.com/action/downloadCitation"
         "?format=bibtex&cookieSet=1&doi={doi}"
-        )   # type: ClassVar[str]
+        )
 
     def __init__(self, url: str) -> None:
         super().__init__(

--- a/papis/downloaders/usenix.py
+++ b/papis/downloaders/usenix.py
@@ -13,7 +13,7 @@ class Downloader(papis.downloaders.Downloader):
             "usenix",
             expected_document_extension="pdf",
         )
-        self._raw_data = None  # type: Optional[str]
+        self._raw_data: Optional[str] = None
 
     @classmethod
     def match(cls, url: str) -> Optional[papis.downloaders.Downloader]:

--- a/papis/format.py
+++ b/papis/format.py
@@ -9,7 +9,7 @@ from papis.document import Document
 logger = papis.logging.get_logger(__name__)
 
 FormatDocType = Union[Document, Dict[str, Any]]
-_FORMATER = None  # type: Optional[Formater]
+_FORMATER: Optional["Formater"] = None
 
 
 class InvalidFormaterError(ValueError):

--- a/papis/fzf.py
+++ b/papis/fzf.py
@@ -11,9 +11,9 @@ T = TypeVar("T")
 
 
 class Command(ABC, Generic[T]):
-    regex = None  # type: Optional[Pattern]
-    command = ""  # type: str
-    key = ""  # type: str
+    regex: Optional[Pattern] = None
+    command: str = ""
+    key: str = ""
 
     def binding(self) -> str:
         return "{0}:{1}".format(self.key, self.command)
@@ -74,7 +74,7 @@ class Picker(papis.pick.Picker[T]):
         if len(options) == 1:
             return [options[0]]
 
-        commands = [Choose(), Open(), Edit()]  # type: Sequence[Command[T]]
+        commands: Sequence[Command[T]] = [Choose(), Open(), Edit()]
 
         bindings = [c.binding() for c in commands
                     ] + papis.config.getlist("fzf-extra-bindings")
@@ -95,7 +95,7 @@ class Picker(papis.pick.Picker[T]):
                 return header_filter(d)
 
         headers = [_header_filter(o) for o in options]
-        docs = []  # type: Sequence[T]
+        docs: Sequence[T] = []
 
         import subprocess as sp
         with sp.Popen(command, stdin=sp.PIPE, stdout=sp.PIPE) as p:

--- a/papis/hooks.py
+++ b/papis/hooks.py
@@ -8,7 +8,7 @@ if TYPE_CHECKING:
 
 logger = papis.logging.get_logger(__name__)
 
-NON_STEVEDORE_HOOKS = {}  # type: Dict[str, List[Callable[[Any], None]]]
+NON_STEVEDORE_HOOKS: Dict[str, List[Callable[[Any], None]]] = {}
 
 
 def _get_namespace(name: str) -> str:

--- a/papis/importer.py
+++ b/papis/importer.py
@@ -45,8 +45,8 @@ class Context:
     """
 
     def __init__(self) -> None:
-        self.data = {}   # type: Dict[str, Any]
-        self.files = []  # type: List[str]
+        self.data: Dict[str, Any] = {}
+        self.files: List[str] = []
 
     def __bool__(self) -> bool:
         return bool(self.files) or bool(self.data)
@@ -78,9 +78,9 @@ class Importer:
         :param uri: uri
         :param name: Name of the importer
         """
-        self.ctx = ctx or Context()  # type: Context
-        self.uri = uri  # type: str
-        self.name = name or os.path.basename(__file__)  # type: str
+        self.ctx: Context = ctx or Context()
+        self.uri: str = uri
+        self.name: str = name or os.path.basename(__file__)
         self.logger = papis.logging.get_logger("papis.importer.{}".format(self.name))
 
     @classmethod
@@ -183,5 +183,5 @@ def get_importers() -> List[Type[Importer]]:
 
 def get_importer_by_name(name: str) -> Type[Importer]:
     """Get an importer class by *name*."""
-    imp = get_import_mgr()[name].plugin  # type: Type[Importer]
+    imp: Type[Importer] = get_import_mgr()[name].plugin
     return imp

--- a/papis/library.py
+++ b/papis/library.py
@@ -8,9 +8,9 @@ class Library:
     def __init__(self, name: str, paths: List[str]) -> None:
         """Create a Library object."""
         self.name = name
-        self.paths = sum(
+        self.paths: List[str] = sum(
             [glob.glob(os.path.expanduser(p)) for p in paths],
-            [])  # type: List[str]
+            [])
 
     def path_format(self) -> str:
         return ":".join(self.paths)

--- a/papis/logging.py
+++ b/papis/logging.py
@@ -148,7 +148,7 @@ def setup(level: Optional[Union[int, str]] = None,
 
     if logfile is None:
         full_tb = level == logging.DEBUG
-        handler = logging.StreamHandler()       # type: logging.Handler
+        handler: logging.Handler = logging.StreamHandler()
         handler.setFormatter(ColoramaFormatter(log_format, full_tb=full_tb))
     else:
         handler = logging.FileHandler(logfile, mode="a")

--- a/papis/pick.py
+++ b/papis/pick.py
@@ -33,8 +33,10 @@ def _extension_name() -> str:
 
 def get_picker(name: str) -> Type[Picker[Option]]:
     """Get the picker named 'name' declared as a plugin"""
-    picker = papis.plugin.get_extension_manager(
-        _extension_name())[name].plugin  # type: Type[Picker[Option]]
+    picker: Type[Picker[Option]] = (
+        papis.plugin.get_extension_manager(_extension_name())[name].plugin
+    )
+
     return picker
 
 
@@ -46,7 +48,7 @@ def pick(
 
     name = papis.config.getstring("picktool")
     try:
-        picker = get_picker(name)  # type: Type[Picker[Option]]
+        picker: Type[Picker[Option]] = get_picker(name)
     except KeyError:
         entrypoints = papis.plugin.get_available_entrypoints(_extension_name())
         logger.error(

--- a/papis/plugin.py
+++ b/papis/plugin.py
@@ -65,7 +65,7 @@ if TYPE_CHECKING:
 
 logger = papis.logging.get_logger(__name__)
 
-MANAGERS = {}  # type: Dict[str, ExtensionManager]
+MANAGERS: Dict[str, "ExtensionManager"] = {}
 
 
 def stevedore_error_handler(manager: "ExtensionManager",

--- a/papis/pubmed.py
+++ b/papis/pubmed.py
@@ -1,4 +1,4 @@
-from typing import Any, Dict, List, Optional
+from typing import Any, Dict, Optional
 
 import papis
 import papis.utils
@@ -21,7 +21,7 @@ type_converter = {
     "paper-conference": "inproceedings",
     "report": "report",
     "thesis": "phdthesis",
-}   # type: Dict[str, str]
+}
 
 
 def handle_pubmed_pages(pages: str) -> str:
@@ -54,7 +54,7 @@ key_conversion = [
     KeyConversionPair("issue", [papis.document.EmptyKeyConversion]),
     KeyConversionPair("title", [papis.document.EmptyKeyConversion]),
     KeyConversionPair("publisher", [papis.document.EmptyKeyConversion]),
-]   # type: List[KeyConversionPair]
+]
 
 
 def pubmed_data_to_papis_data(data: Dict[str, Any]) -> Dict[str, Any]:

--- a/papis/strings.py
+++ b/papis/strings.py
@@ -1,3 +1,3 @@
-no_documents_retrieved_message = "No documents retrieved"  # type: str
-no_folder_attached_to_document = "Document has no folder attached"  # type: str
-time_format = "%Y-%m-%d-%H:%M:%S"  # type: str
+no_documents_retrieved_message = "No documents retrieved"
+no_folder_attached_to_document = "Document has no folder attached"
+time_format = "%Y-%m-%d-%H:%M:%S"

--- a/papis/tui/app.py
+++ b/papis/tui/app.py
@@ -28,7 +28,11 @@ __all__ = [
     "Picker"
 ]
 
-KeyInfo = TypedDict("KeyInfo", {"key": str, "help": str})
+
+class KeyInfo(TypedDict):
+    key: str
+    help: str
+
 
 _KEYS_INFO: Optional[Dict[str, KeyInfo]] = None
 

--- a/papis/tui/app.py
+++ b/papis/tui/app.py
@@ -30,7 +30,7 @@ __all__ = [
 
 KeyInfo = TypedDict("KeyInfo", {"key": str, "help": str})
 
-_KEYS_INFO = None  # type: Optional[Dict[str, KeyInfo]]
+_KEYS_INFO: Optional[Dict[str, KeyInfo]] = None
 
 
 def get_keys_info() -> Dict[str, KeyInfo]:
@@ -294,7 +294,7 @@ class Picker(Application, Generic[Option]):  # type: ignore
             header_filter=header_filter,
             match_filter=match_filter,
             custom_filter=~has_focus(self.help_window)
-        )  # type: OptionsList[Option]
+        )
         self.options_list.search_buffer.on_text_changed += self.update
 
         commands, commands_kb = get_commands(self)
@@ -319,7 +319,7 @@ class Picker(Application, Generic[Option]):  # type: ignore
             self.command_line_prompt.window,
         ])
 
-        help_text = ""  # type: str
+        help_text = ""
         keys_info = get_keys_info()
         for k in keys_info:
             help_text += (

--- a/papis/tui/widgets/diff.py
+++ b/papis/tui/widgets/diff.py
@@ -1,5 +1,5 @@
 from typing import (
-    Dict, Any, List, Union, NamedTuple, Callable, Sequence, Optional)
+    Dict, Any, List, Union, NamedTuple, Callable, Optional)
 
 from prompt_toolkit import Application, print_formatted_text
 from prompt_toolkit.utils import Event
@@ -114,7 +114,7 @@ def diffshow(texta: str,
         "^^^^^^^^^\ndiff from\n",
         "----- {namea}\n".format(namea=namea),
         "+++++ {nameb}\n".format(nameb=nameb),
-    ]  # type: Sequence[str]
+    ]
 
     formatted_text = list(map(
         lambda line:
@@ -156,7 +156,7 @@ def diffdict(dicta: Dict[str, Any],
         "quit": False,
         "add_all": False,
         "cancel": False,
-    }  # type: Dict[str, bool]
+    }
 
     def reset() -> None:
         for k in options:

--- a/papis/tui/widgets/list.py
+++ b/papis/tui/widgets/list.py
@@ -56,29 +56,29 @@ class OptionsList(ConditionalContainer, Generic[Option]):  # type: ignore
             cpu_count = os.cpu_count()
 
         self.search_buffer = search_buffer
-        self.last_query_text = ""  # type: str
+        self.last_query_text = ""
         self.search_buffer.on_text_changed += self.update
 
         self.header_filter = header_filter
         self.match_filter = match_filter
-        self.current_index = default_index  # type: Optional[int]
+        self.current_index = default_index
         self.entries_left_offset = 0
         self.cpu_count = cpu_count
 
-        self.options_headers_linecount = []  # type: List[int]
-        self._indices_to_lines = []  # type: List[int]
+        self.options_headers_linecount: List[int] = []
+        self._indices_to_lines: List[int] = []
 
-        self.options_headers = []  # type: FormattedText
-        self.options_matchers = []  # type: List[str]
-        self.indices = []  # type: List[int]
-        self._options = []  # type: Sequence[Option]
-        self.marks = []  # type: List[int]
-        self.max_entry_height = 1  # type: int
+        self.options_headers: FormattedText = []
+        self.options_matchers: List[str] = []
+        self.indices: List[int] = []
+        self._options: Sequence[Option] = []
+        self.marks: List[int] = []
+        self.max_entry_height = 1
 
         # options are processed here also through the setter
         # ##################################################
         self.set_options(options)
-        self.cursor = Point(0, 0)  # type: Point
+        self.cursor = Point(0, 0)
         # ##################################################
 
         self.content = FormattedTextControl(
@@ -280,10 +280,10 @@ class OptionsList(ConditionalContainer, Generic[Option]):  # type: ignore
 
         self.update_cursor()
         begin_t = time.time()
-        internal_text = functools.reduce(
+        internal_text: List[Tuple[str, str]] = functools.reduce(
             operator.add,
             [self.options_headers[i] for i in self.indices],
-            [])  # type: List[Tuple[str, str]]
+            [])
         logger.debug("Created items in %.1f ms.", 1000 * (time.time() - begin_t))
         return internal_text
 

--- a/papis/utils.py
+++ b/papis/utils.py
@@ -141,13 +141,13 @@ def general_open(file_name: str,
         subprocess.call(cmd)
     else:
         logger.debug("Not waiting for process to finish.")
-        popen_kwargs = {
+        popen_kwargs: Dict[str, Any] = {
             "shell": False,
             "stdin": None,
             "stdout": subprocess.DEVNULL,
             "stderr": subprocess.DEVNULL,
             "close_fds": True
-        }  # type: Dict[str, Any]
+        }
 
         # NOTE: Detach process so that the terminal can be closed without also
         # closing the 'opentool' itself with the open document

--- a/setup.py
+++ b/setup.py
@@ -114,7 +114,7 @@ setup(
         "develop": [
             "flake8-bugbear",
             "flake8-quotes",
-            "flake8<6",
+            "flake8",
             "mypy>=0.7",
             "pep8-naming",
             "pylint",

--- a/tests/cli.py
+++ b/tests/cli.py
@@ -18,8 +18,8 @@ class TestWithLibrary(unittest.TestCase):
 
 class TestCli(TestWithLibrary):
 
-    runner = None  # type: Optional[click.testing.CliRunner]
-    cli = None  # type: Optional[click.BaseCommand]
+    runner: Optional[click.testing.CliRunner] = None
+    cli: Optional[click.BaseCommand] = None
 
     def setUp(self) -> None:
         self.runner = click.testing.CliRunner()


### PR DESCRIPTION
This removes all the comment style annotations `# type: List[str]` in favor of the direct annotations that are available in python 3.6+.

As a plus, we can enable to latest `flake8` too!