### PR TITLE
Updated Dockerfile to correctly execute all testcases

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,3 +1,4 @@
+Dockerfile
 papis/deps/*
 .vim-run
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-ARG PYTHON_VERSION=3.7
+ARG PYTHON_VERSION=3.8
 FROM python:$PYTHON_VERSION
 
 RUN apt-get update
@@ -9,8 +9,6 @@ VOLUME /papis
 
 COPY . /papis
 
-RUN python setup.py develop
-RUN pip install .[develop]
-RUN pip install .[optional]
+RUN pip install -e .[optional,develop]
 
 CMD ["pytest", "tests", "papis", "--cov", "papis"]


### PR DESCRIPTION
The `test_edit.py` testcase executes itself on the command line and failed because it would not find the `tests` module. installing with `-e` seems to fix the issue. Also python 3.8 seems to be required now.