### PR TITLE
windows: fix info.yaml encoding

### DIFF
--- a/papis/arxiv.py
+++ b/papis/arxiv.py
@@ -165,7 +165,7 @@ def find_arxivid_in_text(text: str) -> Optional[str]:
     return None
 
 
-@click.command("arxiv")
+@click.command("arxiv")                 # type: ignore[arg-type]
 @click.pass_context
 @click.help_option("--help", "-h")
 @click.option("--query", "-q", default="", type=str)

--- a/papis/bibtex.py
+++ b/papis/bibtex.py
@@ -218,7 +218,7 @@ class Importer(papis.importer.Importer):
         self.ctx.data = bib_data[0]
 
 
-@click.command("bibtex")
+@click.command("bibtex")                # type: ignore[arg-type]
 @click.pass_context
 @click.argument("bibfile", type=click.Path(exists=True))
 @click.help_option("--help", "-h")

--- a/papis/citations.py
+++ b/papis/citations.py
@@ -166,7 +166,8 @@ def save_citations(doc: papis.document.Document, citations: Citations) -> None:
     if not file_path:
         return
 
-    papis.yaml.list_to_path(citations, file_path)
+    allow_unicode = papis.config.getboolean("info-allow-unicode")
+    papis.yaml.list_to_path(citations, file_path, allow_unicode=allow_unicode)
 
 
 def fetch_and_save_citations(doc: papis.document.Document) -> None:
@@ -250,7 +251,8 @@ def save_cited_by(doc: papis.document.Document, citations: Citations) -> None:
     if not file_path:
         return
 
-    papis.yaml.list_to_path(citations, file_path)
+    allow_unicode = papis.config.getboolean("info-allow-unicode")
+    papis.yaml.list_to_path(citations, file_path, allow_unicode=allow_unicode)
 
 
 def _cites_me_p(doi_doc: Tuple[str, papis.document.Document]) -> Optional[Citation]:
@@ -297,7 +299,8 @@ def fetch_and_save_cited_by_from_database(doc: papis.document.Document) -> None:
 
     file_path = get_cited_by_file(doc)
     if citations and file_path:
-        papis.yaml.list_to_path(citations, file_path)
+        allow_unicode = papis.config.getboolean("info-allow-unicode")
+        papis.yaml.list_to_path(citations, file_path, allow_unicode=allow_unicode)
 
 
 def get_cited_by(doc: papis.document.Document) -> Citations:

--- a/papis/cli.py
+++ b/papis/cli.py
@@ -34,13 +34,13 @@ def query_option(**attrs: Any) -> DecoratorCallable:
 def sort_option(**attrs: Any) -> DecoratorCallable:
     """Adds a ``--sort`` and a ``--reverse`` option as a :mod:`click` decorator."""
     def decorator(f: DecoratorCallable) -> Any:
