### PR TITLE
papis.serve: add sorting options to the tags endpoint

### DIFF
--- a/doc/source/default-settings.rst
+++ b/doc/source/default-settings.rst
@@ -449,6 +449,15 @@ BibTeX options
     or trailing whitespace in the separator, make sure to quote it (for instance,
     ``", "``).
 
+``papis serve`` options
+------------------------
+
+.. papis-config:: serve-default-tag-sorting
+
+   The default sorting strategy used on the "Tags" tab of the web ui. Can be either
+   ``'alpha'`` for sorting by tags' names or ``'numeric'`` for sorting by their frequency
+   of use.
+
 Citations options
 -----------------
 

--- a/papis/commands/serve.py
+++ b/papis/commands/serve.py
@@ -144,7 +144,8 @@ class PapisRequestHandler(http.server.BaseHTTPRequestHandler):
         db.initialize()
 
     @ok_html
-    def page_tags(self, libname: Optional[str] = None) -> None:
+    def page_tags(self, libname: Optional[str] = None,
+                  sort_by: Optional[str] = None) -> None:
         global TAGS_LIST
         libname = libname or papis.api.get_lib_name()
         self._handle_lib(libname)
@@ -159,7 +160,8 @@ class PapisRequestHandler(http.server.BaseHTTPRequestHandler):
 
         page = papis.web.tags.html(libname=libname,
                                    pretitle="TAGS",
-                                   tags=TAGS_LIST[libname] or {})
+                                   tags=TAGS_LIST[libname] or {},
+                                   sort_by=sort_by or "")
 
         self.wfile.write(bytes(str(page), "utf-8"))
         self.wfile.flush()
@@ -445,7 +447,7 @@ class PapisRequestHandler(http.server.BaseHTTPRequestHandler):
                 self.page_query),
             ("^/library/?([^/]+)?/document/([a-z0-9]+)$",
                 self.page_document),
-            ("^/library/([^/]+)/tags$",
+            ("^/library/([^/]+)/tags(?:[?]sort=(.*))?$",
                 self.page_tags),
             ("^/library/([^/]+)/tags/refresh$",
                 self.page_tags_refresh),

--- a/papis/defaults.py
+++ b/papis/defaults.py
@@ -116,6 +116,7 @@ settings: Dict[str, Any] = {
                        ],
 
     "serve-empty-query-get-all-documents": False,
+    "serve-default-tag-sorting": "numeric",
 
     # citations configuration
     "citations-file-name": "citations.yaml",

--- a/papis/web/tags.py
+++ b/papis/web/tags.py
@@ -51,10 +51,11 @@ def html(pretitle: str, libname: str, tags: Dict[str, int],
                              title="Sort by number of occurrences"):
                         wh.icon("arrow-down-1-9")
                 with wh.container():
-                    # either sort by number of occurences or alphabetical
-                    sort_kwargs = dict(key=lambda k: tags[k], reverse=True)
+                    # either sort by number of occurrences or alphabetical
                     if sort_by == "alpha":
-                        sort_kwargs = dict()
-                    for tag in sorted(tags, **sort_kwargs):
+                    	tags = sorted(tags)
+                    elif sort_by in ("", "numeric"):
+                    	tags = sorted(tags, key=lambda k: tags[k], reverse=True)
+                    for tag in tags:
                         _tag(tag=tag, libname=libname)
     return result

--- a/papis/web/tags.py
+++ b/papis/web/tags.py
@@ -51,14 +51,21 @@ def html(pretitle: str, libname: str, tags: Dict[str, int],
                              title="Sort by number of occurrences"):
                         wh.icon("arrow-down-1-9")
                 with wh.container():
+                    sorted_tags = []
                     # either sort by number of occurrences or alphabetical
                     # if option is not set, use the default config
                     if sort_by == "":
-                        sort_by = papis.config.get("serve-default-tag-sorting")
+                        sort_by = str(
+                            papis.config.get("serve-default-tag-sorting")
+                        )
                     if sort_by == "alpha":
-                        tags = sorted(tags)
+                        sorted_tags = sorted(tags)
                     elif sort_by == "numeric":
-                        tags = sorted(tags, key=lambda k: tags[k], reverse=True)
-                    for tag in tags:
+                        sorted_tags = sorted(
+                            tags,
+                            key=lambda k: tags[k],
+                            reverse=True
+                        )
+                    for tag in sorted_tags:
                         _tag(tag=tag, libname=libname)
     return result

--- a/papis/web/tags.py
+++ b/papis/web/tags.py
@@ -48,7 +48,7 @@ def html(pretitle: str, libname: str, tags: Dict[str, int],
                              title="Sort by name"):
                         wh.icon("arrow-down-a-z")
                     with t.a(href=f"/library/{libname}/tags?sort=numeric",
-                             title="sort by number of occurences"):
+                             title="Sort by number of occurrences"):
                         wh.icon("arrow-down-1-9")
                 with wh.container():
                     # either sort by number of occurences or alphabetical

