### PR TITLE
bibtex: do not forcefully capwords references

### DIFF
--- a/papis/bibtex.py
+++ b/papis/bibtex.py
@@ -408,12 +408,13 @@ def ref_cleanup(ref: str) -> str:
     """
     import slugify
     allowed_characters = r"([^a-zA-Z0-9._]+|(?<!\\)[._])"
-    return string.capwords(str(slugify.slugify(
-        ref,
-        lowercase=False,
-        word_boundary=False,
-        separator=" ",
-        regex_pattern=allowed_characters))).replace(" ", "")
+    ref = slugify.slugify(ref,
+                          lowercase=False,
+                          word_boundary=False,
+                          separator="_",
+                          regex_pattern=allowed_characters)
+
+    return str(ref).strip()
 
 
 def create_reference(doc: Dict[str, Any], force: bool = False) -> str:
@@ -451,6 +452,7 @@ def create_reference(doc: Dict[str, Any], force: bool = False) -> str:
         # Just try to get something out of the data
         ref = "{:.30}".format(
               " ".join(string.capwords(str(d)) for d in doc.values()))
+        ref = string.capwords(ref).replace(" ", "").strip()
 
     logger.debug("Generated ref '%s'.", ref)
     return ref_cleanup(ref)

--- a/tests/commands/test_explore.py
+++ b/tests/commands/test_explore.py
@@ -35,7 +35,7 @@ def test_explore_bibtex_cli(tmp_library: TemporaryLibrary) -> None:
         exported_bibtex = fd.read()
 
     assert exported_bibtex == (
-        "@article{FreedomFromThJKri2009,\n"
+        "@article{Freedom_from_th_J_Kri_2009,\n"
         "  author = {J. Krishnamurti},\n"
         "  title = {Freedom from the known},\n"
         "  year = {2009},\n"

--- a/tests/test_bibtex.py
+++ b/tests/test_bibtex.py
@@ -69,9 +69,9 @@ def test_clean_ref(tmp_config: TemporaryConfiguration) -> None:
     import papis.bibtex
 
     for (r, rc) in [
-            ("Einstein über etwas und so 1923", "EinsteinUberEtwasUndSo1923"),
-            ("Äöasf () : Aλבert Eιنς€in", "AoasfAlbertEinseurin"),
-            (r"Albert_Ein\_stein\.1923.b", "AlbertEin_stein.1923B"),
+            ("Einstein über etwas und so 1923", "Einstein_uber_etwas_und_so_1923"),
+            ("Äöasf () : Aλבert Eιنς€in", "Aoasf_Albert_EinsEURin"),
+            (r"Albert_Ein\_stein\.1923.b", "Albert_Ein__stein_.1923_b"),
             ]:
         assert rc == papis.bibtex.ref_cleanup(r)
 

--- a/tests/test_doctor.py
+++ b/tests/test_doctor.py
@@ -97,7 +97,7 @@ def test_refs_check(tmp_config: TemporaryConfiguration) -> None:
 
     error.fix_action()
     assert "ref" in doc
-    assert doc["ref"] == "DnaSequencingSanger"
+    assert doc["ref"] == "DNA_sequencing_Sanger"
 
     # check: empty ref
     doc["ref"] = "    "

--- a/tests/test_document.py
+++ b/tests/test_document.py
@@ -89,7 +89,7 @@ def test_to_bibtex(tmp_config: TemporaryConfiguration) -> None:
     doc.set_folder("path/to/superfolder")
 
     assert papis.bibtex.to_bibtex(doc) == (
-        "@book{HelloFernan3200bce,\n"
+        "@book{Hello_Fernan_3200BCE,\n"
         "  author = {Fernandez, Gilgamesh},\n"
         "  journal = {jcp},\n"
         "  title = {Hello},\n"
@@ -97,7 +97,7 @@ def test_to_bibtex(tmp_config: TemporaryConfiguration) -> None:
         "}")
     doc["journal_abbrev"] = "j"
     assert papis.bibtex.to_bibtex(doc) == (
-        "@book{HelloFernan3200bce,\n"
+        "@book{Hello_Fernan_3200BCE,\n"
         "  author = {Fernandez, Gilgamesh},\n"
         "  journal = {j},\n"
         "  title = {Hello},\n"


### PR DESCRIPTION
Not sure why the references were forcefully capitalized, but this removes that to allow lowercase refs.

@hermlon This should fix that issue.