### PR TITLE
Added bibtex type conversion for bookSection

### DIFF
--- a/papis/bibtex.py
+++ b/papis/bibtex.py
@@ -22,7 +22,8 @@ bibtex_types = [
 bibtex_type_converter = {
     "conferencePaper": "inproceedings",
     "journalArticle": "article",
-    "journal": "article"
+    "journal": "article",
+    "bookSection": "inbook"
 }  # type: Dict[str, str]
 
 bibtex_keys = [


### PR DESCRIPTION
- there is no bibtex entry for bookSection
- closest option would be `inbook` (which apparently covers chapters and sections within a book)