### PR TITLE
Enhance python formatter with extra conversions

### DIFF
--- a/tests/test_format.py
+++ b/tests/test_format.py
@@ -28,6 +28,11 @@ def test_python_formatter(tmp_config: TemporaryConfiguration) -> None:
             data)
         == ": The Phantom Menace ()")
 
+    assert papis.format.format("{doc[title]!y}", data) == "the-phantom-menace"
+    assert papis.format.format("{doc[title]:1.3S}", data) == "Phantom Menace"
+    assert papis.format.format("{doc[title]:.2S}", data) == "The Phantom"
+    assert papis.format.format("{doc[title]:2S}", data) == "The Phantom"
+
 
 @pytest.mark.config_setup(settings={"formatter": "jinja2"})
 def test_jinja_formatter(tmp_config: TemporaryConfiguration) -> None:


### PR DESCRIPTION
This implements a special Formatter for our `PythonFormatter`
https://docs.python.org/3/library/string.html#string.Formatter
that supports some extra operations to make it slightly less likely to switch to the `jinja2` formatter:
* It adds `l`, `u`, `t` and `c` conversions for `lower`, `upper`, `title` and `capitalize`. It also adds a `y` conversion that calls `slugify`! Format strings using these look like
```
"{doc[title]!t}"
```
* It adds a funky formatting spec `S` that can select words from a string. This basically does `" ".join(value.split(" ")[istart:iend])`. It looks something like this to selects words 1 to 3
```
"{doc[title]:1.3S}"
```

@alejandrogallo @jghauser This was mostly an experiment because I stumbled upon that `Formatter` class (didn't know it existed). What do you think? Is it worth adding something like this or is it too unexpected for people used to `str.format`?