### PR TITLE
docs: add commands.doctor to the dev docs

### DIFF
--- a/doc/source/commands/doctor.rst
+++ b/doc/source/commands/doctor.rst
@@ -2,3 +2,4 @@ Doctor
 ------
 
 .. automodule:: papis.commands.doctor
+    :no-index:

--- a/doc/source/conf.py
+++ b/doc/source/conf.py
@@ -30,13 +30,13 @@ sys.path.append(os.path.join(os.path.dirname(__file__), "..", ".."))
 # ones.
 extensions = [
     "sphinx.ext.autodoc",
-    "sphinx.ext.doctest",
-    "sphinx.ext.todo",
     "sphinx.ext.coverage",
+    "sphinx.ext.doctest",
     "sphinx.ext.ifconfig",
-    "sphinx.ext.viewcode",
-    "sphinx.ext.intersphinx",
     "sphinx.ext.inheritance_diagram",
+    "sphinx.ext.intersphinx",
+    "sphinx.ext.todo",
+    "sphinx.ext.viewcode",
     "sphinx_click.ext",
 ]
 
@@ -109,9 +109,18 @@ class PapisConfig(Directive):
         return node.children
 
 
+def remove_module_docstring(app, what, name, obj, options, lines):
+    # NOTE: this is used to remove the module documentation for commands so that
+    # we can show the module members in the `Developer API Reference` section
+    # without the tutorial / examples parts.
+    if what == "module" and ".commands." in name and options.get("members"):
+        del lines[:]
+
+
 def setup(app):
     app.add_directive("click", CustomClickDirective, override=True)
     app.add_directive("papis-config", PapisConfig)
+    app.connect("autodoc-process-docstring", remove_module_docstring)
 
 
 # }}} Exec directive #

--- a/doc/source/developer_reference.rst
+++ b/doc/source/developer_reference.rst
@@ -1,5 +1,5 @@
 Developer API reference
------------------------
+=======================
 
 .. warning::
 
@@ -8,127 +8,133 @@ Developer API reference
    any external plugins.
 
 ``papis.bibtex``
-^^^^^^^^^^^^^^^^
+----------------
 
 .. automodule:: papis.bibtex
     :members:
 
 ``papis.citations``
-^^^^^^^^^^^^^^^^^^^
+-------------------
 
 .. automodule:: papis.citations
     :members:
 
 ``papis.cli``
-^^^^^^^^^^^^^
+-------------
 
 .. automodule:: papis.cli
     :members:
 
 ``papis.commands``
-^^^^^^^^^^^^^^^^^^
+------------------
 
 .. automodule:: papis.commands
     :members:
 
 ``papis.config``
-^^^^^^^^^^^^^^^^
+----------------
 
 .. automodule:: papis.config
     :members:
 
 ``papis.docmatcher``
-^^^^^^^^^^^^^^^^^^^^
+--------------------
 
 .. automodule:: papis.docmatcher
     :members:
 
 ``papis.document``
-^^^^^^^^^^^^^^^^^^
+------------------
 
 .. automodule:: papis.document
     :members:
 
 ``papis.downloaders``
-^^^^^^^^^^^^^^^^^^^^^
+---------------------
 
 .. automodule:: papis.downloaders
    :members:
 
 ``papis.exceptions``
-^^^^^^^^^^^^^^^^^^^^
+--------------------
 
 .. automodule:: papis.exceptions
    :members:
 
 ``papis.filetype``
-^^^^^^^^^^^^^^^^^^
+------------------
 
 .. automodule:: papis.filetype
    :members:
 
 ``papis.format``
-^^^^^^^^^^^^^^^^
+----------------
 
 .. automodule:: papis.format
     :members:
 
 ``papis.git``
-^^^^^^^^^^^^^
+-------------
 
 .. automodule:: papis.git
     :members:
 
 ``papis.id``
-^^^^^^^^^^^^
+------------
 
 .. automodule:: papis.id
     :members:
 
 ``papis.importer``
-^^^^^^^^^^^^^^^^^^
+------------------
 
 .. automodule:: papis.importer
     :members:
 
 ``papis.library``
-^^^^^^^^^^^^^^^^^
+-----------------
 
 .. automodule:: papis.library
     :members:
 
 ``papis.logging``
-^^^^^^^^^^^^^^^^^
+-----------------
 
 .. automodule:: papis.logging
     :members:
 
 ``papis.notes``
-^^^^^^^^^^^^^^^
+---------------
 
 .. automodule:: papis.notes
     :members:
 
 ``papis.pick``
-^^^^^^^^^^^^^^
+--------------
 
 .. automodule:: papis.pick
     :members:
 
 ``papis.plugin``
-^^^^^^^^^^^^^^^^
+----------------
 
 .. automodule:: papis.plugin
     :members:
 
 ``papis.utils``
-^^^^^^^^^^^^^^^
+---------------
 
 .. automodule:: papis.utils
     :members:
 
 ``papis.yaml``
-^^^^^^^^^^^^^^
+--------------
 
 .. automodule:: papis.yaml
+    :members:
+
+``papis.commands.doctor``
+-------------------------
+
+.. automodule:: papis.commands.doctor
     :members:

--- a/papis/commands/doctor.py
+++ b/papis/commands/doctor.py
@@ -438,6 +438,8 @@ def biblatex_type_alias_check(doc: papis.document.Document) -> List[Error]:
     return []
 
 
+# NOTE: `journal` is a key that papis relies on and we do not want to rename it
+BIBLATEX_KEY_ALIAS_IGNORED = {"journal"}
 BIBLATEX_KEY_ALIAS_CHECK_NAME = "biblatex-key-alias"
 
 
@@ -464,19 +466,16 @@ def biblatex_key_alias_check(doc: papis.document.Document) -> List[Error]:
 
         return fixer
 
-    # NOTE: `journal` is a key that papis relies on and we do not want to rename it
-    aliases = bibtex_key_aliases.copy()
-    del aliases["journal"]
-
     return [Error(name=BIBLATEX_KEY_ALIAS_CHECK_NAME,
                   path=folder,
                   msg=("Document key '{}' is an alias for '{}' in BibLaTeX."
-                       .format(key, aliases[key])),
+                       .format(key, bibtex_key_aliases[key])),
                   suggestion_cmd="papis edit --doc-folder {}".format(folder),
                   fix_action=make_fixer(key),
                   payload=key,
                   doc=doc)
-            for key in doc if key in aliases]
+            for key in doc
+            if key not in BIBLATEX_KEY_ALIAS_IGNORED and key in bibtex_key_aliases]
 
 
 BIBLATEX_REQUIRED_KEYS_CHECK_NAME = "biblatex-required-keys"


### PR DESCRIPTION
This adds all the doctor check functions to the docs, so they can be more easily looked through.