### PR TITLE
Fix mypy errors in papis.tui

### DIFF
--- a/papis/commands/cache.py
+++ b/papis/commands/cache.py
@@ -190,19 +190,21 @@ def update_newer(query: str, doc_folder: str, _all: bool,
         logger.warning(papis.strings.no_documents_retrieved_message)
         return
 
-    updated_documents_n = 0
+    updated_documents_count = 0
     cache_path = db.get_cache_path()
+    cache_path_mtime = os.stat(cache_path).st_mtime
 
     for doc in documents:
         info = doc.get_info_file()
-
         if not os.path.exists(info):
             continue
 
-        if os.stat(cache_path).st_mtime < os.stat(info).st_mtime:
-            updated_documents_n += 1
-            logger.info("Updating %s", papis.document.describe(doc))
+        info_mtime = os.stat(info).st_mtime
+        if cache_path_mtime < info_mtime:
+            updated_documents_count += 1
+            logger.info("Updating newer '%s'.", papis.document.describe(doc))
+
             doc.load()
             db.update(doc)
 
-    logger.info("Updated %d documents", updated_documents_n)
+    logger.info("Updated %d documents.", updated_documents_count)

--- a/papis/commands/serve.py
+++ b/papis/commands/serve.py
@@ -3,7 +3,8 @@ import os
 import json
 import http.server
 import urllib.parse
-from typing import Any, List, Optional, Tuple, Callable, Dict  # noqa: ignore
+from typing import Any, List, Optional, Tuple, Callable, Dict
+
 import functools
 import cgi
 import collections
@@ -154,7 +155,7 @@ class PapisRequestHandler(http.server.BaseHTTPRequestHandler):
         if TAGS_LIST.get(libname) is None:
             TAGS_LIST[libname] = collections.defaultdict(int)
             for tag in tags_of_tags:
-                TAGS_LIST[libname][tag] += 1  # type: ignore
+                TAGS_LIST[libname][tag] += 1  # type: ignore[index]
 
         page = papis.web.tags.html(libname=libname,
                                    pretitle="TAGS",

--- a/papis/defaults.py
+++ b/papis/defaults.py
@@ -1,6 +1,6 @@
 import sys
 import os
-from typing import Dict, Any  # noqa: ignore
+from typing import Any, Dict
 
 
 def get_default_opener() -> str:

--- a/papis/fzf.py
+++ b/papis/fzf.py
@@ -1,7 +1,6 @@
 import re
 from abc import ABC, abstractmethod
-from typing.re import Pattern
-from typing import Callable, Sequence, TypeVar, List, Optional, Generic
+from typing import Callable, Sequence, TypeVar, List, Optional, Generic, Pattern
 
 import papis.pick
 import papis.config
@@ -11,7 +10,7 @@ T = TypeVar("T")
 
 
 class Command(ABC, Generic[T]):
-    regex: Optional[Pattern] = None
+    regex: Optional[Pattern[str]] = None
     command: str = ""
     key: str = ""
 

--- a/papis/tui/app.py
+++ b/papis/tui/app.py
@@ -19,7 +19,7 @@ from .widgets.command_line_prompt import Command, CommandLinePrompt
 from .widgets import InfoWindow, HelpWindow, MessageToolbar
 from .widgets.list import Option, OptionsList
 
-from typing import (  # noqa: ignore
+from typing import (
     Optional, Dict, Any, List, Callable, Tuple, Generic,
     Sequence, TypedDict)
 

--- a/papis/tui/app.py
+++ b/papis/tui/app.py
@@ -1,9 +1,8 @@
-from prompt_toolkit.utils import Event
 from prompt_toolkit.application import Application
 from prompt_toolkit.formatted_text.html import HTML
 from prompt_toolkit.enums import EditingMode
 from prompt_toolkit.layout.processors import BeforeInput
-from prompt_toolkit.key_binding import KeyBindings, merge_key_bindings
+from prompt_toolkit.key_binding import KeyBindings, KeyPressEvent, merge_key_bindings
 from prompt_toolkit.filters import has_focus, Condition
 from prompt_toolkit.styles import Style
 from prompt_toolkit.layout.containers import (
@@ -21,7 +20,7 @@ from .widgets.list import Option, OptionsList
 
 from typing import (
     Optional, Dict, Any, List, Callable, Tuple, Generic,
-    Sequence, TypedDict)
+    Sequence, TypedDict, Union)
 
 __all__ = [
     "Option",
@@ -102,157 +101,165 @@ def get_keys_info() -> Dict[str, KeyInfo]:
     return _KEYS_INFO
 
 
-def create_keybindings(app: Application) -> KeyBindings:
+def create_keybindings(app: "Picker[Any]") -> KeyBindings:
     keys_info = get_keys_info()
     kb = KeyBindings()
 
-    @kb.add("escape",  # type: ignore
+    @kb.add("escape",
             filter=Condition(lambda: app.message_toolbar.text))
-    def _(event: Event) -> None:
-        event.app.message_toolbar.text = None
+    def _escape_message(event: KeyPressEvent) -> None:
+        app.message_toolbar.text = None
 
-    @kb.add("escape",  # type: ignore
+    @kb.add("escape",
             filter=Condition(lambda: app.error_toolbar.text))
-    def _escape(event: Event) -> None:
-        event.app.error_toolbar.text = None
+    def _escape_error(event: KeyPressEvent) -> None:
+        app.error_toolbar.text = None
 
-    @kb.add("c-n", filter=~has_focus(app.info_window))  # type: ignore
-    @kb.add(keys_info["move_down_key"]["key"],  # type: ignore
+    @kb.add("c-n",                                      # type: ignore[misc]
             filter=~has_focus(app.info_window))
-    def down_(event: Event) -> None:
-        event.app.options_list.move_down()
-        event.app.refresh()
-        event.app.update()
+    @kb.add(str(keys_info["move_down_key"]["key"]),     # type: ignore[misc]
+            filter=~has_focus(app.info_window))
+    def _down(event: KeyPressEvent) -> None:
+        app.options_list.move_down()
+        app.refresh()
+        app.update()
 
-    @kb.add(  # type: ignore
+    @kb.add(                                            # type: ignore[misc]
         keys_info["move_down_while_info_window_active_key"]["key"],
         filter=has_focus(app.info_window))
-    def down_info(event: Event) -> None:
-        down_(event)
-        event.app.update_info_window()
+    def _down_info(event: KeyPressEvent) -> None:
+        _down(event)
+        app.update_info_window()
 
-    @kb.add("c-p", filter=~has_focus(app.info_window))  # type: ignore
-    @kb.add(keys_info["move_up_key"]["key"],  # type: ignore
+    @kb.add("c-p",                                      # type: ignore[misc]
             filter=~has_focus(app.info_window))
-    def up_(event: Event) -> None:
-        event.app.options_list.move_up()
-        event.app.refresh()
-        event.app.update()
+    @kb.add(keys_info["move_up_key"]["key"],            # type: ignore[misc]
+            filter=~has_focus(app.info_window))
+    def _up(event: KeyPressEvent) -> None:
+        app.options_list.move_up()
+        app.refresh()
+        app.update()
 
-    @kb.add(  # type: ignore
+    @kb.add(                                            # type: ignore[misc]
         keys_info["move_up_while_info_window_active_key"]["key"],
         filter=has_focus(app.info_window))
-    def up_info(event: Event) -> None:
-        up_(event)
-        event.app.update_info_window()
+    def _up_info(event: KeyPressEvent) -> None:
+        _up(event)
+        app.update_info_window()
 
-    @kb.add("q", filter=has_focus(app.help_window))  # type: ignore
-    @kb.add("escape", filter=has_focus(app.help_window))  # type: ignore
-    def _help_quit(event: Event) -> None:
-        event.app.layout.focus(app.help_window.window)
-        event.app.layout.focus(app.command_line_prompt.window)
-        event.app.message_toolbar.text = None
-        event.app.layout.focus(event.app.options_list.search_buffer)
+    @kb.add("q",                                        # type: ignore[misc]
+            filter=has_focus(app.help_window))
+    @kb.add("escape",                                   # type: ignore[misc]
+            filter=has_focus(app.help_window))
+    def _help_quit(event: KeyPressEvent) -> None:
+        app.layout.focus(app.help_window.window)
+        app.layout.focus(app.command_line_prompt.window)
+        app.message_toolbar.text = None
+        app.layout.focus(app.options_list.search_buffer)
 
-    @kb.add("q", filter=has_focus(app.info_window))  # type: ignore
-    @kb.add("s-tab", filter=has_focus(app.info_window))  # type: ignore
-    @kb.add("escape", filter=has_focus(app.info_window))  # type: ignore
-    def _info(event: Event) -> None:
-        event.app.layout.focus(event.app.options_list.search_buffer)
-        event.app.message_toolbar.text = None
+    @kb.add("q",                                        # type: ignore[misc]
+            filter=has_focus(app.info_window))
+    @kb.add("s-tab",                                    # type: ignore[misc]
+            filter=has_focus(app.info_window))
+    @kb.add("escape",                                   # type: ignore[misc]
+            filter=has_focus(app.info_window))
+    def _info(event: KeyPressEvent) -> None:
+        app.layout.focus(app.options_list.search_buffer)
+        app.message_toolbar.text = None
 
-    @kb.add(keys_info["focus_command_line_key"]["key"],  # type: ignore
-            filter=~has_focus(app.command_line_prompt))
-    def _command_window(event: Event) -> None:
-        event.app.layout.focus(app.command_line_prompt.window)
+    @kb.add(                                            # type: ignore[misc]
+        keys_info["focus_command_line_key"]["key"],
+        filter=~has_focus(app.command_line_prompt))
+    def _command_window(event: KeyPressEvent) -> None:
+        app.layout.focus(app.command_line_prompt.window)
 
-    @kb.add("enter", filter=has_focus(app.command_line_prompt))  # type: ignore
-    def _enter_(event: Event) -> None:
-        event.app.layout.focus(event.app.options_list.search_buffer)
-        try:
-            event.app.command_line_prompt.trigger()
-        except Exception as e:
-            event.app.error_toolbar.text = str(e)
-        event.app.command_line_prompt.clear()
-
-    @kb.add("escape",  # type: ignore
+    @kb.add("enter",                                    # type: ignore[misc]
             filter=has_focus(app.command_line_prompt))
-    def _escape_when_commandline_has_focus(event: Event) -> None:
-        event.app.layout.focus(event.app.options_list.search_buffer)
-        event.app.command_line_prompt.clear()
+    def _enter(event: KeyPressEvent) -> None:
+        app.layout.focus(app.options_list.search_buffer)
+        try:
+            app.command_line_prompt.trigger()
+        except Exception as e:
+            app.error_toolbar.text = str(e)
+        app.command_line_prompt.clear()
 
-    @kb.add("c-t")  # type: ignore
-    def _toggle_mark_(event: Event) -> None:
-        event.app.options_list.toggle_mark_current_selection()
+    @kb.add("escape",                                   # type: ignore[misc]
+            filter=has_focus(app.command_line_prompt))
+    def _escape_when_commandline_has_focus(event: KeyPressEvent) -> None:
+        app.layout.focus(app.options_list.search_buffer)
+        app.command_line_prompt.clear()
+
+    @kb.add("c-t")
+    def _toggle_mark_(event: KeyPressEvent) -> None:
+        app.options_list.toggle_mark_current_selection()
 
     return kb
 
 
-def get_commands(app: Application) -> Tuple[List[Command], KeyBindings]:
-
+def get_commands(app: "Picker[Any]") -> Tuple[List[Command], KeyBindings]:
     kb = KeyBindings()
     keys_info = get_keys_info()
 
-    @kb.add("c-q")  # type: ignore
-    @kb.add("c-c")  # type: ignore
-    def exit(event: Event) -> None:
-        event.app.deselect()
-        event.app.exit()
+    @kb.add("c-q")
+    @kb.add("c-c")
+    def exit(event: Union[Command, KeyPressEvent]) -> None:
+        app.deselect()
+        app.exit()
 
-    @kb.add("enter",  # type: ignore
+    @kb.add("enter",                                    # type: ignore[misc]
             filter=has_focus(app.options_list.search_buffer))
-    def select(event: Event) -> None:
-        event.app.exit()
+    def select(event: Union[Command, KeyPressEvent]) -> None:
+        app.exit()
 
-    @kb.add(keys_info["open_document_key"]["key"],  # type: ignore
+    @kb.add(keys_info["open_document_key"]["key"],      # type: ignore[misc]
             filter=has_focus(app.options_list.search_buffer))
-    def open(cmd: Command) -> None:
+    def open(event: Union[Command, KeyPressEvent]) -> None:
         from papis.commands.open import run
-        docs = cmd.app.get_selection()
+        docs = app.get_selection()
         for doc in docs:
             run(doc)
 
-    @kb.add(keys_info["edit_document_key"]["key"],  # type: ignore
+    @kb.add(keys_info["edit_document_key"]["key"],      # type: ignore[misc]
             filter=has_focus(app.options_list.search_buffer))
-    def edit(cmd: Command) -> None:
+    def edit(event: Union[Command, KeyPressEvent]) -> None:
         from papis.commands.edit import run
-        docs = cmd.app.get_selection()
+        docs = app.get_selection()
         for doc in docs:
             run(doc)
-        cmd.app.renderer.clear()
+        app.renderer.clear()
 
-    @kb.add(keys_info["edit_notes_key"]["key"],  # type: ignore
+    @kb.add(keys_info["edit_notes_key"]["key"],         # type: ignore[misc]
             filter=has_focus(app.options_list.search_buffer))
-    def edit_notes(cmd: Command) -> None:
+    def edit_notes(event: KeyPressEvent) -> None:
         from papis.commands.edit import edit_notes
-        docs = cmd.app.get_selection()
+        docs = app.get_selection()
         for doc in docs:
             edit_notes(doc)
-        cmd.app.renderer.clear()
+        app.renderer.clear()
 
-    @kb.add(keys_info["show_help_key"]["key"],  # type: ignore
+    @kb.add(keys_info["show_help_key"]["key"],          # type: ignore[misc]
             filter=~has_focus(app.help_window))
-    def help(event: Event) -> None:
-        event.app.layout.focus(app.help_window.window)
-        event.app.message_toolbar.text = "Press q to quit"
+    def help(event: Union[Command, KeyPressEvent]) -> None:
+        app.layout.focus(app.help_window.window)
+        app.message_toolbar.text = "Press q to quit"
 
-    @kb.add(keys_info["show_info_key"]["key"],  # type: ignore
+    @kb.add(keys_info["show_info_key"]["key"],          # type: ignore[misc]
             filter=~has_focus(app.info_window))
-    def info(cmd: Command) -> None:
-        cmd.app.update_info_window()
-        cmd.app.layout.focus(cmd.app.info_window.window)
+    def info(event: Union[Command, KeyPressEvent]) -> None:
+        app.update_info_window()
+        app.layout.focus(app.info_window.window)
 
-    @kb.add("c-g", "g")  # type: ignore
-    @kb.add(keys_info["go_top_key"]["key"])  # type: ignore
-    def go_top(event: Event) -> None:
-        event.app.options_list.go_top()
-        event.app.refresh()
+    @kb.add("c-g", "g")
+    @kb.add(keys_info["go_top_key"]["key"])
+    def go_top(event: Union[Command, KeyPressEvent]) -> None:
+        app.options_list.go_top()
+        app.refresh()
 
-    @kb.add("c-g", "G")  # type: ignore
-    @kb.add(keys_info["go_bottom_key"]["key"])  # type: ignore
-    def go_end(event: Event) -> None:
-        event.app.options_list.go_bottom()
-        event.app.refresh()
+    @kb.add("c-g", "G")
+    @kb.add(keys_info["go_bottom_key"]["key"])
+    def go_end(event: Union[Command, KeyPressEvent]) -> None:
+        app.options_list.go_bottom()
+        app.refresh()
 
     return ([
         Command("open", run=open, aliases=["op"]),
@@ -262,8 +269,8 @@ def get_commands(app: Application) -> Tuple[List[Command], KeyBindings]:
         Command("info", run=info, aliases=["i"]),
         Command("go_top", run=go_top),
         Command("go_bottom", run=go_end),
-        Command("move_down", run=lambda c: c.app.options_list.move_down()),
-        Command("move_up", run=lambda c: c.app.options_list.move_up()),
+        Command("move_down", run=lambda c: app.options_list.move_down()),
+        Command("move_up", run=lambda c: app.options_list.move_up()),
         # Command("echo", run=_echo),
         Command("help", run=help),
     ], kb)
@@ -343,19 +350,19 @@ class Picker(Application, Generic[Option]):  # type: ignore
             else EditingMode.VI,
             layout=self.layout,
             style=Style.from_dict({
-                "options_list.selected_margin": config.get(
+                "options_list.selected_margin": config.getstring(
                     "options_list.selected_margin_style", section="tui"
                 ),
-                "options_list.unselected_margin": config.get(
+                "options_list.unselected_margin": config.getstring(
                     "options_list.unselected_margin_style", section="tui"
                 ),
-                "error_toolbar": config.get(
+                "error_toolbar": config.getstring(
                     "error_toolbar_style", section="tui"
                 ),
-                "message_toolbar": config.get(
+                "message_toolbar": config.getstring(
                     "message_toolbar_style", section="tui"
                 ),
-                "status_line": config.get(
+                "status_line": config.getstring(
                     "status_line_style", section="tui"
                 ),
             }),

--- a/papis/tui/picker.py
+++ b/papis/tui/picker.py
@@ -1,5 +1,5 @@
 import sys
-from typing import Callable, Sequence, TypeVar
+from typing import Callable, List, Sequence, TypeVar
 
 import papis.pick
 import papis.tui.app as tui
@@ -9,23 +9,18 @@ T = TypeVar("T")
 
 class Picker(papis.pick.Picker[T]):
     def __call__(
-        self,
-        options: Sequence[T],
-        header_filter: Callable[[T], str] = str,
-        match_filter: Callable[[T], str] = str,
-        default_index: int = 0
-            ) -> Sequence[T]:
+            self,
+            options: Sequence[T],
+            header_filter: Callable[[T], str] = str,
+            match_filter: Callable[[T], str] = str,
+            default_index: int = 0
+            ) -> List[T]:
 
         if len(options) == 0:
             return []
+
         if len(options) == 1:
             return [options[0]]
-
-        # patch stdout to stderr if the output is not a tty (terminal)
-        oldstdout = sys.stdout
-        if not sys.stdout.isatty():
-            sys.stdout = sys.stderr
-            sys.__stdout__ = sys.stderr
 
         picker = tui.Picker(
             options,
@@ -33,11 +28,13 @@ class Picker(papis.pick.Picker[T]):
             header_filter,
             match_filter
         )
-        picker.run()
-        result = picker.options_list.get_selection()
 
-        # restore the stdout to normality
-        sys.stdout = oldstdout
-        sys.__stdout__ = oldstdout
+        from contextlib import redirect_stdout
 
-        return result
+        if not sys.stdout.isatty():
+            with redirect_stdout(sys.stderr):
+                picker.run()
+        else:
+            picker.run()
+
+        return picker.options_list.get_selection()

--- a/papis/tui/utils.py
+++ b/papis/tui/utils.py
@@ -70,7 +70,7 @@ def confirm(prompt_string: str,
 
 
 def text_area(text: str,
-              lexer_name: str = ""):
+              lexer_name: str = "") -> None:
     """
     Small implementation of a pager for small pieces of text.
 
@@ -78,15 +78,16 @@ def text_area(text: str,
     :param lexer_name: If the text should be highlighted with
         some kind of grammar, examples are ``yaml``, ``python`` ...
     """
+    from pygments import lex
     from pygments.lexers import find_lexer_class_by_name
 
-    import pygments
-    from prompt_toolkit import print_formatted_text
     pygment_lexer = find_lexer_class_by_name(lexer_name)
-    tokens = list(pygments.lex(text, lexer=pygment_lexer()))
+    tokens = lex(text, lexer=pygment_lexer())  # type: ignore[no-untyped-call]
+
+    from prompt_toolkit import print_formatted_text
+    from prompt_toolkit.styles import Style
     from prompt_toolkit.formatted_text import PygmentsTokens
 
-    from prompt_toolkit.styles import Style
     papis_style = Style.from_dict(PAPIS_PYGMENTS_DEFAULT_STYLE)
     print_formatted_text(PygmentsTokens(tokens), style=papis_style)
 
@@ -135,7 +136,7 @@ def prompt(
         ("", ": "),
     ]
 
-    result = prompt_toolkit.prompt(fragments,
+    result = prompt_toolkit.prompt(fragments,       # type: ignore[arg-type]
                                    validator=validator,
                                    multiline=multiline,
                                    bottom_toolbar=bottom_toolbar,

--- a/papis/tui/widgets/__init__.py
+++ b/papis/tui/widgets/__init__.py
@@ -25,9 +25,7 @@ __all__ = [
 ]
 
 
-class MessageToolbar(ConditionalContainer):  # type: ignore
-    # TODO: add stubs to be able to remove type ignore above
-
+class MessageToolbar(ConditionalContainer):
     def __init__(self, style: str = "") -> None:
         self.message = None
         self.text_control = FormattedTextControl(text="")
@@ -49,13 +47,14 @@ class MessageToolbar(ConditionalContainer):  # type: ignore
         self.text_control.text = value
 
 
-class InfoWindow(ConditionalContainer):  # type: ignore
-    # TODO: add stubs to be able to remove type ignore above
-
+class InfoWindow(ConditionalContainer):
     def __init__(self, lexer_name: str = "yaml") -> None:
         self.buf = Buffer()
         self.buf.text = ""
-        self.lexer = PygmentsLexer(find_lexer_class_by_name(lexer_name))
+
+        lexer = find_lexer_class_by_name(lexer_name)
+        self.lexer = PygmentsLexer(lexer)   # type: ignore[arg-type]
+
         self.window = HSplit([
             HorizontalLine(),
             Window(
@@ -76,9 +75,7 @@ class InfoWindow(ConditionalContainer):  # type: ignore
         self.buf.text = text
 
 
-class HelpWindow(ConditionalContainer):  # type: ignore
-    # TODO: add stubs to be able to remove type ignore above
-
+class HelpWindow(ConditionalContainer):
     def __init__(self) -> None:
         self.text_control = FormattedTextControl(
             text=HTML("")

--- a/papis/tui/widgets/command_line_prompt.py
+++ b/papis/tui/widgets/command_line_prompt.py
@@ -44,7 +44,7 @@ class Command:
         self.aliases = aliases
 
     @property
-    def app(self) -> Application:
+    def app(self) -> Application[Any]:
         return get_app()
 
     @property
@@ -52,7 +52,7 @@ class Command:
         return [self.name] + self.aliases
 
 
-class CommandLinePrompt(ConditionalContainer):  # type: ignore
+class CommandLinePrompt(ConditionalContainer):
     """
     A vim-like command line prompt widget.
     It's supposed to be instantiated only once.
@@ -62,7 +62,8 @@ class CommandLinePrompt(ConditionalContainer):  # type: ignore
             commands = []
 
         self.commands = commands
-        wc = WordCompleter(sum([c.names for c in commands], []))
+        names: List[str] = sum((c.names for c in commands), [])
+        wc = WordCompleter(names)
         self.buf = Buffer(
             completer=wc, complete_while_typing=True
         )

--- a/papis/tui/widgets/diff.py
+++ b/papis/tui/widgets/diff.py
@@ -2,18 +2,17 @@ from typing import (
     Dict, Any, List, Union, NamedTuple, Callable, Optional)
 
 from prompt_toolkit import Application, print_formatted_text
-from prompt_toolkit.utils import Event
 from prompt_toolkit.layout.containers import HSplit, Window, WindowAlign
 from prompt_toolkit.formatted_text import FormattedText
 from prompt_toolkit.layout.controls import FormattedTextControl
 from prompt_toolkit.layout.layout import Layout
-from prompt_toolkit.key_binding import KeyBindings
+from prompt_toolkit.key_binding import KeyBindings, KeyPressEvent
 
 
 class Action(NamedTuple):
     name: str
     key: str
-    action: Callable[[Event], None]
+    action: Callable[[KeyPressEvent], None]
 
 
 def prompt(text: Union[str, FormattedText],
@@ -28,6 +27,9 @@ def prompt(text: Union[str, FormattedText],
     :param actions: A list of Actions as defined in `Action`.
     :param kwargs: kwargs to prompt_toolkit application class
     """
+    if not isinstance(text, FormattedText):
+        text = FormattedText([("", text)])
+
     if actions is None:
         actions = []
 
@@ -39,7 +41,7 @@ def prompt(text: Union[str, FormattedText],
     for action in actions:
         kb.add(action.key)(action.action)
 
-    print_formatted_text(FormattedText(text))
+    print_formatted_text(text)
 
     action_texts = []
     for a in actions:
@@ -67,7 +69,7 @@ def prompt(text: Union[str, FormattedText],
         ] if title else [])
     )
 
-    app = Application(
+    app: Application[Any] = Application(
         layout=Layout(root_container),
         key_bindings=kb,
         **kwargs)
@@ -115,7 +117,7 @@ def diffshow(texta: str,
         "+++++ {nameb}\n".format(nameb=nameb),
     ]
 
-    formatted_text = list(map(
+    formatted_text = FormattedText(map(
         lambda line:
             # match line values
             line.startswith("@") and ("fg:ansimagenta bg:ansiblack", line)
@@ -161,22 +163,26 @@ def diffdict(dicta: Dict[str, Any],
         for k in options:
             options[k] = False
 
-    def oset(event: Event, option: str, value: bool) -> None:
+    def oset(event: KeyPressEvent, option: str, value: bool) -> None:
         options[option] = value
-        event.app.exit(0)
+        event.app.exit(result=0)
 
     actions = [
         Action(
             name="Add all",
             key="a", action=lambda e: oset(e, "add_all", True)),
         Action(
-            name="Split", key="s", action=lambda e: oset(e, "split", True)),
+            name="Split",
+            key="s", action=lambda e: oset(e, "split", True)),
         Action(
-            name="Reject", key="n", action=lambda e: oset(e, "reject", True)),
+            name="Reject",
+            key="n", action=lambda e: oset(e, "reject", True)),
         Action(
-            name="Quit", key="q", action=lambda e: oset(e, "quit", True)),
+            name="Quit",
+            key="q", action=lambda e: oset(e, "quit", True)),
         Action(
-            name="Cancel", key="c", action=lambda e: oset(e, "cancel", True)),
+            name="Cancel",
+            key="c", action=lambda e: oset(e, "cancel", True)),
     ]
 
     keys = [k for k in sorted(set(dicta) | set(dictb))

--- a/papis/tui/widgets/list.py
+++ b/papis/tui/widgets/list.py
@@ -6,7 +6,7 @@ from typing import (
     Callable, Tuple, Pattern, TypeVar)
 
 from prompt_toolkit.formatted_text.html import HTML
-from prompt_toolkit.formatted_text.base import FormattedText  # noqa: ignore
+from prompt_toolkit.formatted_text.base import FormattedText
 from prompt_toolkit.layout.screen import Point
 from prompt_toolkit.buffer import Buffer
 from prompt_toolkit.layout.controls import FormattedTextControl
@@ -232,8 +232,8 @@ class OptionsList(ConditionalContainer, Generic[Option]):  # type: ignore
 
         f = functools.partial(match_against_regex, regex)
         results = papis.utils.parmap(f,
-                                     [(i, l)
-                                      for i, l in
+                                     [(i, matcher)
+                                      for i, matcher in
                                       enumerate(self.options_matchers)
                                       if i in search_indices])
 

--- a/setup.cfg
+++ b/setup.cfg
@@ -58,7 +58,3 @@ ignore_missing_imports = True
 
 [mypy-whoosh.*]
 ignore_missing_imports = True
-
-[mypy-papis.tui.*]
-ignore_missing_imports = True
-ignore_errors = True

--- a/setup.py
+++ b/setup.py
@@ -92,7 +92,7 @@ setup(
         "habanero>=0.6.0",
         "isbnlib>=3.9.1",
         "lxml>=4.3.5",
-        "prompt_toolkit>=2.0.5",
+        "prompt_toolkit>=3.0.0",
         "pygments>=2.2.0",
         "pyparsing>=2.2.0",
         "python-doi>=0.1.1",


### PR DESCRIPTION
This was a chunk of code that was not getting checked before. This fixes all the `mypy` errors in there and and makes the remaining `type: ignore` have an actual error code attached so we catch new errors.