### PR TITLE
Update the update command

### DIFF
--- a/papis/commands/update.py
+++ b/papis/commands/update.py
@@ -1,36 +1,124 @@
 """
-This command is to update document metadata.
+This command allows you to update the document metadata stored in the
+`info.yaml` file. With it, you can either change individual values manually
+or update a document with information automatically retrieved from a variety
+of sources.
+
+When using it to add information, Papis formatting strings and Python
+expressions can be used. See below examples for more information. The command
+also tries to sanitise filenames so that they don't contain any problematic
+characters.
+
+Normally, `papis update` will abort on encountering an error. If you want to
+skip errors and apply as many changes as possible, use the `--batch` flag.
 
 Examples
 ^^^^^^^^
 
-- Update a document automatically and interactively
-  (searching by DOI in Crossref or in other sources...)
+- Search among papers with the tag "classics" and update the author to
+  "Einstein, Albert":
 
     .. code:: sh
 
-        papis update --auto 'author : dyson'
+        papis update --set author "Einstein, Albert" "tags:classics"
 
-- Update your library from a BibTeX file, where many entries are listed.
-  We will try to look for documents in your library that match these
-  entries and will ask you entry per entry to update it. For example,
-  ``libraryfile.bib`` is a file containing many entries, then
+  This will open the picker containing all documents that match the query from
+  where you can select the document you want to update.
 
-    .. code::
+- Set the author_list to the surname "Einstein" and name "Albert":
+
+    .. code:: sh
+
+        papis update --set author_list "[{'family': 'Einstein', 'given': 'Albert'}]"
+
+  As you can see, `papis update` tries to parse the input string as a python
+  expression (such as a list or dictionary). When this succeeds, as in the above
+  example where we're setting a dictionary, it's the parsed expression that is
+  used to update the metadata.
+
+- Update the journal to "Mass and Energy" for all documents with the journal
+  "Energy and Mass":
+
+    .. code:: sh
+
+        papis update --all --set journal "Mass and Energy" "journal:'Energy and Mass'"
+
+
+  The `--all` flag means that the tag is applied to all documents that match the
+  query, rather than allowing you to pick one individual document to update.
+
+- Update a document automatically and interactively (searching by DOI in
+  Crossref or in other sources...)
+
+    .. code:: sh
+
+        papis update --auto "author:dyson"
+
+- Update your library from a BibTeX file, where many entries may be listed:
+
+    .. code:: sh
 
         papis update --from bibtex libraryfile.bib
 
-- Tag all "einstein" papers with the tag "classics"
+  Papis will try to look for documents in your library that match these
+  entries and will ask you for each entry whether you want to update it.
 
-    .. code::
+- Add the ", Albert" to the author string of a documents matching 'Einstein':
 
-        papis update --all --set tags classics einstein
+    .. code:: sh
 
-  and add the tag of "physics" to all papers tagged as "classics"
+        papis update --set author "{doc[author]}, Albert" Einstein
 
-    .. code::
+  The `papis update` command tries to format input strings using the configured
+  formatter. Here, it is used to get the existing author "Albert" and then add
+  the string ", Einstein" to end up with "Einstein, Albert"
 
-        papis update --all --set tags '{doc[tags]} physics' einstein
+- The above can also be achieved with the `--append` option:
+
+    .. code:: sh
+
+        papis update --append author ", Albert" Einstein
+
+    This appends ", Einstein" to the existing author string.
+
+- You can also append an item to a list:
+
+    .. code:: sh
+
+        papis update --append tags physics
+
+    This adds the tag 'physics' to the existing list of tags. If the list
+    doesn't yet exist, it will be created. All duplicate items will be removed
+    from the list.
+
+- To remove an item from a list, use `--remove`:
+
+    .. code:: sh
+
+        papis update --remove tags physics
+
+    If the tag "physics" is in the list of tags, this command removes it.
+
+- To remove a key-value pair entirely, use `--drop`:
+
+    .. code:: sh
+
+        papis update --drop tags
+
+    This removes the all tags.
+
+- There is also a convenience option `--rename` if you want to rename
+  a list item. It's equivalent to doing `--remove` and `--append` sequentially.
+
+    .. code:: sh
+
+        papis update --rename tags physics philosophy
+
+  This renames the tag 'physics' to 'philosophy'. Note that this option being a
+  combination of `--remove` and `--append`, it will append the desired values
+  even if the value to be removed didn't exist. Thus, the above command will add
+  the tag "philosophy" even if the tag "physics" didn't exist before the
+  operation.
 
 Command-line Interface
 ^^^^^^^^^^^^^^^^^^^^^^
@@ -39,27 +127,226 @@ Command-line Interface
     :prog: papis update
 """
 
-from typing import List, Dict, Tuple, Optional, Any
+import ast
+from typing import Any, Dict, List, Optional, Tuple
 
 import click
 
-import papis.utils
-import papis.strings
+import papis.cli
+import papis.commands.doctor
+import papis.config
 import papis.document
 import papis.format
-import papis.cli
-import papis.importer
 import papis.git
+import papis.importer
 import papis.logging
-import papis.commands.doctor
+import papis.strings
+import papis.utils
 
 logger = papis.logging.get_logger(__name__)
 
+KEY_TYPES = papis.commands.doctor.get_key_type_check_keys()
 
