### PR TITLE
Fix click flags default

### DIFF
--- a/papis/cli.py
+++ b/papis/cli.py
@@ -44,6 +44,7 @@ def sort_option(**attrs: Any) -> DecoratorCallable:
             "--reverse", "sort_reverse",
             help="Reverse sort order",
             default=lambda: papis.config.getboolean("sort-reverse"),
+            flag_value=True,
             is_flag=True)
 
         return sort(reverse(f))

--- a/papis/commands/add.py
+++ b/papis/commands/add.py
@@ -493,11 +493,9 @@ def run(paths: List[str],
     "-d", "--subfolder",
     help="Subfolder in the library",
     default=lambda: papis.config.getstring("add-subfolder"))
-@click.option(
+@papis.cli.bool_flag(
     "-p", "--pick-subfolder",
-    help="Pick from existing subfolders",
-    is_flag=True,
-    default=False)
+    help="Pick from existing subfolders")
 @click.option(
     "--folder-name",
     help="Name for the document's folder (papis format)",
@@ -515,10 +513,9 @@ def run(paths: List[str],
     nargs=2,
     multiple=True,
     default=(),)
-@click.option(
+@papis.cli.bool_flag(
     "-b", "--batch",
-    help="Batch mode, do not prompt or otherwise",
-    default=False, is_flag=True)
+    help="Batch mode, do not prompt or otherwise")
 @click.option(
     "--confirm/--no-confirm",
     help="Ask to confirm before adding to the collection",
@@ -537,21 +534,16 @@ def run(paths: List[str],
          "its original location",
     default=False)
 @papis.cli.git_option(help="Git add and commit the new document")
-@click.option(
+@papis.cli.bool_flag(
     "--list-importers", "--li", "list_importers",
-    help="List all available papis importers",
-    default=False,
-    is_flag=True)
-@click.option(
+    help="List all available papis importers")
+@papis.cli.bool_flag(
     "--force-download", "--fd", "force_download",
-    help="Download file with importer even if local file is passed",
-    default=False,
-    is_flag=True)
-@click.option("--fetch-citations",
-              help="Fetch citations from doi",
-              default=lambda: papis.config.getboolean("add-fetch-citations"),
-              flag_value=True,
-              is_flag=True)
+    help="Download file with importer even if local file is passed")
+@papis.cli.bool_flag(
+    "--fetch-citations",
+    help="Fetch citations from a DOI (Digital Object Identifier)",
+    default=lambda: papis.config.getboolean("add-fetch-citations"))
 def cli(files: List[str],
         set_list: List[Tuple[str, str]],
         subfolder: str,

--- a/papis/commands/bibtex.py
+++ b/papis/commands/bibtex.py
@@ -138,10 +138,9 @@ EXPLORER_MGR = explore.get_explorer_mgr()
 
 @click.group("bibtex", cls=papis.commands.AliasedGroup, chain=True)
 @click.help_option("-h", "--help")
-@click.option("--noar", "--no-auto-read", "no_auto_read",
-              default=False,
-              is_flag=True,
-              help="Do not auto read even if the configuration file says it")
+@papis.cli.bool_flag(
+    "--noar", "--no-auto-read", "no_auto_read",
+    help="Do not auto read even if the configuration file says it")
 @click.pass_context
 def cli(ctx: click.Context, no_auto_read: bool) -> None:
     """A papis script to interact with bibtex files"""
@@ -204,14 +203,10 @@ def _add(ctx: click.Context,
 @cli.command("update")
 @click.help_option("-h", "--help")
 @papis.cli.all_option()
-@click.option("--from", "-f", "fromdb",
-              show_default=True,
-              help="Update the document from the library",
-              default=False, is_flag=True)
-@click.option("-t", "--to",
-              help="Update the library document from retrieved document",
-              show_default=True,
-              default=False, is_flag=True)
+@papis.cli.bool_flag("--from", "-f", "fromdb",
+                     help="Update the document from the library")
+@papis.cli.bool_flag("-t", "--to",
+                     help="Update the library document from retrieved document")
 @click.option("-k", "--keys",
               help="Update only given keys (can be given multiple times)",
               type=str,
@@ -361,7 +356,7 @@ def _ref(ctx: click.Context, out: Optional[str]) -> None:
     "bibfile",
     default=lambda: papis.config.get("default-save-bibfile", section="bibtex"),
     required=True, type=click.Path())
-@click.option("-f", "--force", default=False, is_flag=True)
+@papis.cli.bool_flag("-f", "--force", help="Do not ask for confirmation when saving")
 @click.pass_context
 def _save(ctx: click.Context, bibfile: str, force: bool) -> None:
     """Save the documents in the BibTeX format."""
@@ -379,14 +374,11 @@ def _save(ctx: click.Context, bibfile: str, force: bool) -> None:
 @cli.command("sort")
 @click.help_option("-h", "--help")
 @click.option("-k", "--key",
-              help="Field to order it",
+              help="Field to order by",
               default=None,
               type=str,
               required=True)
-@click.option("-r", "--reverse",
-              help="Reverse the order",
-              default=False,
-              is_flag=True)
+@papis.cli.bool_flag("-r", "--reverse", help="Reverse the sort order")
 @click.pass_context
 def _sort(ctx: click.Context, key: Optional[str], reverse: bool) -> None:
     """Sort the documents in the BibTeX file."""

--- a/papis/commands/browse.py
+++ b/papis/commands/browse.py
@@ -129,8 +129,9 @@ def run(document: papis.document.Document,
 @click.option("-k", "--key", default="",
               help="Use the value of the document's key to open in"
                    " the browser, e.g. doi, url, doc_url ...")
-@click.option("-n", "--print", "_print", default=False, is_flag=True,
-              help="Just print out the url, do not open it with browser")
+@papis.cli.bool_flag(
+    "-n", "--print", "_print",
+    help="Just print out the url, do not open it with browser")
 @papis.cli.all_option()
 @papis.cli.doc_folder_option()
 def cli(query: str,

--- a/papis/commands/citations.py
+++ b/papis/commands/citations.py
@@ -65,26 +65,14 @@ logger = papis.logging.get_logger(__name__)
 @click.help_option("--help", "-h")
 @papis.cli.query_argument()
 @papis.cli.sort_option()
-@click.option("-c",
-              "--fetch-citations",
-              default=False,
-              is_flag=True,
-              help="Fetch and save citations")
-@click.option("-d",
-              "--update-from-database",
-              default=False,
-              is_flag=True,
-              help="Fetch and save citations")
-@click.option("-f",
-              "--force",
-              default=False,
-              is_flag=True,
-              help="Force action")
-@click.option("-b",
-              "--fetch-cited-by",
-              default=False,
-              is_flag=True,
-              help="Force action")
+@papis.cli.bool_flag("-c", "--fetch-citations",
+                     help="Fetch and save citations from Crossref")
+@papis.cli.bool_flag("-d", "--update-from-database",
+                     help="Fetch and save citations from database")
+@papis.cli.bool_flag("-b", "--fetch-cited-by",
+                     help="Fetch and save cited-by from database")
+@papis.cli.bool_flag("-f", "--force",
+                     help="Force action")
 @papis.cli.all_option()
 @papis.cli.doc_folder_option()
 def cli(query: str,

--- a/papis/commands/config.py
+++ b/papis/commands/config.py
@@ -75,6 +75,7 @@ from typing import Any, Dict, List, Optional, Tuple
 import click
 import colorama
 
+import papis.cli
 import papis.config
 import papis.commands
 import papis.logging
@@ -214,15 +215,13 @@ def run(
     "-s", "--section",
     help="select a default section for the options",
     default=None)
-@click.option(
+@papis.cli.bool_flag(
     "-d", "--default",
     help="List default configuration setting values, instead of those in the "
-         "configuration file",
-    default=False, is_flag=True)
-@click.option(
+         "configuration file")
+@papis.cli.bool_flag(
     "--json", "json_",
-    help="Print settings in a JSON format",
-    default=False, is_flag=True)
+    help="Print settings in a JSON format")
 def cli(options: List[str],
         section: Optional[str],
         json_: bool,

--- a/papis/commands/default.py
+++ b/papis/commands/default.py
@@ -127,20 +127,17 @@ def generate_profile_writing_function(profiler: "cProfile.Profile",
     invoke_without_command=False)
 @click.help_option("--help", "-h")
 @click.version_option(version=papis.__version__)
-@click.option(
-    "-v",
-    "--verbose",
+@papis.cli.bool_flag(
+    "-v", "--verbose",
     help="Make the output verbose (equivalent to --log DEBUG)",
-    default="PAPIS_DEBUG" in os.environ,
-    is_flag=True)
+    default="PAPIS_DEBUG" in os.environ)
 @click.option(
     "--profile",
     help="Print profiling information into file",
     type=click.Path(),
     default=None)
 @click.option(
-    "-l",
-    "--lib",
+    "-l", "--lib",
     help="Choose a library name or library path (unnamed library)",
     default=lambda: papis.config.getstring("default-library"))
 @click.option(
@@ -149,11 +146,9 @@ def generate_profile_writing_function(profiler: "cProfile.Profile",
     help="Configuration file to use",
     type=click.Path(exists=True),
     default=None)
-@click.option(
+@papis.cli.bool_flag(
     "--pick-lib",
-    help="Pick library to use",
-    default=False,
-    is_flag=True)
+    help="Pick library to use")
 @click.option(
     "-s", "--set", "set_list",
     type=(str, str),

--- a/papis/commands/doctor.py
+++ b/papis/commands/doctor.py
@@ -543,26 +543,20 @@ def run(doc: papis.document.Document, checks: List[str]) -> List[Error]:
               multiple=True,
               type=click.Choice(registered_checks_names()),
               help="Checks to run on every document.")
-@click.option("--json", "_json",
-              default=False, is_flag=True,
-              help="Output the results in json format")
-@click.option("--fix",
-              default=False, is_flag=True,
-              help="Auto fix the errors with the auto fixer mechanism")
-@click.option("-s", "--suggest",
-              default=False, is_flag=True,
-              help="Suggest commands to be run for resolution")
-@click.option("-e", "--explain",
-              default=False, is_flag=True,
-              help="Give a short message for the reason of the error")
-@click.option("--edit",
-              default=False, is_flag=True,
-              help="Edit every file with the edit command.")
+@papis.cli.bool_flag("--json", "_json",
+                     help="Output the results in json format")
+@papis.cli.bool_flag("--fix",
+                     help="Auto fix the errors with the auto fixer mechanism")
+@papis.cli.bool_flag("-s", "--suggest",
+                     help="Suggest commands to be run for resolution")
+@papis.cli.bool_flag("-e", "--explain",
+                     help="Give a short message for the reason of the error")
+@papis.cli.bool_flag("--edit",
+                     help="Edit every file with the edit command.")
 @papis.cli.all_option()
 @papis.cli.doc_folder_option()
-@click.option("--list-checks", "list_checks",
-              default=False, is_flag=True,
-              help="List available checks and their descriptions")
+@papis.cli.bool_flag("--list-checks", "list_checks",
+                     help="List available checks and their descriptions")
 def cli(query: str,
         doc_folder: Tuple[str, ...],
         sort_field: Optional[str],

--- a/papis/commands/edit.py
+++ b/papis/commands/edit.py
@@ -80,12 +80,9 @@ def edit_notes(document: papis.document.Document,
 @papis.cli.doc_folder_option()
 @papis.cli.git_option(help="Add changes made to the info file")
 @papis.cli.sort_option()
-@click.option(
-    "-n",
-    "--notes",
-    help="Edit notes associated to the document",
-    default=False,
-    is_flag=True)
+@papis.cli.bool_flag(
+    "-n", "--notes",
+    help="Edit notes associated to the document")
 @papis.cli.all_option()
 @click.option(
     "-e",

--- a/papis/commands/explore.py
+++ b/papis/commands/explore.py
@@ -195,11 +195,8 @@ def pick(ctx: click.Context, number: Optional[int]) -> None:
 @papis.cli.query_argument()
 @papis.cli.doc_folder_option()
 @click.help_option("--help", "-h")
-@click.option("-b",
-              "--cited-by",
-              default=False,
-              is_flag=True,
-              help="Use the cited-by citations")
+@papis.cli.bool_flag("-b", "--cited-by",
+                     help="Use the cited-by citations")
 @papis.cli.all_option()
 def citations(ctx: click.Context,
               query: str,

--- a/papis/commands/export.py
+++ b/papis/commands/export.py
@@ -95,11 +95,9 @@ def run(documents: List[papis.document.Document], to_format: str) -> str:
 @papis.cli.doc_folder_option()
 @papis.cli.sort_option()
 @papis.cli.all_option()
-@click.option(
+@papis.cli.bool_flag(
     "--folder",
-    help="Export document folder to share",
-    default=False,
-    is_flag=True)
+    help="Export document folder to share")
 @click.option(
     "-o",
     "--out",

--- a/papis/commands/list.py
+++ b/papis/commands/list.py
@@ -149,33 +149,21 @@ def run(documents: List[papis.document.Document],
 @click.help_option("--help", "-h")
 @papis.cli.query_argument()
 @papis.cli.sort_option()
-@click.option(
-    "-i",
-    "--info",
-    help="Show the info file name associated with the document",
-    default=False,
-    is_flag=True)
-@click.option(
-    "--id",
-    "_papis_id",
-    help="Show the papis_id",
-    default=False,
-    is_flag=True)
-@click.option(
+@papis.cli.bool_flag(
+    "-i", "--info",
+    help="Show the info file name associated with the document")
+@papis.cli.bool_flag(
+    "--id", "_papis_id",
+    help="Show the papis_id")
+@papis.cli.bool_flag(
     "-f", "--file", "_file",
-    help="Show the file name associated with the document",
-    default=False,
-    is_flag=True)
-@click.option(
+    help="Show the file name associated with the document")
+@papis.cli.bool_flag(
     "-d", "--dir", "_dir",
-    help="Show the folder name associated with the document",
-    default=False,
-    is_flag=True)
-@click.option(
+    help="Show the folder name associated with the document")
+@papis.cli.bool_flag(
     "-n", "--notes",
-    help="List notes files, if any",
-    default=False,
-    is_flag=True)
+    help="List notes files, if any")
 @click.option(
     "--format", "_format",
     help="List entries using a custom papis format, e.g."
@@ -185,16 +173,12 @@ def run(documents: List[papis.document.Document],
     "--template",
     help="Template file containing a papis format to list entries",
     default=None)
-@click.option(
+@papis.cli.bool_flag(
     "--downloaders",
-    help="List available downloaders",
-    default=False,
-    is_flag=True)
-@click.option(
+    help="List available downloaders")
+@papis.cli.bool_flag(
     "--libraries",
-    help="List defined libraries",
-    default=False,
-    is_flag=True)
+    help="List defined libraries")
 @papis.cli.all_option()
 @papis.cli.doc_folder_option()
 def cli(query: str,

--- a/papis/commands/merge.py
+++ b/papis/commands/merge.py
@@ -66,24 +66,17 @@ def run(keep: papis.document.Document,
 @click.help_option("-h", "--help")
 @papis.cli.query_argument()
 @papis.cli.sort_option()
-@click.option("-s",
-              "--second",
-              help="Keep the second document after merge and erase the first, "
-                   "the default is keep the first",
-              default=False,
-              is_flag=True)
-@click.option("-p",
-              "--pick",
-              help="If your picker does not support picking two documents"
-                   " at once, call twice the picker to get two documents",
-              default=False,
-              is_flag=True)
-@click.option("-k",
-              "--keep",
-              "keep_both",
-              help="Do not erase any document",
-              default=False,
-              is_flag=True)
+@papis.cli.bool_flag(
+    "-s", "--second",
+    help="Keep the second document after merge and erase the first, "
+         "the default is keep the first")
+@papis.cli.bool_flag(
+    "-p", "--pick",
+    help="If your picker does not support picking two documents"
+         " at once, call twice the picker to get two documents")
+@papis.cli.bool_flag(
+    "-k", "--keep", "keep_both",
+    help="Do not erase any document")
 @click.option("-o",
               "--out",
               help="Create the resulting document in this path",

--- a/papis/commands/open.py
+++ b/papis/commands/open.py
@@ -157,16 +157,11 @@ def run(document: papis.document.Document,
     "--tool",
     help="Tool for opening the file (opentool)",
     default="")
-@click.option(
-    "-d",
-    "--dir",
-    "folder",
-    help="Open directory",
-    default=False,
-    is_flag=True)
-@click.option(
-    "-m",
-    "--mark/--no-mark",
+@papis.cli.bool_flag(
+    "-d", "--dir", "folder",
+    help="Open directory")
+@papis.cli.bool_flag(
+    "-m", "--mark/--no-mark",
     help="Open mark",
     default=lambda: papis.config.getboolean("open-mark"))
 def cli(query: str, doc_folder: Tuple[str, ...], tool: str, folder: bool,

--- a/papis/commands/rm.py
+++ b/papis/commands/rm.py
@@ -76,21 +76,15 @@ def run(document: papis.document.Document,
 @papis.cli.git_option(help="Remove in git")
 @papis.cli.sort_option()
 @papis.cli.doc_folder_option()
-@click.option(
+@papis.cli.bool_flag(
     "--file", "_file",
-    help="Remove files from a document instead of the whole folder",
-    is_flag=True,
-    default=False)
-@click.option(
+    help="Remove files from a document instead of the whole folder")
+@papis.cli.bool_flag(
     "-n", "--notes", "_notes",
-    help="Remove the notes file from a document instead of the whole folder",
-    is_flag=True,
-    default=False)
-@click.option(
+    help="Remove the notes file from a document instead of the whole folder")
+@papis.cli.bool_flag(
     "-f", "--force",
-    help="Do not confirm removal",
-    is_flag=True,
-    default=False)
+    help="Do not confirm removal")
 @papis.cli.all_option()
 def cli(query: str,
         git: bool,

--- a/papis/commands/update.py
+++ b/papis/commands/update.py
@@ -86,10 +86,8 @@ def run(document: papis.document.Document,
 @papis.cli.doc_folder_option()
 @papis.cli.all_option()
 @papis.cli.sort_option()
-@click.option("--auto",
-              help="Try to parse information from different sources",
-              default=False,
-              is_flag=True)
+@papis.cli.bool_flag("--auto",
+                     help="Try to parse information from different sources")
 @click.option("--from", "from_importer",
               help="Add document from a specific importer ({})".format(
                   ", ".join(papis.importer.available_importers())
@@ -103,10 +101,8 @@ def run(document: papis.document.Document,
                    "The value can be a papis format.",
               multiple=True,
               type=(str, str),)
-@click.option(
-    "-b", "--batch",
-    help="Batch mode, do not prompt or otherwise",
-    default=False, is_flag=True)
+@papis.cli.bool_flag("-b", "--batch",
+                     help="Batch mode, do not prompt or otherwise")
 def cli(query: str,
         git: bool,
         doc_folder: Tuple[str, ...],


### PR DESCRIPTION
This tries to make issues like #634 less likely.

Just to add a bit of context: `click.option` based flags can have other values besides the boolean `True`/`False` and the default value is given by `flag_value`. If the `flag_value` is not provided, it is set to `not default`, which in the case where `default` is a callable is always false.

TO get around that, this adds a wrapper `papis.cli.bool_flag` specifically for boolean flags like we use throughout that always sets `flag_value`. Hopefully will make it less likely to hit an issue like that.