### PR TITLE
docs: update configuration docs

### DIFF
--- a/doc/source/commands/config.rst
+++ b/doc/source/commands/config.rst
@@ -1,3 +1,5 @@
+.. _command-config:
+
 Config
 ------
 .. automodule:: papis.commands.config

--- a/doc/source/configuration.rst
+++ b/doc/source/configuration.rst
@@ -3,18 +3,22 @@
 Configuration file
 ==================
 
-Papis uses a configuration file in
-`*INI* <https://en.wikipedia.org/wiki/INI_file>`__  format.
+Papis uses a configuration file in `INI <https://en.wikipedia.org/wiki/INI_file>`__
+format. This configuration file will usually be located in
+``~/.config/papis/config`` (on Linux) or similar locations on other platforms.
 
-The basic configuration unit is a library.
-Imagine you want to have a library called ``papers`` and
-another called ``books``.
-You can have these libraries work independently from each other.
+In the Papis configuration file, the main entries will be sections describing
+what libraries you have. For example, assume you have two libraries: a library
+called ``papers`` and another called ``books``. In general, these libraries
+work and can be configured independently from each other.
 
-You would declare these libraries telling papis where the folders
-are in your system, like so:
+In the simplest case, you would simply need to declare their location in your
+system, like so
 
 .. code:: ini
+
+    [settings]
+    default-library = papers
 
     # my library for papers and stuff
     [papers]
@@ -24,16 +28,20 @@ are in your system, like so:
     [books]
     dir = ~/Documents/books
 
-One important aspect of the configuration system is that you can
-override settings on a per library basis, this means that
-you can set settings that should have a value for the library ``papers``
-and another value if you're currently using the library ``books``.
-The settings have to be set in the section under the library definition.
-For example, let's suppose you want to open your documents in ``papers``
-using the pdf reader ``okular`` however in ``books`` you want to open
-the documents in ``firefox``, for some reason, the you would write
+The ``[settings]`` section is used to set global configuration options.
+However, an important aspect of the configuration system is that you can override
+settings on a per library basis. This means that you can set options with different
+values for each of your libraries, depending on the use case you had in mind.
+For example, let's suppose you want to open your documents from ``papers``
+using the PDF reader ``okular`` however in ``books`` you want to open
+the documents in ``firefox`` (for some reason). Then, you would add the following
+lines to your configuration
 
 .. code:: ini
+
+    [settings]
+    opentool = evince
+    default-library = papers
 
     # my library for papers and stuff
     [papers]
@@ -45,136 +53,151 @@ the documents in ``firefox``, for some reason, the you would write
     dir = ~/Documents/books
     opentool = firefox
 
-    [settings]
-    opentool = evince
-    default-library = papers
+Here we also added the ``opentool`` setting the global section ``[settings]``.
+With this configuration file, the two shown libraries will open documents with
+their respective tool, while any other library will default to ``evince``. There
+are many configuration options and you can check their values using the
+:ref:`papis config <command-config>` command, e.g.
 
-Here we wrote also the special section ``[settings]``, which sets global
-settings that are valid in all libraries. Of course, every setting set
-within ``[settings]`` can be overridden by any library through the mechanism
-previously discussed.
+.. code:: sh
+
+    # show all the current options in the [settings] section
+    papis config --section settings
+    # show the default options
+    papis config --default --section settings
+    # show the value of the 'opentool' option for the books library
+    papis -l books config opentool
 
 A more complete example of a configuration file is the following
+(see :ref:`General Settings <general-settings>` for a comprehensive list of
+all the options and more extensive descriptions)
+
+.. warning::
+
+   Many configuration options use special formatted strings that can depend on
+   the document that is being worked on. When using these, make sure to also
+   set the :ref:`config-settings-formatter` to your desired choice. Below, we
+   are using the default ``python`` formatter that is based on :meth:`str.format`.
 
 .. code:: ini
 
