### PR TITLE
commands.doctor: change key-type check to avoid evals

### DIFF
--- a/doc/source/default-settings.rst
+++ b/doc/source/default-settings.rst
@@ -423,11 +423,11 @@ BibTeX options
 
 .. papis-config:: doctor-key-type-check-keys
 
-   A list of two tuples with ``(key, type)`` used by the ``key-type`` check. This
+   A list of strings ``key:type`` used by the ``key-type`` check. This
    check will show an error if the key does not have the corresponding type. The
-   type should be a builtin Python type that can be used with ``eval``. For
-   example, this can be ``[("year", "int"), ("tags", "list")]`` to check that the
-   year is an integers and the tags are given as a list in a document.
+   type should be a builtin Python type. For example, this can be
+   ``["year:int", "tags:list"]`` to check that the year is an integer and the
+   tags are given as a list in a document.
 
 .. papis-config:: doctor-key-type-check-separator
 

--- a/papis/defaults.py
+++ b/papis/defaults.py
@@ -55,11 +55,11 @@ settings: Dict[str, Any] = {
     "doctor-html-codes-keys": ["title", "author", "abstract", "journal"],
     "doctor-html-tags-keys": ["title", "author", "abstract", "journal"],
     "doctor-key-type-check-separator": None,
-    "doctor-key-type-check-keys": [("year", "int"),
-                                   ("month", "int"),
-                                   ("files", "list"),
-                                   ("notes", "str"),
-                                   ("author_list", "list")],
+    "doctor-key-type-check-keys": ["year:int",
+                                   "month:int",
+                                   "files:list",
+                                   "notes:str",
+                                   "author_list:list"],
 
     # papis-serve configuration
     "serve-user-css": [],

--- a/tests/test_doctor.py
+++ b/tests/test_doctor.py
@@ -132,30 +132,26 @@ def test_key_type_check(tmp_config: TemporaryConfiguration,
         })
 
     # check: invalid setting parsing
-    papis.config.set("doctor-key-type-check-keys", ["('year', Unknown)"])
+    papis.config.set("doctor-key-type-check-keys", ["year = WithoutColon"])
     errors = key_type_check(doc)
     assert not errors
 
-    papis.config.set("doctor-key-type-check-keys", ["('year', 'int', 'str')"])
-    errors = key_type_check(doc)
-    assert not errors
-
-    papis.config.set("doctor-key-type-check-keys", ["('year', 'Unknown')"])
+    papis.config.set("doctor-key-type-check-keys", ["year:NotBuiltin"])
     errors = key_type_check(doc)
     assert not errors
 
     # check: incorrect type
-    papis.config.set("doctor-key-type-check-keys", ["('year', 'int')"])
+    papis.config.set("doctor-key-type-check-keys", ["year:int"])
     error, = key_type_check(doc)
     assert error.payload == "year"
 
     # check: correct type
-    papis.config.set("doctor-key-type-check-keys", ["('author_list', 'list')"])
+    papis.config.set("doctor-key-type-check-keys", ["  author_list :    list"])
     errors = key_type_check(doc)
     assert not errors
 
     # check: fix int
-    papis.config.set("doctor-key-type-check-keys", ["('year', 'int')"])
+    papis.config.set("doctor-key-type-check-keys", ["year:int"])
     error, = key_type_check(doc)
     assert error.payload == "year"
     error.fix_action()
@@ -163,13 +159,13 @@ def test_key_type_check(tmp_config: TemporaryConfiguration,
 
     # check: fix list
     papis.config.set("doctor-key-type-check-separator", " ")
-    papis.config.set("doctor-key-type-check-keys", ["('projects', 'list')"])
+    papis.config.set("doctor-key-type-check-keys", ["projects:list"])
     error, = key_type_check(doc)
     assert error.payload == "projects"
     error.fix_action()
     assert doc["projects"] == ["test-key-project"]
 
-    papis.config.set("doctor-key-type-check-keys", ["('tags', 'list')"])
+    papis.config.set("doctor-key-type-check-keys", ["tags:list"])
     error, = key_type_check(doc)
     assert error.payload == "tags"
     error.fix_action()
@@ -182,7 +178,7 @@ def test_key_type_check(tmp_config: TemporaryConfiguration,
     error.fix_action()
     assert doc["tags"] == ["test-key-tag-1", "test-key-tag-2", "test-key-tag-3"]
 
-    papis.config.set("doctor-key-type-check-keys", ["('tags', 'str')"])
+    papis.config.set("doctor-key-type-check-keys", ["tags:str"])
     error, = key_type_check(doc)
     assert error.payload == "tags"
     error.fix_action()


### PR DESCRIPTION
This changes the configuration setting of `doctor-key-type-check-keys`
```
from: [("year", "int"), ("files", "list")]
to:   ["year:int", "files:list"]
```
with the goal of removing the `eval` usage. 
* Changing from a tuple `("year", "int")` to `"year:int"` allows easier parsing without eval.
* Using `getattr(builtins, cls_name, None)` instead of eval. This should also enforce that the types are builtin Python types.

@alejandrogallo Did you have any fancier types in there that would require an `eval`? What do you think about this?