### PR TITLE
commands.init: add some bottom_toolbars to the library names

### DIFF
--- a/papis/commands/init.py
+++ b/papis/commands/init.py
@@ -106,7 +106,9 @@ def cli(dir_path: Optional[str]) -> None:
     dir_path = os.getcwd() if dir_path is None else dir_path
     library_name = papis.tui.utils.prompt(
         "Name of the library",
-        default=os.path.basename(dir_path))
+        default=os.path.basename(dir_path),
+        bottom_toolbar="Known libraries: '{}'".format(
+            "', '".join(papis.config.get_libs())))
 
     if library_name not in config:
         config[library_name] = {}
@@ -115,7 +117,8 @@ def cli(dir_path: Optional[str]) -> None:
 
     library_path = papis.tui.utils.prompt(
         "Path of the library",
-        default=local.get("dir", dir_path))
+        default=local.get("dir", dir_path),
+        bottom_toolbar="Give an existing folder for the library location")
 
     if papis.tui.utils.confirm(f"Make '{library_name}' the default library?",
                                yes=False):

--- a/papis/commands/init.py
+++ b/papis/commands/init.py
@@ -102,6 +102,7 @@ def cli(dir_path: Optional[str]) -> None:
     else:
         logger.info("Using config file: '%s'.", config_file)
 
+    logger.info("Setting library location.")
     dir_path = os.getcwd() if dir_path is None else dir_path
     library_name = papis.tui.utils.prompt(
         "Name of the library",
@@ -116,11 +117,13 @@ def cli(dir_path: Optional[str]) -> None:
         "Path of the library",
         default=local.get("dir", dir_path))
 
-    if papis.tui.utils.confirm(f"Make '{library_name}' the default library?"):
+    if papis.tui.utils.confirm(f"Make '{library_name}' the default library?",
+                               yes=False):
         glob["default-library"] = library_name
 
     local["dir"] = library_path
 
+    logger.info("Setting library custom options.")
     for setting, help_string in INIT_PROMPTS:
         local[setting] = papis.tui.utils.prompt(
             setting,


### PR DESCRIPTION
Adds a list of known libraries to `Name of the library` so the user can avoid overwriting libraries.