-  #
-  # This is a general section, the settings set here will be set for
-  # all libraries
-  #
-  [settings]
-  #
-  # General file opener program, rifle is a nice python program
-  # If you're on macOS, you can write "open", if you're on linux
-  # you can also write "xdg-open", on windows-cygwin, you can set it to
-  # "cygstart"
-  #
-  opentool = rifle
-  # Use ranger as a file browser, a nice python program
-  file-browser = ranger
-  # Ask for confirmation when doing papis add
-  add-confirm = True
-  # Edit the info.yaml file before adding a doc into the library
-  # papis add --edit
-  add-edit = True
-  # Open the files before adding a document into the library
-  # papis add --open
-  add-open = True
-  #
-  # Define custom default match and header formats
-  #
-  match-format = {doc[tags]}{doc.subfolder}{doc[title]}{doc[author]}{doc[year]}
-  #
-  # Define header format with colors and multiline support
-  #
-  header-format = <red>{doc.html_escape[title]}</red>
-    <span color='#ff00ff'>  {doc.html_escape[author]}</span>
-    <yellow>   ({doc.html_escape[year]})</yellow>
+    #
+    # This is a general section, the settings set here will be global for
+    # all libraries
+    #
+    [settings]
+    # General file opener program ("rifle" is a nice general opener). This
+    # setting should be platform dependent, so on macOS you can use "open",
+    # on Linux you can use "xdg-open", on Windows you can set it to "cygstart"
+    # (under Cygwin at least), etc.
+    opentool = rifle
+    # Use "ranger" as a file browser
+    file-browser = ranger
 
-  [tui]
-  editmode = vi
-  options_list.selected_margin_style = bg:ansigreen fg:ansired
-  options_list.unselected_margin_style =
+    # Ask for confirmation when doing "papis add" before adding to the library.
+    # Equivalent to "papis add --confirm".
+    add-confirm = True
+    # Edit the "info.yaml" file before adding a document to the library.
+    # Equivalent to "papis add --edit".
+    add-edit = True
+    # Open any document files before adding the document to the library.
+    # Equivalent to "papis add --open".
+    add-open = True
 
-  # Define a lib
-  [papers]
-  dir = ~/Documents/papers
+    # Define custom default match formats. This format is used when searching
+    # documents in the default picker.
+    match-format = {doc[tags]}{doc.subfolder}{doc[title]}{doc[author]}{doc[year]}
+    # Define header format with colors and multiline support. This formatting
+    # will be used when displaying a document in the default picker.
+    header-format = <red>{doc.html_escape[title]}</red>
+      <span color='#ff00ff'>  {doc.html_escape[author]}</span>
+      <yellow>   ({doc.html_escape[year]})</yellow>
 
-  # override settings from the section tui only for the papers library
-  # you have to prepend "tui-" to the settings
-  tui-editmode = emacs
-  tui-options_list.unselected_margin_style = bg:blue
-  # use whoosh as a database for papers
-  database-backend = whoosh
-  # rename files added by author and title
-  add-file-name = {doc[author]}{doc[title]}
+    # Set options for the default picker and other CLI widgets.
+    [tui]
+    editmode = vi
+    options_list.selected_margin_style = bg:ansigreen fg:ansired
+    options_list.unselected_margin_style =
 
-  # Define a lib for books
-  [books]
-  dir = ~/Documents/books
-  database-backend = whoosh
+    # Define a library for papers
+    [papers]
+    dir = ~/Documents/papers
 
-  # Define a lib for Videos
-  [videos]
-  dir = ~/Videos/courses
+    # Override settings from the "tui" section only for the "papers" library.
+    # When using settings from another settings, the section name needs to be
+    # prepended -- here we prepend "tui-" to the settings.
+    tui-editmode = emacs
+    tui-options_list.unselected_margin_style = bg:blue
 
-  # Define a lib for contacts, why not?
-  # To make it work you just have to define some default settings
-  [contacts]
-  dir = ~/contacts/general
-  database-backend = papis
-  mode = contact
-  header-format = {doc[first_name]} {doc[last_name]}
-  match-format = {doc[org]} {doc[first_name]} {doc[last_name]}
-  browse-query-format = {doc[first_name]} {doc[last_name]}
-  add-open = False
+    # Use whoosh as a database for "papers".
+    database-backend = whoosh
+    # Rename files added by author and title in "papis add"
+    add-file-name = {doc[author]}{doc[title]}
+
+    # Define a library for books.
+    [books]
+    dir = ~/Documents/books
+    database-backend = whoosh
+
+    # Define a library for videos.
+    [videos]
+    dir = ~/Videos/courses
+
+    # Define a lib for contacts (why not?). To make it work you just have to
+    # define some sane settings.
+    [contacts]
+    dir = ~/contacts/general
+    database-backend = papis
+
+    match-format = {doc[org]} {doc[first_name]} {doc[last_name]}
+    header-format = {doc[first_name]} {doc[last_name]}
+
+    browse-query-format = {doc[first_name]} {doc[last_name]}
+    add-open = False
 
 
 Local configuration files
 -------------------------
+
 Papis also offers the possibility of creating local configuration files.
 The name of the local configuration file can be configured with the
