### PR TITLE
Added bibtex type conversion for bookSection

### DIFF
--- a/papis/bibtex.py
+++ b/papis/bibtex.py
@@ -65,6 +65,7 @@ bibtex_type_converter: Dict[str, str] = {
     "conferencePaper": "inproceedings",
     "journalArticle": "article",
     "journal": "article",
+    "bookSection": "inbook",
 }
 
 bibtex_keys: FrozenSet[str] = frozenset([


### PR DESCRIPTION
- there is no bibtex entry for bookSection
- closest option would be `inbook` (which apparently covers chapters and sections within a book