-        sort = click.option(
+        sort: DecoratorCallable = click.option(
             "--sort", "sort_field",
             default=lambda: papis.config.get("sort-field"),
             help="Sort documents with respect to the FIELD",
             metavar="FIELD",
             **attrs)
-        reverse = click.option(
+        reverse: DecoratorCallable = click.option(
             "--reverse", "sort_reverse",
             help="Reverse sort order",
             default=lambda: papis.config.getboolean("sort-reverse"),

--- a/papis/commands/add.py
+++ b/papis/commands/add.py
@@ -473,7 +473,7 @@ def run(paths: List[str],
             "Add document '{}'".format(papis.document.describe(tmp_document)))
 
 
-@click.command(
+@click.command(                         # type: ignore[arg-type]
     "add",
     help="Add a document into a given library"
 )

--- a/papis/commands/bibtex.py
+++ b/papis/commands/bibtex.py
@@ -136,7 +136,8 @@ papis.config.register_default_settings({"bibtex": {
 EXPLORER_MGR = explore.get_explorer_mgr()
 
 
-@click.group("bibtex", cls=papis.commands.AliasedGroup, chain=True)
+@click.group("bibtex",                  # type: ignore[arg-type]
+             cls=papis.commands.AliasedGroup, chain=True)
 @click.help_option("-h", "--help")
 @click.option("--noar", "--no-auto-read", "no_auto_read",
               default=False,
@@ -162,7 +163,7 @@ def cli(ctx: click.Context, no_auto_read: bool) -> None:
 cli.add_command(EXPLORER_MGR["bibtex"].plugin, "read")
 
 
-@cli.command("add")
+@cli.command("add")                     # type: ignore[arg-type]
 @click.help_option("-h", "--help")
 @papis.cli.all_option()
 @papis.cli.query_option()
@@ -201,7 +202,7 @@ def _add(ctx: click.Context,
     ctx.obj["documents"].extend(docs)
 
 
-@cli.command("update")
+@cli.command("update")                  # type: ignore[arg-type]
 @click.help_option("-h", "--help")
 @papis.cli.all_option()
 @click.option("--from", "-f", "fromdb",
@@ -249,7 +250,7 @@ def _update(ctx: click.Context, _all: bool,
     click.get_current_context().obj["documents"] = docs
 
 
-@cli.command("open")
+@cli.command("open")                    # type: ignore[arg-type]
 @click.help_option("-h", "--help")
 @click.pass_context
 def _open(ctx: click.Context) -> None:
@@ -309,7 +310,7 @@ def _edit(ctx: click.Context,
     logger.info("Found %d / %d documents.", len(docs) - not_found, len(docs))
 
 
-@cli.command("browse")
+@cli.command("browse")                  # type: ignore[arg-type]
 @click.help_option("-h", "--help")
 @click.option("-k", "--key", default=None, help="doi, url, ...")
 @click.pass_context
@@ -324,7 +325,7 @@ def _browse(ctx: click.Context, key: Optional[str]) -> None:
         papis.commands.browse.run(d)
 
 
-@cli.command("rm")
+@cli.command("rm")                      # type: ignore[arg-type]
 @click.help_option("-h", "--help")
 @click.pass_context
 def _rm(ctx: click.Context) -> None:
@@ -332,7 +333,7 @@ def _rm(ctx: click.Context) -> None:
     click.echo("Sorry, TODO...")
 
 
-@cli.command("ref")
+@cli.command("ref")                     # type: ignore[arg-type]
 @click.help_option("-h", "--help")
 @click.option("-o", "--out", help="Output ref to a file", default=None)
 @click.pass_context
@@ -350,7 +351,7 @@ def _ref(ctx: click.Context, out: Optional[str]) -> None:
         click.echo(ref)
 
 
-@cli.command("save")
+@cli.command("save")                    # type: ignore[arg-type]
 @click.help_option("-h", "--help")
 @click.argument(
     "bibfile",
@@ -371,7 +372,7 @@ def _save(ctx: click.Context, bibfile: str, force: bool) -> None:
         fd.write(papis.commands.export.run(docs, to_format="bibtex"))
 
 
-@cli.command("sort")
+@cli.command("sort")                    # type: ignore[arg-type]
 @click.help_option("-h", "--help")
 @click.option("-k", "--key",
               help="Field to order it",
@@ -391,7 +392,7 @@ def _sort(ctx: click.Context, key: Optional[str], reverse: bool) -> None:
                                        reverse=reverse))
 
 
-@cli.command("unique")
+@cli.command("unique")                  # type: ignore[arg-type]
 @click.help_option("-h", "--help")
 @click.option("-k", "--key",
               help="Field to test for uniqueness, default is ref",
@@ -439,7 +440,7 @@ def _unique(ctx: click.Context, key: str, o: Optional[str]) -> None:
             f.write(papis.commands.export.run(duplicated_docs, to_format="bibtex"))
 
 
-@cli.command("doctor")
+@cli.command("doctor")                  # type: ignore[arg-type]
 @click.help_option("-h", "--help")
 @click.option("-k", "--key",
               help="Field to test for uniqueness, default is ref",
@@ -466,7 +467,7 @@ def _doctor(ctx: click.Context, key: List[str]) -> None:
             logger.info("\tMissing: %s", k)
 
 
-@cli.command("filter-cited")
+@cli.command("filter-cited")            # type: ignore[arg-type]
 @click.help_option("-h", "--help")
 @click.option("-f", "--file", "_files",
               help="Text file to check for references",
@@ -491,7 +492,7 @@ def _filter_cited(ctx: click.Context, _files: List[str]) -> None:
     ctx.obj["documents"] = found
 
 
-@cli.command("iscited")
+@cli.command("iscited")                 # type: ignore[arg-type]
 @click.help_option("-h", "--help")
 @click.option("-f", "--file", "_files",
               help="Text file to check for references",

--- a/papis/commands/config.py
+++ b/papis/commands/config.py
@@ -204,7 +204,7 @@ def run(
     return result
 
 
-@click.command("config")
+@click.command("config")                # type: ignore[arg-type]
 @click.help_option("--help", "-h")
 @click.argument("options", nargs=-1)
 @click.option(

--- a/papis/commands/default.py
+++ b/papis/commands/default.py
@@ -101,7 +101,7 @@ class MultiCommand(click.core.MultiCommand):
         # If it gets here, it means that it is an external script
         import copy
         from papis.commands.external import external_cli
-        cli = copy.copy(external_cli)
+        cli: click.Command = copy.copy(external_cli)
 
         from papis.commands.external import get_command_help
         cli.context_settings["obj"] = script
@@ -109,6 +109,7 @@ class MultiCommand(click.core.MultiCommand):
             cli.help = get_command_help(script.path)
         cli.name = script.command_name
         cli.short_help = cli.help
+
         return cli
 
 
@@ -121,7 +122,7 @@ def generate_profile_writing_function(profiler: "cProfile.Profile",
     return _on_finish
 
 
-@click.group(
+@click.group(                           # type: ignore[arg-type,type-var]
     cls=MultiCommand,
     invoke_without_command=True)
 @click.help_option("--help", "-h")

--- a/papis/commands/doctor.py
+++ b/papis/commands/doctor.py
@@ -450,7 +450,7 @@ def run(doc: papis.document.Document, checks: List[str]) -> List[Error]:
     return results
 
 
-@click.command("doctor")
+@click.command("doctor")                # type: ignore[arg-type]
 @click.help_option("--help", "-h")
 @papis.cli.query_argument()
 @papis.cli.sort_option()

--- a/papis/commands/edit.py
+++ b/papis/commands/edit.py
@@ -72,7 +72,7 @@ def edit_notes(document: papis.document.Document,
                                                msg)
 
 
-@click.command("edit")
+@click.command("edit")                  # type: ignore[arg-type]
 @click.help_option("-h", "--help")
 @papis.cli.query_argument()
 @papis.cli.doc_folder_option()

--- a/papis/commands/exec.py
+++ b/papis/commands/exec.py
@@ -43,7 +43,8 @@ def run(_file: str) -> None:
         exec(f.read())
 
 
-@click.command("exec", context_settings={"ignore_unknown_options": True})
+@click.command("exec",                  # type: ignore[arg-type]
+               context_settings={"ignore_unknown_options": True})
 @click.help_option("--help", "-h")
 @click.argument("python_file", type=click.Path(exists=True))
 @click.argument("args", nargs=-1)

--- a/papis/commands/explore.py
+++ b/papis/commands/explore.py
@@ -130,7 +130,7 @@ def get_explorer_mgr() -> "ExtensionManager":
     return papis.plugin.get_extension_manager(_extension_name())
 
 
-@click.command("lib")
+@click.command("lib")                   # type: ignore[arg-type]
 @click.pass_context
 @click.help_option("--help", "-h")
 @papis.cli.query_argument()
@@ -157,7 +157,7 @@ def lib(ctx: click.Context, query: str,
     assert isinstance(ctx.obj["documents"], list)
 
 
-@click.command("pick")
+@click.command("pick")                  # type: ignore[arg-type]
 @click.pass_context
 @click.help_option("--help", "-h")
 @click.option("--number", "-n",
@@ -240,7 +240,7 @@ def add(ctx: click.Context) -> None:
         papis.commands.add.run([], d)
 
 
-@click.command("cmd")
+@click.command("cmd")               # type: ignore[arg-type]
 @click.pass_context
 @click.help_option("--help", "-h")
 @click.argument("command", type=str)
@@ -262,7 +262,7 @@ def cmd(ctx: click.Context, command: str) -> None:
         papis.utils.run(shlex.split(fcommand))
 
 
-@click.group("explore",
+@click.group("explore",             # type: ignore[arg-type]
              cls=papis.commands.AliasedGroup,
              invoke_without_command=False, chain=True)
 @click.help_option("--help", "-h")

--- a/papis/commands/export.py
+++ b/papis/commands/export.py
@@ -87,7 +87,7 @@ def run(documents: List[papis.document.Document], to_format: str) -> str:
     return str(ret_string)
 
 
-@click.command("export")
+@click.command("export")                # type: ignore[arg-type]
 @click.help_option("--help", "-h")
 @papis.cli.query_argument()
 @papis.cli.doc_folder_option()
@@ -164,7 +164,7 @@ def cli(query: str,
             shutil.copytree(_doc_folder, outdir)
 
 
-@click.command("export")
+@click.command("export")                # type: ignore[arg-type]
 @click.pass_context
 @click.help_option("--help", "-h")
 @click.option(

--- a/papis/commands/external.py
+++ b/papis/commands/external.py
@@ -55,7 +55,7 @@ def get_exported_variables(ctx: Optional[Dict[str, Any]] = None) -> Dict[str, st
     return exports
 
 
-@click.command(
+@click.command(                         # type: ignore[arg-type]
     context_settings={
         "ignore_unknown_options": True,
         "help_option_names": [],

--- a/papis/commands/git.py
+++ b/papis/commands/git.py
@@ -29,4 +29,5 @@ import papis.commands.run
 cli = copy.deepcopy(papis.commands.run.cli)
 cli.name = "git"
 cli.help = "Run git command in a library or document folder"
-cli = click.option("--prefix", hidden=True, default="git", type=str)(cli)
+cli = click.option("--prefix",
+                   hidden=True, default="git", type=str)(cli)  # type: ignore[arg-type]

--- a/papis/commands/open.py
+++ b/papis/commands/open.py
@@ -151,7 +151,7 @@ def run(document: papis.document.Document,
             papis.api.open_file(file_to_open, wait=False)
 
 
-@click.command("open")
+@click.command("open")                  # type: ignore[arg-type]
 @click.help_option("-h", "--help")
 @papis.cli.query_argument()
 @papis.cli.sort_option()

--- a/papis/commands/run.py
+++ b/papis/commands/run.py
@@ -74,7 +74,8 @@ def run(folder: str, command: Optional[List[str]] = None) -> None:
     papis.utils.run(command, cwd=folder, wait=True)
 
 
-@click.command("run", context_settings={"ignore_unknown_options": True})
+@click.command("run",                   # type: ignore[arg-type]
+               context_settings={"ignore_unknown_options": True})
 @click.help_option("--help", "-h")
 @click.option(
     "--pick", "-p",

--- a/papis/commands/serve.py
+++ b/papis/commands/serve.py
@@ -470,7 +470,7 @@ class PapisRequestHandler(http.server.BaseHTTPRequestHandler):
         self.process_routes(routes)
 
 
-@click.command("serve")
+@click.command("serve")                 # type: ignore[arg-type]
 @click.help_option("-h", "--help")
 @click.option("-p", "--port",
               help="Port to listen to",

--- a/papis/commands/update.py
+++ b/papis/commands/update.py
@@ -81,7 +81,7 @@ def run(document: papis.document.Document,
                 papis.document.describe(document)))
 
 
-@click.command("update")
+@click.command("update")                # type: ignore[arg-type]
 @click.help_option("--help", "-h")
 @papis.cli.git_option()
 @papis.cli.query_argument()

--- a/papis/crossref.py
+++ b/papis/crossref.py
@@ -271,7 +271,7 @@ def doi_to_data(doi_string: str) -> Dict[str, Any]:
         "Could not retrieve data for DOI '{}' from Crossref".format(doi_string))
 
 
-@click.command("crossref")
+@click.command("crossref")              # type: ignore[arg-type]
 @click.pass_context
 @click.help_option("--help", "-h")
 @click.option("--query", "-q", help="General query", default="")

--- a/papis/dblp.py
+++ b/papis/dblp.py
@@ -158,7 +158,7 @@ def is_valid_dblp_key(key: str) -> bool:
         return response.ok
 
 
-@click.command("dblp")
+@click.command("dblp")                  # type: ignore[arg-type]
 @click.pass_context
 @click.help_option("--help", "-h")
 @click.option(

--- a/papis/dissemin.py
+++ b/papis/dissemin.py
@@ -65,7 +65,7 @@ def get_data(query: str = "") -> List[Dict[str, Any]]:
     return sum([dissemindoc_to_papis(d) for d in paperlist["papers"]], [])
 
 
-@click.command("dissemin")
+@click.command("dissemin")              # type: ignore[arg-type]
 @click.pass_context
 @click.help_option("--help", "-h")
 @click.option("--query", "-q", default="", type=str)

--- a/papis/document.py
+++ b/papis/document.py
@@ -323,7 +323,11 @@ class Document(Dict[str, Any]):
     def save(self) -> None:
         """Saves the current document fields into the info file."""
         import papis.yaml
-        papis.yaml.data_to_yaml(self.get_info_file(), dict(self))
+
+        allow_unicode = papis.config.getboolean("info-allow-unicode")
+        papis.yaml.data_to_yaml(self.get_info_file(),
+                                dict(self),
+                                allow_unicode=allow_unicode)
 
     def load(self) -> None:
         """Load information from the info file."""

--- a/papis/isbn.py
+++ b/papis/isbn.py
@@ -63,7 +63,7 @@ def data_to_papis(data: Dict[str, Any]) -> Dict[str, Any]:
         key_conversion, data, keep_unknown_keys=True)
 
 
-@click.command("isbn")
+@click.command("isbn")                  # type: ignore[arg-type]
 @click.pass_context
 @click.help_option("--help", "-h")
 @click.option("--query", "-q", default=None)

--- a/papis/json.py
+++ b/papis/json.py
@@ -13,7 +13,7 @@ def exporter(documents: List[papis.document.Document]) -> str:
     return json.dumps([papis.document.to_dict(doc) for doc in documents])
 
 
-@click.command("json")
+@click.command("json")                  # type: ignore[arg-type]
 @click.pass_context
 @click.argument("jsonfile", type=click.Path(exists=True))
 @click.help_option("--help", "-h")

--- a/papis/yaml.py
+++ b/papis/yaml.py
@@ -115,7 +115,7 @@ def exporter(documents: List[papis.document.Document]) -> str:
     return str(string)
 
 
-@click.command("yaml")
+@click.command("yaml")                  # type: ignore[arg-type]
 @click.pass_context
 @click.argument("yamlfile", type=click.Path(exists=True))
 @click.help_option("--help", "-h")

--- a/setup.cfg
+++ b/setup.cfg
@@ -28,6 +28,7 @@ show_column_numbers = True
 hide_error_codes = False
 pretty = True
 files = papis
+warn_unused_ignores = False
 
 [mypy-arxiv2bib.*]
 ignore_missing_imports = True

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -131,3 +131,19 @@ def test_slugify(tmp_config: TemporaryConfiguration) -> None:
     )
     assert clean_document_name("масса и енергиа.pdf") == "massa-i-energia.pdf"
     assert clean_document_name("الامير الصغير.pdf") == "lmyr-lsgyr.pdf"
+
+
+def test_yaml_unicode_dump(tmp_config: TemporaryConfiguration) -> None:
+    from papis.crossref import get_data
+
+    doi = "10.1111/febs.15572"
+    doc, = get_data(dois=[doi])
+    assert doc["doi"] == doi
+
+    from papis.yaml import data_to_yaml, yaml_to_data
+
+    filename = os.path.join(tmp_config.tmpdir, "test_dump_encoding.yml")
+    data_to_yaml(filename, doc)
+
+    doc = yaml_to_data(filename)
+    assert doc["doi"] == doi


### PR DESCRIPTION
Ensure that all data written to YAML files is in `utf-8`.

Fixes #567.