### PR TITLE
Handle papis.format exceptions

### DIFF
--- a/papis/bibtex.py
+++ b/papis/bibtex.py
@@ -349,22 +349,28 @@ def create_reference(doc: Dict[str, Any], force: bool = False) -> str:
         already has a ``"ref"`` key.
     :returns: a clean reference for the document.
     """
-    ref = ""
     # Check first if the paper has a reference
-    if doc.get("ref") and not force:
-        return str(doc["ref"])
-    elif papis.config.get("ref-format"):
-        ref = papis.format.format(papis.config.getstring("ref-format"), doc)
+    ref = str(doc.get("ref", ""))
+    if not force and ref:
+        return ref
+
+    # Otherwise, try to generate one somehow
+    ref_format = papis.config.get("ref-format")
+    if ref_format is not None:
+        ref = papis.format.format(str(ref_format), doc, default="")
+
+    if not ref:
+        ref = str(doc.get("doi", ""))
+
+    if not ref:
+        ref = str(doc.get("isbn", ""))
+
+    if not ref:
+        # Just try to get something out of the data
+        ref = "{:.30}".format(
+              " ".join(string.capwords(str(d)) for d in doc.values()))
 
     logger.debug("Generated ref '%s'.", ref)
-    if not ref:
-        if doc.get("doi"):
-            ref = doc["doi"]
-        else:
-            # Just try to get something out of the data
-            ref = "{:.30}".format(
-                " ".join(string.capwords(str(d)) for d in doc.values()))
-
     return ref_cleanup(ref)
 
 

--- a/papis/commands/bibtex.py
+++ b/papis/commands/bibtex.py
@@ -297,7 +297,11 @@ def _edit(ctx: click.Context,
             located = papis.utils.locate_document_in_lib(doc)
             if set_tuples:
                 for k, v in set_tuples:
-                    located[k] = papis.format.format(v, located)
+                    try:
+                        located[k] = papis.format.format(v, located)
+                    except papis.format.FormatFailedError as exc:
+                        logger.error("Could not format '%s' with value '%s'.",
+                                     k, v, exc_info=exc)
                 save_doc(located)
             else:
                 papis.commands.edit.run(located)

--- a/papis/commands/browse.py
+++ b/papis/commands/browse.py
@@ -106,7 +106,8 @@ def run(document: papis.document.Document,
         params = {
             "q": papis.format.format(
                 papis.config.getstring("browse-query-format"),
-                document)
+                document,
+                default="{} {}".format(document["author"], document["title"]))
         }
         url = (papis.config.getstring("search-engine")
                + "/?"

--- a/papis/commands/explore.py
+++ b/papis/commands/explore.py
@@ -275,7 +275,7 @@ def cmd(ctx: click.Context, command: str) -> None:
     """
     docs = ctx.obj["documents"]
     for doc in docs:
-        fcommand = papis.format.format(command, doc)
+        fcommand = papis.format.format(command, doc, default="")
         papis.utils.run(shlex.split(fcommand))
 
 

--- a/papis/commands/list.py
+++ b/papis/commands/list.py
@@ -132,7 +132,8 @@ def run(documents: List[papis.document.Document],
         return [d.get_info_file() for d in documents]
     elif fmt:
         return [
-            papis.format.format(fmt, document)
+            papis.format.format(fmt, document,
+                                default=papis.document.describe(document))
             for document in documents
         ]
     elif folders:

--- a/papis/commands/update.py
+++ b/papis/commands/update.py
@@ -133,7 +133,13 @@ def cli(query: str,
         if set_tuples:
             processed_tuples = {}
             for key, value in set_tuples:
-                value = papis.format.format(value, document)
+                try:
+                    value = papis.format.format(value, document)
+                except papis.format.FormatFailedError as exc:
+                    logger.error("Could not format '%s' with value '%s'.",
+                                 key, value, exc_info=exc)
+                    continue
+
                 if key == "notes":
                     value = papis.utils.clean_document_name(value)
                     processed_tuples[key] = value

--- a/papis/document.py
+++ b/papis/document.py
@@ -421,7 +421,7 @@ def describe(document: Union[Document, Dict[str, Any]]) -> str:
     """
     return papis.format.format(
         papis.config.getstring("document-description-format"),
-        document, default=document.get("papis_id", ""))
+        document, default=document["papis_id"])
 
 
 def move(document: Document, path: str) -> None:
@@ -486,7 +486,7 @@ def sort(docs: Sequence[Document], key: str, reverse: bool = False) -> List[Docu
     def document_sort_key(doc: Document) -> Tuple[int, datetime, int, str]:
         priority, date, int_value, str_value = default_sort_key
 
-        value = doc.get(key)
+        value = doc.get(key, None)
         if value is not None:
             str_value = str(value)
 


### PR DESCRIPTION
This adds a default or a `try..except` for most of the calls to `papis.format.format` after #596.