-def run(document: papis.document.Document,
-        data: Optional[Dict[str, Any]] = None,
-        git: bool = False,
-        auto_doctor: bool = False) -> None:
+
+def try_parsing_str(key: str, value: str) -> str:
+    """
+    Tries to parse the input string as a python expression.
+
+    :returns: The parsed input string if string is a python expression,
+        otherwise an unchanged string.
+    """
+    try:
+        value = ast.literal_eval(value)
+    except (SyntaxError, ValueError):
+        logger.debug("Value '%s' of key '%s' is not a python expression.", value, key)
+    return value
+
+
+def run_set(
+    document: papis.document.DocumentLike,
+    to_set: List[Tuple[str, str]],
+    key_types: Dict[str, type],
+) -> None:
+    """
+    Processes a list of `to_set` tuples and applies the resulting changes to the
+    input document. Each tuple is (KEY, VALUE) and results in setting the KEY to
+    the VALUE in the document.
+    """
+    for key, value in to_set:
+        value = papis.format.format(value, document, default=value)
+        value = try_parsing_str(key, value)
+        if isinstance(value, int) and key_types.get(key) is str:
+            value = str(value)
+        if key == "notes" and isinstance(value, str):
+            # TODO: handle renames/deletions of files on disk
+            document[key] = papis.utils.clean_document_name(value)
+            logger.warning(
+                "Document note renamed in the info.yaml file. This does not "
+                "rename any files on disk."
+            )
+        elif key == "files" and isinstance(value, list):
+            # TODO: handle renames/deletions of files on disk
+            document[key] = list()
+            for file in value:
+                if isinstance(file, str):
+                    document[key].append(papis.utils.clean_document_name(file))
+                else:
+                    document[key].append(value)
+            logger.warning(
+                "Document files renamed in the info.yaml file. This does not "
+                "rename any files on disk."
+            )
+        else:
+            document[key] = value
+
+
+def run_append(
+    document: papis.document.DocumentLike,
+    to_append: List[Tuple[str, str]],
+    key_types: Dict[str, type],
+    batch: bool,
+) -> bool:
+    """
+    Processes a list of `to_append` tuples and applies the resulting changes
+    to the input document. Each tuple is (KEY, VALUE) and results in appending
+    the VALUE to the KEY item.
+
+    :returns: A boolean indicating whether the update was successful.
+    """
+    success = True
+    processed_lists = set()
+    supported_keys = key_types.keys() | document
+    for key, value in to_append:
+        if key in supported_keys:
+            value = papis.format.format(value, document, default=value)
+            type_doc = type(document.get(key))
+            type_conf = key_types.get(key)
+            if type_doc is str or (type_doc is type(None) and type_conf is str):
+                document[key] = document.setdefault(key, "") + value
+            elif type_doc is list or (type_doc is type(None) and type_conf is list):
+                value = try_parsing_str(key, value)
+                if key == "files":
+                    value = papis.utils.clean_document_name(str(value))
+                document.setdefault(key, []).append(value)
+                processed_lists.add(key)
+            else:
+                logger.error(
+                    "Items of key '%s' have the type '%s', for which Papis "
+                    "doesn't support the append operation.",
+                    key,
+                    type(document[key]).__name__
+                    if document.get(key)
+                    else key_types[key].__name__,
+                )
+                if not batch:
+                    success = False
+                    break
+        else:
+            logger.error(
+                "We cannot append to key '%s', because we do not know the "
+                "intended type. Please use `papis update --set` instead.",
+                key,
+            )
+            if not batch:
+                success = False
+                break
+
+    for key in processed_lists:
+        document[key] = list(set(document[key]))
+
+    return success
+
+
+def run_remove(
+    document: papis.document.DocumentLike, to_remove: List[Tuple[str, str]], batch: bool
+) -> bool:
+    """
+    Processes a list of `to_remove` tuples and applies the resulting changes
+    to the input document. Each tuple is (KEY, VALUE) and results in removing
+    the VALUE from the KEY item.
+
+    :returns: A boolean indicating whether the update was successful.
+    """
+    success = True
+    for key, value in to_remove:
+        if key in document:
+            if isinstance(document.get(key), list):
+                try:
+                    document[key].remove(value)
+                except ValueError:
+                    try:
+                        document[key].remove(int(value))
+                    except ValueError:
+                        pass  # do nothing if there is nothing to remove
+            else:
+                logger.error(
+                    "You're trying to remove an item from '%s', which has the "
+                    "type '%s'. `papis update --remove` only supports lists.",
+                    key,
+                    type(document.get(key)).__name__,
+                )
+                if not batch:
+                    success = False
+                    break
+        else:
+            logger.info(
+                "Document doesn't have key '%s', cannot remove '%s' from it. "
+                "Continuing...",
+                key,
+                value,
+            )
+
+    return success
+
+
+def run_drop(document: papis.document.DocumentLike, to_remove: List[str]) -> None:
+    """
+    Processes a list of `to_drop` strings and applies the resulting changes
+    to the input document. Each string is a KEY whose value is set to None
+    (and then later in `run()` dropped from the document entirely).
+
+    """
+    for key in to_remove:
+        if key in document:
+            document[key] = None
+        else:
+            logger.info(
+                "Document doesn't have key '%s', cannot remove it. Continuing...", key
+            )
+
+
+def run_rename(
+    document: papis.document.DocumentLike,
+    to_rename: List[Tuple[str, str, str]],
+    batch: bool,
+) -> bool:
+    """
+    Processes a list of `to_rename` tuples and applies the resulting changes
+    to the input document. Each tuple is (KEY, VALUE_OLD, VALUE_NEW) and results in
+    rename the KEY's VALUE_OLD to VALUE_NEW.
+
+
+    :returns: A boolean indicating whether the update was successful.
+    """
+    to_remove = [x[:2] for x in to_rename]
+    to_append = [x[::2] for x in to_rename]
+    success = run_remove(document, to_remove, batch)
+    if success:
+        success = run_append(document, to_append, KEY_TYPES, batch)
+    return success
+
+
+def run(
+    document: papis.document.Document,
+    data: Optional[Dict[str, Any]] = None,
+    git: bool = False,
+    auto_doctor: bool = False,
+) -> None:
+    """
+    Updates the document in the Papis library.
+
+    :returns: None
+    """
     if data is None:
         data = {}
 
