### PR TITLE
cli: use getboolean to get use-git option

### DIFF
--- a/papis/cli.py
+++ b/papis/cli.py
@@ -89,7 +89,7 @@ def git_option(**attrs: Any) -> DecoratorCallable:
     git_help = attrs.pop("help", "Commit changes to git")
     return bool_flag(
         "--git/--no-git",
-        default=lambda: bool(papis.config.get("use-git")),
+        default=lambda: papis.config.getboolean("use-git"),
         help=git_help,
         **attrs)
 

--- a/papis/commands/add.py
+++ b/papis/commands/add.py
@@ -534,19 +534,19 @@ def run(paths: List[str],
 @papis.cli.bool_flag(
     "-b", "--batch",
     help="Batch mode, do not prompt or otherwise")
-@click.option(
+@papis.cli.bool_flag(
     "--confirm/--no-confirm",
     help="Ask to confirm before adding to the collection",
     default=lambda: papis.config.getboolean("add-confirm"))
-@click.option(
+@papis.cli.bool_flag(
     "--open/--no-open", "open_file",
     help="Open file before adding document",
     default=lambda: papis.config.getboolean("add-open"))
-@click.option(
+@papis.cli.bool_flag(
     "--edit/--no-edit",
     help="Edit info file before adding document",
     default=lambda: papis.config.getboolean("add-edit"))
-@click.option(
+@papis.cli.bool_flag(
     "--link/--no-link",
     help="Instead of copying the file to the library, create a link to "
          "its original location",
@@ -555,9 +555,9 @@ def run(paths: List[str],
 @papis.cli.bool_flag(
     "--list-importers", "--li", "list_importers",
     help="List all available papis importers")
-@click.option(
+@papis.cli.bool_flag(
     "--download-files/--no-download-files",
-    help="Download file with importer if available or not.",
+    help="Download file with importer if available or not",
     default=lambda: papis.config.getboolean("add-download-files"))
 @papis.cli.bool_flag(
     "--fetch-citations",


### PR DESCRIPTION
Before it was just using `bool(get("use-git"))`, which would be true if `use-git = false` (only way to make it false would be to not add it to the configuration file).

Fixes #698.