### PR TITLE
testing: reset some globals

### DIFF
--- a/papis/filetype.py
+++ b/papis/filetype.py
@@ -32,7 +32,8 @@ class DjVu(filetype.Type):      # type: ignore[misc]
             )
 
 
-filetype.add_type(DjVu())
+if filetype.get_type(DjVu.MIME) is None:
+    filetype.add_type(DjVu())
 
 
 def guess_content_extension(content: bytes) -> Optional[str]:

--- a/papis/testing.py
+++ b/papis/testing.py
@@ -497,8 +497,14 @@ def tmp_config(request: SubRequest) -> Iterator[TemporaryConfiguration]:
         def test_me(tmp_config: TemporaryConfiguration) -> None:
             ...
     """
+    # NOTE: using markers to pass arguments to fixtures as defined in
+    #   https://docs.pytest.org/en/latest/how-to/fixtures.html#using-markers-to-pass-data-to-fixtures
     marker = request.node.get_closest_marker("config_setup")
     kwargs = marker.kwargs if marker else {}
+
+    # NOTE: support indirect fixture parametrizations that overwrite markers
+    #   https://docs.pytest.org/en/latest/example/parametrize.html#apply-indirect-on-particular-arguments
+    kwargs.update(getattr(request, "param", {}))
 
     with TemporaryConfiguration(**kwargs) as config:
         papis.logging.reset()
@@ -519,6 +525,9 @@ def tmp_library(request: SubRequest) -> Iterator[TemporaryLibrary]:
     """
     marker = request.node.get_closest_marker("library_setup")
     kwargs = marker.kwargs if marker else {}
+
+    # NOTE: support indirect fixture parametrizations that overwrite markers
+    kwargs.update(getattr(request, "param", {}))
 
     with TemporaryLibrary(**kwargs) as lib:
         papis.logging.reset()

--- a/papis/testing.py
+++ b/papis/testing.py
@@ -246,6 +246,15 @@ class TemporaryConfiguration:
         self._monkeypatch.setenv("XDG_CONFIG_HOME", self.tmpdir)
         self._monkeypatch.setenv("XDG_CACHE_HOME", self.tmpdir)
 
+        # monkeypatch globals
+        import papis.format
+        self._monkeypatch.setattr(papis.format, "FORMATTER", None)
+        import papis.database
+        self._monkeypatch.setattr(papis.database, "DATABASES", {})
+        # FIXME: may need to also add the following:
+        #   * reset papis.bibtex globals
+        #   * reset papis.plugin managers
+
         # reload configuration
         import papis.config
         papis.config.set_config_file(self.configfile)

--- a/tests/database/test_database.py
+++ b/tests/database/test_database.py
@@ -12,26 +12,14 @@ try:
 except ImportError:
     pass
 
-
-def database_init(libname: str, backend: str) -> None:
-    papis.config.set("database-backend", backend, section=libname)
-
-    # ensure database exists for the library
-    db = papis.database.get(libname)
-    assert db is not None
-
-    # ensure that its clean
-    db.clear()
-    db.initialize()
+PAPIS_DB_SETTINGS = [{"settings": {"database-backend": b}} for b in PAPIS_DB_BACKENDS]
 
 
-@pytest.mark.parametrize("backend", PAPIS_DB_BACKENDS)
-def test_database_paths(tmp_library: TemporaryLibrary, backend: str) -> None:
-    database_init(tmp_library.libname, backend)
-
+@pytest.mark.parametrize("tmp_library", PAPIS_DB_SETTINGS, indirect=True)
+def test_database_paths(tmp_library: TemporaryLibrary) -> None:
     db = papis.database.get()
     assert db is not None
-    assert db.get_backend_name() == backend
+    assert db.get_backend_name() == papis.config.get("database-backend")
     assert db.get_lib() == papis.config.get_lib_name()
     assert db.get_dirs() == papis.config.get_lib_dirs()
     assert db.get_all_query_string() == papis.database.get_all_query_string()
