### PR TITLE
document: implement copy

### DIFF
--- a/papis/document.py
+++ b/papis/document.py
@@ -334,6 +334,15 @@ class Document(Dict[str, Any]):
         """
         return ""
 
+    def copy(self) -> "Document":
+        doc = Document(data=dict(self))
+
+        folder = self.get_main_folder()
+        if folder:
+            doc.set_folder(folder)
+
+        return doc
+
     @property
     def html_escape(self) -> DocHtmlEscaped:
         return DocHtmlEscaped(self)


### PR DESCRIPTION
Previously `doc.copy()` would return a bare `dict`. This fixes it to return a `Document` with a main folder.