### PR TITLE
doctor: add check for duplicate entries

### DIFF
--- a/doc/source/default-settings.rst
+++ b/doc/source/default-settings.rst
@@ -411,6 +411,13 @@ BibTeX options
     A list of keys used by the ``duplicated-keys`` check. The check will show
     an error if the value of these keys is duplicated across multiple documents.
 
+.. papis-config:: doctor-duplicated-values-keys
+
+   A list of keys used by the ``duplicated-values`` check. The check will show
+   an error if any of the keys listed here have repeated values. This can check,
+   e.g., if a file was mistakenly added multiple times or of a tag already
+   exists in the document.
+
 .. papis-config:: doctor-html-codes-keys
 
     A list of keys used by the ``html-codes`` check. The check will show an error

--- a/papis/defaults.py
+++ b/papis/defaults.py
@@ -54,6 +54,7 @@ settings: Dict[str, Any] = {
     "doctor-default-checks": ["files", "keys-exist", "duplicated-keys"],
     "doctor-keys-exist-keys": ["title", "author", "author_list", "ref"],
     "doctor-duplicated-keys-keys": ["ref"],
+    "doctor-duplicated-values-keys": ["files", "author_list"],
     "doctor-html-codes-keys": ["title", "author", "abstract", "journal"],
     "doctor-html-tags-keys": ["title", "author", "abstract", "journal"],
     "doctor-key-type-check-separator": None,


### PR DESCRIPTION
This adds a new doctor check for duplicates inside a list. The intended use case was to check if the same file was added multiple times / the same tag was added multiple times / the same author was added multiple times, etc.

@jghauser Inspired by some of your work on the update command.