### PR TITLE
add a more complex query syntax introducing literal and, or, not and parenthesis

### DIFF
--- a/papis/docmatcher.py
+++ b/papis/docmatcher.py
@@ -128,7 +128,7 @@ class DocMatcher:
         """
 
         match = None
-        if cls.parsed_search is None or cls.matcher is None:
+        if len(cls.parsed_search) == 0 or cls.matcher is None:
             return match
 
         tokens = []

--- a/papis/docmatcher.py
+++ b/papis/docmatcher.py
@@ -51,13 +51,12 @@ class MatcherCallable(Protocol):
     .. automethod:: __call__
     """
 
-    def __call__(
-        self,
-        document: papis.document.Document,
-        search: Pattern[str],
-        match_format: Optional[str] = None,
-        doc_key: Optional[str] = None,
-    ) -> Any:
+    def __call__(self,
+                 document: papis.document.Document,
+                 search: Pattern[str],
+                 match_format: Optional[str] = None,
+                 doc_key: Optional[str] = None,
+                 ) -> Any:
         """Match a document's keys to a given search pattern.
 
         The matcher can decide whether the *match_format* or the *doc_key* take
@@ -152,9 +151,9 @@ class DocMatcher:
     def set_search(cls, search: str) -> None:
         """Set the search for this instance of the matcher.
 
-        >>> DocMatcher.set_search('author:Hummel')
-        >>> DocMatcher.search
-        'author:Hummel'
+            >>> DocMatcher.set_search('author:Hummel')
+            >>> DocMatcher.search
+            'author:Hummel'
         """
         cls.search = search
 
@@ -162,8 +161,8 @@ class DocMatcher:
     def set_matcher(cls, matcher: MatcherCallable) -> None:
         """Set the matcher callable for the search.
 
-        >>> from papis.database.cache import match_document
-        >>> DocMatcher.set_matcher(match_document)
+            >>> from papis.database.cache import match_document
+            >>> DocMatcher.set_matcher(match_document)
         """
         cls.matcher = matcher
 

--- a/papis/docmatcher.py
+++ b/papis/docmatcher.py
@@ -176,13 +176,13 @@ class DocMatcher:
         error it will log an error message and return None.
 
             >>> print(DocMatcher.parse('hello author : einstein'))
-            [['hello'], ['author', 'einstein']]
+            [['hello'], ['and'], ['author', 'einstein']]
             >>> print(DocMatcher.parse(''))
             []
             >>> print(\
                 DocMatcher.parse(\
                     '"hello world whatever :" tags : \\\'hello ::::\\\''))
-            [['hello world whatever :'], ['tags', 'hello ::::']]
+            [['hello world whatever :'], ['and'], ['tags', 'hello ::::']]
             >>> print(DocMatcher.parse('hello'))
             [['hello']]
 
@@ -193,7 +193,7 @@ class DocMatcher:
             search = cls.search
         parsed_search = parse_query(search)
 
-        if test_syntax(parsed_search):
+        if check_syntax(parsed_search):
             cls.parsed_search = parsed_search
         else:
             cls.parsed_search = []
@@ -218,7 +218,7 @@ def get_regex_from_search(search: str) -> Pattern[str]:
     )
 
 
-def test_syntax(parsed: List[ParseResult]) -> bool:
+def check_syntax(parsed: List[ParseResult]) -> bool:
     """Tests the syntax by replacing all search terms with True,
     then trying to evaluate the resulting string.
     """

--- a/papis/docmatcher.py
+++ b/papis/docmatcher.py
@@ -96,7 +96,7 @@ class DocMatcher:
     #: Search string from which the matcher is constructed.
     search: ClassVar[str] = ""
     #: A parsed version of the :attr:`search` string using :func:`parse_query`.
-    parsed_search: ClassVar[Optional[List[ParseResult]]] = None
+    parsed_search: ClassVar[List[ParseResult]] = []
     #: A :class:`MatcherCallable` used to match the document to the
     #: :attr:`parsed_search`.
     matcher: ClassVar[Optional[MatcherCallable]] = None
@@ -220,6 +220,9 @@ def get_regex_from_search(search: str) -> Pattern[str]:
 def check_query_consistency(parsed: List[ParseResult]) -> bool:
     """Tests the syntax by replacing all search terms with True,
     then trying to evaluate the resulting string.