-``local-config-file`` setting.
+:ref:`config-settings-local-config-file` setting. The local configuration files
+are looked for in the current directory (where the papis command is issued) or
+in the directory of the current library.
 
-The local configuration file can be found in the current directory of
-where you are issuing the papis command or in the directory of the
-library that you are considering in the papis command.
+For instance, suppose that you are in some project folder ``~/Documents/myproject``
+and you have a local config file there with a definition of a new library ``project``.
+Then, whenever you are in the ``~/Documents/myproject`` directory, Papis will also
+read the local configuration file and you will have access to the additional
+library ``project``.
 
-For instance let us suppose that you are in some project folder
-``~/Documents/myproject`` and you have a local config file there
-with a definition of a new library. Then whenever you are
-in the ``~/Documents/myproject`` directory papis will also read the
-local configuration file found there.
+On the other hand, if you have a configuration file in the folder
+for your papers, for instance in::
 
-On the other hand, also if you have a configuration file in the library folder
-for your papers, for instance in
+    ~/Documents/papers/.papis.config
 
-::
-
-  ~/Documents/papers/.papis.config
-
-then every time that you use this library papis will also source this
-configuration file.
+Then, every time that you use this library papis will also source this
+configuration file. This can be used as an alternative to adding more configuration
+options in the main configuration file or if you expect this library to be
+used on more machines with different configurations.
 
 An example of a project using a local configuration file can be seen
-`here <https://github.com/alejandrogallo/datasheets/blob/master/.papis.config/>`__
-, where the repository includes documents for component datasheets
-and every time ``papis`` is using that library the ``.papis.config``
-file is also read and some settings will be getting overridden.
+`here <https://github.com/alejandrogallo/datasheets/blob/master/.papis.config>`__.
+The repository includes documents for component datasheets and every time
+``papis`` is using that library the ``.papis.config`` file is also read and
+some settings will get overridden.
 
 .. _config_py:
 
 Python configuration file
 -------------------------
 
-For some users it would be useful to have a python file that gets
-loaded together with the usual configuration file, this file
-lives in your papis configuration directory with the name ``config.py``,
-for instance for most users it will be in
+For some more dynamic use cases, it would be useful to have a Python file that
+gets loaded together with the usual configuration file. This file lives in your
+Papis configuration directory and has the name ``config.py``. For instance,
+for most users it will be in::
 
-::
-
-  ~/.config/papis/config.py
+    ~/.config/papis/config.py
 
 
 .. include:: default-settings.rst

--- a/papis/format.py
+++ b/papis/format.py
@@ -62,7 +62,21 @@ class PythonFormatter(Formatter):
     (*str.format* based) format string.
 
     This formatter is named ``"python"`` and can be set using the
-    :ref:`config-settings-formatter` setting in the configuration file.
+    :ref:`config-settings-formatter` setting in the configuration file. The
+    formatted string has access to the ``doc`` variable, that is always a
+    :class:`papis.document.Document`. A string using this formatter can look
+    like
+
+    .. code:: python
+
+        "{doc[year]} - {doc[author_list][0][family]} - {doc[title]}"
+
+    Note, however, that according to PEP 3101 some simple formatting is not
+    possible. For example, the following is not allowed
+
+    .. code:: python
+
+        "{doc.title.lower()}"
     """
 
     def format(self,
@@ -96,7 +110,29 @@ class Jinja2Formatter(Formatter):
     templates.
 
     This formatter is named ``"jinja2"`` and can be set using the
-    :ref:`config-settings-formatter` setting in the configuration file.
+    :ref:`config-settings-formatter` setting in the configuration file. The
+    formatted string has access to the ``doc`` variable, that is always a
+    :class:`papis.document.Document`. A string using this formatter can look
+    like
+
+    .. code:: python
+
+        "{{ doc.year }} - {{ doc.author_list[0].family }} - {{ doc.title }}"
+
+    This formatter supports the whole range of Jinja2 control structures and
+    `filters <https://jinja.palletsprojects.com/en/3.1.x/templates/#filters>`__
+    so more advanced string processing is possible. For example, we can titlecase
+    the title using
+
+    .. code:: python
+
+        "{{ doc.title | title }}"
+
+    or give a default value if a key is missing in the document using
+
+    .. code:: python
+
+        "{{ doc.isbn | default('ISBN-NONE', true) }}"
     """
 
     def __init__(self) -> None:


### PR DESCRIPTION
This updates the `configuration.rst` file:
* Cleans up some phrasing here and there.
* Adds a mention to the `papis config` command so users can check settings.
* Adds a warning about the formatter, which is a big part of some configuration settings.

Fixes #704.