### PR TITLE
config: add support for formatted keys

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,30 @@
+# VERSION NEXT (TDB)
+
+## Features
+
+### Major: Improved formatter support ([#711](https://github.com/papis/papis/pull/711))
+
+Papis supports [formatter plugins](https://papis.readthedocs.io/en/latest/configuration.html#config-settings-formatter)
+that act on certain configuration settings that can depend on the current
+document. Until now, when changing from one formatter to another, all settings
+needed to be rewritten (including default ones, since they used the `python`
+formatter).
+
+It is now possible to use the following syntax to set the formatter per
+configuration key
+```ini
+    [settings]
+    ref-format.jinja2 = {{ doc.author_list | slice(3) | join("", attribute="family") }}{{ doc.year }}
+```
+
+The syntax is always `key[.formatter]`. The formatted strings are searched
+alphabetically and the last one is picked, i.e. if both `key.python` and
+`key.jinja2` are provided, the `python` version will be chosen regardless of the
+order in the configuration file. If no formatter is provided for a formatted
+string of this type, then it will fall back to the default formatter set by the
+`formatter` setting. All default settings are now clearly marked as using the
+`python` formatter, so they no longer need to be rewritten when changing formatters.
+
 # VERSION 0.14.1 (March 1, 2025)
 
 ## Features

--- a/doc/source/conf.py
+++ b/doc/source/conf.py
@@ -57,7 +57,6 @@ nitpick_ignore_regex = [
     ["py:class", r".*SubRequest"],
     ]
 
-
 # Add any paths that contain templates here, relative to this directory.
 templates_path = ["_templates"]
 

--- a/doc/source/developer_reference.rst
+++ b/doc/source/developer_reference.rst
@@ -72,6 +72,8 @@ Developer API reference
 ``papis.format``
 ----------------
 
+.. autoclass:: papis.strings.FormattedString
+
 .. automodule:: papis.format
     :members:
 

--- a/papis/bibtex.py
+++ b/papis/bibtex.py
@@ -492,9 +492,11 @@ def create_reference(doc: Dict[str, Any], force: bool = False) -> str:
         return ref
 
     # Otherwise, try to generate one somehow
-    ref_format = papis.config.get("ref-format")
-    if ref_format is not None:
-        ref = papis.format.format(str(ref_format), doc, default="")
+    try:
+        ref_format = papis.config.getformattedstring("ref-format")
+        ref = papis.format.format(ref_format, doc, default="")
+    except ValueError:
+        ref = ""
 
     if not ref:
         ref = str(doc.get("doi", ""))

--- a/papis/cli.py
+++ b/papis/cli.py
@@ -11,6 +11,27 @@ import papis.database
 DecoratorCallable = Callable[..., Any]
 
 
+class FormattedStringParamType(click.ParamType):
+    #: Name of the parameter type (shown in the command-line).
+    name: str = "formatted-text"
+
+    def convert(self,
+                value: Any,
+                param: Optional[click.Parameter],
+                ctx: Optional[click.Context]) -> Any:
+        from papis.strings import FormattedString
+
+        # NOTE: this is required to handle default values which have a formatter
+        # already set and we do not want to remove it
+        if isinstance(value, FormattedString):
+            return value
+
+        return str(value)
+
+    def __repr__(self) -> str:
+        return "FORMATTEDSTRING"
+
+
 def bool_flag(*args: Any, **kwargs: Any) -> DecoratorCallable:
     """A wrapper to :func:`click.option` that hardcodes a boolean flag option."""
     # NOTE: we set the flag_value regardless because the default might be a

--- a/papis/commands/add.py
+++ b/papis/commands/add.py
@@ -182,6 +182,7 @@ def get_file_name(
         doc: papis.document.Document,
         original_filepath: str,
         suffix: str = "",
+        file_name_format: Optional[papis.strings.AnyString] = None,
         base_name_limit: int = 150) -> str:
     warn("'get_file_name' is deprecated and will be removed in the next "
          "version. Use 'papis.paths.get_document_file_name' instead.",
@@ -212,8 +213,8 @@ def ensure_new_folder(path: str) -> str:
 
 def run(paths: List[str],
         data: Optional[Dict[str, Any]] = None,
-        folder_name: Optional[str] = None,
-        file_name: Optional[str] = None,
+        folder_name: Optional[papis.strings.AnyString] = None,
+        file_name: Optional[papis.strings.AnyString] = None,
         subfolder: Optional[str] = None,
         base_path: Optional[str] = None,
         batch: bool = False,
@@ -426,17 +427,17 @@ def run(paths: List[str],
     help="Pick from existing subfolders")
 @click.option(
     "--folder-name",
-    help="Name for the document's folder (papis format)",
-    default=lambda: papis.config.getstring("add-folder-name"))
+    help="Name format for the document main folder",
+    type=papis.cli.FormattedStringParamType(),
+    default=lambda: papis.config.getformattedstring("add-folder-name"))
 @click.option(
     "--file-name",
-    help="File name for the document (papis format)",
+    help="File name format for the document",
+    type=papis.cli.FormattedStringParamType(),
     default=None)
 @click.option(
     "--from", "from_importer",
-    help="Add document from a specific importer ({})".format(
-        ", ".join(papis.importer.available_importers())
-    ),
+    help="Add document from a specific importer",
     type=(click.Choice(papis.importer.available_importers()), str),
     nargs=2,
     multiple=True,
@@ -483,8 +484,8 @@ def cli(files: List[str],
         set_list: List[Tuple[str, str]],
         subfolder: str,
         pick_subfolder: bool,
-        folder_name: str,
-        file_name: Optional[str],
+        folder_name: papis.strings.AnyString,
+        file_name: Optional[papis.strings.AnyString],
         from_importer: List[Tuple[str, str]],
         batch: bool,
         confirm: bool,

--- a/papis/commands/addto.py
+++ b/papis/commands/addto.py
@@ -101,7 +101,8 @@ def run(document: papis.document.Document,
               type=click.Path(exists=True))
 @click.option("-u", "--urls", help="URLs to documents", multiple=True)
 @click.option("--file-name",
-              help="File name for the document (papis format)",
+              help="File name format for the document",
+              type=papis.cli.FormattedStringParamType(),
               default=None)
 @click.option(
     "--link/--no-link",

--- a/papis/commands/bibtex.py
+++ b/papis/commands/bibtex.py
@@ -131,6 +131,7 @@ import papis.cli
 import papis.config
 import papis.format
 import papis.logging
+import papis.strings
 from papis.commands import AliasedGroup
 from papis.commands.explore import get_explorer_by_name
 
@@ -338,10 +339,9 @@ def cli_open(ctx: click.Context) -> None:
 @cli.command("edit")
 @click.help_option("-h", "--help")
 @click.option("-s", "--set", "set_tuples",
-              help="Update document's information with key value. "
-              "The value can be a papis format.",
+              help="Update a document with key value pairs",
               multiple=True,
-              type=(str, str),)
+              type=(str, papis.cli.FormattedStringParamType()),)
 @papis.cli.all_option()
 @click.pass_context
 def cli_edit(ctx: click.Context,
@@ -384,11 +384,12 @@ def cli_edit(ctx: click.Context,
 
         if set_tuples:
             for k, v in set_tuples:
+                kp, vp = papis.strings.process_formatted_string_pair(k, v)
                 try:
-                    located[k] = papis.format.format(v, located)
+                    located[kp] = papis.format.format(vp, located)
                 except papis.format.FormatFailedError as exc:
                     logger.error("Could not format '%s' with value '%s'.",
-                                 k, v, exc_info=exc)
+                                 kp, vp, exc_info=exc)
 
             save_doc(located)
         else:

--- a/papis/commands/browse.py
+++ b/papis/commands/browse.py
@@ -113,7 +113,7 @@ def run(document: papis.document.Document,
         import urllib.parse
         params = {
             "q": papis.format.format(
-                papis.config.getstring("browse-query-format"),
+                papis.config.getformattedstring("browse-query-format"),
                 document,
                 default="{} {}".format(document["author"], document["title"]))
         }

--- a/papis/commands/config.py
+++ b/papis/commands/config.py
@@ -96,6 +96,8 @@ def parse_option(
     """
     :returns: a ``(section, key)`` tuple parsed from *option*.
     """
+    from papis.format import get_available_formatters
+    formatters = set(get_available_formatters())
 
     parts = option.split(".")
     key = section = None
@@ -103,8 +105,12 @@ def parse_option(
         key = parts[0]
         section = default_section
     elif len(parts) == 2:
-        section = parts[0] if parts[0] else None
-        key = parts[1]
+        if parts[1] in formatters:
+            section = default_section
+            key = option
+        else:
+            section = parts[0] if parts[0] else None
+            key = parts[1]
     else:
         raise ValueError(f"Unsupported option format: '{option}'")
 

--- a/papis/commands/doctor.py
+++ b/papis/commands/doctor.py
@@ -1089,7 +1089,7 @@ def run(doc: papis.document.Document,
                                 + list(DEPRECATED_CHECK_NAMES)),
               help="Checks to run on every document.")
 @papis.cli.bool_flag("--json", "_json",
-                     help="Output the results in json format")
+                     help="Output the results in JSON format")
 @papis.cli.bool_flag("--fix",
                      help="Auto fix the errors with the auto fixer mechanism")
 @papis.cli.bool_flag("-s", "--suggest",

--- a/papis/commands/explore.py
+++ b/papis/commands/explore.py
@@ -268,7 +268,7 @@ def add(ctx: click.Context) -> None:
 @click.command("cmd")
 @click.pass_context
 @click.help_option("--help", "-h")
-@click.argument("command", type=str)
+@click.argument("command", type=papis.cli.FormattedStringParamType())
 def cmd(ctx: click.Context, command: str) -> None:
     """
     Run a general command on the document list.

--- a/papis/commands/list.py
+++ b/papis/commands/list.py
@@ -153,7 +153,7 @@ def list_documents(documents: Sequence[papis.document.Document],
                    show_id: bool = False,
                    show_info: bool = False,
                    show_notes: bool = False,
-                   show_format: str = "",
+                   show_format: papis.strings.AnyString = "",
                    template: Optional[str] = None
                    ) -> List[str]:
     """List document properties.
@@ -217,6 +217,7 @@ run = list_documents
 @click.option(
     "--format", "show_format",
     help="Show documents using a custom format, e.g. '{doc[year]} {doc[title]}",
+    type=papis.cli.FormattedStringParamType(),
     default="")
 @papis.cli.bool_flag(
     "--paths", "show_paths",

--- a/papis/commands/open.py
+++ b/papis/commands/open.py
@@ -109,7 +109,7 @@ def run(document: papis.document.Document,
             logger.debug("Getting document's marks.")
             marks = document[papis.config.getstring("mark-key-name")]
             if marks:
-                _mark_fmt = papis.config.getstring("mark-header-format")
+                _mark_fmt = papis.config.getformattedstring("mark-header-format")
                 _mark_name = papis.config.getstring("mark-format-name")
                 _mark_opener = papis.config.getstring("mark-opener-format")
                 if not _mark_fmt:

--- a/papis/commands/rename.py
+++ b/papis/commands/rename.py
@@ -108,8 +108,9 @@ def run(document: papis.document.Document,
 @click.command("rename")
 @click.option(
     "--folder-name",
-    help="Name for the document's folder (papis format)",
-    default=lambda: papis.config.getstring("add-folder-name"))
+    help="Name format for the document main folder",
+    type=papis.cli.FormattedStringParamType(),
+    default=lambda: papis.config.getformattedstring("add-folder-name"))
 @papis.cli.bool_flag(
     "-b", "--batch",
     help="Batch mode, do not prompt")
@@ -120,7 +121,7 @@ def run(document: papis.document.Document,
 @papis.cli.sort_option()
 @papis.cli.doc_folder_option()
 def cli(query: str,
-        folder_name: str,
+        folder_name: papis.strings.AnyString,
         _all: bool,
         batch: bool,
         git: bool,

--- a/papis/database/cache.py
+++ b/papis/database/cache.py
@@ -9,6 +9,7 @@ import papis.config
 import papis.format
 import papis.database.base
 import papis.logging
+from papis.strings import AnyString
 
 logger = papis.logging.get_logger(__name__)
 
@@ -88,7 +89,7 @@ def filter_documents(
 def match_document(
         document: papis.document.Document,
         search: Pattern[str],
-        match_format: Optional[str] = None,
+        match_format: Optional[AnyString] = None,
         doc_key: Optional[str] = None) -> Optional[Match[str]]:
     """Match a document's keys to a given search pattern.
 
@@ -103,10 +104,10 @@ def match_document(
     >>> match_document(document, regex('einstein'), '{doc[title]}') is None
     True
     """
-    match_format = match_format or papis.config.getstring("match-format")
     if doc_key is not None:
         match_string = str(document[doc_key])
     else:
+        match_format = match_format or papis.config.getformattedstring("match-format")
         match_string = papis.format.format(match_format, document)
 
     return search.match(match_string)

--- a/papis/defaults.py
+++ b/papis/defaults.py
@@ -2,6 +2,12 @@ import sys
 import os
 from typing import Any, Dict
 
+from papis.strings import FormattedString
+
+
+def _f(value: str) -> FormattedString:
+    return FormattedString("python", value)
+
 
 def get_default_opener() -> str:
     """Get the default file opener for the current system
@@ -41,8 +47,9 @@ settings: Dict[str, Any] = {
     "doc-url-key-name": "doc_url",
     "default-library": "papers",
     "format-doc-name": "doc",
-    "match-format": "{doc[tags]}{doc.subfolder}{doc[title]}{doc[author]}{doc[year]}",
-    "header-format": (
+    "match-format": _f(
+        "{doc[tags]}{doc.subfolder}{doc[title]}{doc[author]}{doc[year]}"),
+    "header-format": _f(
         "<ansired>{doc.html_escape[title]}</ansired>\n"
         " <ansigreen>{doc.html_escape[author]}</ansigreen>\n"
         "  <ansiblue>({doc.html_escape[year]})</ansiblue> "
@@ -51,7 +58,7 @@ settings: Dict[str, Any] = {
     "header-format-file": None,
     "info-allow-unicode": True,
     "unique-document-keys": ["doi", "isbn", "isbn10", "eprint", "url", "doc_url"],
-    "document-description-format": "{doc[title]} - {doc[author]}",
+    "document-description-format": _f("{doc[title]} - {doc[author]}"),
     "sort-field": None,
     "sort-reverse": False,
     "formatter": "python",
@@ -59,7 +66,7 @@ settings: Dict[str, Any] = {
     "doc-paths-extra-chars": "",
     "doc-paths-word-separator": "-",
     "ref-word-separator": "_",
-    "library-header-format": (
+    "library-header-format": _f(
         "<ansired>{library[name]}</ansired>"
         " <ansiblue>{library[paths]}</ansiblue>"
     ),
@@ -82,12 +89,12 @@ settings: Dict[str, Any] = {
     "bibtex-unicode": False,
     "bibtex-export-file": False,
     "multiple-authors-separator": " and ",
-    "multiple-authors-format": "{au[family]}, {au[given]}",
+    "multiple-authors-format": _f("{au[family]}, {au[given]}"),
 
     # add
-    "ref-format": "{doc[title]:.15} {doc[author]:.6} {doc[year]}",
-    "add-folder-name": "",
-    "add-file-name": None,
+    "ref-format": _f("{doc[title]:.15} {doc[author]:.6} {doc[year]}"),
+    "add-folder-name": _f(""),
+    "add-file-name": _f(""),
     "add-subfolder": "",
     "add-confirm": False,
     "add-edit": False,
@@ -99,7 +106,7 @@ settings: Dict[str, Any] = {
 
     # browse
     "browse-key": "auto",
-    "browse-query-format": "{doc[title]} {doc[author]}",
+    "browse-query-format": _f("{doc[title]} {doc[author]}"),
     "search-engine": "https://duckduckgo.com",
 
     # edit
@@ -142,8 +149,8 @@ settings: Dict[str, Any] = {
     "open-mark": False,
     "mark-key-name": "marks",
     "mark-format-name": "mark",
-    "mark-header-format": "{mark[name]} - {mark[value]}",
-    "mark-match-format": "{mark[name]} - {mark[value]}",
+    "mark-header-format": _f("{mark[name]} - {mark[value]}"),
+    "mark-match-format": _f("{mark[name]} - {mark[value]}"),
     "mark-opener-format": get_default_opener(),
 
     # serve
@@ -231,15 +238,9 @@ settings: Dict[str, Any] = {
     "fzf-binary": "fzf",
     "fzf-extra-flags": ["--ansi", "--multi", "-i"],
     "fzf-extra-bindings": ["ctrl-s:jump"],
-    "fzf-header-format": ("{c.Fore.MAGENTA}"
-                          "{doc[title]:<70.70}"
-                          "{c.Style.RESET_ALL}"
-                          " :: "
-                          "{c.Fore.CYAN}"
-                          "{doc[author]:<20.20}"
-                          "{c.Style.RESET_ALL}"
-                          "{c.Fore.YELLOW}"
-                          "«{doc[year]:4}»"
-                          "{c.Style.RESET_ALL}"
-                          ":{doc[tags]}"),
+    "fzf-header-format": _f(
+        "{c.Fore.MAGENTA}{doc[title]:<70.70}{c.Style.RESET_ALL}"
+        " :: "
+        "{c.Fore.CYAN}{doc[author]:<20.20}{c.Style.RESET_ALL}"
+        "{c.Fore.YELLOW}«{doc[year]:4}»{c.Style.RESET_ALL}:{doc[tags]}"),
 }

--- a/papis/docmatcher.py
+++ b/papis/docmatcher.py
@@ -4,6 +4,7 @@ from typing import Any, ClassVar, List, NamedTuple, Optional, Pattern, Protocol
 import papis.config
 import papis.document
 import papis.logging
+from papis.strings import AnyString, FormattedString
 
 logger = papis.logging.get_logger(__name__)
 
@@ -40,7 +41,7 @@ class MatcherCallable(Protocol):
     def __call__(self,
                  document: papis.document.Document,
                  search: Pattern[str],
-                 match_format: Optional[str] = None,
+                 match_format: Optional[AnyString] = None,
                  doc_key: Optional[str] = None,
                  ) -> Any:
         """Match a document's keys to a given search pattern.
@@ -88,7 +89,7 @@ class DocMatcher:
     matcher: ClassVar[Optional[MatcherCallable]] = None
     #: A format string (defaulting to :confval:`match-format`) used
     #: to match the parsed search results if no document key is present.
-    match_format: ClassVar[str] = ""
+    match_format: ClassVar[FormattedString] = FormattedString(None, "")
 
     @classmethod
     def return_if_match(
@@ -171,7 +172,7 @@ class DocMatcher:
         if search is None:
             search = cls.search
 
-        cls.match_format = papis.config.getstring("match-format")
+        cls.match_format = papis.config.getformattedstring("match-format")
         cls.parsed_search = parse_query(search)
 
         return cls.parsed_search

--- a/papis/document.py
+++ b/papis/document.py
@@ -10,6 +10,7 @@ from typing import (
 
 import papis
 import papis.config
+import papis.strings
 import papis.logging
 
 logger = papis.logging.get_logger(__name__)
@@ -141,9 +142,10 @@ def keyconversion_to_data(conversions: Sequence[KeyConversionPair],
     return new_data
 
 
-def author_list_to_author(data: Dict[str, Any],
-                          separator: Optional[str] = None,
-                          multiple_authors_format: Optional[str] = None) -> str:
+def author_list_to_author(
+        data: Dict[str, Any],
+        separator: Optional[str] = None,
+        multiple_authors_format: Optional[papis.strings.AnyString] = None) -> str:
     """Convert a list of authors into a single author string.
 
     This uses the :confval:`multiple-authors-separator` and the
@@ -165,7 +167,8 @@ def author_list_to_author(data: Dict[str, Any],
         separator = papis.config.getstring("multiple-authors-separator")
 
     if multiple_authors_format is None:
-        multiple_authors_format = papis.config.getstring("multiple-authors-format")
+        multiple_authors_format = (
+            papis.config.getformattedstring("multiple-authors-format"))
 
     if separator is None or multiple_authors_format is None:
         raise ValueError(
@@ -542,7 +545,7 @@ def describe(document: Union[Document, Dict[str, Any]]) -> str:
         :confval:`document-description-format`.
     """
     return papis.format.format(
-        papis.config.getstring("document-description-format"),
+        papis.config.getformattedstring("document-description-format"),
         document, default=document.get("title", str(document)))
 
 

--- a/papis/fzf.py
+++ b/papis/fzf.py
@@ -137,7 +137,7 @@ class Picker(papis.pick.Picker[T]):
             [fzf, "--bind", ",".join(bindings)]
             + papis.config.getlist("fzf-extra-flags"))
 
-        _fmt = papis.config.getstring("fzf-header-format")
+        _fmt = papis.config.getformattedstring("fzf-header-format")
 
         def _header_filter(d: T) -> str:
             if isinstance(d, papis.document.Document):

--- a/papis/notes.py
+++ b/papis/notes.py
@@ -31,8 +31,9 @@ def notes_path(doc: papis.document.Document) -> str:
     from papis.paths import normalize_path
 
     if not has_notes(doc):
-        notes_name = papis.format.format(papis.config.getstring("notes-name"), doc,
-                                         default="notes.tex")
+        notes_name = papis.format.format(
+            papis.config.getformattedstring("notes-name"), doc,
+            default="notes.tex")
         doc["notes"] = normalize_path(notes_name)
         papis.api.save_doc(doc)
 

--- a/papis/pick.py
+++ b/papis/pick.py
@@ -99,14 +99,15 @@ def pick_doc(
     :arg documents: a sequence of documents.
     :returns: a subset of *documents* that was picked.
     """
+    from papis.strings import FormattedString
 
     header_format_path = papis.config.get("header-format-file")
     if header_format_path is not None:
         with open(os.path.expanduser(header_format_path)) as fd:
-            header_format = fd.read().rstrip()
+            header_format = FormattedString(None, fd.read().rstrip())
     else:
-        header_format = papis.config.getstring("header-format")
-    match_format = papis.config.getstring("match-format")
+        header_format = papis.config.getformattedstring("header-format")
+    match_format = papis.config.getformattedstring("match-format")
 
     from functools import partial
 
@@ -148,7 +149,7 @@ def pick_library(libs: Optional[List[str]] = None) -> List[str]:
     if libs is None:
         libs = papis.api.get_libraries()
 
-    header_format = papis.config.getstring("library-header-format")
+    header_format = papis.config.getformattedstring("library-header-format")
 
     def header_filter(lib: str) -> str:
         library = papis.config.get_lib_from_name(lib)

--- a/papis/plugin.py
+++ b/papis/plugin.py
@@ -40,10 +40,11 @@ def get_extension_manager(namespace: str) -> ExtensionManager:
 
 def get_available_entrypoints(namespace: str) -> List[str]:
     """
-    :returns: a list of all available entry points in the given *namespace*.
+    :returns: a list of all available entry points in the given *namespace*
+        sorted alphabetically.
     """
     manager = get_extension_manager(namespace)
-    return [str(e) for e in manager.entry_points_names()]
+    return sorted(str(e) for e in manager.entry_points_names())
 
 
 def get_available_plugins(namespace: str) -> List[Any]:

--- a/papis/strings.py
+++ b/papis/strings.py
@@ -1,3 +1,88 @@
+from typing import Any, Optional, NamedTuple, Tuple, Union
+
+
+class FormattedString(NamedTuple):
+    """A tuple that defines a ``(formatter, string)`` pair.
+
+    In a configuration file, a formatted string can be defined as::
+
+    .. code:: ini
+
+        key = formatted_value
+        other_key.formatter = other_formatted_value
+
+    where the first key will use the default :confval:`formatter` and the second
+    key will use the specificed formatter. These keys can be read using
+    :func:`papis.config.getformattedstring`.
+
+    .. autoattribute:: formatter
+    .. autoattribute:: value
+    """
+
+    #: The formatter that should be used on the string :attr:`value`. If none
+    #: is provided, the default formatter is used, as defined by
+    #: :confval:`formatter`.
+    formatter: Optional[str]
+    #: Value of the
+    value: str
+
+    def __str__(self) -> str:
+        return self.value
+
+    def __repr__(self) -> str:
+        return repr(self.value)
+
+    def __bool__(self) -> bool:
+        return bool(self.value)
+
+    # NOTE: __eq__ and __hash__ are implemented to ensure that formatted
+    # strings can be used in 'click.option' with 'click.Choice'. This is not
+    # very intuitive, as strings with the same text, but different formatters
+    # will be equal. However, this is only an issue if the formatters use the
+    # same templating language.
+
+    def __eq__(self, other: Any) -> bool:
+        if isinstance(other, str):
+            return self.value == other
+        elif isinstance(other, FormattedString):
+            return self.value == other.value
+        else:
+            return False
+
+    def __hash__(self) -> int:
+        return hash(self.value)
+
+
+AnyString = Union[str, FormattedString]
+
+
+def process_formatted_string_pair(
+    key: str,
+    value: AnyString
+) -> Tuple[str, FormattedString]:
+    """
+    :param key: a document key in the format ``key[.formatter]``.
+    :param value: an unformatted value.
+
+    :returns: a ``(key, value)`` pair, where the formatter was removed from the
+        *key* and the *value* is guaranteed to be a :class:`FormattedString`. If the
+        *value* already defines a formatter, it is overwritten by the one defined
+        by the *key*.
+    """
+    if "." in key:
+        key, formatter = key.rsplit(".", maxsplit=1)
+    else:
+        formatter = None
+
+    if isinstance(value, FormattedString):
+        if formatter is not None:
+            value = FormattedString(formatter, value.value)
+    else:
+        value = FormattedString(formatter, value)
+
+    return key, value
+
+
 no_documents_retrieved_message = "No documents retrieved"
 no_folder_attached_to_document = (
     "Document has no folder attached (call 'Document.set_folder' first)")

--- a/papis/testing.py
+++ b/papis/testing.py
@@ -287,7 +287,8 @@ class TemporaryConfiguration:
 
         # monkeypatch globals
         import papis.format
-        self._monkeypatch.setattr(papis.format, "FORMATTER", None)
+        self._monkeypatch.setattr(papis.format, "FORMATTER", {})
+
         import papis.database
         self._monkeypatch.setattr(papis.database, "DATABASES", {})
         # FIXME: may need to also add the following:

--- a/papis/utils.py
+++ b/papis/utils.py
@@ -88,10 +88,6 @@ def parmap(f: Callable[[A], B],
     :param np: number of processes to use when applying the function *f* in
         parallel. This value defaults to ``PAPIS_NP`` or :func:`os.cpu_count`.
     """
-
-    # FIXME: load singleton plugins here instead of on all the processes
-    _ = papis.format.get_formatter()
-
     if np is None:
         np = int(os.environ.get("PAPIS_NP", str(os.cpu_count())))
 

--- a/tests/test_format.py
+++ b/tests/test_format.py
@@ -33,6 +33,16 @@ def test_python_formatter(tmp_config: TemporaryConfiguration) -> None:
     assert papis.format.format("{doc[title]:.2S}", data) == "The Phantom"
     assert papis.format.format("{doc[title]:2S}", data) == "The Phantom"
 
+    # test out a jinja2 format
+    from papis.strings import FormattedString
+    assert len(papis.format.FORMATTER) == 1
+    assert (
+        papis.format.format(
+            FormattedString("jinja2", "{{ doc.author }}: {{ doc.title }}"),
+            document)
+        == "Fulano: A New Hope")
+    assert len(papis.format.FORMATTER) == 2
+
 
 @pytest.mark.config_setup(settings={"formatter": "jinja2"})
 def test_jinja_formatter(tmp_config: TemporaryConfiguration) -> None:
@@ -57,3 +67,35 @@ def test_jinja_formatter(tmp_config: TemporaryConfiguration) -> None:
             "{{ doc.author }}: {{ doc.title }} ({{ doc.blahblah }})",
             data)
         == ": The Phantom Menace ()")
+
+    # test out a python format
+    assert len(papis.format.FORMATTER) == 1
+    from papis.strings import FormattedString
+    assert (
+        papis.format.format(
+            FormattedString("python", "{doc[author]}: {doc[title]}"),
+            document)
+        == "Fulano: A New Hope")
+    assert len(papis.format.FORMATTER) == 2
+
+
+def test_overwritten_keys(tmp_config: TemporaryConfiguration) -> None:
+    pytest.importorskip("jinja2")
+
+    import papis.config
+
+    papis.config.set("ref-format.jinja2", "{{ doc.author|lower }}{{ doc.year }}")
+    document = papis.document.from_data({
+        "author": "Fulano", "year": 2020, "title": "A New Hope"
+    })
+
+    fmt = papis.config.getformattedstring("ref-format")
+    assert fmt.formatter == "jinja2"
+
+    ref = papis.format.format(fmt, document)
+    assert ref == "fulano2020"
+
+    from papis.bibtex import create_reference
+
+    ref = create_reference(document, force=True)
+    assert ref == "fulano2020"


### PR DESCRIPTION
This adds support for entries like these in the configuration file (see discussion in #662):
```
[settings]
add-file-name = {doc[year]}-{doc[author]}-{doc[title]}
ref-format.jinja2 = {{ doc.author_list|slice(3)|join("", attribute="family") }}{{ doc.year }}
```
where the first setting uses the default formatter (whatever `formatter` is set to) and the second setting overwrites the default and forces the `jinja2` formatter. In general, `key[.formatter]` is how this looks like.

For this, it adds some functionality:
* `papis.config.getformattedstring`: this looks thorough the config file for any version of `key.[formatter]` and returns the last one it finds.
* `papis.strings.FormattedString`: a class that's just a `(formatter, string)` tuple and gets passed to `papis.format.format` to allow picking the formatter for each individual string. This is mostly inspired by `prompt_toolkit.FormattedText`.
* `papis.cli.FormattedStringParamType`: a `click.ParamType` that automatically converts command-line parameters to `FormattedString`. It also shows a nice text `--file-name FORMATTED-TEXT` in the command line to mark entries that can be format strings.
* Update the rest of the code to use the above where appropriate!

TODO:
* [x] Need to check what other keys should use formatted strings.
* [x] Not sure the folder name construction in `papis.commands.add::run` works correctly with formatted strings. Need to add some tests for that.
* [x] Probably needs some more testing to make sure nothing is broken. (Currently using this daily, so hopefully will catch some things)

Fixes #662.