### PR TITLE
commands.browse: add browse-key auto option

### DIFF
--- a/doc/source/default-settings.rst
+++ b/doc/source/default-settings.rst
@@ -334,7 +334,7 @@ Bibtex options
 
 .. papis-config:: browse-key
 
-    This settings provides the key that is used to generate a URL for the
+    This setting provides the key that is used to generate a URL for the
     ``papis browse`` command. In the simplest case, ``browse-key`` is just a
     key in the document (e.g. ``url``) that contains a URL to open. It also
     supports the following special values:

--- a/doc/source/default-settings.rst
+++ b/doc/source/default-settings.rst
@@ -348,11 +348,13 @@ Bibtex options
     to ``doi`` constructs the url from ``dx.doi.org/<DOI>``, providing a
     much more accurate url.
 
-    Default value is set to ``url``. If you need functionality
-    with the ``search-engine`` option, set the option to an empty
-    string e.g.  ::
+    The key can be any existing key into the info.yaml file, but the only ones
+    currently mapped to a specific url construction in browse.py are:
+    doi, isbn, ads. If you need functionality with the ``search-engine`` option,
+    set the option to an empty string e.g.  :: browse-key = ''.
 
-        browse-key = ''
+    Default value is set to ``auto`` : it will automatically set the key to the
+    first one found in the yaml file, in order: url, doi, isbn, ads.
 
 .. _edit-command-options:
 

--- a/doc/source/default-settings.rst
+++ b/doc/source/default-settings.rst
@@ -41,15 +41,6 @@ General settings
     Some commands will issue git commands if this option is set to ``True``.
     For example in ``mv`` or ``rename``.
 
-.. papis-config:: browse-query-format
-
-    The query string that is to be searched for in the ``browse`` command
-    whenever a search engine is used.
-
-.. papis-config:: search-engine
-
-    Search engine to be used by some commands like ``browse``.
-
 .. papis-config:: user-agent
 
     User agent used by papis whenever it obtains information from external
@@ -343,18 +334,32 @@ Bibtex options
 
 .. papis-config:: browse-key
 
-    This command provides the key that is used to generate the
-    url. For users that run ``papis add --from-doi``, setting browse-key
-    to ``doi`` constructs the url from ``dx.doi.org/<DOI>``, providing a
-    much more accurate url.
+    This settings provides the key that is used to generate a URL for the
+    ``papis browse`` command. In the simplest case, ``browse-key`` is just a
+    key in the document (e.g. ``url``) that contains a URL to open. It also
+    supports the following special values:
 
-    The key can be any existing key into the info.yaml file, but the only ones
-    currently mapped to a specific url construction in browse.py are:
-    doi, isbn, ads. If you need functionality with the ``search-engine`` option,
-    set the option to an empty string e.g.  :: browse-key = ''.
+    * ``"doi"``: construct a URL from the DOI as ``https://dx.doi.org/<DOI>``.
+    * ``"isbn"``: construct a URL from the ISBN as ``https://isbnsearch/isbn/<ISBN>``.
+    * ``"ads"``: construct a URL for the Astrophysics Data System as
+      ``https://ui.adsabs.harvard.edu/abs/<DOI>``.
+    * ``"auto"``: automatically pick between ``url``, ``doi`` and ``isbn``
+      (first existing key is chosen).
+    * ``"search-engine"``: the :ref:`config-settings-search-engine` is used
+      to search for the contents of :ref:`config-settings-browse-query-format`.
 
-    Default value is set to ``auto`` : it will automatically set the key to the
-    first one found in the yaml file, in order: url, doi, isbn, ads.
+    If the required keys are not found in the document (e.g. the DOI or the
+    ISBN), the key will fallback to the ``"search-engine"`` case.
+
+.. papis-config:: browse-query-format
+
+    The query string that is to be searched for in the ``papis browse`` command
+    whenever a search engine is used (see :ref:`config-settings-browse-key`).
+
+.. papis-config:: search-engine
+
+    Search engine to be used by some commands like ``papis browse``. This should be
+    a base URL that is then used to construct a search as ``<BASE>/?<PARAMS>``.
 
 .. _edit-command-options:
 

--- a/papis/commands/browse.py
+++ b/papis/commands/browse.py
@@ -89,6 +89,14 @@ def run(document: papis.document.Document,
     key = papis.config.getstring("browse-key")
 
     try:
+        if "auto" == key:
+            if document["url"]:
+                key = "url"
+            elif document["doi"]:
+                key = "doi"
+            elif document["isbn"]:
+                key = "isbn"
+
         if "doi" == key:
             url = "https://doi.org/{}".format(document["doi"])
         elif "ads" == key:

--- a/papis/defaults.py
+++ b/papis/defaults.py
@@ -126,7 +126,7 @@ settings: Dict[str, Any] = {
     "serve-timeline-css": ("https://cdn.knightlab.com/libs/timeline3/"
                            "latest/css/timeline.css"),
 
-    "browse-key": "url",
+    "browse-key": "auto",
     "browse-query-format": "{doc[title]} {doc[author]}",
     "search-engine": "https://duckduckgo.com",
     "user-agent": "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_9_3)",


### PR DESCRIPTION
A very small improvement: adding a 'browse-key' auto which allows the program to cleverly choose by itself the key if the document["url"] is not found. A step more on the road of the full automation of papis...