--- a/papis/web/tags.py
+++ b/papis/web/tags.py
@@ -52,10 +52,13 @@ def html(pretitle: str, libname: str, tags: Dict[str, int],
                         wh.icon("arrow-down-1-9")
                 with wh.container():
                     # either sort by number of occurrences or alphabetical
+                    # if option is not set, use the default config
+                    if sort_by == "":
+                        sort_by = papis.config.get("serve-default-tag-sorting")
                     if sort_by == "alpha":
-                    	tags = sorted(tags)
-                    elif sort_by in ("", "numeric"):
-                    	tags = sorted(tags, key=lambda k: tags[k], reverse=True)
+                        tags = sorted(tags)
+                    elif sort_by == "numeric":
+                        tags = sorted(tags, key=lambda k: tags[k], reverse=True)
                     for tag in tags:
                         _tag(tag=tag, libname=libname)
     return result

--- a/papis/web/tags.py
+++ b/papis/web/tags.py
@@ -45,7 +45,7 @@ def html(pretitle: str, libname: str, tags: Dict[str, int],
                     with t.a(href=f"/library/{libname}/tags/refresh"):
                         wh.icon("refresh")
                     with t.a(href=f"/library/{libname}/tags?sort=alpha",
-                             title="sort by name"):
+                             title="Sort by name"):
                         wh.icon("arrow-down-a-z")
                     with t.a(href=f"/library/{libname}/tags?sort=numeric",
                              title="sort by number of occurences"):

--- a/papis/web/tags.py
+++ b/papis/web/tags.py
@@ -35,7 +35,8 @@ def tags_list_div(tags: Tags, libname: str) -> None:
             _tag(tag=tag, libname=libname)
 
 
-def html(pretitle: str, libname: str, tags: Dict[str, int]) -> t.html_tag:
+def html(pretitle: str, libname: str, tags: Dict[str, int],
+         sort_by: str) -> t.html_tag:
     with papis.web.header.main_html_document(pretitle) as result:
         with result.body:
             papis.web.navbar.navbar(libname=libname)
@@ -43,9 +44,17 @@ def html(pretitle: str, libname: str, tags: Dict[str, int]) -> t.html_tag:
                 with t.h1("TAGS"):
                     with t.a(href=f"/library/{libname}/tags/refresh"):
                         wh.icon("refresh")
+                    with t.a(href=f"/library/{libname}/tags?sort=alpha",
+                             title="sort by name"):
+                        wh.icon("arrow-down-a-z")
+                    with t.a(href=f"/library/{libname}/tags?sort=numeric",
+                             title="sort by number of occurences"):
+                        wh.icon("arrow-down-1-9")
                 with wh.container():
-                    for tag in sorted(tags,
-                                      key=lambda k: tags[k],
-                                      reverse=True):
+                    # either sort by number of occurences or alphabetical
+                    sort_kwargs = dict(key=lambda k: tags[k], reverse=True)
+                    if sort_by == "alpha":
+                        sort_kwargs = dict()
+                    for tag in sorted(tags, **sort_kwargs):
                         _tag(tag=tag, libname=libname)
     return result


### PR DESCRIPTION
This adds two further Options besides the refresh icon to select whether to sort the list of tags alphabetically or by their number of occurrences. Formerly, the latter was the default and only option.

Why? I use tags a lot and found myself frequently searching for them on the page. Alphabetical sorting makes that much easier.