### PR TITLE
Merge importers data

### DIFF
--- a/papis/commands/add.py
+++ b/papis/commands/add.py
@@ -537,11 +537,6 @@ def run(paths: List[str],
 @papis.cli.bool_flag(
     "--list-importers", "--li", "list_importers",
     help="List all available papis importers")
-@click.option(
-    "--merge-data", "-m",
-    help="Merge the data from all importers to pickup desired fields at once. "
-         "Take one argument: set the nth importer overwriting the others data.",
-    default=None)
 @papis.cli.bool_flag(
     "--force-download", "--fd", "force_download",
     help="Download file with importer even if local file is passed")
@@ -563,7 +558,6 @@ def cli(files: List[str],
         git: bool,
         link: bool,
         list_importers: bool,
-        merge_data: bool,
         force_download: bool,
         fetch_citations: bool) -> None:
     """
@@ -614,7 +608,7 @@ def cli(files: List[str],
             matching_importers = [matching_importers[i] for i in matching_indices]
 
     imported = papis.utils.collect_importer_data(
-        matching_importers, batch=batch, only_data=only_data, merge_data=merge_data)
+        matching_importers, batch=batch, only_data=only_data)
     ctx.data.update(imported.data)
     ctx.files.extend(imported.files)
 

--- a/papis/commands/add.py
+++ b/papis/commands/add.py
@@ -537,11 +537,6 @@ def run(paths: List[str],
 @papis.cli.bool_flag(
     "--list-importers", "--li", "list_importers",
     help="List all available papis importers")
-@click.option(
-    "--merge-data", "-m",
-    help="Merge the data from all importers to pickup desired fields at once. "
-         "Take one argument: set the nth importer overwriting the others data.",
-    default=None)
 @papis.cli.bool_flag(
     "--force-download", "--fd", "force_download",
     help="Download file with importer even if local file is passed")
@@ -563,7 +558,6 @@ def cli(files: List[str],
         git: bool,
         link: bool,
         list_importers: bool,
-        merge_data: str,
         force_download: bool,
         fetch_citations: bool) -> None:
     """
@@ -614,7 +608,7 @@ def cli(files: List[str],
             matching_importers = [matching_importers[i] for i in matching_indices]
 
     imported = papis.utils.collect_importer_data(
-        matching_importers, batch=batch, only_data=only_data, merge_data=merge_data)
+        matching_importers, batch=batch, only_data=only_data)
     ctx.data.update(imported.data)
     ctx.files.extend(imported.files)
 

--- a/papis/commands/add.py
+++ b/papis/commands/add.py
@@ -537,6 +537,11 @@ def run(paths: List[str],
 @papis.cli.bool_flag(
     "--list-importers", "--li", "list_importers",
     help="List all available papis importers")
+@click.option(
+    "--merge-data", "-m",
+    help="Merge the data from all importers to pickup desired fields at once. "
+         "Take one argument: set the nth importer overwriting the others data.",
+    default=None)
 @papis.cli.bool_flag(
     "--force-download", "--fd", "force_download",
     help="Download file with importer even if local file is passed")
@@ -558,6 +563,7 @@ def cli(files: List[str],
         git: bool,
         link: bool,
         list_importers: bool,
+        merge_data: str,
         force_download: bool,
         fetch_citations: bool) -> None:
     """
@@ -608,7 +614,7 @@ def cli(files: List[str],
             matching_importers = [matching_importers[i] for i in matching_indices]
 
     imported = papis.utils.collect_importer_data(
-        matching_importers, batch=batch, only_data=only_data)
+        matching_importers, batch=batch, only_data=only_data, merge_data=merge_data)
     ctx.data.update(imported.data)
     ctx.files.extend(imported.files)
 

--- a/papis/commands/add.py
+++ b/papis/commands/add.py
@@ -563,7 +563,7 @@ def cli(files: List[str],
         git: bool,
         link: bool,
         list_importers: bool,
-        merge_data: str,
+        merge_data: bool,
         force_download: bool,
         fetch_citations: bool) -> None:
     """

--- a/papis/commands/add.py
+++ b/papis/commands/add.py
@@ -543,6 +543,11 @@ def run(paths: List[str],
     default=False,
     is_flag=True)
 @click.option(
+    "--merge-data", "-m",
+    help="Merge the data from all importers to pickup desired fields at once. "
+         "Take one argument: set the nth importer overwriting the others data.",
+    default=None)
+@click.option(
     "--force-download", "--fd", "force_download",
     help="Download file with importer even if local file is passed",
     default=False,
@@ -567,6 +572,7 @@ def cli(files: List[str],
         link: bool,
         list_importers: bool,
         force_download: bool,
+        merge_data: str,
         fetch_citations: bool) -> None:
     """
     Command line interface for papis-add.
@@ -616,7 +622,7 @@ def cli(files: List[str],
             matching_importers = [matching_importers[i] for i in matching_indices]
 
     imported = papis.utils.collect_importer_data(
-        matching_importers, batch=batch, only_data=only_data)
+        matching_importers, batch=batch, only_data=only_data, merge_data=merge_data)
     ctx.data.update(imported.data)
     ctx.files.extend(imported.files)
 

--- a/papis/commands/add.py
+++ b/papis/commands/add.py
@@ -493,11 +493,9 @@ def run(paths: List[str],
     "-d", "--subfolder",
     help="Subfolder in the library",
     default=lambda: papis.config.getstring("add-subfolder"))
-@click.option(
+@papis.cli.bool_flag(
     "-p", "--pick-subfolder",
-    help="Pick from existing subfolders",
-    is_flag=True,
-    default=False)
+    help="Pick from existing subfolders")
 @click.option(
     "--folder-name",
     help="Name for the document's folder (papis format)",
@@ -515,10 +513,9 @@ def run(paths: List[str],
     nargs=2,
     multiple=True,
     default=(),)
-@click.option(
+@papis.cli.bool_flag(
     "-b", "--batch",
-    help="Batch mode, do not prompt or otherwise",
-    default=False, is_flag=True)
+    help="Batch mode, do not prompt or otherwise")
 @click.option(
     "--confirm/--no-confirm",
     help="Ask to confirm before adding to the collection",
@@ -537,26 +534,21 @@ def run(paths: List[str],
          "its original location",
     default=False)
 @papis.cli.git_option(help="Git add and commit the new document")
-@click.option(
+@papis.cli.bool_flag(
     "--list-importers", "--li", "list_importers",
-    help="List all available papis importers",
-    default=False,
-    is_flag=True)
+    help="List all available papis importers")
 @click.option(
     "--merge-data", "-m",
     help="Merge the data from all importers to pickup desired fields at once. "
          "Take one argument: set the nth importer overwriting the others data.",
     default=None)
-@click.option(
+@papis.cli.bool_flag(
     "--force-download", "--fd", "force_download",
-    help="Download file with importer even if local file is passed",
-    default=False,
-    is_flag=True)
-@click.option("--fetch-citations",
-              help="Fetch citations from doi",
-              default=lambda: papis.config.getboolean("add-fetch-citations"),
-              flag_value=True,
-              is_flag=True)
+    help="Download file with importer even if local file is passed")
+@papis.cli.bool_flag(
+    "--fetch-citations",
+    help="Fetch citations from a DOI (Digital Object Identifier)",
+    default=lambda: papis.config.getboolean("add-fetch-citations"))
 def cli(files: List[str],
         set_list: List[Tuple[str, str]],
         subfolder: str,
@@ -571,8 +563,8 @@ def cli(files: List[str],
         git: bool,
         link: bool,
         list_importers: bool,
-        force_download: bool,
         merge_data: str,
+        force_download: bool,
         fetch_citations: bool) -> None:
     """
     Command line interface for papis-add.

--- a/papis/tui/widgets/diff.py
+++ b/papis/tui/widgets/diff.py
@@ -1,5 +1,5 @@
 from typing import (
-    Dict, Any, List, Union, Tuple, NamedTuple, Callable, Optional)
+    Dict, Any, List, Tuple, NamedTuple, Callable, Optional)
 
 from prompt_toolkit import Application, print_formatted_text
 from prompt_toolkit.layout.containers import HSplit, Window, WindowAlign
@@ -251,7 +251,7 @@ def diffmerge_format_text(key: str,
                           idx: int,
                           defval: int,
                           alt_color: Optional[str] = None,
-                          ) ->Tuple[str, str]:
+                          ) -> Tuple[str, str]:
     """
     Set the text color for diffmerge.
     """

--- a/papis/tui/widgets/diff.py
+++ b/papis/tui/widgets/diff.py
@@ -11,6 +11,7 @@ from prompt_toolkit.key_binding import KeyBindings, KeyPressEvent
 # Needed for diffmerge
 import ast
 
+
 class Action(NamedTuple):
     name: str
     key: str
@@ -245,12 +246,12 @@ def diffdict(dicta: Dict[str, Any],
 
 
 # Maybe we could set user settings to choose the colors...
-def diffmerge_format_text (key: str,
-                           value: str,
-                           idx: int,
-                           defval: int,
-                           alt_color: Optional[str] = None,
-                           ) ->Tuple[str, str]:
+def diffmerge_format_text(key: str,
+                          value: str,
+                          idx: int,
+                          defval: int,
+                          alt_color: Optional[str] = None,
+                          ) ->Tuple[str, str]:
     """
     Set the text color for diffmerge.
     """
@@ -265,7 +266,6 @@ def diffmerge_format_text (key: str,
         color = "fg:ansired bg:ansiblack"
 
     return (color, text)
-
 
 
 def diffmerge_add_all(merged: Dict[str, Any], merge_opt: str) -> Dict[str, Any]:
@@ -287,6 +287,7 @@ def diffmerge_add_all(merged: Dict[str, Any], merge_opt: str) -> Dict[str, Any]:
             pass
 
     return rdict
+
 
 def diffmerge(merged: Dict[str, Any], merge_opt: str, batch: bool) -> Dict[str, Any]:
     """
@@ -321,9 +322,9 @@ def diffmerge(merged: Dict[str, Any], merge_opt: str, batch: bool) -> Dict[str, 
         for k in options:
             options[k] = False
 
-    def oset(event: Event, option: str, value: bool) -> None:
+    def oset(event: KeyPressEvent, option: str, value: bool) -> None:
         options[option] = value
-        event.app.exit(0)
+        event.app.exit(result=0)
 
     actions = [
         Action(
@@ -349,9 +350,9 @@ def diffmerge(merged: Dict[str, Any], merge_opt: str, batch: bool) -> Dict[str, 
         for i, v in enumerate(value, start=1):
             show_all.append(diffmerge_format_text(key, v, i, defval))
 
-    prompt(title="--- Merge view: "  + " ---",
-       text=show_all,
-       actions=actions)
+    prompt(title="--- Merge view: " + " ---",
+           text=show_all,
+           actions=actions)
 
     if options["cancel"] or options["quit"]:
         return {}
@@ -387,9 +388,9 @@ def diffmerge(merged: Dict[str, Any], merge_opt: str, batch: bool) -> Dict[str, 
             # 2) the new value to add or reject
             show_selected.append(diffmerge_format_text(key, v, i, defval, "yellow"))
 
-            prompt(title="--- Pick fields values : "  + " ---",
-               text=show_selected,
-               actions=actions)
+            prompt(title="--- Pick fields values : " + " ---",
+                   text=show_selected,
+                   actions=actions)
 
             if options["cancel"]:
                 return {}

--- a/papis/tui/widgets/diff.py
+++ b/papis/tui/widgets/diff.py
@@ -18,7 +18,7 @@ class Action(NamedTuple):
     action: Callable[[KeyPressEvent], None]
 
 
-def prompt(text: Union[str, FormattedText] | List[Tuple[str, str]],
+def prompt(text,
            title: str = "",
            actions: Optional[List[Action]] = None,
            **kwargs: Any

--- a/papis/tui/widgets/diff.py
+++ b/papis/tui/widgets/diff.py
@@ -18,7 +18,7 @@ class Action(NamedTuple):
     action: Callable[[KeyPressEvent], None]
 
 
-def prompt(text: Union[str, FormattedText],
+def prompt(text: Union[str, FormattedText] | List[Tuple[str, str]],
            title: str = "",
            actions: Optional[List[Action]] = None,
            **kwargs: Any

--- a/papis/utils.py
+++ b/papis/utils.py
@@ -616,10 +616,10 @@ def collect_importer_data(
 
     if merge_data:
         merged = papis.utils.merge_importers_data(merged_data)
-        ctxdata = papis.utils.update_doc_from_merged_data_interactively(merged,
-                                                                        merge_data,
-                                                                        batch)
-
+        if merged and isinstance(merged, dict):
+            ctxdata = papis.utils.update_doc_from_merged_data_interactively(merged,
+                                                                            merge_data,
+                                                                            batch)
         if ctxdata:
             ctx.data.update(ctxdata)
 

--- a/papis/utils.py
+++ b/papis/utils.py
@@ -395,6 +395,33 @@ def update_doc_from_data_interactively(
                     namea=papis.document.describe(document),
                     nameb=data_name))
 
+def update_doc_from_merged_data_interactively(
+        document: Union[papis.document.Document, Dict[str, Any]],
+        merge_opt: str,
+        batch: bool = True,
+        ) -> None:
+    """Shows a TUI to update the *document* interactively with fields from *data*.
+
+    :param document: a document (or a mapping convertible to a document) which
+        is going to be updated.
+    :param data_name: an identifier for the *data* to show in the TUI.
+    """
+    # Remove param data??
+
+    import copy
+    docdata = copy.copy(document)
+
+    import papis.tui.widgets.diff
+    # do not compare some entries
+    docdata.pop("files", None)
+    docdata.pop("tags", None)
+
+    add_data = papis.tui.widgets.diff.diffmerge(docdata, merge_opt, batch=batch)
+
+    if add_data:
+        document.update(add_data)
+        return document
+
 
 def get_cache_home() -> str:
     """Get default cache directory.
@@ -516,10 +543,35 @@ def get_matching_importer_by_name(
     return result
 
 
+def merge_importers_data(all_data: Iterable[Tuple[str, ...]]) -> None:
+    """Merge the data from all the importers selected
+
+    :all_data: combined data from all the selected importers
+    """
+    import papis.tui.widgets.diff
+
+    mdict = {}
+
+    # all_data = raw merged data of all importers/downloaders
+    for dic in all_data:
+        keys = dic.keys()
+        # mdict discards dupplicates values
+        # use str() to normalize comparisons
+        for key in keys:
+            if key in mdict:
+                if not str(dic[key]) in mdict[key]:
+                    mdict[key].append(str(dic[key]))
+            else:
+                mdict[key] = [str(dic[key])]
+
+    return mdict
+
+
 def collect_importer_data(
         importers: Iterable[papis.importer.Importer],
         batch: bool = True,
         only_data: bool = True,
+        merge_data: str = None,
         ) -> papis.importer.Context:
     """Collect all data from the given *importers*.
 
@@ -535,10 +587,14 @@ def collect_importer_data(
     if not importers:
         return ctx
 
+    merged_data = []
+
     for importer in importers:
         if importer.ctx.data:
             logger.info("Merging data from importer '%s'.", importer.name)
-            if batch:
+            if merge_data:
+                merged_data.append(importer.ctx.data)
+            elif batch:
                 ctx.data.update(importer.ctx.data)
             else:
                 papis.utils.update_doc_from_data_interactively(
@@ -556,6 +612,13 @@ def collect_importer_data(
                 papis.utils.open_file(f)
                 if batch or papis.tui.utils.confirm(msg):
                     ctx.files.append(f)
+
+    if merge_data:
+        merged = papis.utils.merge_importers_data(merged_data)
+        ctxdata = papis.utils.update_doc_from_merged_data_interactively(merged, merge_data, batch)
+
+        if ctxdata:
+            ctx.data.update(ctxdata)
 
     return ctx
 

--- a/papis/utils.py
+++ b/papis/utils.py
@@ -572,7 +572,7 @@ def collect_importer_data(
         importers: Iterable[papis.importer.Importer],
         batch: bool = True,
         only_data: bool = True,
-        merge_data: Union[str, None],
+        merge_data: str = "",
         ) -> papis.importer.Context:
     """Collect all data from the given *importers*.
 

--- a/papis/utils.py
+++ b/papis/utils.py
@@ -549,19 +549,21 @@ def merge_importers_data(all_data: Iterable[Tuple[str, ...]]) -> None:
 
     :all_data: combined data from all the selected importers
     """
+    # mdict: Dict[str, list]
     mdict = {}
 
     # all_data = raw merged data of all importers/downloaders
     for dic in all_data:
-        keys = dic.keys()
-        # mdict discards dupplicates values
-        # use str() to normalize comparisons
-        for key in keys:
-            if key in mdict:
-                if not str(dic[key]) in mdict[key]:
-                    mdict[key].append(str(dic[key]))
-            else:
-                mdict[key] = [str(dic[key])]
+        if isinstance(dic, dict):
+            keys = dic.keys()
+            # mdict discards dupplicates values
+            # use str() to normalize comparisons
+            for key in keys:
+                if key in mdict:
+                    if not str(dic[key]) in mdict[key]:
+                        mdict[key].append(str(dic[key]))
+                else:
+                    mdict[key] = [str(dic[key])]
 
     return mdict
 

--- a/papis/utils.py
+++ b/papis/utils.py
@@ -572,7 +572,7 @@ def collect_importer_data(
         importers: Iterable[papis.importer.Importer],
         batch: bool = True,
         only_data: bool = True,
-        merge_data: str(),
+        merge_data: Union[str, None],
         ) -> papis.importer.Context:
     """Collect all data from the given *importers*.
 

--- a/papis/utils.py
+++ b/papis/utils.py
@@ -572,7 +572,7 @@ def collect_importer_data(
         importers: Iterable[papis.importer.Importer],
         batch: bool = True,
         only_data: bool = True,
-        merge_data: str = None,
+        merge_data: str(),
         ) -> papis.importer.Context:
     """Collect all data from the given *importers*.
 

--- a/papis/utils.py
+++ b/papis/utils.py
@@ -620,8 +620,8 @@ def collect_importer_data(
             ctxdata = papis.utils.update_doc_from_merged_data_interactively(merged,
                                                                             merge_data,
                                                                             batch)
-        if ctxdata:
-            ctx.data.update(ctxdata)
+            if ctxdata:
+                ctx.data.update(ctxdata)
 
     return ctx
 

--- a/papis/utils.py
+++ b/papis/utils.py
@@ -395,6 +395,7 @@ def update_doc_from_data_interactively(
                     namea=papis.document.describe(document),
                     nameb=data_name))
 
+
 def update_doc_from_merged_data_interactively(
         document: Union[papis.document.Document, Dict[str, Any]],
         merge_opt: str,
@@ -548,8 +549,6 @@ def merge_importers_data(all_data: Iterable[Tuple[str, ...]]) -> None:
 
     :all_data: combined data from all the selected importers
     """
-    import papis.tui.widgets.diff
-
     mdict = {}
 
     # all_data = raw merged data of all importers/downloaders
@@ -615,7 +614,9 @@ def collect_importer_data(
 
     if merge_data:
         merged = papis.utils.merge_importers_data(merged_data)
-        ctxdata = papis.utils.update_doc_from_merged_data_interactively(merged, merge_data, batch)
+        ctxdata = papis.utils.update_doc_from_merged_data_interactively(merged,
+                                                                        merge_data,
+                                                                        batch)
 
         if ctxdata:
             ctx.data.update(ctxdata)

--- a/tests/downloaders/test_sciencedirect.py
+++ b/tests/downloaders/test_sciencedirect.py
@@ -9,6 +9,7 @@ from tests.testlib import TemporaryConfiguration, ResourceCache
 SCIENCE_DIRECT_URLS = (
     "https://www.sciencedirect.com/science/article/abs/pii/S0009261497040141",
     "https://www.sciencedirect.com/science/article/abs/pii/S2210271X18305656",
+    "https://www.sciencedirect.com/science/article/pii/S146290112300117X",
     )
 
 


### PR DESCRIPTION
The main goal:
  - when selecting several importers/downloaders (Select matching importers (for instance 0, 1, 3-10, a, all...) ...), avoid to has to pick the fields we want to add/reject for each downloader. 

The `diffdict` function only deals with two importers, making a comparison of each other. The `diffmerge` function now can merge as many as importers we can imagine. It discards duplicates to get a clean dictionary listing only the unique values.
When a key has different values from different downloaders, we can pick the one we want.

Personally, I think this way is clearer and faster thant the actual build-in `diffdict` function. 