### PR TITLE
commands.doctor: add separator to key-check

### DIFF
--- a/doc/source/default-settings.rst
+++ b/doc/source/default-settings.rst
@@ -412,7 +412,20 @@ Bibtex options
 
    A list of two tuples with ``(key, type)`` used by the ``key-type`` check. This
    check will show an error if the key does not have the corresponding type. The
-   type should be a builtin Python type that can be used with ``eval``.
+   type should be a builtin Python type that can be used with ``eval``. For
+   example, this can be ``[("year", "int"), ("tags", "list")]`` to check that the
+   year is an integers and the tags are given as a list in a document.
+
+.. papis-config:: doctor-key-type-check-separator
+
+    A separator used by the ``key-type`` check fixer. When converting from
+    :class:`str` to :class:`list`, it is used to split the string into a list,
+    and when converting from :class:`list` to :class:`str`, it is used to join
+    list items. The split will ignore additional whitespace around the separator
+    (for instance, when set to ``,``, the string ``"extra,    whitespace"`` will
+    be converted to the list ``["extra", "whitespace"]``). To preserve leading
+    or trailing whitespace in the separator, make sure to quote it (for instance,
+    ``", "``).
 
 Citations options
 -----------------

--- a/papis/commands/doctor.py
+++ b/papis/commands/doctor.py
@@ -238,6 +238,7 @@ def refs_check(doc: papis.document.Document) -> List[Error]:
     :returns: an error if the reference does not exist or contains invalid
         characters (as required by BibTeX).
     """
+    import papis.bibtex
     from papis.api import save_doc
 
     folder = doc.get_main_folder() or ""
@@ -367,8 +368,11 @@ def key_type_check(doc: papis.document.Document) -> List[Error]:
     """
     Check document keys have expected types.
 
-    The ``doctor-key-type-check-keys`` configuration entry defines a mapping
-    of keys and their expected types.
+    The :ref:`config-settings-doctor-key-type-check-keys` configuration entry
+    defines a mapping of keys and their expected types. If the desired type is
+    a list, the :ref:`config-settings-doctor-key-type-check-separator` setting
+    can be used to split an existing string (and, similarly, if the desired type
+    is a string, it can be used to join a list of items).
 
     :returns: a :class:`list` of errors, one for each key does not have the
         expected type (if it exists).
@@ -376,9 +380,29 @@ def key_type_check(doc: papis.document.Document) -> List[Error]:
     from papis.api import save_doc
     folder = doc.get_main_folder() or ""
 
+    # NOTE: the separator can be quoted so that it can force whitespace
+    separator = papis.config.get("doctor-key-type-check-separator")
+    separator = separator.strip("'").strip('"') if separator else None
+
     def make_fixer(key: str, cls: type) -> FixFn:
         def fixer_convert_list() -> None:
-            doc[key] = [doc[key]]
+            value = doc[key]
+
+            if isinstance(value, str) and separator:
+                doc[key] = re.split(fr"\s*{separator}\s*", value)
+            else:
+                doc[key] = [value]
+
+            save_doc(doc)
+
+        def fixer_convert_str() -> None:
+            value = doc[key]
+
+            if isinstance(value, list) and separator:
+                doc[key] = separator.join(value)
+            else:
+                doc[key] = str(value)
+
             save_doc(doc)
 
         def fixer_convert_any() -> None:
@@ -396,6 +420,8 @@ def key_type_check(doc: papis.document.Document) -> List[Error]:
 
         if cls is list:
             return fixer_convert_list
+        if cls is str:
+            return fixer_convert_str
         else:
             return fixer_convert_any
 

--- a/papis/defaults.py
+++ b/papis/defaults.py
@@ -54,6 +54,7 @@ settings: Dict[str, Any] = {
     "doctor-duplicated-keys-keys": ["ref"],
     "doctor-html-codes-keys": ["title", "author", "abstract", "journal"],
     "doctor-html-tags-keys": ["title", "author", "abstract", "journal"],
+    "doctor-key-type-check-separator": None,
     "doctor-key-type-check-keys": [("year", "int"),
                                    ("month", "int"),
                                    ("files", "list"),


### PR DESCRIPTION
This builds on #652 and adds some extra functionality when dealing with `list -> str` or `str -> list` conversions.

@jghauser What do you think? Could this be used to "fix" tags? i.e. something like this could be used to split them up
```
papis --set doctor-key-type-separator ', ' doctor --check key-type --fix QUERY
```
I added some test cases for that specifically and it seems ok. Did you have other formats in mind?