### PR TITLE
format: fix spelling formater vs formatter

### DIFF
--- a/doc/source/default-settings.rst
+++ b/doc/source/default-settings.rst
@@ -374,8 +374,9 @@ BibTeX options
 
     In ``papis edit`` you can edit notes about the document. ``notes-name``
     is the default name of the notes file, which by default is supposed
-    to be a TeX file. The ``notes-name`` is formated by the ``formater``, so
-    that the filename of notes can be dynamically defined, e.g.:  ::
+    to be a TeX file. The ``notes-name`` is formatted by the
+    :ref:`config-settings-formatter`, so that the filename of notes can be
+    dynamically defined, e.g.:  ::
 
         notes-name = notes_{doc[title]:.15}.tex
 
@@ -383,8 +384,9 @@ BibTeX options
 
     When editing notes for the first time, a preliminary note will be generated
     based on a template. The path to this template is specified by
-    ``notes-template``. The template will then be formated by ``formater``.
-    This can be useful to enforce the same style in the notes for all documents.
+    ``notes-template``. The template will then be formatted by
+    :ref:`config-settings-formatter`. This can be useful to enforce the same
+    style in the notes for all documents.
 
     Default value is set to ``""``, which will return an empty notes file. If
     no file is found at the path to the template, then also an empty notes file
@@ -853,14 +855,16 @@ Other
   papis. If documents have a timestamp, then they will be sortable
   using ``--sort time-added`` option.
 
-.. papis-config:: formater
+.. papis-config:: formatter
 
-    Picks the formater for templated strings in the configuration file and
-    in various strings presented to the user. Supported formaters are
+    Picks the formatter for templated strings in the configuration file and
+    in various strings presented to the user. Supported formatters are
 
-    * ``"python"``: based on :class:`papis.format.PythonFormater`.
-    * ``"jinja2"``: based on :class:`papis.format.Jinja2Formater`.
+    * ``"python"``: based on :class:`papis.format.PythonFormatter`.
+    * ``"jinja2"``: based on :class:`papis.format.Jinja2Formatter`.
 
     Note that the default values of many of the papis configuration settings are
     based on the Python formatter. These will need to all be specified explicitly
-    if another formater is chosen.
+    if another formatter is chosen.
+
+    **Note** The older (misspelled) version ``"formater"`` is deprecated.

--- a/papis/defaults.py
+++ b/papis/defaults.py
@@ -160,7 +160,9 @@ settings: Dict[str, Any] = {
         "[<ansiyellow>{doc.html_escape[tags]}</ansiyellow>]"
     ),
 
-    "formater": "python",
+    "formatter": "python",
+    # FIXME: this is deprecated and should be removed at some point
+    "formater": None,
     "time-stamp": True,
     "info-allow-unicode": True,
     "ref-format": "{doc[title]:.15} {doc[author]:.6} {doc[year]}",

--- a/papis/utils.py
+++ b/papis/utils.py
@@ -88,7 +88,7 @@ def parmap(f: Callable[[A], B],
     """
 
     # FIXME: load singleton plugins here instead of on all the processes
-    _ = papis.format.get_formater()
+    _ = papis.format.get_formatter()
 
     if np is None:
         np = int(os.environ.get("PAPIS_NP", str(os.cpu_count())))

--- a/setup.py
+++ b/setup.py
@@ -198,8 +198,8 @@ setup(
             "papis=papis.tui.picker:Picker",
         ],
         "papis.format": [
-            "jinja2=papis.format:Jinja2Formater",
-            "python=papis.format:PythonFormater",
+            "jinja2=papis.format:Jinja2Formatter",
+            "python=papis.format:PythonFormatter",
         ],
         "papis.command": [
             "add=papis.commands.add:cli",

--- a/tests/test_format.py
+++ b/tests/test_format.py
@@ -7,9 +7,9 @@ import papis.document
 from tests.testlib import TemporaryConfiguration
 
 
-def test_python_formater(tmp_config: TemporaryConfiguration, monkeypatch) -> None:
-    papis.config.set("formater", "python")
-    monkeypatch.setattr(papis.format, "FORMATER", None)
+def test_python_formatter(tmp_config: TemporaryConfiguration, monkeypatch) -> None:
+    papis.config.set("formatter", "python")
+    monkeypatch.setattr(papis.format, "FORMATTER", None)
 
     document = papis.document.from_data({"author": "Fulano", "title": "A New Hope"})
     assert (
@@ -32,10 +32,10 @@ def test_python_formater(tmp_config: TemporaryConfiguration, monkeypatch) -> Non
         == ": The Phantom Menace ()")
 
 
-def test_jinja_formater(tmp_config: TemporaryConfiguration, monkeypatch) -> None:
+def test_jinja_formatter(tmp_config: TemporaryConfiguration, monkeypatch) -> None:
     pytest.importorskip("jinja2")
-    papis.config.set("formater", "jinja2")
-    monkeypatch.setattr(papis.format, "FORMATER", None)
+    papis.config.set("formatter", "jinja2")
+    monkeypatch.setattr(papis.format, "FORMATTER", None)
 
     document = papis.document.from_data({"author": "Fulano", "title": "A New Hope"})
     assert (


### PR DESCRIPTION
This changes to the correct spelling "formatter" everywhere and adds a bunch of deprecation warnings and safeguards. Will need to test a bit, but it should be safe.

@jghauser Better? :grin: 
