### PR TITLE
setup: add lower limit to sphinx-rtd-theme

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -122,7 +122,7 @@ setup(
             "python-coveralls",
             "python-lsp-server",
             "sphinx-click",
-            "sphinx_rtd_theme",
+            "sphinx-rtd-theme>=1",
             "types-PyYAML",
             "types-Pygments",
             "types-beautifulsoup4",


### PR DESCRIPTION
Another try at fixing the RTD build. From the logs
* passing: https://readthedocs.org/api/v2/build/21470845.txt
* failing: https://readthedocs.org/api/v2/build/21604657.txt

it seems like it's not installing a newer `sphinx-rtd-theme` anymore. This forces a newer version in the hopes that it will download it again.