### PR TITLE
Better command overwriting handling

### DIFF
--- a/doc/source/developer_reference.rst
+++ b/doc/source/developer_reference.rst
@@ -25,6 +25,12 @@ Developer API reference
 .. automodule:: papis.cli
     :members:
 
+``papis.commands``
+^^^^^^^^^^^^^^^^^^
+
+.. automodule:: papis.commands
+    :members:
+
 ``papis.config``
 ^^^^^^^^^^^^^^^^
 

--- a/papis/commands/__init__.py
+++ b/papis/commands/__init__.py
@@ -1,8 +1,6 @@
 import os
 import re
-import glob
-from typing import Dict, Optional, Union, NamedTuple
-import difflib
+from typing import Dict, Optional, NamedTuple
 
 import click.core
 
@@ -15,21 +13,29 @@ EXTERNAL_COMMAND_REGEX = re.compile(".*papis-([^ .]+)$")
 
 
 class AliasedGroup(click.core.Group):
-    """
+    """A :class:`click.Group` that accepts command aliases.
+
     This group command is taken from
     `here <https://click.palletsprojects.com/en/5.x/advanced/#command-aliases>`__
-    and is to be used for groups with aliases.
+    and is to be used for groups with aliases. In this case, aliases are
+    defined as prefixes of the command, so for a command named ``remove``,
+    ``rem`` is also accepted as long as it is unique.
     """
 
     def get_command(self,
                     ctx: click.core.Context,
                     cmd_name: str) -> Optional[click.core.Command]:
+        """
+        :returns: given a context and a command name, this returns a
+            :class:`click.Command` object if it exists or returns *None*.
+        """
         rv = click.core.Group.get_command(self, ctx, cmd_name)
         if rv is not None:
             return rv
 
-        matches = difflib.get_close_matches(
-            cmd_name, self.list_commands(ctx), n=2)
+        import difflib
+        matches = difflib.get_close_matches(cmd_name, self.list_commands(ctx), n=2)
+
         if not matches:
             return None
         if len(matches) == 1:
@@ -39,15 +45,33 @@ class AliasedGroup(click.core.Group):
 
 
 class Script(NamedTuple):
+    """A papis command plugin or script.
+
+    These plugins are made available through the main papis command-line as
+    subcommands.
+    """
+
+    #: The name of the command.
     command_name: str
+    #: The path to the script if it is a separate executable.
     path: Optional[str]
-    plugin: Optional[Union[click.Command, AliasedGroup]]
+    #: A :class:`click.Command` if the script is registered as an entry point.
+    plugin: Optional[click.Command]
 
 
 def get_external_scripts() -> Dict[str, Script]:
+    """Get a mapping of all external scripts that should be registered with papis.
+
+    An external script is an executable that can be found in the
+    :func:`papis.config.get_scripts_folder` folder or in the user's PATH.
+    External scripts are recognized if they are prefixed with ``papis-``.
+
+    :returns: a mapping of scripts that have been found.
+    """
+    import glob
     paths = [papis.config.get_scripts_folder()] + os.environ.get("PATH", "").split(":")
 
-    scripts = {}
+    scripts: Dict[str, Script] = {}
     for path in paths:
         for script in glob.iglob(os.path.join(path, "papis-*")):
             m = EXTERNAL_COMMAND_REGEX.match(script)
@@ -67,6 +91,13 @@ def get_external_scripts() -> Dict[str, Script]:
 
 
 def get_scripts() -> Dict[str, Script]:
+    """Get a mapping of commands that should be registered with papis.
+
+    This finds all the commands that are registered as entry points in the
+    namespace ``"papis.command"``.
+
+    :returns: a mapping of scripts that have been found.
+    """
     mgr = papis.plugin.get_extension_manager(COMMAND_EXTENSION_NAME)
 
     scripts = {}
@@ -86,16 +117,28 @@ def get_scripts() -> Dict[str, Script]:
 
 
 def get_all_scripts() -> Dict[str, Script]:
+    """Get a mapping of all commands that should be registered with papis.
+
+    This includes the results from :func:`get_external_scripts` and
+    :func:`get_scripts`. Entrypoint-based scripts take priority, so if an
+    external script with the same name is found it is silently ignored.
+
+    :returns: a mapping of scripts that have been found.
+    """
+
     scripts = get_scripts()
     external_scripts = get_external_scripts()
 
     for name, script in external_scripts.items():
         entry_point_script = scripts.get(name)
         if entry_point_script is not None:
+            plugin = entry_point_script.plugin
+            assert plugin is not None
+
             papis.logging.debug(
                 "WARN: External script '%s' also available as command entry point "
                 "from '%s'. Skipping external script!",
-                script.path, entry_point_script.plugin.callback.__module__
+                script.path, plugin.callback.__module__
                 )
 
             continue

--- a/papis/commands/default.py
+++ b/papis/commands/default.py
@@ -49,9 +49,7 @@ logger = papis.logging.get_logger(__name__)
 
 
 class MultiCommand(click.core.MultiCommand):
-
-    scripts = papis.commands.get_scripts()
-    scripts.update(papis.commands.get_external_scripts())
+    scripts = papis.commands.get_all_scripts()
 
     def list_commands(self, ctx: click.core.Context) -> List[str]:
         """List all matched commands in the command folder and in path

