### PR TITLE
docs: correctly anchor config settings

### DIFF
--- a/doc/source/conf.py
+++ b/doc/source/conf.py
@@ -83,7 +83,7 @@ class PapisConfig(Directive):
         lines.append("")
         lines.append(".. _config-{section}-{key}:".format(section=section, key=key))
         lines.append("")
-        lines.append("`{key} <config-{section}-{key}>`_"
+        lines.append("`{key} <#config-{section}-{key}>`__"
                      .format(section=section, key=key))
 
         if "\n" in str(default):


### PR DESCRIPTION
Fixes the links in the `General settings` section of the docs pointing to non-existent URLs.