### PR TITLE
bibtex: rename bibtex-export-zotero-file without zotero

### DIFF
--- a/doc/source/default-settings.rst
+++ b/doc/source/default-settings.rst
@@ -225,10 +225,13 @@ BibTeX options
     Whether or not to allow direct unicode characters in the document
     fields to be exported into the BibTeX text.
 
-.. papis-config:: bibtex-export-zotero-file
+.. papis-config:: bibtex-export-file
 
-   A boolean value that can be used to add a ``"file"`` field to exported
-   BibTeX entries. The files are added as a semicolon separated string.
+    A boolean value that can be used to add a ``"file"`` field to exported
+    BibTeX entries. The files are added as a semicolon separated string.
+
+    This entry used to be named ``bibtex-export-zotero-file`` and should be
+    used instead.
 
 .. _add-command-options:
 

--- a/papis/bibtex.py
+++ b/papis/bibtex.py
@@ -523,7 +523,7 @@ def to_bibtex(document: papis.document.Document, *, indent: int = 2) -> str:
       field values can contain unicode characters.
     * :ref:`config-settings-bibtex-journal-key` is used to define the field
       name for the journal.
-    * :ref:`config-settings-bibtex-export-zotero-file` is used to also add a
+    * :ref:`config-settings-bibtex-export-file` is used to also add a
       ``"file"`` field to the BibTeX entry, which can be used by e.g. Zotero to
       import documents.
 
@@ -593,11 +593,19 @@ def to_bibtex(document: papis.document.Document, *, indent: int = 2) -> str:
 
         lines.append(f"{bib_key} = {{{bib_value}}}")
 
-    # Handle file for zotero exporting
-    if (papis.config.getboolean("bibtex-export-zotero-file")
-            and document.get_files()):
-        lines.append("{} = {{{}}}".format("file",
-                                          ";".join(document.get_files())))
+    # handle file exporting
+    from papis.exceptions import DefaultSettingValueMissing
+    try:
+        # NOTE: this option is deprecated and should be removed in the future
+        export_file = papis.config.getboolean("bibtex-export-zotero-file")
+        logger.warning("The 'bibtex-export-zotero-file' option is deprecated. "
+                       "Use 'bibtex-export-file' instead.")
+    except DefaultSettingValueMissing:
+        export_file = papis.config.getboolean("bibtex-export-file")
+
+    files = document.get_files()
+    if export_file and files:
+        lines.append("{} = {{{}}}".format("file", ";".join(files)))
 
     separator = ",\n" + " " * indent
     return "@{type}{{{keys},\n}}".format(type=bibtex_type,

--- a/papis/defaults.py
+++ b/papis/defaults.py
@@ -147,7 +147,7 @@ settings: Dict[str, Any] = {
     "file-browser": get_default_opener(),
     "bibtex-unicode": False,
     "bibtex-journal-key": "journal",
-    "bibtex-export-zotero-file": False,
+    "bibtex-export-file": False,
     "bibtex-ignore-keys": "[]",
     "extra-bibtex-keys": "[]",
     "extra-bibtex-types": "[]",


### PR DESCRIPTION
This deprecates `bibtex-export-zotero-file` in favor of just `bibtex-export-file`, since it doesn't necessarily have anything to do with Zotero.

xref #721 