### PR TITLE
Avoid exception when parsing crossref event data that has no 'start' key

### DIFF
--- a/papis/crossref.py
+++ b/papis/crossref.py
@@ -147,8 +147,12 @@ key_conversion = [
     KeyConversionPair("event", [  # Conferences
         {"key": "venue", "action": lambda x: x["location"]},
         {"key": "booktitle", "action": lambda x: x["name"]},
-        {"key": "year", "action": lambda x: _crossref_date_parts(x["start"], 0)},
-        {"key": "month", "action": lambda x: _crossref_date_parts(x["start"], 1)},
+        {"key": "year",
+         "action": (lambda x:
+                    _crossref_date_parts(x["start"], 0) if "start" in x else None)},
+        {"key": "month",
+         "action": (lambda x:
+                    _crossref_date_parts(x["start"], 1) if "start" in x else None)},
     ]),
 ]  # List[papis.document.KeyConversionPair]
 

--- a/papis/document.py
+++ b/papis/document.py
@@ -114,8 +114,10 @@ def keyconversion_to_data(conversions: Sequence[KeyConversionPair],
                 try:
                     new_value = action(papis_value)
                 except Exception as exc:
-                    logger.debug("Error while trying to parse '%s' (%s).",
-                                 papis_key, exc_info=exc)
+                    logger.debug(
+                        "Error parsing papis key '%s' from foreign key '%s' => '%r'.",
+                        papis_key, foreign_key, papis_value, exc_info=exc
+                    )
                     new_value = None
             else:
                 new_value = papis_value


### PR DESCRIPTION
Along the way fixed format string that contained a '%s' without corresponding arg.