### PR TITLE
crossref: remove use of interactive pick_doc

### DIFF
--- a/papis/commands/update.py
+++ b/papis/commands/update.py
@@ -119,6 +119,9 @@ def cli(query: str,
         set_tuples: List[Tuple[str, str]],) -> None:
     """Update a document from a given library."""
 
+    if batch:
+        _all = True
+          
     documents = papis.cli.handle_doc_folder_query_all_sort(query,
                                                            doc_folder,
                                                            sort_field,

--- a/papis/commands/update.py
+++ b/papis/commands/update.py
@@ -103,10 +103,15 @@ def run(document: papis.document.Document,
                    "The value can be a papis format.",
               multiple=True,
               type=(str, str),)
+@click.option(
+    "-b", "--batch",
+    help="Batch mode, do not prompt or otherwise",
+    default=False, is_flag=True)
 def cli(query: str,
         git: bool,
         doc_folder: str,
         from_importer: List[Tuple[str, str]],
+        batch: bool,
         auto: bool,
         _all: bool,
         sort_field: Optional[str],
@@ -170,7 +175,7 @@ def cli(query: str,
                         matching_importers.append(importer)
 
         imported = papis.utils.collect_importer_data(
-            matching_importers, batch=False, only_data=True)
+            matching_importers, batch=batch, only_data=True)
         if "ref" in imported.data:
             logger.debug(
                 "An importer set the 'ref' key. This is not allowed and will be "

--- a/papis/commands/update.py
+++ b/papis/commands/update.py
@@ -166,7 +166,7 @@ def cli(query: str,
                     importer = importer_cls.match_data(document)
                     if importer:
                         try:
-                            importer.fetch_data()
+                            importer.fetch_data(batch=batch)
                         except NotImplementedError:
                             importer.fetch()
                 except NotImplementedError:

--- a/papis/commands/update.py
+++ b/papis/commands/update.py
@@ -103,15 +103,10 @@ def run(document: papis.document.Document,
                    "The value can be a papis format.",
               multiple=True,
               type=(str, str),)
-@click.option(
-    "-b", "--batch",
-    help="Batch mode, do not prompt or otherwise",
-    default=False, is_flag=True)
 def cli(query: str,
         git: bool,
         doc_folder: str,
         from_importer: List[Tuple[str, str]],
-        batch: bool,
         auto: bool,
         _all: bool,
         sort_field: Optional[str],
@@ -119,9 +114,6 @@ def cli(query: str,
         set_tuples: List[Tuple[str, str]],) -> None:
     """Update a document from a given library."""
 
-    if batch:
-        _all = True
-          
     documents = papis.cli.handle_doc_folder_query_all_sort(query,
                                                            doc_folder,
                                                            sort_field,
@@ -166,7 +158,7 @@ def cli(query: str,
                     importer = importer_cls.match_data(document)
                     if importer:
                         try:
-                            importer.fetch_data(batch=batch)
+                            importer.fetch_data()
                         except NotImplementedError:
                             importer.fetch()
                 except NotImplementedError:
@@ -178,7 +170,7 @@ def cli(query: str,
                         matching_importers.append(importer)
 
         imported = papis.utils.collect_importer_data(
-            matching_importers, batch=batch, only_data=True)
+            matching_importers, batch=False, only_data=True)
         if "ref" in imported.data:
             logger.debug(
                 "An importer set the 'ref' key. This is not allowed and will be "

--- a/papis/crossref.py
+++ b/papis/crossref.py
@@ -397,7 +397,7 @@ class Importer(papis.importer.Importer):
 
         return None
 
-    def fetch_data(self, batch=batch) -> None:
+    def fetch_data(self) -> None:
         data = papis.crossref.get_data(dois=[self.uri])
         if data:
             self.ctx.data = data[0]
@@ -441,24 +441,19 @@ class FromCrossrefImporter(papis.importer.Importer):
 
         return None
 
-    def fetch_data(self, batch=False) -> None:
+    def fetch_data(self) -> None:
         self.logger.info("Querying Crossref with '%s'.", self.uri)
         docs = [
             papis.document.from_data(d)
             for d in get_data(query=self.uri)]
 
-        if docs:
-            if not batch:
-                self.logger.info("Got %d matches, picking...", len(docs))
-                docs = list(papis.pick.pick_doc(docs))
+        if not docs:
+            return
 
-            if not docs:
-                return
-
-            doc = docs[0]
-            importer = Importer(uri=doc["doi"])
-            importer.fetch()
-            self.ctx.data = importer.ctx.data.copy()
+        doc = docs[0]
+        importer = Importer(uri=doc["doi"])
+        importer.fetch()
+        self.ctx.data = importer.ctx.data.copy()
 
 
 class Downloader(papis.downloaders.Downloader):

--- a/papis/crossref.py
+++ b/papis/crossref.py
@@ -1,4 +1,4 @@
-import re
+/import re
 import os
 from typing import Any, Dict, List, Optional, Tuple, TYPE_CHECKING
 
@@ -397,7 +397,7 @@ class Importer(papis.importer.Importer):
 
         return None
 
-    def fetch_data(self) -> None:
+    def fetch_data(self, batch=batch) -> None:
         data = papis.crossref.get_data(dois=[self.uri])
         if data:
             self.ctx.data = data[0]
@@ -441,15 +441,16 @@ class FromCrossrefImporter(papis.importer.Importer):
 
         return None
 
-    def fetch_data(self) -> None:
+    def fetch_data(self, batch=False) -> None:
         self.logger.info("Querying Crossref with '%s'.", self.uri)
         docs = [
             papis.document.from_data(d)
             for d in get_data(query=self.uri)]
 
         if docs:
-            self.logger.info("Got %d matches, picking...", len(docs))
-            docs = list(papis.pick.pick_doc(docs))
+            if not batch:
+                self.logger.info("Got %d matches, picking...", len(docs))
+                docs = list(papis.pick.pick_doc(docs))
 
             if not docs:
                 return

--- a/papis/crossref.py
+++ b/papis/crossref.py
@@ -454,6 +454,10 @@ class FromCrossrefImporter(papis.importer.Importer):
         if not docs:
             return
 
+        self.logger.warning(
+            "Crossref query '%s' returned %d results. Picking the first one!",
+            self.uri, len(docs))
+
         doc = docs[0]
         importer = Importer(uri=doc["doi"])
         importer.fetch()

--- a/papis/crossref.py
+++ b/papis/crossref.py
@@ -1,4 +1,4 @@
-/import re
+import re
 import os
 from typing import Any, Dict, List, Optional, Tuple, TYPE_CHECKING
 


### PR DESCRIPTION
--batch option set _all to True (avoid the menu asking to manually select the entries to update if multiple matches)