### PR TITLE
isbn: set a default language to English

### DIFF
--- a/papis/isbn.py
+++ b/papis/isbn.py
@@ -48,11 +48,14 @@ def data_to_papis(data: Dict[str, Any]) -> Dict[str, Any]:
         _k("authors", [{
             "key": "author_list",
             "action": papis.document.split_authors_name
-            }]),
+        }]),
         _k("isbn-13", [
             {"key": "isbn", "action": None},
             {"key": "isbn-13", "action": None},
-            ]),
+        ]),
+        _k("language", [
+            {"key": "language", "action": lambda x: x if x else "en"}
+        ])
         ]
 
     data = {k.lower(): data[k] for k in data}

--- a/tests/resources/isbn/test_isbn_1_out.json
+++ b/tests/resources/isbn/test_isbn_1_out.json
@@ -8,7 +8,7 @@
     ],
     "isbn": "9781930217089",
     "isbn-13": "9781930217089",
-    "language": "",
+    "language": "en",
     "publisher": "R.T. Edwards",
     "title": "An introduction to multigrid methods",
     "year": "2004"

--- a/tests/test_isbn.py
+++ b/tests/test_isbn.py
@@ -37,11 +37,12 @@ def get_unmodified_isbn_data(query: str) -> Any:
 def test_get_data(tmp_config: TemporaryConfiguration) -> None:
     import papis.isbn
 
-    mattuck = papis.isbn.get_data(query="Mattuck feynan diagrams")
-    assert mattuck
-    assert isinstance(mattuck, list)
-    assert isinstance(mattuck[0], dict)
-    assert mattuck[0]["isbn-13"] == "9780486670478"
+    result = papis.isbn.get_data(query="Mattuck feynan diagrams")
+    assert result
+    assert isinstance(result, list)
+    assert isinstance(result[0], dict)
+    assert result[0]["isbn-13"] == "9780486670478"
+    assert result[0]["language"] != ""
 
 
 def test_importer_match(tmp_config: TemporaryConfiguration) -> None:


### PR DESCRIPTION
Not quite sure when, but `isbnlib` started returning an empty language for some documents, i.e. `"Language": ""`. This sets it to English as a healthy default.