@@ -40,9 +28,8 @@ def test_database_paths(tmp_library: TemporaryLibrary, backend: str) -> None:
     assert len(docs) > 0
 
 
-@pytest.mark.parametrize("backend", PAPIS_DB_BACKENDS)
-def test_database_query(tmp_library: TemporaryLibrary, backend: str) -> None:
-    database_init(tmp_library.libname, backend)
+@pytest.mark.parametrize("tmp_library", PAPIS_DB_SETTINGS, indirect=True)
+def test_database_query(tmp_library: TemporaryLibrary) -> None:
     db = papis.database.get()
     docs = db.get_all_documents()
 
@@ -51,9 +38,8 @@ def test_database_query(tmp_library: TemporaryLibrary, backend: str) -> None:
     assert query_docs[0] == docs[0]
 
 
-@pytest.mark.parametrize("backend", PAPIS_DB_BACKENDS)
-def test_database_update(tmp_library: TemporaryLibrary, backend: str) -> None:
-    database_init(tmp_library.libname, backend)
+@pytest.mark.parametrize("tmp_library", PAPIS_DB_SETTINGS, indirect=True)
+def test_database_update(tmp_library: TemporaryLibrary) -> None:
     db = papis.database.get()
     docs = db.get_all_documents()
 
@@ -69,9 +55,8 @@ def test_database_update(tmp_library: TemporaryLibrary, backend: str) -> None:
     assert docs[0]["title"] == title
 
 
-@pytest.mark.parametrize("backend", PAPIS_DB_BACKENDS)
-def test_database_delete(tmp_library: TemporaryLibrary, backend: str) -> None:
-    database_init(tmp_library.libname, backend)
+@pytest.mark.parametrize("tmp_library", PAPIS_DB_SETTINGS, indirect=True)
+def test_database_delete(tmp_library: TemporaryLibrary) -> None:
     db = papis.database.get()
 
     docs = db.get_all_documents()
@@ -82,9 +67,8 @@ def test_database_delete(tmp_library: TemporaryLibrary, backend: str) -> None:
     assert ndocs == ndocs_after_delete + 1
 
 
-@pytest.mark.parametrize("backend", PAPIS_DB_BACKENDS)
-def test_database_add(tmp_library: TemporaryLibrary, backend: str) -> None:
-    database_init(tmp_library.libname, backend)
+@pytest.mark.parametrize("tmp_library", PAPIS_DB_SETTINGS, indirect=True)
+def test_database_add(tmp_library: TemporaryLibrary) -> None:
     db = papis.database.get()
     docs = db.get_all_documents()
     ndocs = len(docs)

--- a/tests/database/test_papis.py
+++ b/tests/database/test_papis.py
@@ -8,34 +8,25 @@ import pytest
 from papis.testing import TemporaryLibrary
 
 
-def database_init(libname: str) -> None:
-    papis.config.set("database-backend", "papis", section=libname)
-
-    # ensure database exists for the library
-    db = papis.database.get(libname)
-    assert isinstance(db, Database)
-
-    # ensure that its clean
-    db.clear()
-    db.initialize()
-    db.save()
-
-
+@pytest.mark.library_setup(settings={"database-backend": "papis"})
 def test_database_query(tmp_library: TemporaryLibrary) -> None:
-    database_init(tmp_library.libname)
     db = papis.database.get()
+    db.initialize()
+
     assert isinstance(db, Database)
     assert db.get_backend_name() == "papis"
-    assert os.path.exists(db._get_cache_file_path())
 
     docs = db.query(".")
     all_docs = db.get_all_documents()
     assert len(docs) > 0
     assert len(docs) == len(all_docs)
 
+    # NOTE: the filepath is only created once a document is queried
+    assert os.path.exists(db.get_cache_path())
 
+
+@pytest.mark.library_setup(settings={"database-backend": "papis"})
 def test_database_reload(tmp_library: TemporaryLibrary) -> None:
