### PR TITLE
config: allow template marker in format config

### DIFF
--- a/tests/test_format.py
+++ b/tests/test_format.py
@@ -56,3 +56,51 @@ def test_jinja_formater(tmp_config: TemporaryConfiguration, monkeypatch) -> None
             "{{ doc.author }}: {{ doc.title }} ({{ doc.blahblah }})",
             data)
         == ": The Phantom Menace ()")
+
+def test_local_formater(tmp_config: TemporaryConfiguration, monkeypatch) -> None:
+    for global_formater in ['jinja2', 'python']:
+        if global_formater == 'jinja2':
+            pytest.importorskip("jinja2")
+        monkeypatch.setattr(papis.format, "FORMATER", None)
+        papis.config.set("formater", global_formater)
+
+        document = papis.document.from_data({"author": "Fulano", "title": "A New Hope"})
+        data = {"title": "The Phantom Menace"}
+        # Python
+        assert (
+            papis.format.format("[python]{doc[author]}: {doc[title]}", document)
+            == "Fulano: A New Hope")
+        assert (
+            papis.format.format("[python]{doc[author]}:\\n\\t»{doc[title]}", document)
+            == "Fulano:\n\t»A New Hope")
+        assert (
+            papis.format.format(
+                "[python]{doc[author]}: {doc[title]} - {doc[blahblah]}",
+                document)
+            == "Fulano: A New Hope - ")
+
+        assert (
+            papis.format.format(
+                "[python]{doc[author]}: {doc[title]} ({doc[blahblah]})",
+                data)
+            == ": The Phantom Menace ()")
+
+        # Jinja2
+        assert (
+            papis.format.format("[jinja2]{{ doc.author }}: {{ doc.title }}", document)
+            == "Fulano: A New Hope")
+        assert (
+            papis.format.format("[jinja2]{{ doc. author }}:\\n\\t»{{ doc.title }}", document)
+            == "Fulano:\n\t»A New Hope")
+        assert (
+            papis.format.format(
+                "[jinja2]{{ doc.author }}: {{ doc.title }} - {{ doc.blahblah }}",
+                document)
+            == "Fulano: A New Hope - ")
+
+        assert (
+            papis.format.format(
+                "[jinja2]{{ doc.author }}: {{ doc.title }} ({{ doc.blahblah }})",
+                data)
+            == ": The Phantom Menace ()")
+


### PR DESCRIPTION
Allow template prefix marker like `[jinja2]` and `[python]` to set formater locally for fields involving templating. This saves one from setting all the other configuration explicitly when he wants to use jinja2.