### PR TITLE
Fixes an error in bib_key conversion

### DIFF
--- a/papis/bibtex.py
+++ b/papis/bibtex.py
@@ -365,7 +365,7 @@ def to_bibtex(document: papis.document.Document, *, indent: int = 2) -> str:
         if bib_key in bibtex_ignore_keys:
             continue
 
-        bib_value = str(document[bib_key])
+        bib_value = str(document[key])
         logger.debug("Processing BibTeX entry: '%s: %s'.", bib_key, bib_value)
 
         if bib_key == "journal":


### PR DESCRIPTION
- outer iteration is done on `key`
- conversion is done to convert some papis fields to appropriate bibtex equivalents (e.g., `abstractNote` -> `abstract`)
- resulting variable was thereafter `bib_key`
- then, the `document` was being queried by `bib_key` (which, if it had been converted, would not be present in `documet`)
- thus anything that got converted would be skipped
- therefore, `bib_value` should be obtained from `document` using original `key` instead of `bib_key`