### PR TITLE
document: add heuristics for splitting authors

### DIFF
--- a/papis/bibtex.py
+++ b/papis/bibtex.py
@@ -263,7 +263,7 @@ def bibtexparser_entry_to_papis(entry: Dict[str, Any]) -> Dict[str, Any]:
             "key": "author_list",
             "action": lambda author: papis.document.split_authors_name([
                 latex_to_unicode(author)
-                ])
+                ], separator="and")
             }]),
     ]
 

--- a/papis/dblp.py
+++ b/papis/dblp.py
@@ -67,7 +67,7 @@ def _dblp_journal(name: str) -> Optional[str]:
 
 
 def _dblp_authors(entries: Dict[str, Any]) -> List[Dict[str, Any]]:
-    return [papis.document.split_authors_name([author["text"]])[0]
+    return [papis.document.split_author_name(author["text"])
             for author in entries["author"]]
 
 

--- a/papis/downloaders/base.py
+++ b/papis/downloaders/base.py
@@ -137,7 +137,7 @@ def parse_meta_authors(soup: "bs4.BeautifulSoup") -> List[Dict[str, Any]]:
     # convert to papis author format
     author_list: List[Dict[str, Any]] = []
     for author, aff in authors_and_affs:
-        fullname, = papis.document.split_authors_name([author.get("content")])
+        fullname = papis.document.split_author_name(author.get("content"))
         affiliation = [{"name": aff.get("content")}] if aff else []
 
         author_list.append({

--- a/tests/test_document.py
+++ b/tests/test_document.py
@@ -162,3 +162,78 @@ def test_dump() -> None:
         )
 
     assert result == expected_result
+
+
+def test_author_separator_heuristics() -> None:
+    import re
+    from papis.document import guess_authors_separator, split_authors_name
+
+    def is_comma_and_re(sep):
+        assert sep
+        assert re.match(sep, ", and")
+        assert re.match(sep, ",and")
+        assert re.match(sep, ",")
+
+    s = "Sanger, F. and Nicklen, S. and Coulson, A. R."
+    expected = [{"family": "Sanger", "given": "F."},
+                {"family": "Nicklen", "given": "S."},
+                {"family": "Coulson", "given": "A. R."}]
+    assert guess_authors_separator(s) == "and"
+    assert split_authors_name([s]) == expected
+
+    expected = [{"family": "Sanger", "given": "Fabian"},
+                {"family": "Nicklen", "given": "Steven"},
+                {"family": "Coulson", "given": "Alexander R."}]
+
+    s = "Fabian Sanger and Steven Nicklen and Alexander R. Coulson"
+    assert guess_authors_separator(s) == "and"
+    assert split_authors_name([s]) == expected
+
+    s = "Fabian Sanger, Steven Nicklen, Alexander R. Coulson"
+    assert guess_authors_separator(s) == ","
+    assert split_authors_name([s]) == expected
+
+    s = "Fabian Sanger, and Steven Nicklen, and Alexander R. Coulson"
+    sep = guess_authors_separator(s)
+    is_comma_and_re(sep)
+    assert split_authors_name([s]) == expected
+
+    s = "Fabian Sanger, Steven Nicklen, and Alexander R. Coulson"
+    sep = guess_authors_separator(s)
+    is_comma_and_re(sep)
+    assert split_authors_name([s]) == expected
+
+    expected = [{"family": "Doe", "given": "John"},
+                {"family": "Dorian", "given": "Jane"},
+                {"family": "Unknown", "given": "James T."}]
+
+    s = "John Doe, Jane Dorian, and James T. Unknown "
+    sep = guess_authors_separator(s)
+    is_comma_and_re(sep)
+    assert split_authors_name([s]) == expected
+
+    expected = [{"family": "Duck", "given": "Dagobert"},
+                {"family": "von Beethoven", "given": "Ludwig"},
+                {"family": "Ford Jr.", "given": "Henry"}]
+
+    s = "Dagobert Duck and von Beethoven, Ludwig and Ford, Jr., Henry"
+    assert guess_authors_separator(s) == "and"
+    assert split_authors_name([s]) == expected
+
+    expected = [{"family": "Turing", "given": "A. M."}]
+
+    s = "Turing, A. M."
+    assert guess_authors_separator(s) == "and"
+    assert split_authors_name([s]) == expected
+
+    expected = [{"family": "Liddel Hart", "given": "Basil"}]
+
+    s = "Liddel Hart, Basil"
+    assert guess_authors_separator(s) == "and"
+    assert split_authors_name([s]) == expected
+
+    # NOTE: we cannot usefully distinguish between these cases:
+    #   s = "Last Last, First"        # one author
+    #   s = "Last, First First"       # one author
+    #   s = "Last Last, First First"  # one author
+    #   s = "First Last, First Last"  # two authors


### PR DESCRIPTION
@f0rki Cherrypicked from #598. There is one change though: the `guess_authors_separator` function always returns a string so that the single author case doesn't need a special `if` every time.

I imagine this heuristic will need tweaking over time, but it looks pretty useful already.