### PR TITLE
Revert mypy ignores

### DIFF
--- a/papis/arxiv.py
+++ b/papis/arxiv.py
@@ -165,7 +165,7 @@ def find_arxivid_in_text(text: str) -> Optional[str]:
     return None
 
 
-@click.command("arxiv")                 # type: ignore[arg-type]
+@click.command("arxiv")
 @click.pass_context
 @click.help_option("--help", "-h")
 @click.option("--query", "-q", default="", type=str)

--- a/papis/bibtex.py
+++ b/papis/bibtex.py
@@ -218,7 +218,7 @@ class Importer(papis.importer.Importer):
         self.ctx.data = bib_data[0]
 
 
-@click.command("bibtex")                # type: ignore[arg-type]
+@click.command("bibtex")
 @click.pass_context
 @click.argument("bibfile", type=click.Path(exists=True))
 @click.help_option("--help", "-h")

--- a/papis/cli.py
+++ b/papis/cli.py
@@ -34,13 +34,13 @@ def query_option(**attrs: Any) -> DecoratorCallable:
 def sort_option(**attrs: Any) -> DecoratorCallable:
     """Adds a ``--sort`` and a ``--reverse`` option as a :mod:`click` decorator."""
     def decorator(f: DecoratorCallable) -> Any:
-        sort: DecoratorCallable = click.option(
+        sort = click.option(
             "--sort", "sort_field",
             default=lambda: papis.config.get("sort-field"),
             help="Sort documents with respect to the FIELD",
             metavar="FIELD",
             **attrs)
-        reverse: DecoratorCallable = click.option(
+        reverse = click.option(
             "--reverse", "sort_reverse",
             help="Reverse sort order",
             default=lambda: papis.config.getboolean("sort-reverse"),

--- a/papis/commands/add.py
+++ b/papis/commands/add.py
@@ -478,7 +478,7 @@ def run(paths: List[str],
             "Add document '{}'".format(papis.document.describe(tmp_document)))
 
 
-@click.command(                         # type: ignore[arg-type]
+@click.command(
     "add",
     help="Add a document into a given library"
 )

--- a/papis/commands/bibtex.py
+++ b/papis/commands/bibtex.py
@@ -136,8 +136,7 @@ papis.config.register_default_settings({"bibtex": {
 EXPLORER_MGR = explore.get_explorer_mgr()
 
 
-@click.group("bibtex",                  # type: ignore[arg-type]
-             cls=papis.commands.AliasedGroup, chain=True)
+@click.group("bibtex", cls=papis.commands.AliasedGroup, chain=True)
 @click.help_option("-h", "--help")
 @click.option("--noar", "--no-auto-read", "no_auto_read",
               default=False,
@@ -163,7 +162,7 @@ def cli(ctx: click.Context, no_auto_read: bool) -> None:
 cli.add_command(EXPLORER_MGR["bibtex"].plugin, "read")
 
 
-@cli.command("add")                     # type: ignore[arg-type]
+@cli.command("add")
 @click.help_option("-h", "--help")
 @papis.cli.all_option()
 @papis.cli.query_option()
@@ -202,7 +201,7 @@ def _add(ctx: click.Context,
     ctx.obj["documents"].extend(docs)
 
 
-@cli.command("update")                  # type: ignore[arg-type]
+@cli.command("update")
 @click.help_option("-h", "--help")
 @papis.cli.all_option()
 @click.option("--from", "-f", "fromdb",
@@ -250,7 +249,7 @@ def _update(ctx: click.Context, _all: bool,
     click.get_current_context().obj["documents"] = docs
 
 
-@cli.command("open")                    # type: ignore[arg-type]
+@cli.command("open")
 @click.help_option("-h", "--help")
 @click.pass_context
 def _open(ctx: click.Context) -> None:
@@ -314,7 +313,7 @@ def _edit(ctx: click.Context,
     logger.info("Found %d / %d documents.", len(docs) - not_found, len(docs))
 
 
-@cli.command("browse")                  # type: ignore[arg-type]
+@cli.command("browse")
 @click.help_option("-h", "--help")
 @click.option("-k", "--key", default=None, help="doi, url, ...")
 @click.pass_context
@@ -329,7 +328,7 @@ def _browse(ctx: click.Context, key: Optional[str]) -> None:
         papis.commands.browse.run(d)
 
 
-@cli.command("rm")                      # type: ignore[arg-type]
+@cli.command("rm")
 @click.help_option("-h", "--help")
 @click.pass_context
 def _rm(ctx: click.Context) -> None:
@@ -337,7 +336,7 @@ def _rm(ctx: click.Context) -> None:
     click.echo("Sorry, TODO...")
 
 
-@cli.command("ref")                     # type: ignore[arg-type]
+@cli.command("ref")
 @click.help_option("-h", "--help")
 @click.option("-o", "--out", help="Output ref to a file", default=None)
 @click.pass_context
@@ -355,7 +354,7 @@ def _ref(ctx: click.Context, out: Optional[str]) -> None:
         click.echo(ref)
 
 
-@cli.command("save")                    # type: ignore[arg-type]
+@cli.command("save")
 @click.help_option("-h", "--help")
 @click.argument(
     "bibfile",
@@ -376,7 +375,7 @@ def _save(ctx: click.Context, bibfile: str, force: bool) -> None:
         fd.write(papis.commands.export.run(docs, to_format="bibtex"))
 
 
-@cli.command("sort")                    # type: ignore[arg-type]
+@cli.command("sort")
 @click.help_option("-h", "--help")
 @click.option("-k", "--key",
               help="Field to order it",
@@ -396,7 +395,7 @@ def _sort(ctx: click.Context, key: Optional[str], reverse: bool) -> None:
                                        reverse=reverse))
 
 
-@cli.command("unique")                  # type: ignore[arg-type]
+@cli.command("unique")
 @click.help_option("-h", "--help")
 @click.option("-k", "--key",
               help="Field to test for uniqueness, default is ref",
@@ -444,7 +443,7 @@ def _unique(ctx: click.Context, key: str, o: Optional[str]) -> None:
             f.write(papis.commands.export.run(duplicated_docs, to_format="bibtex"))
 
 
-@cli.command("doctor")                  # type: ignore[arg-type]
+@cli.command("doctor")
 @click.help_option("-h", "--help")
 @click.option("-k", "--key",
               help="Field to test for uniqueness, default is ref",
@@ -471,7 +470,7 @@ def _doctor(ctx: click.Context, key: List[str]) -> None:
             logger.info("\tMissing: %s", k)
 
 
-@cli.command("filter-cited")            # type: ignore[arg-type]
+@cli.command("filter-cited")
 @click.help_option("-h", "--help")
 @click.option("-f", "--file", "_files",
               help="Text file to check for references",
@@ -496,7 +495,7 @@ def _filter_cited(ctx: click.Context, _files: List[str]) -> None:
     ctx.obj["documents"] = found
 
 
-@cli.command("iscited")                 # type: ignore[arg-type]
+@cli.command("iscited")
 @click.help_option("-h", "--help")
 @click.option("-f", "--file", "_files",
               help="Text file to check for references",

--- a/papis/commands/config.py
+++ b/papis/commands/config.py
@@ -207,7 +207,7 @@ def run(
     return result
 
 
-@click.command("config")                # type: ignore[arg-type]
+@click.command("config")
 @click.help_option("--help", "-h")
 @click.argument("options", nargs=-1)
 @click.option(

--- a/papis/commands/default.py
+++ b/papis/commands/default.py
@@ -102,7 +102,7 @@ class MultiCommand(click.core.MultiCommand):
         # If it gets here, it means that it is an external script
         import copy
         from papis.commands.external import external_cli
-        cli: click.Command = copy.copy(external_cli)
+        cli = copy.copy(external_cli)
 
         from papis.commands.external import get_command_help
         cli.context_settings["obj"] = script
@@ -110,7 +110,6 @@ class MultiCommand(click.core.MultiCommand):
             cli.help = get_command_help(script.path)
         cli.name = script.command_name
         cli.short_help = cli.help
-
         return cli
 
 
@@ -123,7 +122,7 @@ def generate_profile_writing_function(profiler: "cProfile.Profile",
     return _on_finish
 
 
-@click.group(                           # type: ignore[arg-type,type-var]
+@click.group(
     cls=MultiCommand,
     invoke_without_command=False)
 @click.help_option("--help", "-h")

--- a/papis/commands/default.py
+++ b/papis/commands/default.py
@@ -48,7 +48,7 @@ if TYPE_CHECKING:
 logger = papis.logging.get_logger(__name__)
 
 
-class MultiCommand(click.core.MultiCommand):
+class ScriptLoaderGroup(click.Group):
 
     scripts = papis.commands.get_all_scripts()
     script_names = sorted(scripts)
@@ -56,8 +56,8 @@ class MultiCommand(click.core.MultiCommand):
     def list_commands(self, ctx: click.core.Context) -> List[str]:
         """List all matched commands in the command folder and in path
 
-        >>> mc = MultiCommand()
-        >>> rv = mc.list_commands(None)
+        >>> group = ScriptLoaderGroup()
+        >>> rv = group.list_commands(None)
         >>> len(rv) > 0
         True
         """
@@ -69,11 +69,11 @@ class MultiCommand(click.core.MultiCommand):
             name: str) -> Optional[click.core.Command]:
         """Get the command to be run
 
-        >>> mc = MultiCommand()
-        >>> cmd = mc.get_command(None, 'add')
+        >>> group = ScriptLoaderGroup()
+        >>> cmd = group.get_command(None, 'add')
         >>> cmd.name, cmd.help
         ('add', 'Add...')
-        >>> mc.get_command(None, 'this command does not exist')
+        >>> group.get_command(None, 'this command does not exist')
         Command ... is unknown!
         """
         try:
@@ -123,7 +123,7 @@ def generate_profile_writing_function(profiler: "cProfile.Profile",
 
 
 @click.group(
-    cls=MultiCommand,
+    cls=ScriptLoaderGroup,
     invoke_without_command=False)
 @click.help_option("--help", "-h")
 @click.version_option(version=papis.__version__)

--- a/papis/commands/doctor.py
+++ b/papis/commands/doctor.py
@@ -534,7 +534,7 @@ def run(doc: papis.document.Document, checks: List[str]) -> List[Error]:
     return results
 
 
-@click.command("doctor")                # type: ignore[arg-type]
+@click.command("doctor")
 @click.help_option("--help", "-h")
 @papis.cli.query_argument()
 @papis.cli.sort_option()

--- a/papis/commands/edit.py
+++ b/papis/commands/edit.py
@@ -74,7 +74,7 @@ def edit_notes(document: papis.document.Document,
                                                msg)
 
 
-@click.command("edit")                  # type: ignore[arg-type]
+@click.command("edit")
 @click.help_option("-h", "--help")
 @papis.cli.query_argument()
 @papis.cli.doc_folder_option()

--- a/papis/commands/exec.py
+++ b/papis/commands/exec.py
@@ -44,8 +44,7 @@ def run(_file: str) -> None:
         exec(f.read())
 
 
-@click.command("exec",                  # type: ignore[arg-type]
-               context_settings={"ignore_unknown_options": True})
+@click.command("exec", context_settings={"ignore_unknown_options": True})
 @click.help_option("--help", "-h")
 @click.argument("python_file", type=click.Path(exists=True))
 @click.argument("args", nargs=-1)

--- a/papis/commands/explore.py
+++ b/papis/commands/explore.py
@@ -130,7 +130,7 @@ def get_explorer_mgr() -> "ExtensionManager":
     return papis.plugin.get_extension_manager(EXPLORER_EXTENSION_NAME)
 
 
-@click.command("lib")                   # type: ignore[arg-type]
+@click.command("lib")
 @click.pass_context
 @click.help_option("--help", "-h")
 @papis.cli.query_argument()
@@ -159,7 +159,7 @@ def lib(ctx: click.Context, query: str,
     assert isinstance(ctx.obj["documents"], list)
 
 
-@click.command("pick")                  # type: ignore[arg-type]
+@click.command("pick")
 @click.pass_context
 @click.help_option("--help", "-h")
 @click.option("--number", "-n",
@@ -254,7 +254,7 @@ def add(ctx: click.Context) -> None:
         papis.commands.add.run([], d)
 
 
-@click.command("cmd")               # type: ignore[arg-type]
+@click.command("cmd")
 @click.pass_context
 @click.help_option("--help", "-h")
 @click.argument("command", type=str)
@@ -279,7 +279,7 @@ def cmd(ctx: click.Context, command: str) -> None:
         papis.utils.run(shlex.split(fcommand))
 
 
-@click.group("explore",             # type: ignore[arg-type]
+@click.group("explore",
              cls=papis.commands.AliasedGroup,
              invoke_without_command=False, chain=True)
 @click.help_option("--help", "-h")

--- a/papis/commands/export.py
+++ b/papis/commands/export.py
@@ -89,7 +89,7 @@ def run(documents: List[papis.document.Document], to_format: str) -> str:
     return str(ret_string)
 
 
-@click.command("export")                # type: ignore[arg-type]
+@click.command("export")
 @click.help_option("--help", "-h")
 @papis.cli.query_argument()
 @papis.cli.doc_folder_option()
@@ -166,7 +166,7 @@ def cli(query: str,
             shutil.copytree(_doc_folder, outdir)
 
 
-@click.command("export")                # type: ignore[arg-type]
+@click.command("export")
 @click.pass_context
 @click.help_option("--help", "-h")
 @click.option(

--- a/papis/commands/external.py
+++ b/papis/commands/external.py
@@ -54,7 +54,7 @@ def get_exported_variables(ctx: Optional[Dict[str, Any]] = None) -> Dict[str, st
     return exports
 
 
-@click.command(                         # type: ignore[arg-type]
+@click.command(
     context_settings={
         "ignore_unknown_options": True,
         "help_option_names": [],

--- a/papis/commands/git.py
+++ b/papis/commands/git.py
@@ -34,5 +34,4 @@ import papis.commands.run
 cli = copy.deepcopy(papis.commands.run.cli)
 cli.name = "git"
 cli.help = "Run git command in a library or document folder"
-cli = click.option("--prefix",
-                   hidden=True, default="git", type=str)(cli)  # type: ignore[arg-type]
+cli = click.option("--prefix", hidden=True, default="git", type=str)(cli)

--- a/papis/commands/open.py
+++ b/papis/commands/open.py
@@ -147,7 +147,7 @@ def run(document: papis.document.Document,
             papis.api.open_file(file_to_open, wait=False)
 
 
-@click.command("open")                  # type: ignore[arg-type]
+@click.command("open")
 @click.help_option("-h", "--help")
 @papis.cli.query_argument()
 @papis.cli.sort_option()

--- a/papis/commands/run.py
+++ b/papis/commands/run.py
@@ -73,8 +73,7 @@ def run(folder: str, command: Optional[List[str]] = None) -> None:
     papis.utils.run(command, cwd=folder, wait=True)
 
 
-@click.command("run",                   # type: ignore[arg-type]
-               context_settings={"ignore_unknown_options": True})
+@click.command("run", context_settings={"ignore_unknown_options": True})
 @click.help_option("--help", "-h")
 @click.option(
     "--pick", "-p",

--- a/papis/commands/serve.py
+++ b/papis/commands/serve.py
@@ -470,7 +470,7 @@ class PapisRequestHandler(http.server.BaseHTTPRequestHandler):
         self.process_routes(routes)
 
 
-@click.command("serve")                 # type: ignore[arg-type]
+@click.command("serve")
 @click.help_option("-h", "--help")
 @click.option("-p", "--port",
               help="Port to listen to",

--- a/papis/commands/update.py
+++ b/papis/commands/update.py
@@ -79,7 +79,7 @@ def run(document: papis.document.Document,
                 papis.document.describe(document)))
 
 
-@click.command("update")                # type: ignore[arg-type]
+@click.command("update")
 @click.help_option("--help", "-h")
 @papis.cli.git_option()
 @papis.cli.query_argument()

--- a/papis/crossref.py
+++ b/papis/crossref.py
@@ -275,7 +275,7 @@ def doi_to_data(doi_string: str) -> Dict[str, Any]:
         "Could not retrieve data for DOI '{}' from Crossref".format(doi_string))
 
 
-@click.command("crossref")              # type: ignore[arg-type]
+@click.command("crossref")
 @click.pass_context
 @click.help_option("--help", "-h")
 @click.option("--query", "-q", help="General query", default="")

--- a/papis/dblp.py
+++ b/papis/dblp.py
@@ -158,7 +158,7 @@ def is_valid_dblp_key(key: str) -> bool:
         return response.ok
 
 
-@click.command("dblp")                  # type: ignore[arg-type]
+@click.command("dblp")
 @click.pass_context
 @click.help_option("--help", "-h")
 @click.option(

--- a/papis/dissemin.py
+++ b/papis/dissemin.py
@@ -65,7 +65,7 @@ def get_data(query: str = "") -> List[Dict[str, Any]]:
     return sum([dissemindoc_to_papis(d) for d in paperlist["papers"]], [])
 
 
-@click.command("dissemin")              # type: ignore[arg-type]
+@click.command("dissemin")
 @click.pass_context
 @click.help_option("--help", "-h")
 @click.option("--query", "-q", default="", type=str)

--- a/papis/isbn.py
+++ b/papis/isbn.py
@@ -63,7 +63,7 @@ def data_to_papis(data: Dict[str, Any]) -> Dict[str, Any]:
         key_conversion, data, keep_unknown_keys=True)
 
 
-@click.command("isbn")                  # type: ignore[arg-type]
+@click.command("isbn")
 @click.pass_context
 @click.help_option("--help", "-h")
 @click.option("--query", "-q", default=None)

--- a/papis/json.py
+++ b/papis/json.py
@@ -13,7 +13,7 @@ def exporter(documents: List[papis.document.Document]) -> str:
     return json.dumps([papis.document.to_dict(doc) for doc in documents])
 
 
-@click.command("json")                  # type: ignore[arg-type]
+@click.command("json")
 @click.pass_context
 @click.argument("jsonfile", type=click.Path(exists=True))
 @click.help_option("--help", "-h")

--- a/papis/yaml.py
+++ b/papis/yaml.py
@@ -115,7 +115,7 @@ def exporter(documents: List[papis.document.Document]) -> str:
     return str(string)
 
 
-@click.command("yaml")                  # type: ignore[arg-type]
+@click.command("yaml")
 @click.pass_context
 @click.argument("yamlfile", type=click.Path(exists=True))
 @click.help_option("--help", "-h")

--- a/setup.cfg
+++ b/setup.cfg
@@ -28,7 +28,6 @@ show_column_numbers = True
 hide_error_codes = False
 pretty = True
 files = papis
-warn_unused_ignores = False
 
 [mypy-arxiv2bib.*]
 ignore_missing_imports = True


### PR DESCRIPTION
This reverts the `type: ignore` for click added in #571. Click fixed all those issues in version 8.1.6 (so 8.1.4 and 8.1.5 only are broken for mypy).

It also fixes a new issue with `commands.default.MultiCommand`: turns out `click.group(cls=GroupType)` expects a Group subclass, not a MultiCommand subclass.