+
+    :param a parsed a search string.
+    :returns: a boolean indicating whether the query is logically consistent
     """
 
     test = []
@@ -252,7 +255,7 @@ def add_implicit_query_operators(parsed: List[ParseResult]) -> List[ParseResult]
     for idx, token in enumerate(parsed):
         result.append(token)
         if idx != last and token.needs_operator_after() and \
-            parsed[idx + 1].needs_operator_before():
+                parsed[idx + 1].needs_operator_before():
             # add 'and' when queries or syntax have have no operator in between
             result.append(
                 ParseResult(

--- a/papis/docmatcher.py
+++ b/papis/docmatcher.py
@@ -261,8 +261,7 @@ def proofread(parsed: List[ParseResult]) -> List[ParseResult]:
             )
             fixes += 1
 
-    if fixes > 0:
-        logger.debug("Fixed query by adding %s missing 'and' operator(s).", fixes)
+    logger.debug("Fixed query by adding %s missing 'and' operator(s).", fixes)
 
     return result
 

--- a/papis/docmatcher.py
+++ b/papis/docmatcher.py
@@ -24,7 +24,7 @@ class ParseResult(NamedTuple):
     string: str
     #: A regex pattern constructed from the :attr:`search` using
     #: :func:`get_regex_from_search`.
-    pattern: Pattern[str] = None
+    pattern: Pattern[str]
     #: A document key that was matched for this result, if any.
     doc_key: Optional[str] = None
 
@@ -196,7 +196,7 @@ class DocMatcher:
         if test_syntax(parsed_search):
             cls.parsed_search = parsed_search
         else:
-            cls.parsed_search = None
+            cls.parsed_search = []
 
         return cls.parsed_search
 
@@ -254,7 +254,11 @@ def proofread(parsed: List[ParseResult]) -> List[ParseResult]:
         result.append(token)
         if idx != last and token.needsboolafter() and parsed[idx + 1].needsboolbefore():
             # add 'and' when queries or syntax have have no operator in between
-            result.append(ParseResult(syntax=True, string="and"))
+            result.append(
+                ParseResult(
+                    syntax=True, string="and", pattern=get_regex_from_search("")
+                )
+            )
             fixes += 1
 
     if fixes > 0:

--- a/tests/test_docmatcher.py
+++ b/tests/test_docmatcher.py
@@ -48,20 +48,18 @@ def test_parse_query(tmp_config: TemporaryConfiguration) -> None:
     from papis.docmatcher import parse_query
 
     rs = parse_query("hello   author : einstein")
-    assert rs[0].search == "hello"
-    assert rs[1].doc_key == "author"
-    assert rs[1].search == "einstein"
+    assert rs[0].string == "hello"
+    assert rs[1].string == "and"
+    assert rs[2].doc_key == "author"
+    assert rs[2].string == "einstein"
 
-    r, = parse_query("doi : 123.123/124_123")
-    assert r.doc_key == "doi"
-    assert r.search == "123.123/124_123"
-
-    r, = parse_query("doi : 123.123/124_123(80)12")
-    assert r.doc_key == "doi"
-    assert r.search == "123.123/124_123(80)12"
+    rs = parse_query("doi : 123.123/124_123")
+    assert rs[0].doc_key == "doi"
+    assert rs[0].string == "123.123/124_123"
 
     rs = parse_query('tt : asfd   author : "Albert einstein"')
     assert rs[0].doc_key == "tt"
-    assert rs[0].search == "asfd"
-    assert rs[1].doc_key == "author"
-    assert rs[1].search == "Albert einstein"
+    assert rs[0].string == "asfd"
+    assert rs[1].string == "and"
+    assert rs[2].doc_key == "author"
+    assert rs[2].string == "Albert einstein"


### PR DESCRIPTION
This adds a more complex syntax to papis docmatcher introducing an explicit **and**, **or**, **not** and the use of **parenthesis**.

*This is my first pull request ever! Please let me know if I did something wrong or completely missed any step in the desired procedure. Given the importance of the docmatcher in papis, please consider this as a starting point for a discussion on how to best implement this.*

The way this works is relatively simple: 
1. `papis_query` matches each query instance and the available operators and parenthesis
2. before returning the parsed query missing `and` operators get added via the `proofread` function. This is supposed to make sure the original syntax still works
3. `return_if_match` then passes each query to the matcher and puts everything together again. e.g.:
    - `author: einstein or title: photons` -> `True or False`
    - `einstein and photons not albert` -> `True and True and not True`
4. This resulting boolean operation is then evaluated using vanilla python (e.g. `True or False` = `True`)

Here are some advantages and disadvantages to consider:

**Pros:**
- In theory this introduces the possibility to write very complex queries. 

**Cons:**
- It is slower than the original implementation since it cannot stop once any expression evaluates to `False`. Instead, it always evaluates each single query. I guess this is not an issue for normal usage with a decent amount of documents and a similarly decent level of query complexity. However, when using this for scripting with large numbers of concatenated `or` operators, this might become an issue.
- Of course this is more error prone than the original implementation. At this point the `proofread` function only catches missing `and` operators using a very simple logic, but it does not fix other syntax errors. e.g. "einstein or and albert" will just fail to evaluate. I guess one could come up with some rules for these cases as well but probably not for everything. Also, this may confuse users even more. Maybe it would be necessary to be more verbose here: 
  - Report exactly where `and` operators where inserted
  - When evaluation fails, catch `SyntaxError` message and use it to hint to where the error is

**Some more thoughts to consider:**

As expected, this doesn't pass the `test_parse_query` test, since I changed the logic of the output format. 

This uses literal `and` `or` etc. I was not sure wether Alejandro was suggesting some sort of "escaped" operators such as `.or.` `.and.` and so forth.

This introduces some minor changes in how queries are evaluated. For instance "einstein albert" was translated to a single regex pattern but is parsed as "einstein and albert" now. This means that the order of words does not matter any more. To me personally, this makes more sense but of course this is a matter of taste and you might not want to change how things work for the users. 

I selfishely added `alphas8bit` to the `papis_value_word` matcher because I realized that I was'nt able to search for my own surname :). `papis_value_word` also allows for parnthesis which of course is not the case anymore in this pull request. 


*edit note: fix typos, add ideas to make this more verbose*

