### PR TITLE
Fix tests calling themselves

### DIFF
--- a/tests/commands/scripts.py
+++ b/tests/commands/scripts.py
@@ -1,0 +1,36 @@
+import sys
+
+
+def sed_replace(filename: str) -> None:
+    # NOTE: this function is used by 'test_edit_run' to provide a cross-platform
+    # way to edit a file that the test can later recognize and see it was called
+    with open(filename) as fd:
+        contents = "\n".join([
+            line.replace("title: ", "title: test_edit") for line in fd
+            ])
+
+    with open(filename, "w") as fd:
+        fd.write(contents)
+
+
+def echo(filename: str) -> None:
+    # NOTE: this function is used by 'test_open_run' to provide a cross-platform
+    # custom command that shows it tried to open a file
+    print("Attempted to open '{}'".format(filename))
+
+
+if __name__ == "__main__":
+    cmd, filename = sys.argv[-2:]
+
+    try:
+        ret = 0
+        if cmd == "sed":
+            sed_replace(filename)
+        elif cmd == "echo":
+            echo(filename)
+        else:
+            ret = 1
+    except Exception:
+        ret = 1
+
+    raise SystemExit(ret)

--- a/tests/commands/test_edit.py
+++ b/tests/commands/test_edit.py
@@ -5,9 +5,11 @@ import papis.database
 
 from tests.testlib import TemporaryLibrary, PapisRunner
 
+script = os.path.join(os.path.dirname(__file__), "scripts.py")
+
 
 @pytest.mark.library_setup(settings={
-    "editor": "python {}".format(__file__),
+    "editor": "python {} sed".format(script)
     })
 def test_edit_run(tmp_library: TemporaryLibrary) -> None:
     import papis.config
@@ -70,20 +72,3 @@ def test_edit_cli(tmp_library: TemporaryLibrary) -> None:
 
     expected_notes_path = os.path.join(folder, notes_name)
     assert os.path.exists(expected_notes_path)
-
-
-def sed_replace(filename: str) -> None:
-    # NOTE: this function is used by 'test_edit_run' to provide a cross-platform
-    # way to edit a file that the test can later recognize and see it was called
-    with open(filename) as fd:
-        contents = "\n".join([
-            line.replace("title: ", "title: test_edit") for line in fd
-            ])
-
-    with open(filename, "w") as fd:
-        fd.write(contents)
-
-
-if __name__ == "__main__":
-    import sys
-    sed_replace(sys.argv[-1])

--- a/tests/commands/test_open.py
+++ b/tests/commands/test_open.py
@@ -1,6 +1,9 @@
+import os
 import pytest
 
 from tests.testlib import TemporaryLibrary, PapisRunner
+
+script = os.path.join(os.path.dirname(__file__), "scripts.py")
 
 
 @pytest.mark.library_setup(settings={
@@ -30,14 +33,5 @@ def test_open_cli(tmp_library: TemporaryLibrary) -> None:
 
     result = cli_runner.invoke(
         cli,
-        ["--tool", "python {}".format(__file__), "--mark", "--all", "Krishnamurti"])
+        ["--tool", "python {} echo".format(script), "--mark", "--all", "Krishnamurti"])
     assert result.exit_code == 0
-
-
-def echo(filename: str) -> None:
-    print("Attempted to open '{}'".format(filename))
-
-
-if __name__ == "__main__":
-    import sys
-    echo(sys.argv[-1])


### PR DESCRIPTION
The edit test at `commands/test_edit.py` was calling itself to modify a `info.yaml` file for testing purposes. This moves that code to a separate file to not require editable installs (see #597).