### PR TITLE
Feature: Allow .pdf urls to work with arxiv importer.

### DIFF
--- a/papis/arxiv.py
+++ b/papis/arxiv.py
@@ -158,7 +158,9 @@ def find_arxivid_in_text(text: str) -> Optional[str]:
     with suppress(StopIteration):
         m = next(miter)
         if m:
-            return m.group("arxivid")
+            aid = m.group("arxivid")
+            aid = aid[:-4] if aid.endswith('.pdf') else aid
+            return aid
 
     return None
 

--- a/papis/arxiv.py
+++ b/papis/arxiv.py
@@ -159,7 +159,7 @@ def find_arxivid_in_text(text: str) -> Optional[str]:
         m = next(miter)
         if m:
             aid = m.group("arxivid")
-            aid = aid[:-4] if aid.endswith('.pdf') else aid
+            aid = aid[:-4] if aid.endswith(".pdf") else aid
             return aid
 
     return None

--- a/tests/test_arxiv.py
+++ b/tests/test_arxiv.py
@@ -34,7 +34,7 @@ def test_find_arxiv_id(tmp_config: TemporaryConfiguration) -> None:
 
     for url, arxivid in test_data:
         assert papis.arxiv.find_arxivid_in_text(url) == arxivid, \
-                f"Could not retrieve correct arxivid from {url}"
+            f"Could not retrieve correct arxivid from {url}"
 
 
 def test_match(tmp_config: TemporaryConfiguration) -> None:

--- a/tests/test_arxiv.py
+++ b/tests/test_arxiv.py
@@ -26,10 +26,15 @@ def test_find_arxiv_id(tmp_config: TemporaryConfiguration) -> None:
         ("http://arxiv.org/abs/1110.3658>", "1110.3658"),
         ("https://arxiv.com/abs/1110.3658>", "1110.3658"),
         ("https://arxiv.org/1110.3658>", "1110.3658"),
+        ("https://arxiv.org/pdf/1110.3658.pdf", "1110.3658"),
+        ("http://arxiv.org/pdf/1110.3658.pdf", "1110.3658"),
+        ("https://arxiv.com/pdf/1110.3658.pdf", "1110.3658"),
+        ("http://arxiv.com/pdf/1110.3658.pdf", "1110.3658"),
     ]
 
     for url, arxivid in test_data:
-        assert papis.arxiv.find_arxivid_in_text(url) == arxivid
+        assert papis.arxiv.find_arxivid_in_text(url) == arxivid, \
+                f"Could not retrieve correct arxivid from {url}"
 
 
 def test_match(tmp_config: TemporaryConfiguration) -> None:


### PR DESCRIPTION
Currently, adding arxiv papers using
```
papis add --from arxiv STRING
```
does not allow adding the `.pdf` url as a string (e.g. `https://arxiv.org/pdf/physics/0504179.pdf`).

This pull request checks if the string retrieved from the regular expression ends with .pdf and if so removes it.
It also adds tests for the new usecases as well as a more describing assertion error.