### PR TITLE
Modernize using pyupgrade

### DIFF
--- a/papis/api.py
+++ b/papis/api.py
@@ -191,7 +191,7 @@ def get_documents_in_lib(
     elif isinstance(search, dict):
         return db.query_dict(search)
     else:
-        raise TypeError("Unknown search parameter: '{}'".format(search))
+        raise TypeError(f"Unknown search parameter: '{search}'")
 
 
 def clear_lib_cache(lib: Optional[str] = None) -> None:

--- a/papis/arxiv.py
+++ b/papis/arxiv.py
@@ -61,7 +61,7 @@ def get_data(
     result = []
     clean_params = {x: dict_params[x] for x in dict_params if dict_params[x]}
     search_query = "+AND+".join(
-        ["{}:{}".format(key, clean_params[key]) for key in clean_params]
+        [f"{key}:{clean_params[key]}" for key in clean_params]
     )
     logger.debug("Performing query: '%s'.", search_query)
 
@@ -100,7 +100,7 @@ def get_data(
 
 def validate_arxivid(arxivid: str) -> None:
     with papis.utils.get_session() as session:
-        response = session.get("{}/{}".format(ARXIV_ABS_URL, arxivid))
+        response = session.get(f"{ARXIV_ABS_URL}/{arxivid}")
 
     if not response.ok:
         raise ValueError(
@@ -233,7 +233,7 @@ class Downloader(papis.downloaders.Downloader):
     def match(cls, url: str) -> Optional[papis.downloaders.Downloader]:
         arxivid = find_arxivid_in_text(url)
         if arxivid:
-            url = "{}/{}".format(ARXIV_ABS_URL, arxivid)
+            url = f"{ARXIV_ABS_URL}/{arxivid}"
             down = Downloader(url)
             down._arxivid = arxivid
             return down
@@ -264,7 +264,7 @@ class Downloader(papis.downloaders.Downloader):
         if not arxivid:
             return None
 
-        pdf_url = "{}/{}.pdf".format(ARXIV_PDF_URL, arxivid)
+        pdf_url = f"{ARXIV_PDF_URL}/{arxivid}.pdf"
         self.logger.debug("Using document URL: '%s'.", pdf_url)
 
         return pdf_url
@@ -281,7 +281,7 @@ class Importer(papis.importer.Importer):
         except ValueError:
             aid = find_arxivid_in_text(uri)
 
-        uri = "{}/{}".format(ARXIV_ABS_URL, aid)
+        uri = f"{ARXIV_ABS_URL}/{aid}"
 
         super().__init__(name="arxiv", uri=uri)
         self.downloader = Downloader(uri)
@@ -291,14 +291,14 @@ class Importer(papis.importer.Importer):
     def match(cls, uri: str) -> Optional[papis.importer.Importer]:
         arxivid = find_arxivid_in_text(uri)
         if arxivid:
-            return Importer(uri="{}/{}".format(ARXIV_ABS_URL, arxivid))
+            return Importer(uri=f"{ARXIV_ABS_URL}/{arxivid}")
 
         try:
             validate_arxivid(uri)
         except ValueError:
             return None
         else:
-            return Importer(uri="{}/{}".format(ARXIV_ABS_URL, uri))
+            return Importer(uri=f"{ARXIV_ABS_URL}/{uri}")
 
     @property
     def arxivid(self) -> Optional[str]:

--- a/papis/arxiv.py
+++ b/papis/arxiv.py
@@ -178,12 +178,12 @@ def find_arxivid_in_text(text: str) -> Optional[str]:
 @click.option("--category", default="", type=str)
 @click.option("--id-list", default="", type=str)
 @click.option("--page", default=0, type=int)
-@click.option("--max", "-m", default=20, type=int)
+@click.option("--max", "-m", "max_results", default=20, type=int)
 def explorer(
         ctx: click.core.Context,
         query: str, author: str, title: str, abstract: str, comment: str,
         journal: str, report_number: str, category: str, id_list: str,
-        page: int, max: int) -> None:
+        page: int, max_results: int) -> None:
     """
     Look for documents on `arXiv.org <arxiv.org/>`__.
 
@@ -216,7 +216,7 @@ def explorer(
         category=category,
         id_list=id_list,
         page=page or 0,
-        max_results=max)
+        max_results=max_results)
     docs = [papis.document.from_data(data=d) for d in data]
     ctx.obj["documents"] += docs
 

--- a/papis/bibtex.py
+++ b/papis/bibtex.py
@@ -2915,8 +2915,8 @@ def unicode_to_latex(text: str) -> str:
     #    u"\u2AC6\u0338": r"\nsupseteqq",
     #    u"\u2AFD\u20E5": r"{\rlap{\textbackslash}{{/}\!\!{/}}}",
 
-    unicode_to_latex_table = dict(
-        (ord(k), v)
+    unicode_to_latex_table = {
+        ord(k): v
         for k, v in unicode_to_latex_table_base.items()
-    )
+    }
     return text.translate(unicode_to_latex_table)

--- a/papis/bibtex.py
+++ b/papis/bibtex.py
@@ -438,7 +438,7 @@ def to_bibtex(document: papis.document.Document, *, indent: int = 2) -> str:
     # process keys
     supports_unicode = papis.config.getboolean("bibtex-unicode")
     journal_key = papis.config.getstring("bibtex-journal-key")
-    lines = ["{}".format(ref)]
+    lines = [f"{ref}"]
 
     for key in sorted(document):
         bib_key = bibtex_key_converter.get(key, key)
@@ -464,7 +464,7 @@ def to_bibtex(document: papis.document.Document, *, indent: int = 2) -> str:
         if not supports_unicode:
             bib_value = unicode_to_latex(bib_value)
 
-        lines.append("{} = {{{}}}".format(bib_key, bib_value))
+        lines.append(f"{bib_key} = {{{bib_value}}}")
 
     # Handle file for zotero exporting
     if (papis.config.getboolean("bibtex-export-zotero-file")

--- a/papis/cli.py
+++ b/papis/cli.py
@@ -86,11 +86,11 @@ def all_option(**attrs: Any) -> DecoratorCallable:
 
 def git_option(**attrs: Any) -> DecoratorCallable:
     """Adds a ``--git`` option as a :mod:`click` decorator."""
-    help = attrs.pop("help", "Commit changes to git")
+    git_help = attrs.pop("help", "Commit changes to git")
     return bool_flag(
         "--git/--no-git",
         default=lambda: bool(papis.config.get("use-git")),
-        help=help,
+        help=git_help,
         **attrs)
 
 

--- a/papis/commands/__init__.py
+++ b/papis/commands/__init__.py
@@ -79,7 +79,7 @@ class AliasedGroup(click.core.Group):
             return None
         if len(matches) == 1:
             return click.core.Group.get_command(self, ctx, str(matches[0]))
-        ctx.fail("Too many matches: {}".format(matches))
+        ctx.fail(f"Too many matches: {matches}")
         return None
 
 

--- a/papis/commands/add.py
+++ b/papis/commands/add.py
@@ -194,7 +194,7 @@ def get_file_name(
 
     # Remove extension from file_name_base, if any
     file_name_base = re.sub(
-        r"([.]{})?$".format(ext),
+        fr"([.]{ext})?$",
         "",
         file_name_base
     )
@@ -208,7 +208,7 @@ def get_file_name(
     )
 
     # Adding the recognised extension
-    return "{}.{}".format(filename_basename, ext)
+    return f"{filename_basename}.{ext}"
 
 
 def get_hash_folder(data: Dict[str, Any], document_paths: List[str]) -> str:
@@ -249,7 +249,7 @@ def ensure_new_folder(path: str) -> str:
 
     new_path = path
     while os.path.exists(new_path):
-        new_path = "{}-{}".format(path, next(suffix))
+        new_path = f"{path}-{next(suffix)}"
 
     return new_path
 
@@ -301,7 +301,7 @@ def run(paths: List[str],
 
     for p in in_documents_paths:
         if not os.path.exists(p):
-            raise FileNotFoundError("File '{}' not found".format(p))
+            raise FileNotFoundError(f"File '{p}' not found")
 
     in_documents_names = [
         papis.utils.clean_document_name(doc_path)

--- a/papis/commands/addto.py
+++ b/papis/commands/addto.py
@@ -71,7 +71,7 @@ def run(document: papis.document.Document,
             local_in_file_path = in_file_path
 
         if not os.path.exists(local_in_file_path):
-            raise FileNotFoundError("File '{}' not found".format(in_file_path))
+            raise FileNotFoundError(f"File '{in_file_path}' not found")
 
         # Rename the file in the staging area
         new_filename = get_file_name(

--- a/papis/commands/bibtex.py
+++ b/papis/commands/bibtex.py
@@ -383,9 +383,9 @@ def _save(ctx: click.Context, bibfile: str, force: bool) -> None:
 def _sort(ctx: click.Context, key: Optional[str], reverse: bool) -> None:
     """Sort the documents in the BibTeX file."""
     docs = ctx.obj["documents"]
-    ctx.obj["documents"] = list(sorted(docs,
-                                       key=lambda d: str(d[key]),
-                                       reverse=reverse))
+    ctx.obj["documents"] = sorted(docs,
+                                  key=lambda d: str(d[key]),
+                                  reverse=reverse)
 
 
 @cli.command("unique")

--- a/papis/commands/config.py
+++ b/papis/commands/config.py
@@ -106,7 +106,7 @@ def parse_option(
         section = parts[0] if parts[0] else None
         key = parts[1]
     else:
-        raise ValueError("Unsupported option format: '{}'".format(option))
+        raise ValueError(f"Unsupported option format: '{option}'")
 
     return section, key
 
@@ -252,13 +252,13 @@ def cli(options: List[str],
                     lines.append("")
 
                 is_first = False
-                lines.append("[{}]".format(section))
+                lines.append(f"[{section}]")
 
                 for key, value in settings.items():
                     lines.append(format_option(key, value))
         else:
             if section is not None and all("." not in o for o in options):
-                lines.append("[{}]".format(section))
+                lines.append(f"[{section}]")
 
             for key, value in result.items():
                 lines.append(format_option(key, value))

--- a/papis/commands/default.py
+++ b/papis/commands/default.py
@@ -87,11 +87,11 @@ class ScriptLoaderGroup(click.Group):
                 click.echo("Command '{name}' is unknown! Did you mean '{matches}'?"
                            .format(name=name, matches="' or '".join(matches)))
             else:
-                click.echo("Command '{name}' is unknown!".format(name=name))
+                click.echo(f"Command '{name}' is unknown!")
 
             # return the match if there was only one match
             if len(matches) == 1:
-                click.echo("I suppose you meant: '{}'".format(matches[0]))
+                click.echo(f"I suppose you meant: '{matches[0]}'")
                 script = self.scripts[matches[0]]
             else:
                 return None
@@ -222,9 +222,9 @@ def run(verbose: bool,
 
     if not library.paths:
         raise RuntimeError(
-            "Library '{}' does not have any existing folders attached to it. "
+            f"Library '{lib}' does not have any existing folders attached to it. "
             "Please define and create the paths in the configuration file"
-            .format(lib))
+            )
 
     # Now the library should be set, let us check if there is a
     # local configuration file there, and if there is one, then

--- a/papis/commands/doctor.py
+++ b/papis/commands/doctor.py
@@ -194,8 +194,8 @@ def files_check(doc: papis.document.Document) -> List[Error]:
 
     return [Error(name=FILES_CHECK_NAME,
                   path=folder,
-                  msg="File '{}' declared but does not exist".format(f),
-                  suggestion_cmd="papis edit --doc-folder {}".format(folder),
+                  msg=f"File '{f}' declared but does not exist",
+                  suggestion_cmd=f"papis edit --doc-folder {folder}",
                   fix_action=make_fixer(f),
                   payload=f,
                   doc=doc)
@@ -217,8 +217,8 @@ def keys_exist_check(doc: papis.document.Document) -> List[Error]:
 
     return [Error(name=KEYS_EXIST_CHECK_NAME,
                   path=folder,
-                  msg="Key '{}' does not exist.".format(k),
-                  suggestion_cmd="papis edit --doc-folder {}".format(folder),
+                  msg=f"Key '{k}' does not exist.",
+                  suggestion_cmd=f"papis edit --doc-folder {folder}",
                   fix_action=lambda: None,
                   payload=k,
                   doc=doc)
@@ -269,8 +269,7 @@ def refs_check(doc: papis.document.Document) -> List[Error]:
         return [Error(name=REFS_CHECK_NAME,
                       path=folder,
                       msg="Reference missing.",
-                      suggestion_cmd=("papis edit --doc-folder {}"
-                                      .format(folder)),
+                      suggestion_cmd=f"papis edit --doc-folder {folder}",
                       fix_action=create_ref_fixer,
                       payload="ref",
                       doc=doc)]
@@ -279,8 +278,8 @@ def refs_check(doc: papis.document.Document) -> List[Error]:
     if m:
         return [Error(name=REFS_CHECK_NAME,
                       path=folder,
-                      msg="Bad characters ({}) found in reference.".format(set(m)),
-                      suggestion_cmd="papis edit --doc-folder {}".format(folder),
+                      msg=f"Bad characters ({set(m)}) found in reference.",
+                      suggestion_cmd=f"papis edit --doc-folder {folder}",
                       fix_action=clean_ref_fixer,
                       payload="ref",
                       doc=doc)]
@@ -317,8 +316,8 @@ def duplicated_keys_check(doc: papis.document.Document) -> List[Error]:
 
         results.append(Error(name=DUPLICATED_KEYS_NAME,
                              path=folder,
-                             msg="Key '{}' is duplicated ({}).".format(key, value),
-                             suggestion_cmd="papis edit {}:'{}'".format(key, value),
+                             msg=f"Key '{key}' is duplicated ({value}).",
+                             suggestion_cmd=f"papis edit {key}:'{value}'",
                              fix_action=lambda: None,
                              payload=key,
                              doc=doc))
@@ -344,7 +343,7 @@ def bibtex_type_check(doc: papis.document.Document) -> List[Error]:
         return [Error(name=BIBTEX_TYPE_CHECK_NAME,
                       path=folder,
                       msg="Document does not define a type.",
-                      suggestion_cmd="papis edit --doc-folder {}".format(folder),
+                      suggestion_cmd=f"papis edit --doc-folder {folder}",
                       fix_action=lambda: None,
                       payload="type",
                       doc=doc)]
@@ -352,9 +351,8 @@ def bibtex_type_check(doc: papis.document.Document) -> List[Error]:
     if bib_type not in papis.bibtex.bibtex_types:
         return [Error(name=BIBTEX_TYPE_CHECK_NAME,
                       path=folder,
-                      msg=("Document type '{}' is not a valid BibTeX type."
-                           .format(bib_type)),
-                      suggestion_cmd="papis edit --doc-folder {}".format(folder),
+                      msg=f"Document type '{bib_type}' is not a valid BibTeX type.",
+                      suggestion_cmd=f"papis edit --doc-folder {folder}",
                       fix_action=lambda: None,
                       payload=bib_type,
                       doc=doc)]
@@ -397,12 +395,10 @@ def key_type_check(doc: papis.document.Document) -> List[Error]:
         if doc_value is not None and not isinstance(doc_value, cls):
             results.append(Error(name=KEY_TYPE_CHECK_NAME,
                                  path=folder,
-                                 msg=("Key '{}' ({}) should be of type '{}'"
-                                      " but found '{}'"
-                                      .format(key, doc_value,
-                                              cls, type(doc_value).__name__)),
-                                 suggestion_cmd=("papis edit --doc-folder {}"
-                                                 .format(folder)),
+                                 msg=(
+                                     f"Key '{key}' ({doc_value}) should be of type "
+                                     f"'{cls}' but got '{type(doc_value).__name__}'."),
+                                 suggestion_cmd=f"papis edit --doc-folder {folder}",
                                  fix_action=lambda: None,
                                  payload=key,
                                  doc=doc))
@@ -445,10 +441,8 @@ def html_codes_check(doc: papis.document.Document) -> List[Error]:
         if m:
             results.append(Error(name=HTML_CODES_CHECK_NAME,
                                  path=folder,
-                                 msg=("Field '{}' contains HTML codes {}"
-                                      .format(key, m)),
-                                 suggestion_cmd=(
-                                     "papis edit --doc-folder {}".format(folder)),
+                                 msg=f"Field '{key}' contains HTML codes {m}",
+                                 suggestion_cmd=f"papis edit --doc-folder {folder}",
                                  fix_action=make_fixer(key),
                                  payload=key,
                                  doc=doc))
@@ -497,10 +491,8 @@ def html_tags_check(doc: papis.document.Document) -> List[Error]:
         if m:
             results.append(Error(name=HTML_TAGS_CHECK_NAME,
                                  path=folder,
-                                 msg=("Field '{}' contains HTML tags: {}"
-                                      .format(key, m)),
-                                 suggestion_cmd=(
-                                     "papis edit --doc-folder {}".format(folder)),
+                                 msg=f"Field '{key}' contains HTML tags: {m}",
+                                 suggestion_cmd=f"papis edit --doc-folder {folder}",
                                  fix_action=make_fixer(key),
                                  payload=key,
                                  doc=doc))
@@ -605,13 +597,13 @@ def cli(query: str,
     from papis.commands.edit import run as edit_run
 
     for error in errors:
-        click.echo("{e.name}\t{e.payload}\t{e.path}".format(e=error))
+        click.echo(f"{error.name}\t{error.payload}\t{error.path}")
 
         if explain:
-            click.echo("\tReason: {}".format(error.msg))
+            click.echo(f"\tReason: {error.msg}")
 
         if suggest:
-            click.echo("\tSuggestion: {}".format(error.suggestion_cmd))
+            click.echo(f"\tSuggestion: {error.suggestion_cmd}")
 
         if fix:
             error.fix_action()

--- a/papis/commands/external.py
+++ b/papis/commands/external.py
@@ -67,7 +67,7 @@ def external_cli(ctx: click.core.Context, flags: List[str]) -> None:
     script: papis.commands.Script = ctx.obj
     path = script.path
     if not path:
-        raise FileNotFoundError("Path for script '{}' not found".format(script))
+        raise FileNotFoundError(f"Path for script '{script}' not found")
 
     cmd = [path] + list(flags)
     logger.debug("Calling external command '%s'.", cmd)

--- a/papis/commands/merge.py
+++ b/papis/commands/merge.py
@@ -100,10 +100,10 @@ def cli(query: str,
         logger.warning(papis.strings.no_documents_retrieved_message)
         return
 
-    documents = list(papis.pick.pick_doc(documents))
+    documents = papis.pick.pick_doc(documents)
 
     if pick:
-        other_documents = list(papis.pick.pick_doc(documents))
+        other_documents = papis.pick.pick_doc(documents)
         documents += other_documents
 
     if len(documents) != 2:

--- a/papis/commands/merge.py
+++ b/papis/commands/merge.py
@@ -100,10 +100,10 @@ def cli(query: str,
         logger.warning(papis.strings.no_documents_retrieved_message)
         return
 
-    documents = [d for d in papis.pick.pick_doc(documents)]
+    documents = list(papis.pick.pick_doc(documents))
 
     if pick:
-        other_documents = [d for d in papis.pick.pick_doc(documents)]
+        other_documents = list(papis.pick.pick_doc(documents))
         documents += other_documents
 
     if len(documents) != 2:

--- a/papis/commands/rename.py
+++ b/papis/commands/rename.py
@@ -46,7 +46,7 @@ def run(document: papis.document.Document,
     if git:
         papis.git.commit(
             new_folder_path,
-            "Rename from '{}' to '{}'".format(folder, new_name))
+            f"Rename from '{folder}' to '{new_name}'")
 
     db.delete(document)
     logger.debug("New document folder: '%s'.", new_folder_path)

--- a/papis/commands/rm.py
+++ b/papis/commands/rm.py
@@ -43,7 +43,7 @@ def run(document: papis.document.Document,
         if git:
             papis.git.remove(_doc_folder, filepath)
             papis.git.add(_doc_folder, document.get_info_file())
-            papis.git.commit(_doc_folder, "Remove file '{}'".format(filepath))
+            papis.git.commit(_doc_folder, f"Remove file '{filepath}'")
 
     if notespath is not None:
         os.remove(notespath)
@@ -54,7 +54,7 @@ def run(document: papis.document.Document,
             papis.git.remove(_doc_folder, notespath)
             papis.git.add(_doc_folder, document.get_info_file())
             papis.git.commit(_doc_folder,
-                             "Remove notes file '{}'".format(notespath))
+                             f"Remove notes file '{notespath}'")
 
     # if neither files nor notes were deleted -> delete whole document
     if not (filepath or notespath):
@@ -115,7 +115,7 @@ def cli(query: str,
                 continue
             filepath = filepaths[0]
             if not force:
-                tbar = "The file {} would be removed".format(filepath)
+                tbar = f"The file {filepath} would be removed"
                 if not papis.tui.utils.confirm(
                         "Are you sure?", bottom_toolbar=tbar):
                     continue
@@ -131,7 +131,7 @@ def cli(query: str,
                 document["notes"]
             )
             if not force:
-                tbar = "The file {} would be removed".format(notespath)
+                tbar = f"The file {notespath} would be removed"
                 if not papis.tui.utils.confirm(
                         "Are you sure?", bottom_toolbar=tbar):
                     continue

--- a/papis/commands/run.py
+++ b/papis/commands/run.py
@@ -111,7 +111,7 @@ def cli(run_command: List[str],
         documents = papis.document.sort(documents, sort_field, sort_reverse)
 
     if not _all and pick:
-        documents = list(papis.pick.pick_doc(documents))
+        documents = papis.pick.pick_doc(documents)
 
     if _all and not pick:
         documents = papis.database.get().get_all_documents()

--- a/papis/commands/run.py
+++ b/papis/commands/run.py
@@ -111,7 +111,7 @@ def cli(run_command: List[str],
         documents = papis.document.sort(documents, sort_field, sort_reverse)
 
     if not _all and pick:
-        documents = [d for d in papis.pick.pick_doc(documents)]
+        documents = list(papis.pick.pick_doc(documents))
 
     if _all and not pick:
         documents = papis.database.get().get_all_documents()

--- a/papis/commands/serve.py
+++ b/papis/commands/serve.py
@@ -169,7 +169,7 @@ class PapisRequestHandler(http.server.BaseHTTPRequestHandler):
         libname = libname or papis.api.get_lib_name()
         self._handle_lib(libname)
         TAGS_LIST[libname] = None
-        self.redirect("/library/{}/tags".format(libname))
+        self.redirect(f"/library/{libname}/tags")
 
     @ok_html
     def page_libraries(self) -> None:
@@ -245,11 +245,11 @@ class PapisRequestHandler(http.server.BaseHTTPRequestHandler):
         self._send_json(docs)
 
     def redirect(self, url: str, code: int = 301) -> None:
-        page = ("""
+        page = (f"""
                   <head>
                      <meta http-equiv="Refresh" content="0; URL={url}">
                   </head>
-                """.format(url=url))
+                """)
         self.send_response(code)
         self.send_header_html()
         self.send_header("Location", url)
@@ -281,7 +281,7 @@ class PapisRequestHandler(http.server.BaseHTTPRequestHandler):
                 self.wfile.write(f.read())
             self.wfile.flush()
         else:
-            raise FileNotFoundError("File '{}' does not exist".format(path))
+            raise FileNotFoundError(f"File '{path}' does not exist")
 
     def process_routes(self,
                        routes: List[Tuple[str, Any]]) -> None:
@@ -299,8 +299,8 @@ class PapisRequestHandler(http.server.BaseHTTPRequestHandler):
             self._send_json_error(400, str(e))
         else:
             self._send_json_error(404,
-                                  "Server path {} not understood"
-                                  .format(self.path))
+                                  f"Server path {self.path} not understood"
+                                  )
 
     def _handle_lib(self, libname: str) -> None:
         papis.api.set_lib_from_name(libname)
@@ -313,7 +313,7 @@ class PapisRequestHandler(http.server.BaseHTTPRequestHandler):
         doc = db.find_by_id(papis_id)
         if not doc:
             raise ValueError(
-                "Document with ref '{}' not found in the database".format(papis_id)
+                f"Document with ref '{papis_id}' not found in the database"
                 )
         return doc
 
@@ -351,7 +351,7 @@ class PapisRequestHandler(http.server.BaseHTTPRequestHandler):
         try:
             papis.yaml.yaml_to_data(fdr.name, raise_exception=True)
         except ValueError as e:
-            self._send_json_error(404, "Error in info file: {}".format(e))
+            self._send_json_error(404, f"Error in info file: {e}")
             os.unlink(fdr.name)
             return
         else:
@@ -407,7 +407,7 @@ class PapisRequestHandler(http.server.BaseHTTPRequestHandler):
                 self.wfile.flush()
             return
 
-        raise FileNotFoundError("File '{}' does not exist".format(path))
+        raise FileNotFoundError(f"File '{path}' does not exist")
 
     def do_POST(self) -> None:              # noqa: N802
         """

--- a/papis/config.py
+++ b/papis/config.py
@@ -359,7 +359,7 @@ def general_get(key: str,
     # If the <section> is not given, then only the general and library settings
     # are checked.
 
-    qualified_key = key if section is None else "{}-{}".format(section, key)
+    qualified_key = key if section is None else f"{section}-{key}"
     candidate_sections = (
         # NOTE: these are in overwriting order: general < custom < lib
         [(global_section, qualified_key)]
@@ -471,8 +471,8 @@ def getlist(key: str, section: Optional[str] = None) -> List[str]:
         rawvalue = eval(rawvalue)
     except Exception:
         raise SyntaxError(
-            "The key '{}' must be a valid Python object: {}"
-            .format(key, rawvalue))
+            f"The key '{key}' must be a valid Python object: {rawvalue}"
+            )
     else:
         if not isinstance(rawvalue, list):
             raise SyntaxError(
@@ -556,12 +556,12 @@ def get_lib_from_name(libname: str) -> papis.library.Library:
             config[lib.name] = {"dirs": str(lib.paths)}
         else:
             raise RuntimeError(
-                "Library '{lib}' does not seem to exist. "
+                f"Library '{libname}' does not seem to exist. "
                 "To add a library simply write the following "
-                "in your configuration file located at '{config}'\n\n"
-                "\t[{lib}]\n"
-                "\tdir = path/to/your/{lib}/folder"
-                .format(lib=libname, config=get_config_file()))
+                f"in your configuration file located at '{get_config_file()}'\n\n"
+                f"\t[{libname}]\n"
+                f"\tdir = path/to/your/{libname}/folder"
+                )
     else:
         try:
             # NOTE: can't use `getstring(...)` due to cyclic dependency

--- a/papis/crossref.py
+++ b/papis/crossref.py
@@ -272,7 +272,7 @@ def doi_to_data(doi_string: str) -> Dict[str, Any]:
     if results:
         return results[0]
     raise ValueError(
-        "Could not retrieve data for DOI '{}' from Crossref".format(doi_string))
+        f"Could not retrieve data for DOI '{doi_string}' from Crossref")
 
 
 @click.command("crossref")

--- a/papis/database/__init__.py
+++ b/papis/database/__init__.py
@@ -33,7 +33,7 @@ def _instantiate_database(backend_name: str, library: Library) -> Database:
         import papis.database.whoosh
         return papis.database.whoosh.Database(library)
     else:
-        raise ValueError("Invalid database backend: '{}'".format(backend_name))
+        raise ValueError(f"Invalid database backend: '{backend_name}'")
 
 
 def get_all_query_string() -> str:

--- a/papis/database/base.py
+++ b/papis/database/base.py
@@ -55,7 +55,7 @@ class Database(ABC):
         :param query_string: Query string
         """
         raise NotImplementedError(
-            "Match not defined for backend '{}'".format(self.get_backend_name()))
+            f"Match not defined for backend '{self.get_backend_name()}'")
 
     @abstractmethod
     def clear(self) -> None:

--- a/papis/database/cache.py
+++ b/papis/database/cache.py
@@ -209,7 +209,7 @@ class Database(papis.database.base.Database):
     def query_dict(self,
                    dictionary: Dict[str, str]) -> List[papis.document.Document]:
         query_string = " ".join(
-            ['{}:"{}" '.format(key, val) for key, val in dictionary.items()])
+            [f'{key}:"{val}" ' for key, val in dictionary.items()])
         return self.query(query_string)
 
     def query(self, query_string: str) -> List[papis.document.Document]:

--- a/papis/database/whoosh.py
+++ b/papis/database/whoosh.py
@@ -227,7 +227,7 @@ class Database(papis.database.base.Database):
             user_fields = self.get_schema_init_fields()
             db_fields = self.get_schema()
 
-            user_field_names = sorted(list(user_fields))
+            user_field_names = sorted(user_fields)
             db_field_names = sorted(db_fields.names())
 
             # If the user fields and the fields in the DB

--- a/papis/database/whoosh.py
+++ b/papis/database/whoosh.py
@@ -116,7 +116,7 @@ class Database(papis.database.base.Database):
     def query_dict(self,
                    dictionary: Dict[str, str]) -> List[papis.document.Document]:
         query_string = " AND ".join(
-            ['{}:"{}" '.format(key, val) for key, val in dictionary.items()])
+            [f'{key}:"{val}" ' for key, val in dictionary.items()])
         return self.query(query_string)
 
     def query(self, query_string: str) -> List[papis.document.Document]:

--- a/papis/dblp.py
+++ b/papis/dblp.py
@@ -56,7 +56,7 @@ DBLP_KEY_CONVERSION = [
 
 def _dblp_journal(name: str) -> Optional[str]:
     import json
-    result = json.loads(search(query="{}$".format(name), api="venue"))
+    result = json.loads(search(query=f"{name}$", api="venue"))
 
     hits = result["result"]["hits"].get("hit")
     if hits is None or len(hits) != 1:
@@ -95,8 +95,7 @@ def search(
     """
     if not (0 < max_results <= DBLP_MAX_RESULS):
         raise ValueError(
-            "Cannot request more than {} results (got {})"
-            .format(DBLP_MAX_RESULS, max_results)
+            f"Cannot request more than {DBLP_MAX_RESULS} results (got {max_results})"
             )
 
     if not (0 < max_completions <= DBLP_MAX_COMPLETIONS):
@@ -107,12 +106,12 @@ def search(
 
     if output_format not in DBLP_FORMATS:
         raise ValueError(
-            "Unsupported format: '{}' (expected {})".format(output_format, DBLP_FORMATS)
+            f"Unsupported format: '{output_format}' (expected {DBLP_FORMATS})"
             )
 
     url = DBLP_API_ENDPOINTS.get(api.lower())
     if url is None:
-        raise ValueError("Unknown API endpoint '{}'".format(api))
+        raise ValueError(f"Unknown API endpoint '{api}'")
 
     with papis.utils.get_session() as session:
         response = session.get(
@@ -219,7 +218,7 @@ class Importer(papis.importer.Importer):
         if is_valid_dblp_key(self.uri):
             url = DBLP_BIB_FORMAT.format(uri=self.uri)
         else:
-            url = "{}.bib".format(self.uri[:-5])
+            url = f"{self.uri[:-5]}.bib"
 
         with papis.utils.get_session() as session:
             response = session.get(url)

--- a/papis/dblp.py
+++ b/papis/dblp.py
@@ -73,7 +73,7 @@ def _dblp_authors(entries: Dict[str, Any]) -> List[Dict[str, Any]]:
 
 def search(
         query: str = "",
-        format: str = "json",
+        output_format: str = "json",
         max_results: int = 30,
         max_completions: int = 10,
         api: str = "publ",
@@ -105,9 +105,9 @@ def search(
             .format(DBLP_MAX_COMPLETIONS, max_completions)
             )
 
-    if format not in DBLP_FORMATS:
+    if output_format not in DBLP_FORMATS:
         raise ValueError(
-            "Unsupported format: '{}' (expected {})".format(format, DBLP_FORMATS)
+            "Unsupported format: '{}' (expected {})".format(output_format, DBLP_FORMATS)
             )
 
     url = DBLP_API_ENDPOINTS.get(api.lower())
@@ -119,7 +119,7 @@ def search(
             url,
             params={
                 "q": query,
-                "format": format,
+                "format": output_format,
                 "h": str(max_results),
                 "f": "0",
                 "c": str(max_completions),
@@ -131,7 +131,7 @@ def search(
 def get_data(query: str = "", max_results: int = 30) -> List[Dict[str, Any]]:
     import json
     response = json.loads(
-        search(query=query, format="json", max_results=max_results)
+        search(query=query, output_format="json", max_results=max_results)
         )
     result = response.get("result")
     hits = result["hits"].get("hit")

--- a/papis/dissemin.py
+++ b/papis/dissemin.py
@@ -25,7 +25,7 @@ def dissemin_authors_to_papis_authors(data: Dict[str, Any]) -> Dict[str, Any]:
             )
         new_data["author_list"] = authors
         new_data["author"] = ",".join(
-            ["{a[given_name]} {a[surname]}".format(a=a) for a in authors])
+            [f"{a['given_name']} {a['surname']}" for a in authors])
     return new_data
 
 

--- a/papis/docmatcher.py
+++ b/papis/docmatcher.py
@@ -27,8 +27,8 @@ class ParseResult(NamedTuple):
     doc_key: Optional[str]
 
     def __repr__(self) -> str:
-        doc_key = "{!r}, ".format(self.doc_key) if self.doc_key is not None else ""
-        return "[{}{!r}]".format(doc_key, self.search)
+        doc_key = f"{self.doc_key!r}, " if self.doc_key is not None else ""
+        return f"[{doc_key}{self.search!r}]"
 
 
 class MatcherCallable(Protocol):

--- a/papis/document.py
+++ b/papis/document.py
@@ -44,11 +44,11 @@ EmptyKeyConversion = KeyConversion(key=None, action=None)
 
 
 class KeyConversionPair(NamedTuple):
-    #: A string denoting the foreign key (in the input data).
-    foreign_key: str
-    #: A :class:`list` of :class:`KeyConversion` mappings used to
-    #: rename and post-process the :attr:`foreign_key` and its value.
-    list: List[KeyConversion]
+    #: A string denoting the key in the input data.
+    from_key: str
+    #: A :class:`list` of :class:`KeyConversion` key mapping rules used to
+    #: rename and post-process the :attr:`from_key` and its value.
+    rules: List[KeyConversion]
 
 
 def keyconversion_to_data(conversions: Sequence[KeyConversionPair],
@@ -101,22 +101,22 @@ def keyconversion_to_data(conversions: Sequence[KeyConversionPair],
 
     for key_pair in conversions:
 
-        foreign_key = key_pair.foreign_key
-        if foreign_key not in data:
+        from_key = key_pair.from_key
+        if from_key not in data:
             continue
 
-        for conv_data in key_pair.list:
-            papis_key: str = conv_data.get("key") or foreign_key
-            papis_value = data[foreign_key]
+        for rule in key_pair.rules:
+            papis_key = str(rule.get("key") or from_key)
+            papis_value = data[from_key]
 
-            action = conv_data.get("action")
+            action = rule.get("action")
             if action:
                 try:
                     new_value = action(papis_value)
                 except Exception as exc:
                     logger.debug(
-                        "Error parsing papis key '%s' from foreign key '%s' => '%r'.",
-                        papis_key, foreign_key, papis_value, exc_info=exc
+                        "Error converting value from key '%s' to '%s': %r.",
+                        from_key, papis_key, papis_value, exc_info=exc
                     )
                     new_value = None
             else:
@@ -129,8 +129,9 @@ def keyconversion_to_data(conversions: Sequence[KeyConversionPair],
                 new_data[papis_key] = new_value
 
     if keep_unknown_keys:
+        from_keys = {c.from_key for c in conversions}
         for key, value in data.items():
-            if key in [c.foreign_key for c in conversions]:
+            if key in from_keys:
                 continue
             new_data[key] = value
 

--- a/papis/document.py
+++ b/papis/document.py
@@ -190,7 +190,7 @@ def split_authors_name(authors: List[str],
 
     author_list = []
     for subauthors in authors:
-        for author in re.split(r"\s+{}\s+".format(separator), subauthors):
+        for author in re.split(fr"\s+{separator}\s+", subauthors):
             parts = splitname(author)
             given = " ".join(parts["first"])
             family = " ".join(parts["von"] + parts["last"] + parts["jr"])
@@ -400,7 +400,7 @@ def dump(document: Document) -> str:
     width = (width // 4 + 2) * 4 - 1
 
     return "\n".join([
-        "{:{}}{}".format("{}:".format(key), width, value)
+        "{:{}}{}".format(f"{key}:", width, value)
         for key, value in sorted(document.items())
         ])
 

--- a/papis/downloaders/__init__.py
+++ b/papis/downloaders/__init__.py
@@ -90,7 +90,7 @@ class Downloader(papis.importer.Importer):
             cookies = {}
 
         super().__init__(uri=uri, name=name, ctx=ctx)
-        self.logger = papis.logging.get_logger("papis.downloader.{}".format(self.name))
+        self.logger = papis.logging.get_logger(f"papis.downloader.{self.name}")
 
         self.expected_document_extensions = expected_document_extension
         self.priority = priority
@@ -125,8 +125,8 @@ class Downloader(papis.importer.Importer):
             *None* otherwise.
         """
         raise NotImplementedError(
-            "Matching URI not implemented for '{}.{}'"
-            .format(cls.__module__, cls.__name__))
+            f"Matching URI not implemented for '{cls.__module__}.{cls.__name__}'"
+            )
 
     @papis.importer.cache
     def fetch(self) -> None:
@@ -210,7 +210,7 @@ class Downloader(papis.importer.Importer):
             if doc_rawdata and self.check_document_format():
                 extension = self.get_document_extension()
                 if extension:
-                    extension = ".{}".format(extension)
+                    extension = f".{extension}"
 
                 with tempfile.NamedTemporaryFile(
                         mode="wb+", delete=False,
@@ -240,7 +240,7 @@ class Downloader(papis.importer.Importer):
         return self._soup
 
     def __str__(self) -> str:
-        return "Downloader({}, uri={})".format(self.name, self.uri)
+        return f"Downloader({self.name}, uri={self.uri})"
 
     def get_bibtex_url(self) -> Optional[str]:
         """
@@ -248,8 +248,7 @@ class Downloader(papis.importer.Importer):
             metadata about the document.
         """
         raise NotImplementedError(
-            "Getting a BibTeX URL not implemented for the '{}' downloader".
-            format(self.name))
+            f"Getting a BibTeX URL not implemented for the '{self.name}' downloader")
 
     def get_bibtex_data(self) -> Optional[str]:
         """Get BibTeX data available at :meth:`get_bibtex_url`, if any.
@@ -283,24 +282,24 @@ class Downloader(papis.importer.Importer):
         APIs to gather metadata about the document.
         """
         raise NotImplementedError(
-            "Getting data is not implemented for the '{}' downloader"
-            .format(self.name))
+            f"Getting data is not implemented for the '{self.name}' downloader"
+            )
 
     def get_doi(self) -> Optional[str]:
         """
         :returns: a DOI for the document, if any.
         """
         raise NotImplementedError(
-            "Getting the DOI not implemented for the '{}' downloader"
-            .format(self.name))
+            f"Getting the DOI not implemented for the '{self.name}' downloader"
+            )
 
     def get_document_url(self) -> Optional[str]:
         """
         :returns: a URL to a file that should be downloaded.
         """
         raise NotImplementedError(
-            "Getting a document URL not implemented for the '{}' downloader"
-            .format(self.name))
+            f"Getting a document URL not implemented for the '{self.name}' downloader"
+            )
 
     def get_document_data(self) -> Optional[bytes]:
         """Get data for the downloaded file that is given by :meth:`get_document_url`.
@@ -474,7 +473,7 @@ def download_document(
                            "recognizable (binary) mimetype: '%s'.",
                            response.headers["Content-Type"])
 
-    ext = ".{}".format(ext) if ext else ""
+    ext = f".{ext}" if ext else ""
     with tempfile.NamedTemporaryFile(
             mode="wb+",
             suffix=ext,

--- a/papis/downloaders/acm.py
+++ b/papis/downloaders/acm.py
@@ -31,7 +31,6 @@ class Downloader(papis.downloaders.Downloader):
         return None
 
     def get_document_url(self) -> Optional[str]:
-        durl = ("https://dl.acm.org/doi/pdf/{doi}"
-                .format(doi=self.get_doi()))
+        durl = f"https://dl.acm.org/doi/pdf/{self.get_doi()}"
         self.logger.debug("Using document URL: '%s'.", durl)
         return durl

--- a/papis/downloaders/frontiersin.py
+++ b/papis/downloaders/frontiersin.py
@@ -30,13 +30,11 @@ class Downloader(papis.downloaders.Downloader):
         return None
 
     def get_document_url(self) -> Optional[str]:
-        durl = ("https://www.frontiersin.org/articles/{doi}/pdf"
-                .format(doi=self.get_doi()))
+        durl = f"https://www.frontiersin.org/articles/{self.get_doi()}/pdf"
         self.logger.debug("Using document URL: '%s'.", durl)
         return durl
 
     def get_bibtex_url(self) -> Optional[str]:
-        url = ("https://www.frontiersin.org/articles/{doi}/bibTex"
-               .format(doi=self.get_doi()))
+        url = f"https://www.frontiersin.org/articles/{self.get_doi()}/bibTex"
         self.logger.debug("Using BibTeX URL: '%s'.", url)
         return url

--- a/papis/downloaders/hal.py
+++ b/papis/downloaders/hal.py
@@ -33,11 +33,11 @@ class Downloader(papis.downloaders.fallback.Downloader):
     def match(
             cls, url: str) -> Optional[papis.downloaders.fallback.Downloader]:
         subdomains = "|".join(cls.SUPPORTED_ARCHIVES_OUVERTES_SUBDOMAINS)
-        if re.match(r".*({})\.archives-ouvertes\.fr.*".format(subdomains), url):
+        if re.match(fr".*({subdomains})\.archives-ouvertes\.fr.*", url):
             return Downloader(url)
 
         subdomains = r"|".join(cls.SUPPORTED_HAL_SCIENCE_SUBDOMAINS)
-        if re.match(r".*//({})\.science.*".format(subdomains), url):
+        if re.match(fr".*//({subdomains})\.science.*", url):
             return Downloader(url)
 
         return None

--- a/papis/downloaders/ieee.py
+++ b/papis/downloaders/ieee.py
@@ -14,7 +14,7 @@ class Downloader(papis.downloaders.Downloader):
     def match(cls, url: str) -> Optional[papis.downloaders.Downloader]:
         m = re.match(r"^ieee:(.*)", url, re.IGNORECASE)
         if m:
-            url = "https://ieeexplore.ieee.org/document/{}".format(m.group(1))
+            url = f"https://ieeexplore.ieee.org/document/{m.group(1)}"
             return Downloader(url)
         if re.match(r".*ieee.org.*", url):
             url = re.sub(r"\.pdf.*$", "", url)

--- a/papis/downloaders/scitationaip.py
+++ b/papis/downloaders/scitationaip.py
@@ -30,14 +30,14 @@ class Downloader(papis.downloaders.Downloader):
 
     def get_document_url(self) -> Optional[str]:
         # https://aip.scitation.org/doi/pdf/10.1063/1.4873138
-        durl = ("https://aip.scitation.org/doi/pdf/{doi}"
-                .format(doi=self.get_doi()))
+        durl = f"https://aip.scitation.org/doi/pdf/{self.get_doi()}"
         self.logger.debug("Using document URL: '%s'.", durl)
+
         return durl
 
     def get_bibtex_url(self) -> Optional[str]:
         url = ("https://aip.scitation.org/action/downloadCitation"
-               "?format=bibtex&cookieSet=1&doi={doi}"
-               .format(doi=self.get_doi()))
+               f"?format=bibtex&cookieSet=1&doi={self.get_doi()}")
         self.logger.debug("Using BibTeX URL: '%s'.", url)
+
         return url

--- a/papis/downloaders/thesesfr.py
+++ b/papis/downloaders/thesesfr.py
@@ -71,6 +71,6 @@ class Downloader(papis.downloaders.Downloader):
         >>> d.get_bibtex_url()
         'https://www.theses.fr/2014TOU30305.bib'
         """
-        url = "https://www.theses.fr/{id}.bib".format(id=self.get_identifier())
+        url = f"https://www.theses.fr/{self.get_identifier()}.bib"
         self.logger.debug("Using BibTeX URL: '%s'.", url)
         return url

--- a/papis/downloaders/worldscientific.py
+++ b/papis/downloaders/worldscientific.py
@@ -36,8 +36,7 @@ class Downloader(papis.downloaders.Downloader):
         return None
 
     def get_document_url(self) -> Optional[str]:
-        durl = ("https://www.worldscientific.com/doi/pdf/{doi}"
-                .format(doi=self.get_doi()))
+        durl = f"https://www.worldscientific.com/doi/pdf/{self.get_doi()}"
         self.logger.debug("Using document URL: '%s'.", durl)
         return durl
 

--- a/papis/exceptions.py
+++ b/papis/exceptions.py
@@ -8,16 +8,16 @@ class DefaultSettingValueMissing(KeyError):
     default value."""
 
     def __init__(self, key: str) -> None:
-        message = """
+        message = f"""
 
-    The configuration setting '{0}' is not defined.
+    The configuration setting '{key}' is not defined.
     Try setting its value in your configuration file as such:
 
         [settings]
-        {0} = some-value
+        {key} = some-value
 
     Don't forget to check the documentation.
-        """.format(key)
+        """
         super().__init__(message)
 
 

--- a/papis/format.py
+++ b/papis/format.py
@@ -162,7 +162,7 @@ def get_formater(name: Optional[str] = None) -> Formater:
                 papis.plugin.get_available_entrypoints(FORMATER_EXTENSION_NAME))
             logger.error("Invalid formater '%s'. Registered formaters are '%s'.",
                          name, "', '".join(entrypoints), exc_info=exc)
-            raise InvalidFormaterError("Invalid formater: '{}'".format(name))
+            raise InvalidFormaterError(f"Invalid formater: '{name}'")
 
         logger.debug("Using '%s' formater.", name)
 

--- a/papis/fzf.py
+++ b/papis/fzf.py
@@ -15,7 +15,7 @@ class Command(ABC, Generic[T]):
     key: str = ""
 
     def binding(self) -> str:
-        return "{}:{}".format(self.key, self.command)
+        return f"{self.key}:{self.command}"
 
     def indices(self, line: str) -> Optional[List[int]]:
         m = self.regex.match(line) if self.regex else None

--- a/papis/hooks.py
+++ b/papis/hooks.py
@@ -12,7 +12,7 @@ NON_STEVEDORE_HOOKS: Dict[str, List[Callable[[Any], None]]] = {}
 
 
 def _get_namespace(name: str) -> str:
-    return "papis.hook.{}".format(name)
+    return f"papis.hook.{name}"
 
 
 def get(name: str) -> "ExtensionManager":

--- a/papis/importer.py
+++ b/papis/importer.py
@@ -86,7 +86,7 @@ class Importer:
         self.ctx: Context = ctx or Context()
         self.uri: str = uri
         self.name: str = name
-        self.logger = papis.logging.get_logger("papis.importer.{}".format(self.name))
+        self.logger = papis.logging.get_logger(f"papis.importer.{self.name}")
 
     @classmethod
     def match(cls, uri: str) -> Optional["Importer"]:
@@ -108,8 +108,8 @@ class Importer:
         """
 
         raise NotImplementedError(
-            "Matching URI is not implemented for '{}.{}'"
-            .format(cls.__module__, cls.__name__))
+            f"Matching URI is not implemented for '{cls.__module__}.{cls.__name__}'"
+            )
 
     @classmethod
     def match_data(cls, data: Dict[str, Any]) -> Optional["Importer"]:
@@ -166,7 +166,7 @@ class Importer:
             .format(type(self).__module__, type(self).__name__))
 
     def __str__(self) -> str:
-        return "{}({}, uri={})".format(type(self).__name__, self.name, self.uri)
+        return f"{type(self).__name__}({self.name}, uri={self.uri})"
 
 
 def get_import_mgr() -> "stevedore.extension.ExtensionManager":

--- a/papis/logging.py
+++ b/papis/logging.py
@@ -48,7 +48,7 @@ class ColoramaFormatter(logging.Formatter):
             tb = buffer.getvalue().strip()
             buffer.close()
 
-            return "\n".join("  ┆ {}".format(line) for line in tb.split("\n"))
+            return "\n".join(f"  ┆ {line}" for line in tb.split("\n"))
         else:
             msg = str(exc_info[1])
             if len(msg) > 48:
@@ -80,7 +80,7 @@ class ColoramaFormatter(logging.Formatter):
 
         if record.exc_info and not self.full_tb:
             exc_text = self.formatException(record.exc_info)
-            record.msg = "{} {}".format(record.msg, exc_text)
+            record.msg = f"{record.msg} {exc_text}"
             record.exc_text = None
             record.exc_info = None
 
@@ -132,7 +132,7 @@ def setup(level: Optional[Union[int, str]] = None,
             verbose = False
 
     if color not in ("always", "auto", "no"):
-        raise ValueError("Unknown 'color' value: '{}'".format(color))
+        raise ValueError(f"Unknown 'color' value: '{color}'")
 
     if _disable_color(color):
         # Turn off colorama (strip escape sequences from the output)
@@ -144,10 +144,10 @@ def setup(level: Optional[Union[int, str]] = None,
         try:
             level = int(getattr(logging, level))
         except AttributeError:
-            raise ValueError("Unknown logger level: '{}'".format(level))
+            raise ValueError(f"Unknown logger level: '{level}'")
     else:
         if logging.getLevelName(level).startswith("Level"):
-            raise ValueError("Unknown logger level: '{}'".format(level))
+            raise ValueError(f"Unknown logger level: '{level}'")
 
     log_format = (
         "{c.Fore.GREEN}%(name)s{c.Style.RESET_ALL}: %(message)s"
@@ -155,9 +155,9 @@ def setup(level: Optional[Union[int, str]] = None,
 
     if verbose:
         level = logging.DEBUG
-        log_format = "[%(relativeCreated)d %(levelname)s] {}".format(log_format)
+        log_format = f"[%(relativeCreated)d %(levelname)s] {log_format}"
     else:
-        log_format = "[%(levelname)s] {}".format(log_format)
+        log_format = f"[%(levelname)s] {log_format}"
 
     if logfile is None:
         full_tb = level == logging.DEBUG

--- a/papis/pubmed.py
+++ b/papis/pubmed.py
@@ -29,7 +29,7 @@ def handle_pubmed_pages(pages: str) -> str:
     start, end = [x.strip() for x in pages.split("-")]
     end = "{}{}".format(start[:max(0, len(start) - len(end))], end)
 
-    return "{}--{}".format(start, end)
+    return f"{start}--{end}"
 
 
 KeyConversionPair = papis.document.KeyConversionPair
@@ -81,7 +81,7 @@ def get_data(query: str = "") -> Dict[str, Any]:
     with papis.utils.get_session() as session:
         response = session.get(
             PUBMED_URL.format(pmid=query.strip(), database=PUBMED_DATABASE),
-            headers={"user-agent": "papis/{}".format(papis.__version__)},
+            headers={"user-agent": f"papis/{papis.__version__}"},
             )
 
     import json

--- a/papis/tui/__init__.py
+++ b/papis/tui/__init__.py
@@ -4,7 +4,7 @@ PapisConfigType = Dict[str, Dict[str, Any]]
 
 
 def get_default_settings() -> PapisConfigType:
-    return dict(tui={
+    return {"tui": {
         "status_line_format": (
             "{selected_index}/{number_of_documents}  "
             + "F1:help  "
@@ -32,4 +32,4 @@ def get_default_settings() -> PapisConfigType:
         "mark_key": "c-t",
 
         "editmode": "emacs",
-    })
+    }}

--- a/papis/tui/app.py
+++ b/papis/tui/app.py
@@ -334,9 +334,7 @@ class Picker(Application, Generic[Option]):  # type: ignore
         keys_info = get_keys_info()
         for k in keys_info:
             help_text += (
-                "<ansired>{k[key]}</ansired>: {k[help]}\n".format(
-                    k=keys_info[k]
-                )
+                f"<ansired>{keys_info[k]['key']}</ansired>: {keys_info[k]['help']}\n"
             )
         self.help_window.text = HTML(help_text)
 

--- a/papis/tui/utils.py
+++ b/papis/tui/utils.py
@@ -132,7 +132,7 @@ def prompt(
 
     fragments = [
         ("", prompt_string),
-        ("fg:ansired", " ({})".format(default)),
+        ("fg:ansired", f" ({default})"),
         ("", ": "),
     ]
 
@@ -160,7 +160,7 @@ def select_range(options: List[Any],
                  accept_none: bool = False,
                  bottom_toolbar: Optional[str] = None) -> List[int]:
     for i, o in enumerate(options):
-        click.echo("{i}. {o}".format(i=i, o=o))
+        click.echo(f"{i}. {o}")
 
     possible_indices = range(len(options))
     all_keywords = ["all", "a"]

--- a/papis/tui/widgets/command_line_prompt.py
+++ b/papis/tui/widgets/command_line_prompt.py
@@ -93,7 +93,7 @@ class CommandLinePrompt(ConditionalContainer):
                 "More than one command matches the input: ['{}']"
                 .format("', '".join(cmd.name for cmd in cmds)))
         elif not cmds:
-            raise ValueError("No command found for '{}'".format(name))
+            raise ValueError(f"No command found for '{name}'")
 
         input_cmd.pop(0)
         cmds[0].run(cmds[0], *input_cmd)

--- a/papis/tui/widgets/diff.py
+++ b/papis/tui/widgets/diff.py
@@ -117,15 +117,15 @@ def diffshow(texta: str,
         "+++++ {nameb}\n".format(nameb=nameb),
     ]
 
-    formatted_text = FormattedText(map(
-        lambda line:
-            # match line values
-            line.startswith("@") and ("fg:ansimagenta bg:ansiblack", line)
-            or line.startswith("+") and ("fg:ansigreen bg:ansiblack", line)
-            or line.startswith("-") and ("fg:ansired bg:ansiblack", line)
-            or line.startswith("?") and ("fg:ansiyellow bg:ansiblack", line)
-            or line.startswith("^^^") and ("bg:ansiblack fg:ansimagenta", line)
-            or ("", line), raw_text))
+    formatted_text = FormattedText([
+        line.startswith("@") and ("fg:ansimagenta bg:ansiblack", line)
+        or line.startswith("+") and ("fg:ansigreen bg:ansiblack", line)
+        or line.startswith("-") and ("fg:ansired bg:ansiblack", line)
+        or line.startswith("?") and ("fg:ansiyellow bg:ansiblack", line)
+        or line.startswith("^^^") and ("bg:ansiblack fg:ansimagenta", line)
+        or ("", line)
+        for line in raw_text
+    ])
 
     prompt(title="--- Diff view: " + title + " ---",
            text=formatted_text,

--- a/papis/tui/widgets/diff.py
+++ b/papis/tui/widgets/diff.py
@@ -113,8 +113,8 @@ def diffshow(texta: str,
 
     raw_text = _diffs + [
         "^^^^^^^^^\ndiff from\n",
-        "----- {namea}\n".format(namea=namea),
-        "+++++ {nameb}\n".format(nameb=nameb),
+        f"----- {namea}\n",
+        f"+++++ {nameb}\n",
     ]
 
     formatted_text = FormattedText([
@@ -224,7 +224,7 @@ def diffdict(dicta: Dict[str, Any],
         diffshow(
             texta=str(dicta.get(key, "")) + "\n",
             textb=str(dictb.get(key, "")) + "\n",
-            title='changes for key "{}"'.format(key),
+            title=f'changes for key "{key}"',
             namea=namea,
             nameb=nameb,
             actions=actions)

--- a/papis/utils.py
+++ b/papis/utils.py
@@ -132,7 +132,7 @@ def run(cmd: Sequence[str],
     # exist, so we check for it manually here
     import shutil
     if not shutil.which(cmd[0]):
-        raise FileNotFoundError("Command not found: '{}'".format(cmd[0]))
+        raise FileNotFoundError(f"Command not found: '{cmd[0]}'")
 
     import subprocess
     if wait:
@@ -196,7 +196,7 @@ def general_open(file_name: str,
     import shutil
     if shutil.which(cmd[0]) is None:
         raise FileNotFoundError(
-            "Command not found for '{}': '{}'".format(key, opener))
+            f"Command not found for '{key}': '{opener}'")
 
     run(cmd, wait=wait)
 
@@ -441,7 +441,7 @@ def get_matching_importer_or_downloader(
         + papis.downloaders.get_available_downloaders())
 
     for cls in all_importer_classes:
-        name = "{}.{}".format(cls.__module__, cls.__name__)
+        name = f"{cls.__module__}.{cls.__name__}"
         logger.debug("Trying with importer "
                      "{c.Back.BLACK}{c.Fore.YELLOW}%s{c.Style.RESET_ALL}.",
                      name)
@@ -551,7 +551,7 @@ def collect_importer_data(
                         importer.name,
                         "\n\t".join(importer.ctx.files))
 
-            msg = "Use this file? (from {})".format(importer.name)
+            msg = f"Use this file? (from {importer.name})"
             for f in importer.ctx.files:
                 papis.utils.open_file(f)
                 if batch or papis.tui.utils.confirm(msg):
@@ -610,10 +610,9 @@ def dump_object_doc(
         headline = re_whitespace.sub(" ", lines[0].strip())
         if bright:
             name = (
-                "{c.Style.BRIGHT}{name}{c.Style.RESET_ALL}"
-                .format(c=colorama, name=name))
+                f"{colorama.Style.BRIGHT}{name}{colorama.Style.RESET_ALL}"
+                )
 
-        result.append("{name}{sep}{headline}"
-                      .format(name=name, sep=sep, headline=headline))
+        result.append(f"{name}{sep}{headline}")
 
     return result

--- a/papis/web/ace.py
+++ b/papis/web/ace.py
@@ -4,9 +4,9 @@ Module for helping ace.js editor functionality.
 
 
 def make_onsubmit_function(name: str, editor: str, content_id: str) -> str:
-    return """
+    return f"""
 function {name}() {{
-    let input = document.querySelector("#{_id}");
+    let input = document.querySelector("#{content_id}");
     input.value = {editor}.getValue();
 }}
-    """.format(name=name, editor=editor, _id=content_id)
+    """

--- a/papis/web/djvujs.py
+++ b/papis/web/djvujs.py
@@ -25,8 +25,9 @@ def widget(_unquoted_file_path: str, viewer_id: str = "djvuViewer") -> None:
     argument.
     """
     t.div(id=viewer_id)
-    t.script(tu.raw(MAIN_CODE.substitute(**dict(selector=viewer_id,
-                                                path=_unquoted_file_path))))
+    t.script(tu.raw(
+        MAIN_CODE.substitute(**{"selector": viewer_id, "path": _unquoted_file_path})
+    ))
 
     t.script(src=DJVUJS_LIB_SRC)
     t.script(src=DJVUJS_VIEWER_SRC)

--- a/papis/web/document.py
+++ b/papis/web/document.py
@@ -28,19 +28,19 @@ def links(doc: papis.document.Document, small: bool = True) -> None:
             url_link("check-circle", "doi",
                      "https://doi.org/{}".format(doc["doi"]))
             url_link("database", "ads",
-                     "https://ui.adsabs.harvard.edu/abs/{}"
-                     .format(quoted_doi))
+                     f"https://ui.adsabs.harvard.edu/abs/{quoted_doi}"
+                     )
             if "files" not in doc:
                 url_link("lock-open", "unp",
                          "https://unpaywall.org/{}".format(doc["doi"]))
         else:
             quoted_title = urllib.parse.quote(doc["title"])
             url_link("crosshairs", "xref",
-                     "https://search.crossref.org/?q={}&from_ui=yes"
-                     .format(quoted_title))
+                     f"https://search.crossref.org/?q={quoted_title}&from_ui=yes"
+                     )
             url_link("database", "ads",
-                     "https://ui.adsabs.harvard.edu/search/q=title:{}"
-                     .format(quoted_title))
+                     f"https://ui.adsabs.harvard.edu/search/q=title:{quoted_title}"
+                     )
 
         url_link("globe", "ddg",
                  "https://duckduckgo.com/?q={}"

--- a/papis/web/docview.py
+++ b/papis/web/docview.py
@@ -84,7 +84,7 @@ def html(libname: str, doc: papis.document.Document) -> t.html_tag:
                     for i, fpath in enumerate(doc.get_files()):
                         _tab_element(wh.file_icon,
                                      [fpath],
-                                     "#file-tab-{}".format(i))
+                                     f"#file-tab-{i}")
                     _tab_element(wh.icon_span,
                                  ["compress-alt", "Citations"],
                                  "#citations-tab")
@@ -120,10 +120,10 @@ def html(libname: str, doc: papis.document.Document) -> t.html_tag:
                               height=100,
                               style="min-height: 500px",
                               cls="form-control")
-                        _script = """
-                            let bib_editor = ace.edit("{}");
+                        _script = f"""
+                            let bib_editor = ace.edit("{_bibtex_id}");
                             bib_editor.session.setMode("ace/mode/bibtex");
-                        """.format(_bibtex_id)
+                        """
                         t.script(tu.raw(_script),
                                  charset="utf-8",
                                  type="text/javascript")
@@ -139,7 +139,7 @@ def html(libname: str, doc: papis.document.Document) -> t.html_tag:
                                                                   libfolder,
                                                                   libname)
 
-                        with t.div(id="file-tab-{}".format(i),
+                        with t.div(id=f"file-tab-{i}",
                                    role="tabpanel",
                                    aria_labelledby="file-tab",
                                    cls="tab-pane fade"):

--- a/papis/web/header.py
+++ b/papis/web/header.py
@@ -6,7 +6,7 @@ import papis.web.latex
 
 
 def header(pretitle: str) -> None:
-    t.title("{} Papis web".format(pretitle))
+    t.title(f"{pretitle} Papis web")
     t.meta(name="apple-mobile-web-app-capable", content="yes")
     t.meta(charset="UTF-8")
     t.meta(name="apple-mobile-web-app-capable", content="yes")

--- a/papis/web/html.py
+++ b/papis/web/html.py
@@ -18,7 +18,7 @@ def flex(where: str, cls: str = "", **kwargs: Any) -> t.html_tag:
 
 
 def alert(node: t.html_tag, type_: str, **kwargs: Any) -> t.html_tag:
-    with node(cls=("alert alert-{} ".format(type_)
+    with node(cls=(f"alert alert-{type_} "
                    + "alert-dismissible fade show"),
               role="alert",
               **kwargs) as result:

--- a/papis/web/info.py
+++ b/papis/web/info.py
@@ -23,7 +23,7 @@ def widget(doc: papis.document.Document, libname: str) -> None:
 
     with wh.flex("center"):
         with t.form(method="POST",
-                    onsubmit="{}()".format(onsubmit_name),
+                    onsubmit=f"{onsubmit_name}()",
                     cls="p-3",
                     action=wp.update_info(libname, doc)):
             t.textarea(type="text",
@@ -41,11 +41,11 @@ def widget(doc: papis.document.Document, libname: str) -> None:
         style="min-height: 500px",
         cls="form-control")
 
-    _script = """
-    let {editor} = ace.edit("{}");
-    {editor}.session.setMode("ace/mode/yaml");
-    {}
-    """.format(_yaml_id, onsubmit_body, editor=editor_name)
+    _script = f"""
+    let {editor_name} = ace.edit("{_yaml_id}");
+    {editor_name}.session.setMode("ace/mode/yaml");
+    {onsubmit_body}
+    """
 
     t.script(tu.raw(_script),
              charset="utf-8",

--- a/papis/web/libraries.py
+++ b/papis/web/libraries.py
@@ -19,7 +19,7 @@ def html(libname: str) -> t.html_tag:
                 with t.ol(cls="list-group"):
                     libs = papis.api.get_libraries()
                     for lib in libs:
-                        with t.a(href="/library/{}".format(lib)):
+                        with t.a(href=f"/library/{lib}"):
                             t.attr(cls="list-group-item "
                                    "list-group-item-action")
                             wh.icon("book")

--- a/papis/web/navbar.py
+++ b/papis/web/navbar.py
@@ -29,12 +29,12 @@ def navbar(libname: str) -> t.html_tag:
             with t.div(id="navbarNav"):
                 t.attr(cls="collapse navbar-collapse")
                 with t.ul(cls="navbar-nav"):
-                    _li("Search", "/library/{libname}".format(libname=libname),
+                    _li("Search", f"/library/{libname}",
                         active=True)
                     _li("All",
-                        "/library/{libname}/all".format(libname=libname))
+                        f"/library/{libname}/all")
                     _li("Tags",
-                        "/library/{libname}/tags".format(libname=libname))
+                        f"/library/{libname}/tags")
                     _li("Libraries", "/libraries")
 
     return nav

--- a/papis/web/notes.py
+++ b/papis/web/notes.py
@@ -32,7 +32,7 @@ def widget(libname: str, doc: papis.document.Document) -> None:
     with wh.flex("center"):
         with t.form(method="POST",
                     cls="p-3",
-                    onsubmit="{}()".format(onsubmit_name),
+                    onsubmit=f"{onsubmit_name}()",
                     action=wp.update_notes(libname, doc)):
             t.textarea(type="text",
                        id=_notes_input_id,
@@ -48,21 +48,18 @@ def widget(libname: str, doc: papis.document.Document) -> None:
         height=100,
         style="min-height: 500px")
 
-    _script = """
-let {editor} = ace.edit("{editor_id}");
-ace.require('ace/ext/settings_menu').init({editor});
+    _script = f"""
+let {editor_name} = ace.edit("{_notes_id}");
+ace.require('ace/ext/settings_menu').init({editor_name});
 ace.config.loadModule('ace/ext/keybinding_menu',
                         (module) =>  {{
-                            module.init({editor});
+                            module.init({editor_name});
                         }});
-// {editor}.setKeyboardHandler('ace/keyboard/vim');
-{editor}.session.setMode("ace/mode/{ext}");
+// {editor_name}.setKeyboardHandler('ace/keyboard/vim');
+{editor_name}.session.setMode("ace/mode/{_notes_extension}");
 
-{onsubmit}
-    """.format(onsubmit=onsubmit_body,
-               editor=editor_name,
-               ext=_notes_extension,
-               editor_id=_notes_id)
+{onsubmit_body}
+    """
 
     t.script(tu.raw(_script),
              charset="utf-8",

--- a/papis/web/paths.py
+++ b/papis/web/paths.py
@@ -26,7 +26,7 @@ def query_path(libname: str) -> str:
     """
     Path for submiting queries.
     """
-    return "/library/{libname}/query".format(libname=libname)
+    return f"/library/{libname}/query"
 
 
 def fetch_citations_server_path(libname: str, doc: Dict[str, Any]) -> str:

--- a/papis/web/pdfjs.py
+++ b/papis/web/pdfjs.py
@@ -14,7 +14,7 @@ VIEWER_PATH = "pdfjs/web/viewer.html"
 def widget(_unquoted_file_path: str) -> None:
     _file_path = urllib.parse.quote(_unquoted_file_path, safe="")
 
-    viewer_path = ("/static/{}?file={}".format(VIEWER_PATH, _file_path))
+    viewer_path = (f"/static/{VIEWER_PATH}?file={_file_path}")
 
     with wh.flex("center"):
         with t.div(cls="btn-group", role="group"):
@@ -48,7 +48,7 @@ def detect_pdfjs() -> bool:
 
 
 def error_message() -> str:
-    return """
+    return f"""
 No installation of pdfjs found.
 
 If you want to be able to read and see PDF files from within
@@ -56,7 +56,7 @@ the papis web applications you need to install pdfjs.
 
 You can download the PDFJS bundle from the url
 
-    {url}
+    {PDFJS_URL}
 
 and extract it to your config directory under 'web/pdfjs', for instance
 in '~/.config/papis/web/pdfjs/'.
@@ -65,7 +65,7 @@ On linux and mac you can simply run the following lines
 
     mkdir -p ~/.config/papis/web/pdfjs
     cd ~/.config/papis/web/pdfjs
-    wget "{url}" -O pdfjs.zip
+    wget "{PDFJS_URL}" -O pdfjs.zip
     unzip pdfjs.zip
     rm pdfjs.zip
-    """.format(url=PDFJS_URL)
+    """

--- a/papis/web/search.py
+++ b/papis/web/search.py
@@ -19,7 +19,7 @@ QUERY_PLACEHOLDER = "insert query..."
 
 
 def _clear_cache(libname: str) -> None:
-    with t.a(href="/library/{libname}/clear_cache".format(libname=libname)):
+    with t.a(href=f"/library/{libname}/clear_cache"):
         t.i(cls=wh.fa("refresh"),
             data_bs_toggle="tooltip",
             title="Clear Cache")

--- a/papis/web/tags.py
+++ b/papis/web/tags.py
@@ -25,8 +25,7 @@ def ensure_tags_list(tags: Tags) -> List[str]:
 def _tag(tag: str, libname: str) -> t.html_tag:
     return t.a(tag,
                cls="badge bg-dark " + PAPIS_TAG_CLASS,
-               href=("/library/{libname}/query?q=tags:{0}"
-                     .format(tag, libname=libname)))
+               href=f"/library/{libname}/query?q=tags:{tag}")
 
 
 def tags_list_div(tags: Tags, libname: str) -> None:
@@ -42,7 +41,7 @@ def html(pretitle: str, libname: str, tags: Dict[str, int]) -> t.html_tag:
             papis.web.navbar.navbar(libname=libname)
             with wh.container():
                 with t.h1("TAGS"):
-                    with t.a(href="/library/{}/tags/refresh".format(libname)):
+                    with t.a(href=f"/library/{libname}/tags/refresh"):
                         wh.icon("refresh")
                 with wh.container():
                     for tag in sorted(tags,

--- a/papis/web/timeline.py
+++ b/papis/web/timeline.py
@@ -24,8 +24,8 @@ def widget(documents: Sequence[Dict[str, Any]],
         _text = papis.document.describe(_d)
         _href = wp.doc_server_path(libname, _d)
         if _href:
-            return (r"<a href='{}'>{}<i class='fa fa-check'></i></a>"
-                    .format(_href, _text))
+            return fr"<a href='{_href}'>{_text}<i class='fa fa-check'></i></a>"
+
         return _text
 
     json_data = [{"text": {"text": _make_text(d)},
@@ -35,11 +35,11 @@ def widget(documents: Sequence[Dict[str, Any]],
                                  and isinstance(d["month"], int)
                                  else 1}}
                  for d in documents if "year" in d]
-    t.script(tu.raw("""
-    new TL.Timeline('{}',
-                    {{'events': {} }},
+    t.script(tu.raw(f"""
+    new TL.Timeline('{_id}',
+                    {{'events': {json_data} }},
                     {{
                       timenav_height_percentage: 80,
                       width: "100%"
                     }})
-    """.format(_id, json_data)))
+    """))

--- a/setup.py
+++ b/setup.py
@@ -162,9 +162,9 @@ setup(
         "tui",
         "zotero",
     ],
-    package_data=dict(
-        papis=["py.typed"],
-    ),
+    package_data={
+        "papis": ["py.typed"],
+    },
     data_files=data_files,
     packages=included_packages,
     entry_points={

--- a/tests/commands/test_addto.py
+++ b/tests/commands/test_addto.py
@@ -42,5 +42,5 @@ def test_addto_cli(tmp_library: TemporaryLibrary, nfiles: int = 5) -> None:
         infile, _ = os.path.splitext(os.path.basename(infile))
         return outfile.startswith(clean_document_name(infile))
 
-    assert all([eq(outfile, infile) for outfile, infile in zip(files, inputfiles)]), (
+    assert all(eq(outfile, infile) for outfile, infile in zip(files, inputfiles)), (
         list(zip(files, inputfiles)))

--- a/tests/test_arxiv.py
+++ b/tests/test_arxiv.py
@@ -84,5 +84,5 @@ def test_validate_arxivid(tmp_config: TemporaryConfiguration) -> None:
 
     import pytest
     for bad in ["1206.6272v3", "blahv2"]:
-        with pytest.raises(ValueError):
+        with pytest.raises(ValueError, match="not an arxivid"):
             papis.arxiv.validate_arxivid(bad)

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -294,24 +294,13 @@ def test_get_list(tmp_config: TemporaryConfiguration) -> None:
 
     papis.config.set("super-key-list", "[asdf,2,3,4]")
     assert papis.config.get("super-key-list") == "[asdf,2,3,4]"
-    try:
+
+    with pytest.raises(SyntaxError, match="must be a valid Python object"):
         papis.config.getlist("super-key-list")
-    except SyntaxError as e:
-        assert (
-            str(e) == (
-                "The key 'super-key-list' must be a valid Python object: "
-                "[asdf,2,3,4]")
-        )
 
     papis.config.set("super-key-list", "2")
     assert papis.config.get("super-key-list") == "2"
     assert papis.config.getint("super-key-list") == 2
-    try:
+
+    with pytest.raises(SyntaxError, match="must be a valid Python list"):
         papis.config.getlist("super-key-list")
-    except SyntaxError as e:
-        assert (
-            str(e) == (
-                "The key 'super-key-list' must be a valid Python list. "
-                "Got: 2 (type 'int')"
-            )
-        )

--- a/tests/test_dblp.py
+++ b/tests/test_dblp.py
@@ -45,6 +45,7 @@ def test_valid_dblp_key(tmp_config: TemporaryConfiguration, monkeypatch,
             assert not papis.dblp.is_valid_dblp_key(key)
 
 
+@pytest.mark.xfail(reason="dblp times out sometimes")
 def test_importer_match(tmp_config: TemporaryConfiguration, monkeypatch,
                         has_connection: bool = True) -> None:
     with monkeypatch.context() as m:

--- a/tests/test_document.py
+++ b/tests/test_document.py
@@ -54,7 +54,7 @@ def test_main_features() -> None:
 
     assert doc.has("title")
     assert doc["title"] == "Hello World"
-    assert set(doc.keys()) == set(["title", "author"])
+    assert set(doc.keys()) == {"title", "author"}
     assert not doc.has("doi")
 
     doc["doi"] = "123123.123123"
@@ -63,7 +63,7 @@ def test_main_features() -> None:
     del doc["doi"]
     assert not doc.has("doi")
     assert doc["doi"] == ""
-    assert set(doc.keys()) == set(["title", "author"])
+    assert set(doc.keys()) == {"title", "author"}
 
     doc.set_folder(os.path.join(DOCUMENT_RESOURCES, "document"))
     assert doc.get_main_folder_name()
@@ -138,7 +138,7 @@ def test_pickle() -> None:
 
 def test_sort(tmp_config: TemporaryConfiguration) -> None:
     docs = [
-        papis.document.from_data(dict(title="Hello world", year=1990)),
+        papis.document.from_data({"title": "Hello world", "year": 1990}),
         papis.document.from_data({"author": "Turing", "year": "1932"}),
     ]
     sdocs = papis.document.sort(docs, key="year", reverse=False)

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -73,31 +73,31 @@ def test_general_open_with_spaces(tmp_config: TemporaryConfiguration) -> None:
 def test_locate_document(tmp_config: TemporaryConfiguration) -> None:
     from papis.document import from_data
     docs = [
-        from_data(dict(doi="10.1021/ct5004252", title="Hello world")),
+        from_data({"doi": "10.1021/ct5004252", "title": "Hello world"}),
         from_data(
-            dict(
-                doi="10.123/12afad12",
-                author="noone really",
-                title="Hello world"
-            )
+            {
+                "doi": "10.123/12afad12",
+                "author": "noone really",
+                "title": "Hello world"
+            }
         ),
     ]
 
     from papis.utils import locate_document
 
-    doc = from_data(dict(doi="10.1021/CT5004252"))
+    doc = from_data({"doi": "10.1021/CT5004252"})
     found_doc = locate_document(doc, docs)
     assert found_doc is not None
 
-    doc = from_data(dict(doi="CT5004252"))
+    doc = from_data({"doi": "CT5004252"})
     found_doc = locate_document(doc, docs)
     assert found_doc is None
 
-    doc = from_data(dict(author="noone really"))
+    doc = from_data({"author": "noone really"})
     found_doc = locate_document(doc, docs)
     assert found_doc is None
 
-    doc = from_data(dict(title="Hello world"))
+    doc = from_data({"title": "Hello world"})
     found_doc = locate_document(doc, docs)
     assert found_doc is None
 

--- a/tools/create-docker-image.py
+++ b/tools/create-docker-image.py
@@ -11,9 +11,7 @@ if __name__ == "__main__":
     parser = argparse.ArgumentParser()
     parser.add_argument(
         "-p", help="Python version",
-        choices=map(
-            lambda x: "{}.{}".format(*x),
-            zip(it.repeat(3), range(3, 8))))
+        choices=("{}.{}".format(*x) for x in zip(it.repeat(3), range(3, 8))))
     parser.add_argument("dockerfile")
     parser.add_argument(
         "--norun",

--- a/tools/create-docker-image.py
+++ b/tools/create-docker-image.py
@@ -11,7 +11,7 @@ if __name__ == "__main__":
     parser = argparse.ArgumentParser()
     parser.add_argument(
         "-p", help="Python version",
-        choices=("{}.{}".format(*x) for x in zip(it.repeat(3), range(3, 8))))
+        choices=["{}.{}".format(*x) for x in zip(it.repeat(3), range(3, 8))])
     parser.add_argument("dockerfile")
     parser.add_argument(
         "--norun",


### PR DESCRIPTION
This fixes some issue that came up from running
```
ruff check --target-version py37 --select UP papis
```
(essentially running [pyupgrade](https://github.com/asottile/pyupgrade)). The main change is using the more modern f-strings `f"see {value}"` formatting where it makes sense.