--- a/papis/commands/default.py
+++ b/papis/commands/default.py
@@ -49,7 +49,9 @@ logger = papis.logging.get_logger(__name__)
 
 
 class MultiCommand(click.core.MultiCommand):
+
     scripts = papis.commands.get_all_scripts()
+    script_names = sorted(scripts)
 
     def list_commands(self, ctx: click.core.Context) -> List[str]:
         """List all matched commands in the command folder and in path
@@ -59,9 +61,7 @@ class MultiCommand(click.core.MultiCommand):
         >>> len(rv) > 0
         True
         """
-        _rv = list(self.scripts)
-        _rv.sort()
-        return _rv
+        return self.script_names
 
     def get_command(
             self,

--- a/papis/commands/external.py
+++ b/papis/commands/external.py
@@ -19,8 +19,8 @@ logger = papis.logging.get_logger(__name__)
 def get_command_help(path: str) -> str:
     """Get help string from external commands."""
     magic_word = papis.config.getstring("scripts-short-help-regex")
-    with open(path) as _fd:
-        for line in _fd:
+    with open(path) as fd:
+        for line in fd:
             match = re.match(magic_word, line)
             if match:
                 return str(match.group(1))

--- a/papis/logging.py
+++ b/papis/logging.py
@@ -3,9 +3,11 @@ import sys
 import logging
 from typing import Any, Optional, Tuple, Union
 
+import click
 import colorama
 
 
+PAPIS_DEBUG = "PAPIS_DEBUG" in os.environ
 LEVEL_TO_COLOR = {
     "CRITICAL": colorama.Style.BRIGHT + colorama.Fore.RED,
     "ERROR": colorama.Style.BRIGHT + colorama.Fore.RED,
@@ -13,6 +15,11 @@ LEVEL_TO_COLOR = {
     "INFO": colorama.Fore.CYAN,
     "DEBUG": colorama.Fore.WHITE,
 }
+
+
+def debug(msg: str, *args: Any) -> None:
+    if PAPIS_DEBUG:
+        click.echo(msg % args)
 
 
 class ColoramaFormatter(logging.Formatter):


### PR DESCRIPTION
This adds some clear messages about how commands are loaded. Namely:
* If two external commands have the same name, i.e. `papis-something`, but are located in different paths, a message is printed and the last one in `$PATH` is preferred. Before no message was printed.
* If an entrypoint commands, declared in `setup.py`, and an external command have the same name, the entry point is always preferred. Before the external command was preferred.
 
The messages are only printed with `PAPIS_DEBUG=ON`, but we can change that if we want it to be a more obvious warning (?).