### PR TITLE
Add exporter for typst bibliography format

### DIFF
--- a/papis/hayagriva.py
+++ b/papis/hayagriva.py
@@ -1,0 +1,131 @@
+from typing import Any, Dict, List
+
+import papis.document
+import papis.logging
+
+logger = papis.logging.get_logger(__name__)
+
+# NOTE: the Hayagriva YAML format is described at
+#   https://github.com/typst/hayagriva/blob/main/docs/file-format.md
+
+HAYAGRIVA_TYPES = frozenset({
+    "article", "chapter", "entry", "anthos", "report", "thesis", "web",
+    "scene", "artwork", "patent", "case", "newspaper", "legislation",
+    "manuscript", "tweet", "misc", "periodical", "proceedings",
+    "book", "blog", "reference", "conference", "anthology", "repository",
+    "thread", "video", "audio", "exibition",
+})
+
+# NOTE: only types that are different are stored
+# NOTE: keep in sync with papis.bibtex.bibtex_types
+BIBTEX_TO_HAYAGRIVA_TYPE_MAP = {
+    # regular types (Section 2.1.1)
+    # "article": "article",
+    # "book": "book",
+    "mvbook": "book",
+    "inbook": "chapter",
+    "bookinbook": "anthos",
+    "suppbook": "chapter",
+    "booklet": "book",
+    "collection": "anthology",
+    "mvcollection": "anthology",
+    "incollection": "anthos",
+    "suppcollection": "anthos",
+    "dataset": "misc",
+    "manual": "report",
+    # "misc": "misc",
+    "online": "web",
+    # "patent": "patent",
+    # "periodical": "periodical",
+    "suppperiodical": "periodical",
+    # "proceedings": "proceedings",
+    "mvproceedings": "proceedings",
+    "inproceedings": "proceedings",
+    "reference": "reference",
+    "mvreference": "reference",
+    "inreference": "reference",
+    "report": "report",
+    # "set": "misc",
+    "software": "misc",
+    # "thesis": "thesis",
+    "unpublished": "manuscript",
+    # "xdata",
+    # "custom[a-f]",
+    # non-standard types (Section 2.1.3)
+    # "artwork": "artwork",
+    # "audio": "audio",
+    # "bibnote": "misc",
+    "commentary": "misc",
+    "image": "misc",
+    "jurisdiction": "case",
+    # "legislation": "legislation",
+    "legal": "legislation",
+    "letter": "misc",
+    "movie": "video",
+    "music": "audio",
+    "performance": "scene",
+    "review": "article",
+    "standard": "article",
+    # "video": "video",
+    # type aliases (Section 2.1.2)
+    "conference": "conference",
+    "electronic": "web",
+    "masterthesis": "thesis",
+    "phdthesis": "thesis",
+    "techreport": "report",
+    "www": "web",
+}
+
+# NOTE: not all fields are implemented, since they're not well-supported
+_k = papis.document.KeyConversionPair
+PAPIS_TO_HAYAGRIVA_KEY_CONVERSION_MAP = [
+    _k("type", [{"key": "type", "action": lambda t: to_hayagriva_type(t)}]),
+    _k("title", [papis.document.EmptyKeyConversion]),
+    _k("author_list", [{"key": "author", "action": lambda a: to_hayagriva_authors(a)}]),
+    _k("year", [papis.document.EmptyKeyConversion]),
+    _k("date", [{"key": "date", "action": None}]),
+    _k("editor", [papis.document.EmptyKeyConversion]),
+    _k("publisher", [papis.document.EmptyKeyConversion]),
+    _k("location", [papis.document.EmptyKeyConversion]),
+    _k("organization", [papis.document.EmptyKeyConversion]),
+    _k("institution", [{"key": "organization", "action": None}]),
+    _k("issue", [papis.document.EmptyKeyConversion]),
+    _k("volume", [papis.document.EmptyKeyConversion]),
+    _k("volumes", [{"key": "volume-total", "action": None}]),
+    _k("edition", [papis.document.EmptyKeyConversion]),
+    _k("pages", [{"key": "page-range", "action": None}]),
+    _k("pagetotal", [{"key": "page-total", "action": None}]),
+    _k("url", [papis.document.EmptyKeyConversion]),
+    _k("doi", [papis.document.EmptyKeyConversion]),
+    _k("eprint", [{"key": "serial-number", "action": None}]),
+    _k("isbn", [papis.document.EmptyKeyConversion]),
+    _k("issn", [papis.document.EmptyKeyConversion]),
+    _k("language", [papis.document.EmptyKeyConversion]),
+]
+
+
+def to_hayagriva_type(entry_type: str) -> str:
+    # NOTE: the fields are case insensitive, but typst seems to capitalize them
+    return BIBTEX_TO_HAYAGRIVA_TYPE_MAP.get(entry_type, entry_type).capitalize()
+
+
+def to_hayagriva_authors(authors: List[Dict[str, Any]]) -> List[Dict[str, Any]]:
+    return [{"given-name": a["given"], "name": a["family"]} for a in authors]
+
+
+def to_hayagriva(doc: papis.document.Document) -> Dict[str, Any]:
+    from papis.document import keyconversion_to_data
+    data = keyconversion_to_data(PAPIS_TO_HAYAGRIVA_KEY_CONVERSION_MAP, doc)
+
+    return data
+
+
+def exporter(documents: List[papis.document.Document]) -> str:
+    import yaml
+    from papis.bibtex import create_reference
+
+    result = yaml.dump({
+        create_reference(doc): to_hayagriva(doc) for doc in documents
+        }, allow_unicode=True, indent=2, sort_keys=True)
+
+    return str(result)

