### PR TITLE
Add `papis tag` command

### DIFF
--- a/papis/commands/tag.py
+++ b/papis/commands/tag.py
@@ -1,0 +1,185 @@
+"""
+This command allows users to add and remove tags to documents in their library.
+
+Examples
+^^^^^^^^
+
+- To add a tag use the `--add` (or `--append`/`-p`) option:
+
+    .. code:: sh
+
+        papis tag --add TAG1 --add TAG2 QUERY
+
+  This will add TAG1 and TAG2 to a document matched by QUERY. You can repeat
+  `--add` as many times as you need. The query is any query supported by papis.
+  If the query matches more than one document, Papis' picker will be started to
+  let you pick the document from those matched (just as with Papis' other
+  commands).
+
+  Tags are only added if they do not already exist, which is to say that the
+  same tag cannot exist more than once in a given document.
+
+- To remove a tag use the `--remove` (or `-r`) option:
+
+    .. code:: sh
+
+        papis tag --remove TAG1 QUERY
+
+  This removes TAG1 from the document. If it didn't exist before, nothing
+  happens. You can use `--remove` as many times as you like to remove multiple
+  tags.
+
+- Use `--drop` (or `-d`) to remove all tags:
+
+    .. code:: sh
+
+        papis tag --drop --add TAG1 QUERY
+
+  This removes all tags from the document and then adds TAG1. You can of course
+  also use `--drop` by itself to simply remove all tags without adding new
+  ones.
+
+- Use `--all` (or `-a`) with any of the other options to apply the tagging
+  operation to all matching documents:
+
+    .. code:: sh
+
+        papis tag --all --add TAG1 QUERY
+
+  This adds TAG1 to all documents matching the QUERY rather than opening the
+  picker to let you choose one.
+
+"""
+from typing import List, Optional, Tuple, Any, Dict
+
+import click
+
+import papis.cli
+import papis.commands
+import papis.importer
+import papis.strings
+
+logger = papis.logging.get_logger(__name__)
+
+
+@click.command("tag")
+@click.help_option("--help", "-h")
+@papis.cli.git_option()
+@papis.cli.bool_flag(
+    "-d",
+    "--drop",
+    help="Drop all tags",
+    default=False,
+)
+@click.option(
+    "-p",
+    "--add",
+    "--append",
+    "to_add",
+    help="Add a tag",
+    multiple=True,
+    type=str,
+)
+@click.option(
+    "-r",
+    "--remove",
+    "to_remove",
+    help="Remove a tag",
+    multiple=True,
+    type=str,
+)
+@click.option(
+    "-n",
+    "--rename",
+    "to_rename",
+    help="Rename a tag (<OLD-TAG NEW-TAG>)",
+    multiple=True,
+    type=(str, str),
+)
+@papis.cli.doc_folder_option()
+@papis.cli.all_option()
+@papis.cli.sort_option()
+@papis.cli.query_argument()
+def cli(
+    git: bool,
+    drop: bool,
+    to_add: List[str],
+    to_remove: List[str],
+    to_rename: List[Tuple[str, str]],
+    sort_field: Optional[str],
+    sort_reverse: bool,
+    query: str,
+    doc_folder: Tuple[str, ...],
+    _all: bool,
+) -> None:
+    """
+    Change a document's tags.
+    """
+
+    # if do_tag:
+    documents = papis.cli.handle_doc_folder_query_all_sort(
+        query, doc_folder, sort_field, sort_reverse, _all
+    )
+
+    if not documents:
+        logger.warning(papis.strings.no_documents_retrieved_message)
+        return
+
+    from papis.commands.update import run_append, run_remove, run_drop, run_rename, run
+
+    key_types: Dict[str, type] = {"tags": list}
+
+    success = True
+    processed_documents: List[Any] = []
+    for document in documents:
+        tags = document.get("tags", [])
+        if not isinstance(tags, list):
+            processed_documents.clear()
+            logger.error(
+                "The document with papis_id '%s' contains tags that aren't "
+                "defined as a list of items. As `papis tag` only supports "
+                "lists, tagging has been aborted and no documents have been "
+                "changed. You can use `papis doctor --check key-type --fix` to "
+                "convert all your tags to use lists.",
+                document["papis_id"],
+            )
+            break
+
+        ctx = papis.importer.Context()
+
+        ctx.data.update(document)
+        if drop and success:
+            run_drop(ctx.data, ["tags"])
+
+        if to_add and success:
+            to_add_tuples = [("tags", tag) for tag in to_add]
+            success = run_append(ctx.data, to_add_tuples, key_types, False)
+
+        if to_remove and success:
+            to_remove_tuples = [("tags", tag) for tag in to_remove]
+            success = run_remove(ctx.data, to_remove_tuples, False)
+
+        if to_rename:
+            to_rename_tuples = [
+                ("tags", old_tag, new_tag) for old_tag, new_tag in to_rename
+            ]
+            success = run_rename(ctx.data, to_rename_tuples, False)
+
+        if success:
+            processed_documents.append((document, ctx.data))
+
+        if not success:
+            processed_documents.clear()
+            logger.error(
+                "Papis has encountered an unexpected error while processing "
+                "document '%s'. Tagging has been aborted and no documents have "
+                "been changed. Please report this bug at "
+                "https://github.com/papis/papis.",
+                document["papis_id"],
+            )
+            break
+
+    for document, data in processed_documents:
+        run(document, data=data, git=git, auto_doctor=False)
+
+    logger.info("Updated tags in %d documents", len(processed_documents))

