### PR TITLE
windows: fix opentool usage

### DIFF
--- a/papis/defaults.py
+++ b/papis/defaults.py
@@ -8,9 +8,13 @@ def get_default_opener() -> str:
     """
     if sys.platform.startswith("darwin"):
         return "open"
-    if os.name == "nt":
-        return "start"
-    return "xdg-open"
+    elif sys.platform == "win32":
+        # NOTE: 'start' is a cmd internal command and cannot be called on its
+        # own without 'call(..., shell=True)' so this calls 'cmd.exe' directly
+        return "cmd.exe /c start"
+    else:
+        # NOTE: should work on Linux / FreeBSD / cygwin
+        return "xdg-open"
 
 
 settings: Dict[str, Any] = {

--- a/papis/utils.py
+++ b/papis/utils.py
@@ -128,7 +128,7 @@ def run(cmd: Sequence[str],
 
     logger.debug("Running command: '%s'.", cmd)
 
-    # NOTE: Detached processes do not fail properly when the command does not
+    # NOTE: detached processes do not fail properly when the command does not
     # exist, so we check for it manually here
     import shutil
     if not shutil.which(cmd[0]):
@@ -137,30 +137,30 @@ def run(cmd: Sequence[str],
     import subprocess
     if wait:
         logger.debug("Waiting for process to finish.")
-        subprocess.call(cmd, cwd=cwd, env=env)
+        subprocess.call(cmd, shell=False, cwd=cwd, env=env)
     else:
-        logger.debug("Not waiting for process to finish.")
-        popen_kwargs: Dict[str, Any] = {
-            "cwd": cwd,
-            "env": env,
-            "shell": False,
-            "stdin": None,
-            "stdout": subprocess.DEVNULL,
-            "stderr": subprocess.DEVNULL,
-        }
-
-        # NOTE: Detach process so that the terminal can be closed without also
+        # NOTE: detach process so that the terminal can be closed without also
         # closing the 'opentool' itself with the open document
+        platform_kwargs: Dict[str, Any] = {}
         if sys.platform == "win32":
-            popen_kwargs["creationflags"] = subprocess.DETACHED_PROCESS
-            popen_kwargs["creationflags"] |= subprocess.CREATE_NEW_PROCESS_GROUP
+            platform_kwargs["creationflags"] = (
+                subprocess.DETACHED_PROCESS
+                | subprocess.CREATE_NEW_PROCESS_GROUP)
         else:
             # NOTE: 'close_fds' is not supported on windows with stdout/stderr
             # https://docs.python.org/3/library/subprocess.html#subprocess.Popen
-            popen_kwargs["close_fds"] = True
+            platform_kwargs["close_fds"] = True
             cmd.insert(0, "nohup")
 
-        subprocess.Popen(cmd, **popen_kwargs)
+        logger.debug("Not waiting for process to finish.")
+        subprocess.Popen(cmd,
+                         shell=False,
+                         cwd=cwd,
+                         env=env,
+                         stdin=None,
+                         stdout=subprocess.DEVNULL,
+                         stderr=subprocess.DEVNULL,
+                         **platform_kwargs)
 
 
 def general_open(file_name: str,
@@ -188,15 +188,15 @@ def general_open(file_name: str,
         opener = default_opener
 
     import shlex
-    if sys.platform == "win32":
-        cmd = shlex.split(str(opener), posix=False) + [file_name]
-    else:
-        cmd = shlex.split("{} '{}'".format(opener, file_name))
+
+    # NOTE: 'opener' can be a command with arguments, so we split it properly
+    is_windows = sys.platform == "win32"
+    cmd = shlex.split(str(opener), posix=not is_windows) + [file_name]
 
     import shutil
-    if not shutil.which(cmd[0]):
+    if shutil.which(cmd[0]) is None:
         raise FileNotFoundError(
-            "Command not found for key '{}': '{}'".format(key, opener))
+            "Command not found for '{}': '{}'".format(key, opener))
 
     run(cmd, wait=wait)
 

--- a/tests/commands/test_open.py
+++ b/tests/commands/test_open.py
@@ -1,4 +1,5 @@
 import os
+import sys
 import pytest
 
 from tests.testlib import TemporaryLibrary, PapisRunner
@@ -34,4 +35,15 @@ def test_open_cli(tmp_library: TemporaryLibrary) -> None:
     result = cli_runner.invoke(
         cli,
         ["--tool", "python {} echo".format(script), "--mark", "--all", "Krishnamurti"])
+    assert result.exit_code == 0
+
+
+@pytest.mark.skipif(sys.platform != "win32", reason="uses windows commands")
+def test_open_windows_cli(tmp_library: TemporaryLibrary) -> None:
+    from papis.commands.open import cli
+    cli_runner = PapisRunner()
+
+    result = cli_runner.invoke(
+        cli,
+        ["--tool", 'cmd.exe /c start ""', "--all", "Krishnamurti"])
     assert result.exit_code == 0

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -12,7 +12,7 @@ def test_default_opener(tmp_config: TemporaryConfiguration) -> None:
     if sys.platform.startswith("darwin"):
         assert papis.defaults.get_default_opener() == "open"
     elif sys.platform.startswith("win"):
-        assert papis.defaults.get_default_opener() == "start"
+        assert papis.defaults.get_default_opener() == "cmd.exe /c start"
     else:
         assert papis.defaults.get_default_opener() == "xdg-open"
 


### PR DESCRIPTION
Updates `general_open` to actually work with the default `start` command on Windows. 

Seems like that needed `shell=True` because it's an internal shell command. This changes the default to call `cmd.exe /c start` instead.

Fixes #568.