--- a/papis/hayagriva.py
+++ b/papis/hayagriva.py
@@ -1,4 +1,4 @@
-from typing import Any, Dict, List
+from typing import Any, Dict, List, Optional
 
 import papis.document
 import papis.logging
@@ -165,6 +165,8 @@ def to_hayagriva(doc: papis.document.Document) -> Dict[str, Any]:
     htype = BIBTEX_TO_HAYAGRIVA_TYPE_MAP.get(bibtype, bibtype)
 
     parent_known_keys = HAYAGRIVA_TYPE_PARENT_KEYS[htype]
+    ptype: Optional[str] = None
+
     if htype == "article":
         if "proceedings" in bibtype:
             # NOTE: heuristic: proceedings are published and have a DOI
@@ -180,8 +182,8 @@ def to_hayagriva(doc: papis.document.Document) -> Dict[str, Any]:
         ptype = HAYAGRIVA_PARENT_TYPES.get(htype)
 
     # NOTE: the type is case insensitive, but typst seems to capitalize them
-    data = {"type": htype.capitalize()}
-    parent = {"type": ptype.capitalize()} if ptype else {}
+    data: Dict[str, Any] = {"type": htype.capitalize()}
+    parent: Dict[str, Any] = {"type": ptype.capitalize()} if ptype else {}
 
     for foreign_key, conversions in PAPIS_TO_HAYAGRIVA_KEY_CONVERSION_MAP:
         if foreign_key not in doc:

--- a/setup.py
+++ b/setup.py
@@ -175,6 +175,7 @@ setup(
         ],
         "papis.exporter": [
             "bibtex=papis.bibtex:exporter",
+            "hayagriva=papis.hayagriva:exporter",
             "json=papis.json:exporter",
             "yaml=papis.yaml:exporter",
         ],

--- a/setup.py
+++ b/setup.py
@@ -175,8 +175,8 @@ setup(
         ],
         "papis.exporter": [
             "bibtex=papis.bibtex:exporter",
-            "hayagriva=papis.hayagriva:exporter",
             "json=papis.json:exporter",
+            "typst=papis.hayagriva:exporter",
             "yaml=papis.yaml:exporter",
         ],
         "papis.importer": [

--- a/tests/resources/hayagriva_1_out.yml
+++ b/tests/resources/hayagriva_1_out.yml
@@ -1,0 +1,14 @@
+author:
+- given-name: A. M.
+  name: Turing
+doi: 10.1112/plms/s2-42.1.230
+page-range: 230--265
+parent:
+  date: '1937'
+  issue: '1'
+  title: Proceedings of the London Mathematical Society
+  type: Periodical
+  volume: s2-42
+title: On Computable Numbers with an Application to the Entscheidungsproblem
+type: Article
+url: https://api.wiley.com/onlinelibrary/tdm/v1/articles/10.1112%2Fplms%2Fs2-42.1.230

--- a/tests/test_haragriva.py
+++ b/tests/test_haragriva.py
@@ -1,0 +1,18 @@
+import os
+
+import papis.yaml
+import papis.hayagriva
+
+from tests.testlib import TemporaryLibrary
+
+
+def test_exporter(tmp_library: TemporaryLibrary) -> None:
+    db = papis.database.get()
+    doc, = db.query_dict({"author": "turing"})
+
+    filename = os.path.join(os.path.dirname(__file__),
+                            "resources", "hayagriva_1_out.yml")
+    result = papis.hayagriva.to_hayagriva(doc)
+    expected = papis.yaml.yaml_to_data(filename)
+
+    assert result == expected

--- a/tests/testlib.py
+++ b/tests/testlib.py
@@ -35,7 +35,8 @@ PAPIS_TEST_DOCUMENTS = [
         "volume": "I",
         "_test_files": 0,
     }, {
-        "author": "Turing A. M.",
+        "type": "article",
+        "author": "Turing, A. M.",
         "doi": "10.1112/plms/s2-42.1.230",
         "issue": "1",
         "journal": "Proceedings of the London Mathematical Society",


### PR DESCRIPTION
This adds an exporter for the bibliography format supported by [`typst`](https://github.com/typst/typst) which is described [here](https://github.com/typst/hayagriva/blob/main/docs/file-format.md). It's a reasonably simple YAML format, so we just need to translate `papis` keys.

TODO:
* [x] Add some tests
* [x] Support for the `parent` key for chapters in books and proceedings.