@@ -68,22 +355,32 @@ def run(document: papis.document.Document,
 
     if not folder or not info:
         from papis.exceptions import DocumentFolderNotFound
+
         raise DocumentFolderNotFound(papis.document.describe(document))
 
     document.update(data)
+
+    # delete all keys that do not have a value
+    to_drop = [k for k, v in document.items() if not v]
+    [document.pop(k) for k in to_drop]
+
     if auto_doctor:
-        logger.info("Running doctor auto-fixers on document: '%s'.",
-                    papis.document.describe(document))
+        logger.info(
+            "Running doctor auto-fixers on document: '%s'.",
+            papis.document.describe(document),
+        )
         papis.commands.doctor.fix_errors(document)
 
     from papis.api import save_doc
+
     save_doc(document)
 
     if git:
         papis.git.add_and_commit_resource(
-            folder, info,
-            "Update information for '{}'".format(
-                papis.document.describe(document)))
+            folder,
+            info,
+            "Update information for '{}'".format(papis.document.describe(document)),
+        )
 
 
 @click.command("update")
@@ -93,103 +390,163 @@ def run(document: papis.document.Document,
 @papis.cli.doc_folder_option()
 @papis.cli.all_option()
 @papis.cli.sort_option()
-@papis.cli.bool_flag("--auto",
-                     help="Try to parse information from different sources")
-@papis.cli.bool_flag("--auto-doctor/--no-auto-doctor",
-                     help="Apply papis doctor to newly added documents.",
-                     default=lambda: papis.config.getboolean("auto-doctor"))
-@click.option("--from", "from_importer",
-              help="Add document from a specific importer ({})".format(
-                  ", ".join(papis.importer.available_importers())
-              ),
-              type=(click.Choice(papis.importer.available_importers()), str),
-              nargs=2,
-              multiple=True,
-              default=(),)
-@click.option("-s", "--set", "set_tuples",
-              help="Update document's information with key value. "
-                   "The value can be a papis format.",
-              multiple=True,
-              type=(str, str),)
-@papis.cli.bool_flag("-b", "--batch",
-                     help="Batch mode, do not prompt or otherwise")
-def cli(query: str,
-        git: bool,
-        doc_folder: Tuple[str, ...],
-        from_importer: List[Tuple[str, str]],
-        batch: bool,
-        auto: bool,
-        auto_doctor: bool,
-        _all: bool,
-        sort_field: Optional[str],
-        sort_reverse: bool,
-        set_tuples: List[Tuple[str, str]],) -> None:
-    """Update a document from a given library."""
+@papis.cli.bool_flag("--auto", help="Try to parse information from different sources")
+@papis.cli.bool_flag(
+    "--auto-doctor/--no-auto-doctor",
+    help="Apply papis doctor to newly added documents.",
+    default=lambda: papis.config.getboolean("auto-doctor"),
+)
+@click.option(
+    "--from",
+    "from_importer",
+    help="Add document from a specific importer ({})".format(
+        ", ".join(papis.importer.available_importers())
+    ),
+    type=(click.Choice(papis.importer.available_importers()), str),
+    nargs=2,
+    multiple=True,
+    default=(),
+)
+@click.option(
+    "-s",
+    "--set",
+    "to_set",
+    help="Set the key to the given value (<KEY VALUE>).",
+    multiple=True,
+    type=(str, str),
+)
+@click.option(
+    "-d",
+    "--drop",
+    "to_drop",
+    help="Drop a key from the document.",
+    multiple=True,
+    type=str,
+)
+@click.option(
+    "-p",
+    "--append",
+    "to_append",
+    help="Append a value to a document key (<KEY VALUE>).",
+    multiple=True,
+    type=(str, str),
+)
+@click.option(
+    "-r",
+    "--remove",
+    "to_remove",
+    help="Remove an item from a list (<KEY VALUE>).",
+    multiple=True,
+    type=(str, str),
+)
+@click.option(
+    "-n",
+    "--rename",
+    "to_rename",
+    help="Rename an item in a list (<KEY OLD-VALUE NEW-VALUE>).",
+    multiple=True,
+    type=(str, str, str),
+)
+@papis.cli.bool_flag("-b", "--batch", help="Batch mode, do not prompt or otherwise")
+def cli(
+    query: str,
+    git: bool,
+    doc_folder: Tuple[str, ...],
+    from_importer: List[Tuple[str, str]],
+    batch: bool,
+    auto: bool,
+    auto_doctor: bool,
+    _all: bool,
+    sort_field: Optional[str],
+    sort_reverse: bool,
+    to_set: List[Tuple[str, str]],
+    to_drop: List[str],
+    to_append: List[Tuple[str, str]],
+    to_remove: List[Tuple[str, str]],
+    to_rename: List[Tuple[str, str, str]],
+) -> None:
+    """Update document metadata"""
+    success = True
 
-    documents = papis.cli.handle_doc_folder_query_all_sort(query,
-                                                           doc_folder,
-                                                           sort_field,
-                                                           sort_reverse,
-                                                           _all)
+    documents = papis.cli.handle_doc_folder_query_all_sort(
+        query, doc_folder, sort_field, sort_reverse, _all
+    )
     if not documents:
         logger.warning(papis.strings.no_documents_retrieved_message)
         return
 
+    processed_documents = []
     for document in documents:
         ctx = papis.importer.Context()
 
-        logger.info("Updating {c.Back.WHITE}{c.Fore.BLACK}%s{c.Style.RESET_ALL}.",
-                    papis.document.describe(document))
-
         ctx.data.update(document)
-        if set_tuples:
-            processed_tuples = {}
-            for key, value in set_tuples:
-                try:
-                    value = papis.format.format(value, document)
-                except papis.format.FormatFailedError as exc:
-                    logger.error("Could not format '%s' with value '%s'.",
-                                 key, value, exc_info=exc)
-                    continue
+        if to_set:
+            run_set(ctx.data, to_set, KEY_TYPES)
 
-                if key == "notes":
-                    value = papis.utils.clean_document_name(value)
-                    processed_tuples[key] = value
-                else:
-                    processed_tuples[key] = value
-            ctx.data.update(processed_tuples)
+        if to_append and success:
+            success = run_append(ctx.data, to_append, KEY_TYPES, batch)
 
-        # NOTE: use 'papis addto' to add files, so this only adds data
-        matching_importers = papis.utils.get_matching_importer_by_name(
-            from_importer, download_files=False)
+        if to_remove and success:
+            success = run_remove(ctx.data, to_remove, batch)
 
-        if not from_importer and auto:
-            for importer_cls in papis.importer.get_importers():
-                try:
-                    importer = importer_cls.match_data(document)
-                    if importer:
-                        try:
-                            importer.fetch_data()
-                        except NotImplementedError:
-                            importer.fetch()
-                except NotImplementedError:
-                    continue
-                except Exception as exc:
-                    logger.exception("Failed to match document data.", exc_info=exc)
-                else:
-                    if importer and importer.ctx:
-                        matching_importers.append(importer)
+        if to_drop and success:
+            run_drop(ctx.data, to_drop)
 
-        imported = papis.utils.collect_importer_data(
-            matching_importers, batch=batch, use_files=False)
-        if "ref" in imported.data:
-            logger.debug(
-                "An importer set the 'ref' key. This is not allowed and will be "
-                "automatically removed. Check importers: '%s'",
-                "', '".join(importer.name for importer in matching_importers))
+        if to_rename:
+            success = run_rename(ctx.data, to_rename, batch)
 
-            del imported.data["ref"]
+        if success:
+            logger.info(
+                "Updating {c.Back.WHITE}{c.Fore.BLACK}%s{c.Style.RESET_ALL}.",
+                papis.document.describe(document),
+            )
 
-        ctx.data.update(imported.data)
+            # NOTE: use 'papis addto' to add files, so this only adds data
+            # by setting 'only_data' to True always
+            matching_importers = papis.utils.get_matching_importer_by_name(
+                from_importer, only_data=True
+            )
 
-        run(document, data=ctx.data, git=git, auto_doctor=auto_doctor)
+            if not from_importer and auto:
+                for importer_cls in papis.importer.get_importers():
+                    try:
+                        importer = importer_cls.match_data(document)
+                        if importer:
+                            try:
+                                importer.fetch_data()
+                            except NotImplementedError:
+                                importer.fetch()
+                    except NotImplementedError:
+                        continue
+                    except Exception as exc:
+                        logger.exception("Failed to match document data.", exc_info=exc)
+                    else:
+                        if importer and importer.ctx:
+                            matching_importers.append(importer)
+
+            imported = papis.utils.collect_importer_data(
+                matching_importers, batch=batch, only_data=True
+            )
+            if "ref" in imported.data:
+                logger.debug(
+                    "An importer set the 'ref' key. This is not allowed and will be "
+                    "automatically removed. Check importers: '%s'",
+                    "', '".join(importer.name for importer in matching_importers),
+                )
+
+                del imported.data["ref"]
+
+            # TODO: add interactive merging to avoid overwriting user changes
+            ctx.data.update(imported.data)
+
+            processed_documents.append((document, ctx.data))
+
+        if not success and not batch:
+            processed_documents.clear()
+            logger.error(
+                "Aborting operation. No documents have been changed.",
+            )
+            break
+
+    for document, data in processed_documents:
+        run(document, data=data, git=git, auto_doctor=auto_doctor)

--- a/papis/defaults.py
+++ b/papis/defaults.py
@@ -104,7 +104,17 @@ settings: Dict[str, Any] = {
                                    "month:int",
                                    "files:list",
                                    "notes:str",
-                                   "author_list:list"],
+                                   "author_list:list",
+                                   "doi:str",
+                                   "ref:str",
+                                   "isbn:str",
+                                   "author:str",
+                                   "journal:str",
+                                   "note:str",
+                                   "type:str",
+                                   "publisher:str",
+                                   "title:str",
+                                   "shorttitle:str"],
     "doctor-key-type-check-separator": None,
 
     # open

