### PR TITLE
rtd: remove deprecated system_packages

### DIFF
--- a/.readthedocs.yml
+++ b/.readthedocs.yml
@@ -14,4 +14,3 @@ python:
       path: .
       extra_requirements:
         - develop
-  system_packages: true


### PR DESCRIPTION
This seems to be going away (plus it seems to have been broken before)
https://github.com/readthedocs/readthedocs.org/pull/10562