### PR TITLE
Use better names for only_data arguments

### DIFF
--- a/papis/commands/add.py
+++ b/papis/commands/add.py
@@ -588,12 +588,12 @@ def cli(files: List[str],
 
     # gather importers / downloaders
     matching_importers = papis.utils.get_matching_importer_by_name(
-        from_importer, only_data=not download_files)
+        from_importer, download_files=download_files)
 
     if not from_importer and files:
         matching_importers = sum((
             papis.utils.get_matching_importer_or_downloader(
-                f, only_data=not download_files)
+                f, download_files=download_files)
             for f in files), [])
 
         if matching_importers and not batch:
@@ -611,7 +611,7 @@ def cli(files: List[str],
 
     # merge importer data + commandline data into a single set
     imported = papis.utils.collect_importer_data(
-        matching_importers, batch=batch, only_data=not download_files)
+        matching_importers, batch=batch, use_files=download_files)
 
     ctx = papis.importer.Context()
     ctx.data = imported.data

--- a/papis/commands/update.py
+++ b/papis/commands/update.py
@@ -149,9 +149,8 @@ def cli(query: str,
             ctx.data.update(processed_tuples)
 
         # NOTE: use 'papis addto' to add files, so this only adds data
-        # by setting 'only_data' to True always
         matching_importers = papis.utils.get_matching_importer_by_name(
-            from_importer, only_data=True)
+            from_importer, download_files=False)
 
         if not from_importer and auto:
             for importer_cls in papis.importer.get_importers():
@@ -171,7 +170,7 @@ def cli(query: str,
                         matching_importers.append(importer)
 
         imported = papis.utils.collect_importer_data(
-            matching_importers, batch=batch, only_data=True)
+            matching_importers, batch=batch, use_files=False)
         if "ref" in imported.data:
             logger.debug(
                 "An importer set the 'ref' key. This is not allowed and will be "


### PR DESCRIPTION
This just updates some functions in `papis.utils` to have better named arguments that are in line with #641.