--- a/papis/testing.py
+++ b/papis/testing.py
@@ -75,13 +75,14 @@ PAPIS_TEST_DOCUMENTS = [
     {
         "author": "doc without files",
         "title": "Title of doc without files",
-        "year": "1093",
+        "year": 1093,
         "_test_files": 0,
     },
     {
         "author": "J. Krishnamurti",
         "title": "Freedom from the known",
-        "year": "2009",
+        "year": 2009,
+        "tags": ["tag1", 1234],
         "_test_files": 1,
     }, {
         "author": "K. Popper",
@@ -100,19 +101,19 @@ PAPIS_TEST_DOCUMENTS = [
         "title": "On Computable Numbers with an Application to the Entscheidungsproblem",           # noqa: E501
         "url": "https://api.wiley.com/onlinelibrary/tdm/v1/articles/10.1112%2Fplms%2Fs2-42.1.230",  # noqa: E501
         "volume": "s2-42",
-        "year": "1937",
+        "year": 1937,
         "_test_files": 2,
     },
     {
         "author": "test_author",
         "title": "Test Document 1 (wRkdff)",
-        "year": "2019",
+        "year": 2019,
         "_test_files": 1
     },
     {
         "author": "test_author",
         "title": "Test Document 2 (ZD9QRz)",
-        "year": "2019",
+        "year": 2019,
         "_test_files": 1
     },
 ]

--- a/tests/commands/test_export.py
+++ b/tests/commands/test_export.py
@@ -66,7 +66,7 @@ def test_export_json_cli(tmp_library: TemporaryLibrary) -> None:
 
     assert len(data) == 1
     assert "Krishnamurti" in data[0]["author"]
-    assert data[0]["year"] == "2009"
+    assert data[0]["year"] == 2009
 
     outfile = os.path.join(tmp_library.tmpdir, "test.json")
     result = cli_runner.invoke(
@@ -96,7 +96,7 @@ def test_export_yaml_cli(tmp_library: TemporaryLibrary) -> None:
     data = yaml.safe_load(result.output)
 
     assert "Krishnamurti" in data["author"]
-    assert data["year"] == "2009"
+    assert data["year"] == 2009
 
     outfile = os.path.join(tmp_library.tmpdir, "test.yaml")
     result = cli_runner.invoke(

--- a/tests/commands/test_update.py
+++ b/tests/commands/test_update.py
@@ -19,9 +19,8 @@ def _get_resource_file(filename: str) -> str:
 
 
 def update_doc_from_data_interactively(
-        document: Document,
-        data: Dict[str, Any],
-        data_name: str) -> None:
+    document: Document, data: Dict[str, Any], data_name: str
+) -> None:
     document.update(data)
 
 
@@ -32,103 +31,447 @@ def test_update_run(tmp_library: TemporaryLibrary) -> None:
     docs = db.get_all_documents()
     doc = docs[0]
 
+    expected_doc = docs[0]
+    expected_doc["tags"] = ["test_tag"]
+
     tags = "test_tag"
     run(doc, data={"tags": tags})
 
-    doc, = db.query_dict({"tags": tags})
-    assert doc["tags"] == tags
+    (doc,) = db.query_dict({"tags": tags})
+    assert doc == expected_doc
 
 
-@pytest.mark.parametrize(("isbn", "doi"), [
-    ("92130123", "10.213.phys.rev/213"),
-    ("", "")
-    ])
-def test_update_cli(tmp_library: TemporaryLibrary, isbn: str, doi: str) -> None:
+def test_update_set_general_cli(tmp_library: TemporaryLibrary) -> None:
     from papis.commands.update import cli
+
     cli_runner = PapisRunner()
 
-    result = cli_runner.invoke(
-        cli,
-        ["__no_document__"])
+    result = cli_runner.invoke(cli, ["__no_document__"])
     assert result.exit_code == 0
     assert not result.output
 
     result = cli_runner.invoke(
         cli,
-        ["--set", "isbn", isbn]
-        + ["--set", "doi", doi, "krishnamurti"])
+        ["--set", "doi", "10.213.phys.rev/213"]
+        + ["--set", "ref", "NewRef"]
+        + ["--set", "year", "1234"]
+        + ["--set", "author_list", "[{'family': 'Krishnamurti', 'given': 'J.'}]"]
+        + ["krishnamurti"],
+    )
     assert result.exit_code == 0
 
     db = papis.database.get()
-    doc, = db.query_dict({"author": "Krishnamurti"})
-    assert doc["doi"] == doi
-    assert doc["isbn"] == isbn
+    (doc,) = db.query_dict({"author": "Krishnamurti"})
+    assert doc["doi"] == "10.213.phys.rev/213"
+    assert doc["ref"] == "NewRef"
+    assert doc["year"] == 1234
+    assert doc["author_list"] == [{"family": "Krishnamurti", "given": "J."}]
 
 
-def test_update_yaml_cli(tmp_library: TemporaryLibrary,
-                         resource_cache: ResourceCache,
-                         monkeypatch: pytest.MonkeyPatch) -> None:
+def test_update_set_clean_cli(tmp_library: TemporaryLibrary) -> None:
     from papis.commands.update import cli
+
+    cli_runner = PapisRunner()
+
+    result = cli_runner.invoke(cli, ["__no_document__"])
+    assert result.exit_code == 0
+    assert not result.output
+
+    result = cli_runner.invoke(
+        cli,
+        ["--set", "notes", "a note $ to be cleaned.md"]
+        + ["--set", "files", "['file 1.pdf', 'file @.epub']"]
+        + ["krishnamurti"],
+    )
+    assert result.exit_code == 0
+
+    db = papis.database.get()
+    (doc,) = db.query_dict({"author": "Krishnamurti"})
+    assert doc["notes"] == "a-note-to-be-cleaned.md"
+    assert doc["files"] == ["file-1.pdf", "file-.epub"]
+
+
+def test_update_set_force_str_cli(tmp_library: TemporaryLibrary) -> None:
+    from papis.commands.update import cli
+
+    cli_runner = PapisRunner()
+
+    result = cli_runner.invoke(cli, ["__no_document__"])
+    assert result.exit_code == 0
+    assert not result.output
+
+    result = cli_runner.invoke(
+        cli,
+        ["--set", "title", "1234"] + ["krishnamurti"],
+    )
+    assert result.exit_code == 0
+
+    db = papis.database.get()
+    (doc,) = db.query_dict({"author": "Krishnamurti"})
+    assert doc["title"] == "1234"
+
+
+def test_update_append_general_cli(tmp_library: TemporaryLibrary) -> None:
+    from papis.commands.update import cli
+
+    cli_runner = PapisRunner()
+
+    result = cli_runner.invoke(cli, ["__no_document__"])
+    assert result.exit_code == 0
+    assert not result.output
+
+    result = cli_runner.invoke(
+        cli,
+        ["--append", "title", "appended"] + ["krishnamurti"],
+    )
+    assert result.exit_code == 0
+
+    db = papis.database.get()
+    (doc,) = db.query_dict({"author": "Krishnamurti"})
+    assert doc["title"] == "Freedom from the knownappended"
+
+
+def test_update_append_to_new_key_cli(tmp_library: TemporaryLibrary) -> None:
+    from papis.commands.update import cli
+
+    cli_runner = PapisRunner()
+
+    result = cli_runner.invoke(cli, ["__no_document__"])
+    assert result.exit_code == 0
+    assert not result.output
+
+    result = cli_runner.invoke(
+        cli,
+        ["--append", "notes", "a-note.md"] + ["krishnamurti"],
+    )
+    assert result.exit_code == 0
+
+    db = papis.database.get()
+    (doc,) = db.query_dict({"author": "Krishnamurti"})
+    assert doc["notes"] == "a-note.md"
+
+
+def test_update_append_to_int_cli(tmp_library: TemporaryLibrary) -> None:
+    from papis.commands.update import cli
+
+    cli_runner = PapisRunner()
+
+    result = cli_runner.invoke(cli, ["__no_document__"])
+    assert result.exit_code == 0
+    assert not result.output
+
+    result = cli_runner.invoke(
+        cli,
+        ["--append", "year", "123"] + ["krishnamurti"],
+    )
+    assert result.exit_code == 0
+
+    db = papis.database.get()
+    (doc,) = db.query_dict({"author": "Krishnamurti"})
+    assert doc["year"] == 2009
+
+
+def test_update_append_str_to_empty_int_cli(tmp_library: TemporaryLibrary) -> None:
+    from papis.commands.update import cli
+
+    cli_runner = PapisRunner()
+
+    result = cli_runner.invoke(cli, ["__no_document__"])
+    assert result.exit_code == 0
+    assert not result.output
+
+    result = cli_runner.invoke(
+        cli,
+        ["--append", "year", "string"] + ["popper"],
+    )
+    assert result.exit_code == 0
+
+    db = papis.database.get()
+    (doc,) = db.query_dict({"author": "popper"})
+    assert doc.get("year") is None
+
+
+def test_update_append_clean_cli(tmp_library: TemporaryLibrary) -> None:
+    from papis.commands.update import cli
+
+    cli_runner = PapisRunner()
+
+    result = cli_runner.invoke(cli, ["__no_document__"])
+    assert result.exit_code == 0
+    assert not result.output
+
+    result = cli_runner.invoke(
+        cli, ["--append", "files", "some file name.pdf"] + ["krishnamurti"]
+    )
+    assert result.exit_code == 0
+
+    db = papis.database.get()
+    (doc,) = db.query_dict({"author": "Krishnamurti"})
+    assert "some-file-name.pdf" in doc["files"]
+
+
+def test_update_append_del_duplicates_in_list_cli(
+    tmp_library: TemporaryLibrary,
+) -> None:
+    from papis.commands.update import cli
+
+    cli_runner = PapisRunner()
+
+    result = cli_runner.invoke(cli, ["__no_document__"])
+    assert result.exit_code == 0
+    assert not result.output
+
+    result = cli_runner.invoke(
+        cli,
+        ["--append", "files", "file1.pdf"]
+        + ["--append", "files", "file1.pdf"]
+        + ["krishnamurti"],
+    )
+    assert result.exit_code == 0
+
+    db = papis.database.get()
+    (doc,) = db.query_dict({"author": "Krishnamurti"})
+    assert doc["files"].count("file1.pdf") == 1
+
+
+def test_update_remove_general_cli(
+    tmp_library: TemporaryLibrary,
+) -> None:
+    from papis.commands.update import cli
+
+    cli_runner = PapisRunner()
+
+    result = cli_runner.invoke(cli, ["__no_document__"])
+    assert result.exit_code == 0
+    assert not result.output
+
+    result = cli_runner.invoke(
+        cli,
+        ["--remove", "tags", "tag1"] + ["--remove", "tags", "1234"] + ["krishnamurti"],
+    )
+    assert result.exit_code == 0
+
+    db = papis.database.get()
+    (doc,) = db.query_dict({"author": "Krishnamurti"})
+    assert doc.get("tags") is None
+
+
+def test_update_remove_from_missing_key_cli(
+    tmp_library: TemporaryLibrary,
+) -> None:
+    from papis.commands.update import cli
+
+    cli_runner = PapisRunner()
+
+    result = cli_runner.invoke(cli, ["__no_document__"])
+    assert result.exit_code == 0
+    assert not result.output
+
+    result = cli_runner.invoke(
+        cli,
+        ["--remove", "missingkey", "value"]
+        + ["--remove", "tags", "tag1"]
+        + ["krishnamurti"],
+    )
+    assert result.exit_code == 0
+
+    db = papis.database.get()
+    (doc,) = db.query_dict({"author": "Krishnamurti"})
+    assert doc["tags"] == [1234]
+
+
+def test_update_remove_from_str_cli(
+    tmp_library: TemporaryLibrary,
+) -> None:
+    from papis.commands.update import cli
+
+    cli_runner = PapisRunner()
+
+    result = cli_runner.invoke(cli, ["__no_document__"])
+    assert result.exit_code == 0
+    assert not result.output
+
+    result = cli_runner.invoke(
+        cli,
+        ["--remove", "title", "known"] + ["krishnamurti"],
+    )
+    assert result.exit_code == 0
+
+    db = papis.database.get()
+    (doc,) = db.query_dict({"author": "Krishnamurti"})
+    assert doc["title"] == "Freedom from the known"
+
+
+def test_update_drop_general_cli(
+    tmp_library: TemporaryLibrary,
+) -> None:
+    from papis.commands.update import cli
+
+    cli_runner = PapisRunner()
+
+    result = cli_runner.invoke(cli, ["__no_document__"])
+    assert result.exit_code == 0
+    assert not result.output
+
+    result = cli_runner.invoke(
+        cli,
+        ["--drop", "title"] + ["krishnamurti"],
+    )
+    assert result.exit_code == 0
+
+    db = papis.database.get()
+    (doc,) = db.query_dict({"author": "Krishnamurti"})
+    assert doc.get("title") is None
+
+
+def test_update_drop_missing_key_cli(
+    tmp_library: TemporaryLibrary,
+) -> None:
+    from papis.commands.update import cli
+
+    cli_runner = PapisRunner()
+
+    result = cli_runner.invoke(cli, ["__no_document__"])
+    assert result.exit_code == 0
+    assert not result.output
+
+    result = cli_runner.invoke(
+        cli,
+        ["--drop", "notes"] + ["krishnamurti"],
+    )
+    assert result.exit_code == 0
+
+
+def test_update_rename_general_cli(
+    tmp_library: TemporaryLibrary,
+) -> None:
+    from papis.commands.update import cli
+
+    cli_runner = PapisRunner()
+
+    result = cli_runner.invoke(cli, ["__no_document__"])
+    assert result.exit_code == 0
+    assert not result.output
+
+    result = cli_runner.invoke(
+        cli,
+        ["--rename", "tags", "tag1", "tag_renamed1"]
+        + ["--rename", "tags", "1234", "2345"]
+        + ["krishnamurti"],
+    )
+    assert result.exit_code == 0
+
+    db = papis.database.get()
+    (doc,) = db.query_dict({"author": "Krishnamurti"})
+    assert "tag_renamed1" in doc["tags"]
+    assert 2345 in doc["tags"]
+
+
+def test_update_rename_missing_value_cli(
+    tmp_library: TemporaryLibrary,
+) -> None:
+    from papis.commands.update import cli
+
+    cli_runner = PapisRunner()
+
+    result = cli_runner.invoke(cli, ["__no_document__"])
+    assert result.exit_code == 0
+    assert not result.output
+
+    result = cli_runner.invoke(
+        cli,
+        ["--rename", "tags", "tag_nonexistent", "tag_renamed1"] + ["krishnamurti"],
+    )
+    assert result.exit_code == 0
+
+
+def test_update_batch_cli(
+    tmp_library: TemporaryLibrary,
+) -> None:
+    from papis.commands.update import cli
+
+    cli_runner = PapisRunner()
+
+    result = cli_runner.invoke(cli, ["__no_document__"])
+    assert result.exit_code == 0
+    assert not result.output
+
+    result = cli_runner.invoke(
+        cli,
+        ["--batch"]
+        + ["--append", "year", "123"]  # this fails
+        + ["--remove", "year", "123"]  # this fails
+        + ["--append", "tags", "tag3"]  # but this should still work
+        + ["krishnamurti"],
+    )
+    assert result.exit_code == 0
+
+    db = papis.database.get()
+    (doc,) = db.query_dict({"author": "Krishnamurti"})
+    assert "tag3" in doc["tags"]
+
+
+def test_update_yaml_cli(
+    tmp_library: TemporaryLibrary,
+    resource_cache: ResourceCache,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    from papis.commands.update import cli
+
     cli_runner = PapisRunner()
 
     filename = os.path.join(resource_cache.cachedir, "update", "russell.yaml")
 
     import papis.utils
-    with monkeypatch.context() as m:
-        m.setattr(papis.utils, "update_doc_from_data_interactively",
-                  update_doc_from_data_interactively)
 
-        result = cli_runner.invoke(
-            cli,
-            ["--from", "yaml", filename, "krishnamurti"])
+    with monkeypatch.context() as m:
+        m.setattr(
+            papis.utils,
+            "update_doc_from_data_interactively",
+            update_doc_from_data_interactively,
+        )
+
+        result = cli_runner.invoke(cli, ["--from", "yaml", filename, "krishnamurti"])
         assert result.exit_code == 0
 
     import papis.yaml
+
     data = papis.yaml.yaml_to_data(filename)
 
     db = papis.database.get()
-    doc, = db.query_dict({"author": "Russell"})
+    (doc,) = db.query_dict({"author": "Russell"})
 
     assert doc["doi"] == data["doi"]
 
 
-def test_update_bibtex_cli(tmp_library: TemporaryLibrary,
-                           resource_cache: ResourceCache,
-                           monkeypatch: pytest.MonkeyPatch) -> None:
+def test_update_bibtex_cli(
+    tmp_library: TemporaryLibrary,
+    resource_cache: ResourceCache,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
     from papis.commands.update import cli
+
     cli_runner = PapisRunner()
 
     filename = os.path.join(resource_cache.cachedir, "update", "wannier.bib")
 
     import papis.utils
-    with monkeypatch.context() as m:
-        m.setattr(papis.utils, "update_doc_from_data_interactively",
-                  update_doc_from_data_interactively)
 
-        result = cli_runner.invoke(
-            cli,
-            ["--from", "bibtex", filename, "krishnamurti"])
+    with monkeypatch.context() as m:
+        m.setattr(
+            papis.utils,
+            "update_doc_from_data_interactively",
+            update_doc_from_data_interactively,
+        )
+
+        result = cli_runner.invoke(cli, ["--from", "bibtex", filename, "krishnamurti"])
         assert result.exit_code == 0
 
     import papis.bibtex
-    data, = papis.bibtex.bibtex_to_dict(filename)
+
+    (data,) = papis.bibtex.bibtex_to_dict(filename)
 
     db = papis.database.get()
-    doc, = db.query_dict({"author": "Wannier"})
+    (doc,) = db.query_dict({"author": "Wannier"})
 
     assert doc["doi"] == data["doi"]
-
-
-def test_update_cli_ref(tmp_library: TemporaryLibrary) -> None:
-    from papis.commands.update import cli
-    cli_runner = PapisRunner()
-
-    result = cli_runner.invoke(
-        cli,
-        ["krishnamurti", "--set", "ref", "NewRef"])
-    assert result.exit_code == 0
-    assert not result.output
-
-    db = papis.database.get()
-    doc, = db.query_dict({"author": "krishnamurti"})
-    assert doc["ref"] == "NewRef"

--- a/tests/resources/hayagriva_1_out.yml
+++ b/tests/resources/hayagriva_1_out.yml
@@ -4,7 +4,7 @@ author:
 doi: 10.1112/plms/s2-42.1.230
 page-range: 230--265
 parent:
-  date: '1937'
+  date: 1937
   issue: '1'
   title: Proceedings of the London Mathematical Society
   type: Periodical


### PR DESCRIPTION
OK, here it is! This has taken a while and turned out to be a bit more complex than I anticipated. Given the many different ways of using it, there are bound to be errors lurking in it still. I'd appreciate if you could try out your various use cases and let me know how it's going. Tests are also still missing...

I've left a bunch of comments throughout (indicated with `TODO` and such) regarding things that I wasn't sure about. Let me know what you think. I'm sure I've also done some things in a silly/hackish way -- I would appreciate any feedback!

I've got another PR coming with the `papis tag` command. It's basically done as it'll be super simple given that it'll be using all the logic from `papis update`. At the moment, I'm importing `papis.commands.update` but I can also move the relevant functions to `papis.update` (as @alejandrogallo wanted for `papis.tag`) if that's how it's done properly).

I've changed the name of the `papis update` options a bit from what @alejandrogallo suggested, because I wanted to avoid some confusion and establish the string and list versions as having equal standing.