### PR TITLE
commands.default: use section when setting config

### DIFF
--- a/papis/commands/default.py
+++ b/papis/commands/default.py
@@ -237,6 +237,17 @@ def run(verbose: bool,
             papis.config.get_configuration())
 
     # read in configuration from command-line
+    sections = papis.config.get_configuration().sections()
     for pair in set_list:
-        logger.debug("Setting '%s' to '%s'.", *pair)
-        papis.config.set(pair[0], pair[1])
+        # NOTE: search for a matching section so that we can overwrite entries
+        # from the command-line as well (the section takes precendence)
+        key, value, section = pair[0], pair[1], None
+        for s in sections:
+            if key.startswith(s):
+                key, section = key[len(s) + 1:], s
+
+        logger.debug("Setting '%s' to '%s' (section '%s').",
+                     key, value,
+                     section if section else papis.config.GENERAL_SETTINGS_NAME)
+
+        papis.config.set(key, value, section=section)


### PR DESCRIPTION
When the configuration file has a section like
```
[bibtex]
auto-read = true
```
Then,
```
papis --set bibtex-auto-read false bibtex ...
```
doesn't work as expected because the new setting gets put in the main `[settings]` section. Then, when we try `papis.config.get` the `[bibtex]` section takes precedence and the setting isn't actually changed. This tries to extract a section from the `--set` flag and use that. It's probably not foolproof, but it seems to work for some simple cases.

