### PR TITLE
commands.doctor: use click.pause instead of input

### DIFF
--- a/papis/commands/doctor.py
+++ b/papis/commands/doctor.py
@@ -617,5 +617,5 @@ def cli(query: str,
             error.fix_action()
 
         if edit and error.doc:
-            input("Press any key to edit...")
+            click.pause("Press any key to edit...")
             edit_run(error.doc)


### PR DESCRIPTION
`input` only stops on Enter while `click.pause` stops on any key pressed.