### PR TITLE
rtd: bump image to python 3.11

### DIFF
--- a/.readthedocs.yml
+++ b/.readthedocs.yml
@@ -4,9 +4,9 @@ sphinx:
   configuration: doc/source/conf.py
 
 build:
-  os: ubuntu-20.04
+  os: ubuntu-22.04
   tools:
-    python: "3.10"
+    python: "3.11"
 
 python:
   install:


### PR DESCRIPTION
The readthedocs builds have been failing recently:
https://readthedocs.org/projects/papis/builds/21604354/
Not quite sure what brought that on. From a bit of googling, the error seems to be due the `sphinx_rtd_theme` not supporting Sphinx v7, but those should be fixed and updated already.

This bumps the image used by RTD to the latest versions to see if that helps at all, but generally not sure what's going on :\