-    database_init(tmp_library.libname)
     db = papis.database.get()
     assert isinstance(db, Database)
 
@@ -47,8 +38,8 @@ def test_database_reload(tmp_library: TemporaryLibrary) -> None:
     assert ndocs == ndocs_reload
 
 
+@pytest.mark.library_setup(settings={"database-backend": "papis"})
 def test_database_missing(tmp_library: TemporaryLibrary) -> None:
-    database_init(tmp_library.libname)
     db = papis.database.get()
     assert isinstance(db, Database)
 
@@ -71,10 +62,10 @@ def test_filter_documents() -> None:
     assert len(filter_documents([document], search="title : ein")) != 1
 
 
+@pytest.mark.library_setup(settings={"database-backend": "papis"})
 def test_cache_path(tmp_library: TemporaryLibrary) -> None:
-    database_init(tmp_library.libname)
-
     db = papis.database.get()
+    _ = db.get_documents()
 
     assert os.path.exists(db.get_cache_path())
     assert not os.path.isdir(db.get_cache_path())

--- a/tests/database/test_whoosh.py
+++ b/tests/database/test_whoosh.py
@@ -7,22 +7,10 @@ import papis.database
 from papis.testing import TemporaryLibrary
 
 
-def database_init(libname: str) -> None:
-    papis.config.set("database-backend", "whoosh", section=libname)
-
-    # ensure database exists for the library
-    db = papis.database.get(libname)
-    assert db is not None
-
-    # ensure that its clean
-    db.clear()
-    db.initialize()
-
-
+@pytest.mark.library_setup(settings={"database-backend": "whoosh"})
 def test_database_query(tmp_library: TemporaryLibrary) -> None:
     pytest.importorskip("whoosh")
 
-    database_init(tmp_library.libname)
     db = papis.database.get()
     assert db.get_backend_name() == "whoosh"
 
@@ -32,9 +20,8 @@ def test_database_query(tmp_library: TemporaryLibrary) -> None:
     assert len(docs) == len(all_docs)
 
 
+@pytest.mark.library_setup(settings={"database-backend": "whoosh"})
 def test_cache_path(tmp_library: TemporaryLibrary) -> None:
-    database_init(tmp_library.libname)
-
     db = papis.database.get()
 
     assert os.path.exists(db.get_cache_path())

--- a/tests/test_format.py
+++ b/tests/test_format.py
@@ -7,9 +7,7 @@ from papis.testing import TemporaryConfiguration
 
 
 @pytest.mark.config_setup(settings={"formatter": "python"})
-def test_python_formatter(tmp_config: TemporaryConfiguration, monkeypatch) -> None:
-    monkeypatch.setattr(papis.format, "FORMATTER", None)
-
+def test_python_formatter(tmp_config: TemporaryConfiguration) -> None:
     document = papis.document.from_data({"author": "Fulano", "title": "A New Hope"})
     assert (
         papis.format.format("{doc[author]}: {doc[title]}", document)
@@ -32,9 +30,8 @@ def test_python_formatter(tmp_config: TemporaryConfiguration, monkeypatch) -> No
 
 
 @pytest.mark.config_setup(settings={"formatter": "jinja2"})
-def test_jinja_formatter(tmp_config: TemporaryConfiguration, monkeypatch) -> None:
+def test_jinja_formatter(tmp_config: TemporaryConfiguration) -> None:
     pytest.importorskip("jinja2")
-    monkeypatch.setattr(papis.format, "FORMATTER", None)
 
     document = papis.document.from_data({"author": "Fulano", "title": "A New Hope"})
     assert (


### PR DESCRIPTION
This updates the testing module to
* Temporarily monkeypatch cached globals like `papis.format.FORMATTER` and `papis.database.DATABASES`, so that the tests don't need to.
* Support parametrizing fixtures using the `indirect=True` keyword, which is used to set the `database-backend` before entering the test.