### PR TITLE
Unify command calling

### DIFF
--- a/papis/commands/explore.py
+++ b/papis/commands/explore.py
@@ -92,6 +92,7 @@ import shlex
 
 import click
 
+import papis.utils
 import papis.tui.utils
 import papis.commands
 import papis.document
@@ -255,13 +256,10 @@ def cmd(ctx: click.Context, command: str) -> None:
         pick cmd 'papis scihub {doc[doi]}'
 
     """
-    from subprocess import call
     docs = ctx.obj["documents"]
     for doc in docs:
         fcommand = papis.format.format(command, doc)
-        splitted_command = shlex.split(fcommand)
-        logger.info("Calling command '%s'.", splitted_command)
-        call(splitted_command)
+        papis.utils.run(shlex.split(fcommand))
 
 
 @click.group("explore",

--- a/papis/commands/external.py
+++ b/papis/commands/external.py
@@ -9,6 +9,7 @@ from typing import Any, Dict, List, Optional
 
 import click
 
+import papis.utils
 import papis.config
 import papis.commands
 import papis.logging
@@ -76,5 +77,4 @@ def external_cli(ctx: click.core.Context, flags: List[str]) -> None:
     environ = os.environ.copy()
     environ.update(get_exported_variables(params))
 
-    import subprocess
-    subprocess.call(cmd, env=environ)
+    papis.utils.run(cmd, env=environ)

--- a/papis/commands/mv.py
+++ b/papis/commands/mv.py
@@ -32,14 +32,12 @@ def run(document: papis.document.Document,
     if not folder:
         raise DocumentFolderNotFound(papis.document.describe(document))
 
-    cmd = ["git", "-C", folder] if git else []
-    cmd += ["mv", folder, new_folder_path]
-    db = papis.database.get()
-    logger.debug("Running command '%s'.", cmd)
+    papis.utils.run((["git"] if git else []) + ["mv", folder, new_folder_path],
+                    cwd=folder)
 
-    import subprocess
-    subprocess.call(cmd)
+    db = papis.database.get()
     db.delete(document)
+
     new_document_folder = os.path.join(
         new_folder_path,
         os.path.basename(folder))

--- a/papis/commands/rename.py
+++ b/papis/commands/rename.py
@@ -12,6 +12,7 @@ from typing import Optional
 import click
 
 import papis.cli
+import papis.utils
 import papis.database
 import papis.strings
 import papis.git
@@ -33,19 +34,14 @@ def run(document: papis.document.Document,
         raise DocumentFolderNotFound(papis.document.describe(document))
 
     subfolder = os.path.dirname(folder)
-
     new_folder_path = os.path.join(subfolder, new_name)
 
     if os.path.exists(new_folder_path):
         logger.warning("Path '%s' already exists.", new_folder_path)
         return
 
-    cmd = ["git", "-C", folder] if git else []
-    cmd += ["mv", folder, new_folder_path]
-
-    import subprocess
-    logger.debug("Running command '%s'.", cmd)
-    subprocess.call(cmd)
+    papis.utils.run((["git"] if git else []) + ["mv", folder, new_folder_path],
+                    cwd=folder)
 
     if git:
         papis.git.commit(

--- a/tests/commands/test_add.py
+++ b/tests/commands/test_add.py
@@ -102,6 +102,7 @@ def test_get_file_name(tmp_library: TemporaryLibrary) -> None:
     assert filename == "blah-2.yaml"
 
 
+@pytest.mark.library_setup(use_git=True)
 def test_add_run(tmp_library: TemporaryLibrary, nfiles: int = 5) -> None:
     from papis.commands.add import run
 
@@ -111,7 +112,7 @@ def test_add_run(tmp_library: TemporaryLibrary, nfiles: int = 5) -> None:
             ["/path/does/not/exist.pdf"],
             data={"author": "Bohm", "title": "My effect"})
 
-    # add n files
+    # add no files
     run([], data={"author": "Evangelista", "title": "MRCI"})
 
     db = papis.database.get()
@@ -134,7 +135,7 @@ def test_add_run(tmp_library: TemporaryLibrary, nfiles: int = 5) -> None:
     }
     paths = [tmp_library.create_random_file() for _ in range(nfiles)]
 
-    run(paths, data=data)
+    run(paths, data=data, git=True)
 
     doc, = db.query_dict({"author": "Kutzelnigg"})
     assert len(doc.get_files()) == nfiles

--- a/tests/commands/test_rm.py
+++ b/tests/commands/test_rm.py
@@ -19,6 +19,7 @@ def test_rm_run(tmp_library: TemporaryLibrary) -> None:
     assert not os.path.exists(folder)
 
 
+@pytest.mark.library_setup(use_git=True)
 def test_rm_files_run(tmp_library: TemporaryLibrary) -> None:
     from papis.commands.rm import run
 
@@ -31,7 +32,7 @@ def test_rm_files_run(tmp_library: TemporaryLibrary) -> None:
     filename = doc.get_files()[0]
     assert os.path.exists(filename)
 
-    run(doc, filepath=filename)
+    run(doc, filepath=filename, git=True)
     assert not os.path.exists(filename)
 
     db.clear()

--- a/tests/commands/test_run.py
+++ b/tests/commands/test_run.py
@@ -1,3 +1,4 @@
+import pytest
 import papis.config
 
 from tests.testlib import TemporaryLibrary
@@ -7,8 +8,7 @@ def test_run_run(tmp_library: TemporaryLibrary) -> None:
     from papis.commands.run import run
 
     libdir, = papis.config.get_lib_dirs()
-    status = run(libdir, command=["ls"])
-    assert status == 0
+    run(libdir, command=["ls"])
 
-    status = run(libdir, command=["nonexistent"])
-    assert status != 0
+    with pytest.raises(FileNotFoundError):
+        run(libdir, command=["nonexistent"])

--- a/tests/test_arxiv.py
+++ b/tests/test_arxiv.py
@@ -1,9 +1,11 @@
+import pytest
 import papis.arxiv
 import papis.downloaders
 
 from tests.testlib import TemporaryConfiguration
 
 
+@pytest.mark.xfail(reason="arxiv times out sometimes")
 def test_get_data(tmp_config: TemporaryConfiguration) -> None:
     data = papis.arxiv.get_data(
         author="Garnet Chan",
@@ -50,6 +52,7 @@ def test_match(tmp_config: TemporaryConfiguration) -> None:
     assert down.arxivid == "1701.08223v2"
 
 
+@pytest.mark.xfail(reason="arxiv times out sometimes")
 def test_downloader_getter(tmp_config: TemporaryConfiguration) -> None:
     import papis.bibtex
 

--- a/tests/testlib.py
+++ b/tests/testlib.py
@@ -220,8 +220,10 @@ class TemporaryConfiguration:
 class TemporaryLibrary(TemporaryConfiguration):
     def __init__(self,
                  settings: Optional[Dict[str, Any]] = None,
+                 use_git: bool = False,
                  populate: bool = True) -> None:
         super().__init__(settings=settings)
+        self.use_git = use_git
         self.populate = populate
 
     def __enter__(self) -> "TemporaryLibrary":
@@ -238,6 +240,20 @@ class TemporaryLibrary(TemporaryConfiguration):
         # populate library
         if self.populate:
             populate_library(self.libdir)
+
+        if self.use_git:
+            from papis.utils import run
+
+            # make sure to initialize a git repository for the library
+            run(["git", "init", "-b", "main"], cwd=self.libdir)
+            run(["git", "config", "user.name", "papis"],
+                cwd=self.libdir)
+            run(["git", "config", "user.email", "papis@example.com"],
+                cwd=self.libdir)
+
+            if self.populate:
+                run(["git", "add", "."], cwd=self.libdir)
+                run(["git", "commit", "-m", "Initial commit"], cwd=self.libdir)
 
         return self
 


### PR DESCRIPTION
This unifies all the `subprocess` calls to a `papis.utils.run` that does the proper escaping and anything else that's needed. All commands are ported to use this.