### PR TITLE
commands.add: fix download when remote URL is given

### DIFF
--- a/papis/commands/add.py
+++ b/papis/commands/add.py
@@ -598,7 +598,9 @@ def cli(files: List[str],
                         "Select the ones you want to use.")
 
             matching_indices = papis.tui.utils.select_range(
-                ["{} (files: {}) ".format(imp.name, ", ".join(imp.ctx.files))
+                ["{} (files: {}) ".format(
+                    imp.name,
+                    ", ".join(imp.ctx.files) if imp.ctx.files else "no")
                  for imp in matching_importers],
                 "Select matching importers (for instance 0, 1, 3-10, a, all...)")
 

--- a/papis/commands/add.py
+++ b/papis/commands/add.py
@@ -584,7 +584,7 @@ def cli(files: List[str],
         confirm = False
         open_file = False
 
-    only_data = bool(files) and not force_download
+    only_data = bool(ctx.files) and not force_download
     matching_importers = papis.utils.get_matching_importer_by_name(
         from_importer, only_data=only_data)
 


### PR DESCRIPTION
Tested with
```
papis add 'https://arxiv.org/abs/2305.00377'
```
and it now downloads the PDF correctly again. @alejandrogallo Does this fix it for you too?

Fixes #556