--- a/setup.py
+++ b/setup.py
@@ -227,6 +227,7 @@ setup(
             "rm=papis.commands.rm:cli",
             "run=papis.commands.run:cli",
             "serve=papis.commands.serve:cli",
+            "tag=papis.commands.tag:cli",
             "update=papis.commands.update:cli",
             "cache=papis.commands.cache:cli",
             "init=papis.commands.init:cli",

--- a/tests/commands/test_tag.py
+++ b/tests/commands/test_tag.py
@@ -1,0 +1,201 @@
+import os
+
+import papis.database
+
+from papis.testing import TemporaryLibrary, PapisRunner
+
+
+def _get_resource_file(filename: str) -> str:
+    resources = os.path.join(
+        os.path.dirname(os.path.abspath(__file__)), "resources", "update"
+    )
+    filepath = os.path.join(resources, filename)
+    assert os.path.exists(filepath)
+
+    return filepath
+
+
+def test_tag_add_general_cli(tmp_library: TemporaryLibrary) -> None:
+    from papis.commands.tag import cli
+
+    cli_runner = PapisRunner()
+
+    result = cli_runner.invoke(cli, ["__no_document__"])
+    assert result.exit_code == 0
+    assert not result.output
+
+    result = cli_runner.invoke(
+        cli,
+        ["--add", "tag3"] + ["--add", "2345"] + ["krishnamurti"],
+    )
+    assert result.exit_code == 0
+
+    db = papis.database.get()
+    (doc,) = db.query_dict({"author": "Krishnamurti"})
+    assert "tag1" in doc["tags"]
+    assert 2345 in doc["tags"]
+
+
+def test_tag_add_to_new_key_cli(tmp_library: TemporaryLibrary) -> None:
+    from papis.commands.tag import cli
+
+    cli_runner = PapisRunner()
+
+    result = cli_runner.invoke(cli, ["__no_document__"])
+    assert result.exit_code == 0
+    assert not result.output
+
+    result = cli_runner.invoke(
+        cli,
+        ["--add", "tag3"] + ["doc without files"],
+    )
+    assert result.exit_code == 0
+
+    db = papis.database.get()
+    (doc,) = db.query_dict({"author": "doc without files"})
+    assert doc["tags"] == ["tag3"]
+
+
+def test_tag_add_del_duplicates_in_list_cli(
+    tmp_library: TemporaryLibrary,
+) -> None:
+    from papis.commands.tag import cli
+
+    cli_runner = PapisRunner()
+
+    result = cli_runner.invoke(cli, ["__no_document__"])
+    assert result.exit_code == 0
+    assert not result.output
+
+    result = cli_runner.invoke(
+        cli,
+        ["--add", "tag3"] + ["--add", "tag3"] + ["krishnamurti"],
+    )
+    assert result.exit_code == 0
+
+    db = papis.database.get()
+    (doc,) = db.query_dict({"author": "Krishnamurti"})
+    assert doc["tags"].count("tag3") == 1
+
+
+def test_tag_remove_general_cli(
+    tmp_library: TemporaryLibrary,
+) -> None:
+    from papis.commands.tag import cli
+
+    cli_runner = PapisRunner()
+
+    result = cli_runner.invoke(cli, ["__no_document__"])
+    assert result.exit_code == 0
+    assert not result.output
+
+    result = cli_runner.invoke(
+        cli,
+        ["--remove", "tag1"] + ["--remove", "1234"] + ["krishnamurti"],
+    )
+    assert result.exit_code == 0
+
+    db = papis.database.get()
+    (doc,) = db.query_dict({"author": "Krishnamurti"})
+    assert doc.get("tags") is None
+
+
+def test_tag_remove_from_missing_key_cli(
+    tmp_library: TemporaryLibrary,
+) -> None:
+    from papis.commands.tag import cli
+
+    cli_runner = PapisRunner()
+
+    result = cli_runner.invoke(cli, ["__no_document__"])
+    assert result.exit_code == 0
+    assert not result.output
+
+    result = cli_runner.invoke(
+        cli,
+        ["--remove", "tag"] + ["doc without files"],
+    )
+    assert result.exit_code == 0
+
+
+def test_tag_drop_general_cli(
+    tmp_library: TemporaryLibrary,
+) -> None:
+    from papis.commands.tag import cli
+
+    cli_runner = PapisRunner()
+
+    result = cli_runner.invoke(cli, ["__no_document__"])
+    assert result.exit_code == 0
+    assert not result.output
+
+    result = cli_runner.invoke(
+        cli,
+        ["--drop"] + ["krishnamurti"],
+    )
+    assert result.exit_code == 0
+
+    db = papis.database.get()
+    (doc,) = db.query_dict({"author": "Krishnamurti"})
+    assert doc.get("tags") is None
+
+
+def test_tag_drop_missing_key_cli(
+    tmp_library: TemporaryLibrary,
+) -> None:
+    from papis.commands.tag import cli
+
+    cli_runner = PapisRunner()
+
+    result = cli_runner.invoke(cli, ["__no_document__"])
+    assert result.exit_code == 0
+    assert not result.output
+
+    result = cli_runner.invoke(
+        cli,
+        ["--drop"] + ["doc without files"],
+    )
+    assert result.exit_code == 0
+
+
+def test_tag_rename_general_cli(
+    tmp_library: TemporaryLibrary,
+) -> None:
+    from papis.commands.tag import cli
+
+    cli_runner = PapisRunner()
+
+    result = cli_runner.invoke(cli, ["__no_document__"])
+    assert result.exit_code == 0
+    assert not result.output
+
+    result = cli_runner.invoke(
+        cli,
+        ["--rename", "tag1", "tag_renamed1"]
+        + ["--rename", "1234", "2345"]
+        + ["krishnamurti"],
+    )
+    assert result.exit_code == 0
+
+    db = papis.database.get()
+    (doc,) = db.query_dict({"author": "Krishnamurti"})
+    assert "tag_renamed1" in doc["tags"]
+    assert 2345 in doc["tags"]
+
+
+def test_tag_rename_missing_value_cli(
+    tmp_library: TemporaryLibrary,
+) -> None:
+    from papis.commands.tag import cli
+
+    cli_runner = PapisRunner()
+
+    result = cli_runner.invoke(cli, ["__no_document__"])
+    assert result.exit_code == 0
+    assert not result.output
+
+    result = cli_runner.invoke(
+        cli,
+        ["--rename", "tag_nonexistent", "tag_renamed1"] + ["krishnamurti"],
+    )
+    assert result.exit_code == 0


### PR DESCRIPTION
This is a draft of a new `papis tag` command that allows adding/removing/clearing tags. There are some docs inside to show you what's possible.

This is mostly just a first working draft to get some feedback. Here are some questions/considerations I'm unsure about:

- Is this a useful thing to ship with papis? We already have `papis update` that can do some of what `papis tag` can do. Is there too much overlap? Should this maybe rather be an additional script?
- What functionality would you like to see? Maybe it could be useful to apply all tags from one doc to another for instance...
- Better idea for the names/structure of the options? For instance I would have liked to use `--add` for adding tags, but the short version of that is `-a` which is already used by `--all`. I've also considered using `+TAG` and `-TAG`, but haven't found a straightforward way of implementing this in python click (and it isn't consistent with other papis commands).
- I'm not all that well versed with python, so any suggestions for improvements are very welcome.
- I've added a new config option for the `tag-format`. I've made some assumptions regarding how people list their tags, namely that they're either a list, or a string separated by `, `, `; ` or ` `. I've considered allowing any arbitrary separators, but that's not very easy to set in the config because of the white space. I've also considered trying to detect the tag-format automatically (which I actually do in `papis.nvim`), but opted against it as it isn't foolproof (which is more acceptable for `papis.nvim` as it doesn't edit any documents).

Note that there might be bugs in here, so don't use with your actual library. Also, it requires explicitly setting the `tag-format` in your config.

EDIT: Bunch of errors in the CI, looks like my winging of the typing system hasn't quite gone right (and I also introduced a bunch of trailing white space when I wrote the explanations). :sweat_smile: I'll get to these!