### PR TITLE
commands.doctor: add some colors to the output

### DIFF
--- a/papis/commands/doctor.py
+++ b/papis/commands/doctor.py
@@ -644,16 +644,28 @@ def cli(query: str,
         click.echo(json.dumps(list(map(error_to_dict, errors))))
         return
 
+    import colorama as c
+
     from papis.commands.edit import run as edit_run
 
-    for error in errors:
-        click.echo(f"{error.name}\t{error.payload}\t{error.path}")
+    for i, error in enumerate(errors):
+        if i != 0:
+            click.echo()
+
+        click.echo(
+            f"{c.Style.BRIGHT}{c.Fore.RED}{error.name}{c.Style.RESET_ALL}"
+            f"\t{c.Style.BRIGHT}{error.payload}{c.Style.RESET_ALL}"
+            f"\t{c.Fore.YELLOW}{error.path}{c.Style.RESET_ALL}")
 
         if explain:
-            click.echo(f"\tReason: {error.msg}")
+            click.echo(
+                f"\t{c.Style.BRIGHT}{c.Fore.CYAN}Reason{c.Style.RESET_ALL}: "
+                f"{error.msg}")
 
         if suggest:
-            click.echo(f"\tSuggestion: {error.suggestion_cmd}")
+            click.echo(
+                f"\t{c.Style.BRIGHT}{c.Fore.GREEN}Suggestion{c.Style.RESET_ALL}: "
+                f"{error.suggestion_cmd}")
 
         if fix:
             error.fix_action()


### PR DESCRIPTION
Added some colors to the output (that largely match what's in `papis.logging`). It looks like this in my terminal

![Screenshot_20230909_110518](https://github.com/papis/papis/assets/777240/0353e9b1-c63e-4fe6-ac04-9399ba50062d)

@jghauser What do you think? For a lot of errors, the output was hard to parse at a glance, so I thought some colors would do it good!