### PR TITLE
commands.add: show document before adding

### DIFF
--- a/papis/commands/rm.py
+++ b/papis/commands/rm.py
@@ -142,9 +142,9 @@ def cli(query: str,
         for document in documents:
             if not force:
                 logger.warning("Removing folder: '%s'.", document.get_main_folder())
-                logger.warning("The following document will be removed:")
                 papis.tui.utils.text_area(
                     text=papis.document.dump(document),
+                    title="This document will be removed",
                     lexer_name="yaml")
                 if not papis.tui.utils.confirm(
                         "Do you want to remove the document?"):

--- a/papis/document.py
+++ b/papis/document.py
@@ -478,17 +478,22 @@ def dump(document: Document) -> str:
 
     >>> doc = from_data({'title': 'Hello World'})
     >>> dump(doc)
-    'title:     Hello World'
+    'title: Hello World'
     """
-    # NOTE: this tries to align all the values to the next multiple of 4 of the
-    # longest key length, for a minimum of visual consistency
-    width = max(len(key) for key in document)
-    width = (width // 4 + 2) * 4 - 1
+    import yaml
+    from papis.yaml import Dumper   # type: ignore[attr-defined]
 
-    return "\n".join([
-        "{:{}}{}".format(f"{key}:", width, value)
-        for key, value in sorted(document.items())
-        ])
+    data = dict(document)
+
+    # NOTE: poping some usually very long and unhelpful fields
+    data.pop("citations", None)
+    data.pop("abstract", None)
+    data.pop("papis_id", None)
+
+    return str(yaml.dump(data,
+                         Dumper=Dumper,
+                         allow_unicode=True,
+                         default_flow_style=False)).strip()
 
 
 def delete(document: Document) -> None:

--- a/papis/tui/utils.py
+++ b/papis/tui/utils.py
@@ -70,26 +70,36 @@ def confirm(prompt_string: str,
 
 
 def text_area(text: str,
+              title: str = "",
               lexer_name: str = "") -> None:
     """
     Small implementation of a pager for small pieces of text.
 
-    :param text: text
-    :param lexer_name: If the text should be highlighted with
-        some kind of grammar, examples are ``yaml``, ``python`` ...
+    :param text: main text to be displayed.
+    :param title: a title for the text.
+    :param lexer_name: a pygments lexer name (e.g. ``yaml``, ``python``) if the
+        text should be highlighted.
     """
-    from pygments import lex
     from pygments.lexers import find_lexer_class_by_name
 
     pygment_lexer = find_lexer_class_by_name(lexer_name)
-    tokens = lex(text, lexer=pygment_lexer())  # type: ignore[no-untyped-call]
 
-    from prompt_toolkit import print_formatted_text
+    from prompt_toolkit.lexers import PygmentsLexer
+    from prompt_toolkit.shortcuts import print_container
     from prompt_toolkit.styles import Style
-    from prompt_toolkit.formatted_text import PygmentsTokens
+    from prompt_toolkit.widgets import Frame, TextArea
 
     papis_style = Style.from_dict(PAPIS_PYGMENTS_DEFAULT_STYLE)
-    print_formatted_text(PygmentsTokens(tokens), style=papis_style)
+    print_container(
+        Frame(
+            TextArea(
+                text=text,
+                lexer=PygmentsLexer(pygment_lexer),  # type: ignore[arg-type]
+            ),
+            title=title,
+        ),
+        style=papis_style,
+    )
 
 
 def yes_no_dialog(title: str, text: str) -> Any:

--- a/tests/commands/test_add.py
+++ b/tests/commands/test_add.py
@@ -321,6 +321,7 @@ def test_add_lib_cli(tmp_library: TemporaryLibrary,
     with monkeypatch.context() as m:
         m.setattr(papis.utils, "update_doc_from_data_interactively",
                   lambda doc, d, name: doc.update(d))
+        m.setattr(papis.tui.utils, "text_area", lambda *args, **kwargs: None)
         m.setattr(papis.utils, "open_file", lambda x: None)
         m.setattr(papis.tui.utils, "confirm", lambda *args: True)
 

--- a/tests/test_arxiv.py
+++ b/tests/test_arxiv.py
@@ -81,6 +81,7 @@ def test_importer_downloader_fetch(tmp_config: TemporaryConfiguration,
         assert doc is None
 
 
+@pytest.mark.xfail(reason="arxiv times out sometimes")
 def test_validate_arxivid(tmp_config: TemporaryConfiguration) -> None:
     from papis.arxiv import validate_arxivid
     # good

--- a/tests/test_document.py
+++ b/tests/test_document.py
@@ -153,10 +153,10 @@ def test_dump() -> None:
 
     result = papis.document.dump(doc)
     expected_result = (
-        "author:            Turing, Alan\n"
-        "some-longer-key:   value\n"
-        "title:             Computing machinery and intelligence\n"
-        "year:              1950"
+        "author: Turing, Alan\n"
+        "some-longer-key: value\n"
+        "title: Computing machinery and intelligence\n"
+        "year: 1950"
         )
 
     assert result == expected_result


### PR DESCRIPTION
After #616, `papis add` would no longer show any information about the document being added. Before it just showed the results of a diff with the importer data, so if there was no importer it also wouldn't show anything. This prints out the document on purpose before asking for confirmation. On my system it looks like:
![Screenshot_20230914_101907](https://github.com/papis/papis/assets/777240/9a05726e-c2cb-4082-91a7-a612b45f9fb0)

@jghauser I tried to make this look like the resulting `info.yaml` file and use similar styling to `tui.widgets.diff` (mainly the black background). What do you think? I mostly wanted it because it can happen that the metadata isn't correct (hit this with the `isbn` importer especially) and it's nice to see beforehand.
