### PR TITLE
docs: update default-settings.rst

### DIFF
--- a/doc/source/default-settings.rst
+++ b/doc/source/default-settings.rst
@@ -409,6 +409,14 @@ Add options
     In this case, the fetching can be disabled by using ``--no-fetch-citations``
     on an individual basis.
 
+.. papis-config:: auto-doctor
+
+   A setting that controls the default for the ``--auto-doctor`` flag of
+   ``papis add`` and ``papis update``. If set to *True*, then the flag will be
+   enabled by default and the doctor fixes will be applied to new documents.
+   In this case, the automatic fixers can be disabled by using
+   ``--no-auto-doctor`` on an individual basis.
+
 .. papis-config:: time-stamp
 
     A setting that controls if a timestamp is added to a document on
@@ -603,6 +611,97 @@ Serve (Web App) options
    The default sorting strategy used on the "Tags" tab of the Web UI. Can be
    either ``'alpha'`` for sorting by tags' names or ``'numeric'`` for sorting by
    their frequency of use.
+
+.. papis-config:: serve-empty-query-get-all-documents
+
+    If *True*, when no documents are found by a query then all documents are
+    shown instead. By default this is false, since showing all the documents
+    can be slow.
+
+.. papis-config:: serve-enable-timeline
+
+    If *True*, the :ref:`config-settings-time-stamp` of documents is used to
+    create a timeline for when the documents were added.
+
+.. papis-config:: serve-timeline-max
+
+    Maximum number of documents to display in the timeline.
+
+Frameworks
+^^^^^^^^^^
+
+All the frameworks used by the web UI are taken from the configuration file. This
+allows users to easily provide newer versions that may fix some bugs or other
+inconsistencies.
+
+.. warning::
+
+    Updating the URLs for one of the frameworks may result in a broken UI, as
+    Papis is not compatible with all versions. For safety only update minor
+    bugfix releases, not major new updates.
+
+.. papis-config:: serve-user-css
+
+    A list of ``href`` URLs that will be added to the header of each webpage
+    of the web UI. These style sheets are added to the end and can be used to
+    overwrite previous entries.
+
+.. papis-config:: serve-user-js
+
+    A list of ``href`` URLs that will be added to the header of each webpage
+    of the web UI. These scripts are added to the end and can be used to
+    overwrite previous entries.
+
+.. papis-config:: serve-bootstrap-css
+
+    Link to the desired version of the Bootstrap framework.
+
+.. papis-config:: serve-bootstrap-js
+
+    Link to the desired version of the Bootstrap framework.
+
+.. papis-config:: serve-jquery-js
+
+    Link to the desired version of the jQuery framework.
+
+.. papis-config:: serve-jquery.dataTables-css
+
+    Link to the desired version of the `jQuery DataTables <https://datatables.net/>`__
+    framework.
+
+.. papis-config:: serve-jquery.dataTables-js
+
+    Link to the desired version of the `jQuery DataTables <https://datatables.net/>`__
+    framework.
+
+.. papis-config:: serve-katex-css
+
+    Link to the desired version of the `KaTeX <https://katex.org/>`__ framework.
+
+.. papis-config:: serve-katex-js
+
+    Link to the desired version of the `KaTeX <https://katex.org/>`__ framework.
+
+.. papis-config:: serve-katex-auto-render-js
+
+    Link to the desired version of the
+   `KaTeX Auto-render <https://katex.org/docs/autorender.html>`__ extension.
+
+.. papis-config:: serve-ace-urls
+
+    A list of links to the desired version of the `Ace editor <https://ace.c9.io/>`__.
+    This should contain all necessary links to all the desired modes and
+    keybindings, as exemplified by the default values.
+
+.. papis-config:: serve-timeline-css
+
+    Link to the desired version of the `Timeline <https://timeline.knightlab.com/>`__
+    widget.
+
+.. papis-config:: serve-timeline-js
+
+    Link to the desired version of the `Timeline <https://timeline.knightlab.com/>`__
+    widget.
 
 Citations options
 -----------------

--- a/doc/source/default-settings.rst
+++ b/doc/source/default-settings.rst
@@ -5,120 +5,175 @@ General settings
 
 .. papis-config:: local-config-file
 
-    Name AND relative path of the local configuration file that papis
-    will additionally read if the file is present in the current
-    directory or in the base directory of a given library.
+    Relative path of the local configuration file that Papis will additionally
+    read. The file must be present in the current directory or in the base
+    directory of a given library.
 
-    This is useful, for instance, if you have a library somewhere
-    for which you want special configuration settings
-    but do not want these settings to cluster in your configuration
-    file. It is also useful if you're sharing a library with someone
-    else and you want them to have the same settings in that library as
-    you. Imagine you're sharing a library of datasheets with your friend
-    Fulano. You have your library at
-
-    ::
+    This can be used to set special configuration settings for a library that
+    do not clutter your global configuration file. This is particularly useful
+    if the library is shared with someone else (or just on a different machine)
+    and you want them to have the same settings. For example, say you're sharing
+    a library with your friend Fulano. You have your library at::
 
         ~/Documents/lib-with-fulano
 
-    and you've set a local configuration file there
-
-    ::
+    and you've created a local configuration file at::
 
         ~/Documents/lib-with-fulano/.papis.config
 
-    then whenever Fulano uses that library and the file is also present,
-    his papis program will also read the configuration settings at
-    the path above.
+    Then, you can share your library (through e.g. Dropbox or a network drive)
+    and have the same settings for the library across machines, e.g. to generate
+    consistent references with :ref:`config-settings-ref-format`. In this setup,
+    whenever Fulano uses that library, their Papis calls will also read the
+    configuration settings and use the same settings.
 
 .. papis-config:: dir-umask
 
-    This is the default ``umask`` that will be used to create the new
-    documents' directories.
+    This is the default :func:`os.umask` that will be used to create the new
+    directories for documents and libraries.
 
 .. papis-config:: use-git
 
-    Some commands will issue git commands if this option is set to ``True``.
-    For example in ``mv`` or ``rename``.
+    Some commands will issue `git <https://git-scm.com/>`__ commands if this
+    option is set to *True*. For example ``papis mv`` or ``papis rename`` can
+    automatically commit any changes to a document by default. See
+    :ref:`Git support <git-support>` for additional details.
 
 .. papis-config:: user-agent
 
-    User agent used by papis whenever it obtains information from external
-    servers.
+    `User agent <https://en.wikipedia.org/wiki/User_agent>`__ used by Papis
+    whenever querying information from external sources.
 
 .. papis-config:: scripts-short-help-regex
 
-    This is the format of the short help indicator in external papis
-    commands.
+    This is the format of the short help indicator in external Papis
+    commands. In general, for an external command, the first lines are expected
+    to resemble
+
+    .. code:: python
+
+        #!/usr/bin/env python3
+        # papis-short-help: My awesome script fixes everything
 
 .. papis-config:: info-name
 
-    The default name of the information files.
+    The default name for files containing the document metadata. In Papis, these
+    are referred to as *info files* (see :ref:`info-file`) and contain metadata
+    in the YAML format.
 
 .. papis-config:: doc-url-key-name
 
-    Some documents might have, apart from an url, also a file url associated with them.
-    The key name appearing in the information file is defined by
-    this setting.
+    Some documents might have multiple URLs associated with them, e.g. remote
+    URLs from different sources or a file URL. This setting can be used to
+    choose which one is more appropriate to use in different settings, e.g.
+    the Crossref importer uses it to download files.
 
 .. papis-config:: default-library
 
-    The name of the library that is to be searched when ``papis``
-    is run without library arguments.
+    The name of the library that is to be used when Papis is run without the
+    ``-l``/``--lib`` argument. Papis will not immediately check if this library
+    exists in the configuration file or that it is correctly configured.
 
 .. papis-config:: format-doc-name
 
     This setting controls the name of the document in the papis format strings
-    like in format strings such as ``match-format`` or ``header-format``.
-    For instance, if you are managing videos, you might want to
-    set this option to ``vid`` in order to set  the ``header-format`` to
-    ``{vid[title]} - {vid[director]} - {vid[duration]}``.
-
-.. papis-config:: match-format
-
-    Default format that is used to match a document against in order to select
-    it. For example if the ``match-format`` is equal to
-    ``{doc[year]} {doc[author]}`` then the title of a document will not work
-    to match a document, only the year and author.
-
-.. papis-config:: header-format
-
-    Default format that is used to show a document in order to select it.
-
-.. papis-config:: header-format-file
-
-    This option should have the path of a file with the ``header-format``
-    template. Sometimes templates can get big so this is a way
-    of not cluttering the config file with text.
-
-    As an example you would set
+    like in format strings such as :ref:`config-settings-match-format` or
+    :ref:`config-settings-header-format`. For instance, if you are managing
+    videos, you might want to set this option to ``vid`` in order to set  the
+    :ref:`config-settings-header-format` to
 
     .. code:: ini
 
-        [papers]
+        header-format = {vid[title]} - {vid[director]} - {vid[duration]}.
 
-        header-format-file = ~/.papis/config/styles/header.txt
+.. papis-config:: match-format
+
+    Default format that is used to match a document in the default Papis picker
+    and in the ``papis`` database backend. For example, if the ``match-format``
+    is set to ``{doc[year]} {doc[author]}``, then words from the title will not
+    match the document, only using the year or the author will work. It is
+    recommended to set this to all the keys used by :ref:`config-settings-header-format`,
+    so that any visible information can be matched.
+
+.. papis-config:: header-format
+
+    Default format that is used to show a document in the default Papis picker.
+    This can be a complex multiline string containing any key from a document.
+
+.. papis-config:: header-format-file
+
+    If the :ref:`config-settings-header-format` grows too complex, it can be
+    stored in a separate file. This option should give the path to that file (in
+    which case the ``header-format`` option will be ignored). For example, this
+    can be set to
+
+    .. code:: ini
+
+        header-format-file = ~/.config/papis/styles/header-format.txt
 
 .. papis-config:: info-allow-unicode
 
-    This flag is to be set if you want to allow unicode characters
-    in your info file or not. If it is set to false then a representation
-    for the unicode characters will be written in its place.
-    Since we should be living in an unicode world, it is set to ``True``
-    by default.
+    If *True*, this flag will allow unicode characters in your *info files*.
+    Otherwise, the strings will be decoded and written as bytes. Unless you have
+    very strong reasons not to, this should always be set to *True* (we live
+    a unicode world after all!).
+
+.. papis-config:: unique-document-keys
+
+    Whenever you add a new document, Papis tries to figure out if
+    you have already added this document before. This is partially done
+    checking for matches in some special keys. This setting controls which keys
+    are checked.
+
+    For instance, if you add a paper with a given ``doi``, and then you
+    add another document with the same ``doi``, then Papis will notify
+    you that there is already another document with this ``doi`` because
+    the ``doi`` key is part of the ``unique-document-keys`` option.
+
+.. papis-config:: document-description-format
+
+    Papis sometimes will have to tell you which document it is processing. This
+    format string can be used to display the document to the user in a
+    non-intrusive way. Preferable, this should be a short string that allows
+    easily identifying which document is being referenced.
+
+.. papis-config:: sort-field
+
+    This setting controls which field queries are sorted by before being presented
+    to the user in, e.g., the picker. Most commands support a ``--sort`` option
+    that uses this setting as its default value.
+
+.. papis-config:: sort-reverse
+
+    A setting that augments :ref:`config-settings-sort-field` by allowing the
+    documents to be sorted in reverse order. Most commands support a ``--reverse``
+    flag that uses this setting as a default value.
+
+.. papis-config:: formatter
+
+    Picks the formatter for templated strings in the configuration file and
+    in various strings presented to the user. Supported formatters are
+
+    * ``"python"``: based on :class:`papis.format.PythonFormatter`.
+    * ``"jinja2"``: based on :class:`papis.format.Jinja2Formatter`.
+
+    Note that the default values of many of the papis configuration settings are
+    based on the Python formatter. These will need to all be specified explicitly
+    if another formatter is chosen.
+
+    **Note** The older (misspelled) version ``"formater"`` is deprecated.
 
 Tools options
 -------------
 
 .. papis-config:: opentool
 
-    This is the general program that will be used to open documents.
-    As for now papis is not intended to detect the type of document to be opened
-    and decide upon how to open the document. You should set this
-    to the right program for the tool. If you are on linux you might want
-    to take a look at `ranger <https://ranger.github.io>`__ or let
-    the default handle it in your system.
-    For mac users you might set this to ``open``.
+    This is a general program that will be used to open document files. Papis
+    is not intended to detect the type of file that is being opened or decide on
+    how to open the document. Therefore, the ``opentool`` should handle this
+    functionality. If you are on Linux, you might want to take a look at
+    `ranger <https://ranger.github.io>`__ or just use ``xdg-open``. For macOS
+    users, this should likely be set to ``open``.
 
 .. papis-config:: browser
     :default: $BROWSER
@@ -128,26 +183,32 @@ Tools options
 
 .. papis-config:: picktool
 
-    This is the program used whenever papis asks you to pick a document
-    or options in general.
+    This is the program used whenever Papis asks to pick a document for a
+    query, pick a file to open, or any other such use case with multiple options.
+    The following pickers are available:
 
-    Only option is:
-        - papis
+    * ``"papis"``: uses ``papis.picker.Picker`` to display and search
+      through documents.
+    * ``"fzf"``: uses `fzf <https://github.com/junegunn/fzf>` to display and search
+      through documents.
+
+    Papis pickers use a plugin architecture similar to other components
+    (see :ref:`plugin-architecture`) with the ``papis.picker`` entrypoint. Note
+    that not all plugins will support all the same features.
 
 .. papis-config:: editor
     :default: $EDITOR
 
     Editor used to edit files in papis, e.g., for the ``papis edit``
-    command. It defaults to the ``$EDITOR`` environment variable, if this is
-    not set then it will default to the ``$VISUAL`` environment variable.
-    Otherwise the default editor in your system will be used.
+    command. This will search for the ``$EDITOR`` environment variable or the
+    ``$VISUAL`` environment variables to obtain a default if it is not set.
+    Otherwise, the default :ref:`config-settings-opentool` will be used.
 
 .. papis-config:: file-browser
 
-    File browser to be used when opening a directory. It defaults to the
-    default file browser in your system, however, you can set it to different
-    file browsers such as ``dolphin``, ``thunar`` or ``ranger`` just to name a few.
-
+    File browser used when opening a directory. It defaults to the default file
+    browser in your system. However, you can set it to different file browsers,
+    such as ``dolphin``, ``thunar`` or ``ranger``, to name a few.
 
 .. _bibtex-options:
 
@@ -156,87 +217,89 @@ BibTeX options
 
 .. papis-config:: bibtex-journal-key
 
-  Journal publishers may request abbreviated journal titles. This
-  option allows the user to set the key for the journal entry when using
-  ``papis export --bibtex``.
-
-  Set as ``full_journal_title`` or ``abbrev_journal_title`` for
-  whichever style required. Default is ``journal``.
+    This option allows the user to set the key for the journal entry when using
+    ``papis export --bibtex``. The intended use of such a setting is to allow
+    selecting e.g. abbreviated journal titles for publishers that require it.
+    For example, if the document has a ``abbrev_journal_title`` key that should
+    be used instead of the default ``journal`` key.
 
 .. papis-config:: extra-bibtex-keys
-  :default: []
 
-  When exporting documents in BibTeX format, you might want to add
-  non-standard BibTeX keys such as ``doc_url`` or ``tags``. You can add
-  these as a valid python list of strings, for instance:
+    A list of additional keys, besides the known standard BibTeX keys from
+    :data:`~papis.bibtex.bibtex_keys`, to add to the BibTeX export. This can be
+    used to include keys such as ``doc_url`` or ``tags`` to the export by
+    setting
 
-  .. code:: ini
+    .. code:: ini
 
-    [mylib]
-    extra-bibtex-keys = ["tags", "doc_url"]
+        [mylib]
+        extra-bibtex-keys = ["doc_url", "tags"]
+
+    These keys will likely not be recognized by the BibTeX engine, so they should
+    be used with care. However, they can be useful when exporting documents as
+    a form of backup to be imported in another library later.
 
 .. papis-config:: bibtex-ignore-keys
-   :default: []
 
-  When exporting a document to the BibTeX format, do not export the keys
-  appearing in this list. This might be useful if you have some keys
-  that have a lot of content, such as ``abstract``, or maybe you
-  have used a valid BibTeX key for some other purposes, like the ``note``
-  key.
+    A list of keys that should be ignored when exporting to BibTeX. This might
+    be useful if you have some keys that have a lot of content, such as
+    ``abstract``, or maybe you have used a valid BibTeX key for some other
+    purpose, like the ``note`` key.
 
 .. papis-config:: extra-bibtex-types
-  :default: []
 
-  Allow non-standard BibTeX types to be recognized, e.g,
+    A list of additional types, besides the known standard BibTeX types from
+    :data:`~papis.bibtex.bibtex_types`, that should be allowed for a BibTeX export.
+    These types can be added as
 
-  .. code:: ini
+    .. code:: ini
 
-    [mylib]
-    extra-bibtex-types = ["wikipedia", "video", "song"]
-
-  See the `BibTeX reference <https://mirror.easyname.at/ctan/biblio/bibtex/base/btxdoc.pdf>`__
-  or the `BibLaTeX reference <https://ftp.snt.utwente.nl/pub/software/tex/macros/latex/contrib/biblatex/doc/biblatex.pdf>`__
-  for supported types.
-
-.. papis-config:: multiple-authors-format
-
-    When retrieving automatic author information from services like
-    `crossref.org <https://www.crossref.org>`__, papis usually builds the
-    ``author`` field for the given document. The format how every single author
-    name is built is given by this setting, for instance you could customize it
-    by the following:
-
-    ::
-
-        multiple-authors-format = {au[surname]} -- {au[given_name]}
-
-    which would given in the case of Albert Einstein the string
-    ``Einstein -- Albert``.
-
-.. papis-config:: multiple-authors-separator
-
-    Similarly to ``multiple-authors-format``, this is the string that
-    separates single authors in the ``author`` field. If it is set to
-    `` and `` then you would have ``<author 1> and <author 2> and ....``
-    in the ``author`` field.
+        [mylib]
+        extra-bibtex-types = ["wikipedia", "video", "song"]
 
 .. papis-config:: bibtex-unicode
 
-    Whether or not to allow direct unicode characters in the document
-    fields to be exported into the BibTeX text.
+    A flag used to choose whether or not to allow direct Unicode characters in
+    the document fields to be exported into the BibTeX text. Some engines, such
+    as `Biber <https://github.com/plk/biber>`__ support Unicode by default and
+    should be used whenever possible.
 
 .. papis-config:: bibtex-export-file
 
-    A boolean value that can be used to add a ``"file"`` field to exported
-    BibTeX entries. The files are added as a semicolon separated string.
+    A flag that can be used to add a ``"file"`` field to exported BibTeX entries.
+    The files are added as a semicolon separated string.
 
     This entry used to be named ``bibtex-export-zotero-file`` and should be
     used instead.
 
+.. papis-config:: multiple-authors-format
+
+    A format string for concatenating author fields into a string that can be
+    used for display purposes or for building the ``author`` key for the
+    document. For example, when retrieving automatic author information from
+    services like `Crossref <https://www.crossref.org>`__, Papis builds the
+    ``author`` using this setting. For instance, this can be set to
+
+    .. code:: ini
+
+        multiple-authors-format = {au[family]} -- {au[given]}
+
+    which for the author ``{"family": "Einstein", "given": "Albert"}`` would
+    construct the string ``Einstein -- Albert``. In most circumstances, multiple
+    authors are then concatenated together using
+    :ref:`config-settings-multiple-authors-separator`.
+
+.. papis-config:: multiple-authors-separator
+
+    A string used with :ref:`config-settings-multiple-authors-format` to
+    concatenate multiple authors, e.g. into the ``authors`` document key.
+    By default, this is set to ``and``, which is the separator used by
+    BibTeX in its so-called *name-lists*.
+
 .. _add-command-options:
 
-``papis add`` options
----------------------
+Add options
+-----------
 
 .. papis-config:: ref-format
 
@@ -275,68 +338,85 @@ BibTeX options
 
             ref-format = {doc[author_list][0][surname]}\.{doc[year]}
 
-.. papis-config:: add-confirm
-
-    If set to ``True``, every time you run ``papis add``
-    the flag ``--confirm`` will be added automatically. If is set to ``True``
-    and you add it, i.e., you run ``papis add --confirm``, then it will
-    have the contrary effect, i.e., it will not ask for confirmation.
-
 .. papis-config:: add-folder-name
-    :default: empty string
 
-    Default name for the folder of newly added documents. For example, if you want
-    the folder of your documents to be named after the format
+    Set the default name for the folder of newly added documents. For example,
+    if you want the folder of your documents to be named after the format
     ``author-title`` then you should set it to
-    the papis format: ``{doc[author]}-{doc[title]}``. You can create formatted
-    subfolders by using path separators (i.e., ``/``) in this format string, e.g.,
-    ``{doc[year]} / {doc[title]}``.
-    Per default a hash followed by the author name is created.
+
+    .. code:: ini
+
+        add-folder-name = ``{doc[author]}-{doc[title]}``
+
+    You can create formatted subfolders by using path separators
+    (i.e., ``/``) in this format string, e.g.
+
+    .. code:: ini
+
+        add-folder-name = ``{doc[year]} / {doc[author]}-{doc[title]}``
+
+    If this setting is empty, a (MD5) hash of some document contents followed
+    by the author names is used. This will generally result in unique folder
+    names. If a folder name is not unique and the document does not appear to
+    be a duplicate, a suffix ``-a``, ``-b``, etc. is added to the names.
 
 .. papis-config:: add-file-name
 
-    Same as ``add-folder-name``, but for files, not folders. If it is not set,
-    the names of the files will be cleaned and taken ``as-is``.
+    Set the default file name for newly added documents, similarly to
+    :ref:`config-settings-add-folder-name`. If it is not set, the names of the
+    files will be cleaned and taken *as-is*.
 
-.. papis-config:: add-interactive
+.. papis-config:: add-subfolder
 
-    If set to ``True``, every time you run ``papis add``
-    the flag ``--interactive`` will be added automatically. If is set to
-    ``True`` and you add it, i.e., you run ``papis add --interactive``, then it
-    will have the contrary effect, i.e., it will not run in interactive mode.
+    Configure a default for the ``--subfolder`` command-line option of ``papis add``.
+    Note that, this setting is not allowed to contain formatting options. However,
+    one can also specify nested sub-folders.
+
+.. papis-config:: add-confirm
+
+    A setting that controls the default for the ``--confirm`` flag of ``papis add``.
+    If set to *True*, then the flag will be added by default and additional
+    confirmation will be asked for when adding the document. In this case, the
+    confirmation can be turned off using ``--no-confirm`` on an individual basis.
 
 .. papis-config:: add-edit
 
-    If set to ``True``, every time you run ``papis add``
-    the flag ``--edit`` will be added automatically. If it is set to
-    ``True`` and you add something, i.e., you run ``papis add --edit``, then it
-    will have the contrary effect, i.e., it will not prompt to edit the info
-    file.
+    A setting that controls the default for the ``--edit`` flag of ``papis add``.
+    If set to *True*, then the flag will be added by default and an editor will
+    be opened before the document is saved for additional modifications. In this
+    case, the edit can be disabled using ``--no-edit`` on an individual basis.
 
 .. papis-config:: add-open
 
-    If set to ``True``, every time you run ``papis add``
-    the flag ``--open`` will be added automatically. If it is set to
-    ``True`` and you add something, i.e., you run ``papis add --open``, then it
-    will have the contrary effect, i.e., it will not open the attached files
-    before adding the document to the library.
-
-.. papis-config:: add-subfolder
-    :default: empty string
-
-    Configure a default for the ``--subfolder`` command line option. Note that, this setting is not
-    allowed to contain formatting options. However, one can also specify nested sub-folders.
+    A setting that controls the default for the ``--open`` flag of ``papis add``.
+    If set to *True*, then the flag will be added by default and a viewer will
+    be opened to allow checking every file added to the document. In this
+    case, the open can be disabled using ``--no-open`` on an individual basis.
 
 .. papis-config:: add-download-files
 
-    If set to *True* the ``--download-files`` flag will be added to every call
-    of the ``papis add`` command (and ``--no-download-files`` if set to *False*).
-    This flag is used to control downloading larger document files (e.g. PDFs)
-    by the importers and downloaders that support it (metadata is always
-    downloaded by ``papis add``).
+    A setting that controls the default for the ``--download-files`` flag of
+    ``papis add``. If set to *True*, then the flag will be added by default and
+    the selected importers and downloaders will attempt to also download files
+    (metadata is always downloaded). In this case, the download can be disabled
+    by using ``--no-download-files`` on an individual basis.
 
-``papis browse`` options
-------------------------
+.. papis-config:: add-fetch-citations
+
+    A setting that controls the default for the ``--fetch-citations flag of
+    ``papis add``. If set to *True*, then the flag will be added by default
+    and Papis will attempt to retrieve citations for the newly added document.
+    In this case, the fetching can be disabled by using ``--no-fetch-citations``
+    on an individual basis.
+
+.. papis-config:: time-stamp
+
+    A setting that controls if a timestamp is added to a document on
+    ``papis add``. The timestamp uses the standard ISO format and can be used
+    for sorting and querying like any other fields.
+
+Browse options
+--------------
 
 .. papis-config:: browse-key
 
@@ -369,35 +449,36 @@ BibTeX options
 
 .. _edit-command-options:
 
-``papis edit`` options
-----------------------
+Edit options
+------------
 
 .. papis-config:: notes-name
 
     In ``papis edit`` you can edit notes about the document. ``notes-name``
-    is the default name of the notes file, which by default is supposed
-    to be a TeX file. The ``notes-name`` is formatted by the
+    is the default name of the notes file. The ``notes-name`` is formatted by the
     :ref:`config-settings-formatter`, so that the filename of notes can be
-    dynamically defined, e.g.:  ::
+    dynamically defined, e.g.:
 
-        notes-name = notes_{doc[title]:.15}.tex
+    .. code:: ini
+
+        notes-name = notes_{doc[ref]}.rst
 
 .. papis-config:: notes-template
 
-    When editing notes for the first time, a preliminary note will be generated
-    based on a template. The path to this template is specified by
+    When editing notes for the first time, a preliminary notes file will be
+    generated based on a template. The path to this template is specified by
     ``notes-template``. The template will then be formatted by
     :ref:`config-settings-formatter`. This can be useful to enforce the same
     style in the notes for all documents.
 
-    Default value is set to ``""``, which will return an empty notes file. If
-    no file is found at the path to the template, then also an empty notes file
-    will be generated.
+    Default value is set to the empty ``""``, which will return an empty notes
+    file. If no file is found at the path to the template, then also an empty
+    notes file will be generated.
 
 .. _marks-options:
 
-``papis doctor`` options
-------------------------
+Doctor options
+--------------
 
 .. papis-config:: doctor-default-checks
 
@@ -417,7 +498,7 @@ BibTeX options
 
    A list of keys used by the ``duplicated-values`` check. The check will show
    an error if any of the keys listed here have repeated values. This can check,
-   e.g., if a file was mistakenly added multiple times or of a tag already
+   e.g., if a file was mistakenly added multiple times or if a tag already
    exists in the document.
 
 .. papis-config:: doctor-html-codes-keys
@@ -449,14 +530,79 @@ BibTeX options
     or trailing whitespace in the separator, make sure to quote it (for instance,
     ``", "``).
 
-``papis serve`` options
-------------------------
+Open options
+------------
+
+.. papis-config:: open-mark
+
+    A setting that controls the default for the ``--mark`` flag of ``papis open``.
+    If set to *True*, then the flag will be added by default and the mark will
+    be opened for editing. In this case, the open can be disabled using
+    ``--no-mark`` on an individual basis.
+
+.. papis-config:: mark-key-name
+
+    This is the default key name for the marks in the *info file*. For
+    example, if you set ``mark-key-name = bookmarks`` then you would have
+    in your ``info.yaml`` file
+
+    .. code:: yaml
+
+        author: J. Krishnamurti
+        bookmarks:
+        - name: Chapter 1
+          value: 120
+
+.. papis-config:: mark-format-name
+
+    This is the name of the mark to be passed to
+    :ref:`config-settings-mark-header-format` and other such settings, similarly
+    to :ref:`config-settings-format-doc-name`. For example, if we want to set
+    it to ``m``, then other settings must be consistent, e.g.
+
+    .. code:: ini
+
+        mark-format-name = m
+        mark-header-format = {m[value]} - {m[name]}
+
+.. papis-config:: mark-header-format
+
+    This is the format of the mark when shown in a picker, similarly to
+    :ref:`config-settings-header-format`. This can be changed to allow for
+    more complex marks. However, by default, we just assume that each mark is
+    of the form ``{"name": <NAME>, "value": <VALUE>}``.
+
+.. papis-config:: mark-match-format
+
+    Format in which the mark name has to match the user input, similarly to
+    :ref:`config-settings-match-format`.
+
+.. papis-config:: mark-opener-format
+
+    Due to the difficulty to generalize opening a general document at a given
+    bookmark, the user should set this to whatever suits their needs. For example
+
+    - If you are using the PDF viewer ``evince`` and you want to open a
+      mark, you would use::
+
+        mark-opener-format = evince -p {mark[value]}
+
+    - If you are using ``okular`` you would use::
+
+        mark-opener-format = okular -p {mark[value]}
+
+    - If you are using ``zathura``, then use::
+
+        mark-opener-format = zathura -P {mark[value]}
+
+Serve (Web App) options
+-----------------------
 
 .. papis-config:: serve-default-tag-sorting
 
-   The default sorting strategy used on the "Tags" tab of the web ui. Can be either
-   ``'alpha'`` for sorting by tags' names or ``'numeric'`` for sorting by their frequency
-   of use.
+   The default sorting strategy used on the "Tags" tab of the Web UI. Can be
+   either ``'alpha'`` for sorting by tags' names or ``'numeric'`` for sorting by
+   their frequency of use.
 
 Citations options
 -----------------
@@ -471,85 +617,15 @@ You can change the name of the citation files, however we discourage this.
 
     The name of the file to store the citations to the document.
 
-
-Marks
------
-
-.. papis-config:: open-mark
-
-    If this option is set to ``True``, every time papis opens
-    a document it will ask to open a mark first.
-    If it is set to ``False``, then doing
-
-    .. code::
-
-        papis open --mark
-
-    will avoid opening a mark.
-
-.. papis-config:: mark-key-name
-
-    This is the default key name for the marks in the info file. For
-    example, if you set ``mark-key-name = bookmarks`` then you would have
-    in your ``info.yaml`` file
-
-    .. code::
-
-        author: J. Krishnamurti
-        bookmarks:
-        - name: Chapter 1
-          value: 120
-
-.. papis-config:: mark-format-name
-
-    This is the name of the mark to be passed to the options
-    ``mark-header-format`` etc... E.g. if you set ``mark-format-name = m``
-    then you could set ``mark-header-format = {m[value]} - {m[name]}``.
-
-.. papis-config:: mark-header-format
-
-    This is the format in which the mark will appear whenever the user
-    has to pick one. You can change this in order to make ``marks`` work
-    in the way you like. Per default it is assumed that every mark
-    has a ``name`` and a ``value`` key.
-
-.. papis-config:: mark-match-format
-
-    Format in which the mark name has to match the user input.
-
-.. papis-config:: mark-opener-format
-
-    Due to the difficulty to generalize opening a general document
-    at a given bookmark, the user should set this in whichever way
-    it suits their needs. For example
-
-    - If you are using the pdf viewer ``evince`` and you want to open a
-      mark, you would use
-
-        ::
-
-            mark-opener-format = evince -p {mark[value]}
-
-    - If you are using ``okular`` you would use
-
-        ::
-
-            mark-opener-format = okular -p {mark[value]}
-
-    - If you are using ``zathura``, do
-
-        ::
-
-            mark-opener-format = zathura -P {mark[value]}
-
 Downloaders
 -----------
 
 .. papis-config:: downloader-proxy
 
-    There is the possibility of download papers using a proxy.
-    To know more you can checkout this
-    `link <https://docs.python-requests.org/en/latest/user/advanced/#proxies>`__.
+    There is the possibility of download papers using a proxy. We use :mod:`requests`
+    to handle web queries, which has extensive documentation on how to use
+    proxies
+    `here <https://docs.python-requests.org/en/latest/user/advanced/#proxies>`__.
 
 .. papis-config:: isbn-service
 
@@ -562,49 +638,48 @@ Databases
 
 .. papis-config:: default-query-string
 
-    This is the default query that a command will take if no
-    query string is typed in the command line. For example this is
-    the query that is passed to the command ``open`` whenever no search
-    string is typed:
-
-    ::
-
-        papis open
-
-    Imagine you want to open all papers authored by ``John Smith`` whenever you do not
-    specify an input query string, i.e., ``papis open``. Then setting
-
-    ::
+    This is the default query that a command will take if no query string is given
+    at the command line. For example, if you want to open all papers authored
+    by ``John Smith`` whenever you do not specify an input query string, then setting::
 
         default-query-string = author:"John Smith"
 
-    would do the trick.
-    Notice that the current example has been
-    done assuming the ``database-backend = papis``.
+    would do the trick. Note that each :ref:`config-settings-database-backend`
+    will have a different search query, so this setting is specific to the
+    default ``papis`` backend.
 
 .. papis-config:: database-backend
 
-    The backend to use in the database. As for now papis supports
-    the own database system ``papis`` and
-    `whoosh <https://whoosh.readthedocs.io/en/latest/>`__.
+    The backend to use in the database. The database is used to store the
+    document in a library for improved querying performance and can be better
+    thought of as a cache. The supported backends are
+
+    - ``"papis"``: a backend that uses the :mod:`pickle` format as a storage
+      format and has a query syntax based on :mod:`papis.docmatcher`.
+    - ``"whoosh"``: a backend that uses `whoosh <https://whoosh.readthedocs.io/en/latest/>`__.
+      for its storage and querying needs.
 
 .. papis-config:: use-cache
 
-    Set to ``False`` if you do not want to use the ``cache``
-    for the given library. This is only effective if you're using the
-    ``papis`` database-backend.
+    If set to *False*, then no database caching layer is used. This is only
+    effective when using the ``papis`` backend and disables the storage aspects,
+    while keeping the query syntax.
+
+    If the cache is disabled, then every call to Papis commands will have to
+    walk the library directory tree to gather all the documents. This can be
+    very slow for large libraries.
 
 .. papis-config:: cache-dir
-  :default: $XDG_CACHE_HOME
+    :default: $XDG_CACHE_HOME
+
+    The default directory where the cache for the ``papis`` backend is stored.
 
 .. papis-config:: whoosh-schema-fields
 
     Python list with the ``TEXT`` fields that should be included in the
     whoosh database schema. For instance, say that you want to be able
     to search for the ``doi`` and ``ref`` of the documents, then you could
-    include
-
-    ::
+    include::
 
         whoosh-schema-fields = ['doi', 'ref']
 
@@ -612,55 +687,50 @@ Databases
 
     This is the model for the whoosh schema, check
     `the documentation <https://whoosh.readthedocs.io/en/latest/schema.html>`__
-    for more information.
+    for more information. The resulting string is passed to :func:`eval`, so
+    care should be taken when modifying it.
 
 Terminal user interface (picker)
 --------------------------------
 
-These options are for the terminal user interface (tui).
-They are defined in the section ``tui`` which means that you can set them
-in your configuration file globally like
+These options are for the terminal user interface (TUI). The TUI is mainly used
+by the default Papis picker, but other small widgets also make use of some elements.
+The TUI can be heavily customized as well in the separate ``tui`` section. For
+example,
 
 .. code:: ini
 
     [tui]
     status_line_format = "F1: Help"
-    ...
 
-or inside the library sections prepending a ``tui-``,
+These settings are based on styling and options used by
+:ref:`prompt_toolkit <prompt_toolkit:getting_started>`, so their documentation
+should be consulted.
 
-.. code:: ini
+Styling
+^^^^^^^
 
-    [papers]
-    tui-status_line_format = "Library papers**
-    ...
+For styling the individual components, see the extensive documentation available
+`here <https://python-prompt-toolkit.readthedocs.io/en/master/pages/advanced_topics/styling.html>`__.
 
 .. papis-config:: status_line_format
     :section: tui
 
-    This is the format of the string that appears at the bottom in the
-    status line.  Right now there are only two variables defined:
-
-    - ``selected_index``
-    - ``number_of_documents``
-
-    Which are self-explanatory.
+    This is the format of the string that appears at the bottom in the picker
+    status line. Right now there are only two variables defined:
+    ``selected_index`` and ``number_of_documents``.
 
 .. papis-config:: status_line_style
     :section: tui
 
-    The style the status line should have.
-    Examples are ``fg:#ff00aa bg:black`` etc...
-    More information can be found
-    `here
-    <https://python-prompt-toolkit.readthedocs.io/en/master/pages/advanced_topics/styling.html>`__
-    .
+    The style the status line should based on the ``prompt_toolkit`` styling,
+    e.g.``fg:#ff00aa bg:black``.
 
 .. papis-config:: message_toolbar_style
     :section: tui
 
-    The style of the message toolbar, this toolbar is the one
-    where messages of the ``echo`` command are rendered for instance.
+    The style of the message toolbar. This toolbar is the one where messages of
+    the ``echo`` command are rendered.
 
 .. papis-config:: options_list.selected_margin_style
     :section: tui
@@ -670,26 +740,26 @@ or inside the library sections prepending a ``tui-``,
 .. papis-config:: options_list.unselected_margin_style
     :section: tui
 
-    Style of the margin of the unselected documents in the picker.
-    If you don't want any coloring for them you can just set this setting
-    to the empty string as such
-
-    ::
-
-        tui-options_list.unselected_margin_style =
+    Style of the margin of the unselected documents in the picker. If no
+    styling is desired on these elements, this setting can be empty.
 
 .. papis-config:: error_toolbar_style
     :section: tui
 
-    The style for the error messages.
+    The style for the error message toolbar.
 
 .. papis-config:: editmode
     :section: tui
 
-    Whenever the user is typing text, one can use either
-    ``emacs`` like keybindings or ``vi``. If this does not tell you
+    Controls keybindings when typing text in various TUI widgets. This can be
+    set to either ``emacs`` or ``vi`` type keybindings. If this does not tell you
     anything, you can just leave it as is.
 
+Key bindings
+^^^^^^^^^^^^
+
+For information about keybindings, see the corresponding
+`documentation <https://python-prompt-toolkit.readthedocs.io/en/master/pages/advanced_topics/key_bindings.html>`__.
 
 .. papis-config:: move_down_key
     :section: tui
@@ -730,25 +800,17 @@ or inside the library sections prepending a ``tui-``,
 FZF integration
 ---------------
 
-From version `0.12 <https://github.com/papis/papis/issues/334>`__
-papis ships with an *out-of-the-box*
-`fzf <https://github.com/junegunn/fzf>`__ integration for the picker.  A
-minimal terminal user interface is provided and together with options
-for its customization. You can set the picktool to ``fzf`` by setting
+Papis ships with *out-of-the-box* `fzf <https://github.com/junegunn/fzf>`__
+integration for the picker.  A minimal terminal user interface is provided,
+together with options for its customization. You can set the picktool to
+``fzf`` to select this picker.
 
-.. code:: ini
-
-   picktool = fzf
-
-in the configuration section of your library.
-
-In comparison to the *built-in* papis tui the advantage of the fzf
-picker is that it is much faster, however a disadvantage is that it is
-restricted to one-line entries.
-Also it is important to notice that ``fzf`` will **only**
-match against what is shown on the terminal screen, as opposed to the papis
-matcher, that can match against the **whole** title and **whole** author
-text since this is controlled by the ``match-format`` setting.
+In comparison to the *built-in* Papis picker TUI, the advantage of the fzf
+picker is that it is much faster. However, a disadvantage is that it is
+restricted to one-line entries. It is also important to note that ``fzf`` will
+**only** match against what is shown on the terminal screen, as opposed to the
+Papis matcher, that can match against the **whole** title and **whole** author
+text, since this is controlled by the ``match-format`` setting.
 However, for many uses it might not bother the user to have this limitation
 of fzf.
 
@@ -762,37 +824,33 @@ of fzf.
 
 .. papis-config:: fzf-extra-bindings
 
-    Extra bindings to fzf as a python list.
-    Refer to the fzf documentation for more details.
+    Extra bindings to fzf as a Python list. Refer to the fzf documentation for
+    more details.
 
 .. papis-config:: fzf-header-format
 
     Format for the entries for fzf.
-    Notice that if you want colors you should have in ``fzf-extra-flags``
-    the ``--ansi`` flag and include the colors in the header-format
-    as ``ansi`` escape sequences.
+    Notice that if you want colors you should add the ``--ansi`` flag to
+    ``fzf-extra-flags`` and include the colors in the
+    :ref:`config-settings-header-format` as ``ansi`` escape sequences.
 
-    The papis format string is given the additional variable
-    ``c`` which contains the package ``colorama`` in it.
-    Refer to the ``colorama`` documentation to see which colors
-    are available
-    `here <https://github.com/tartley/colorama/blob/master/colorama/ansi.py#L49>`__.
-    For instance, if you want the title in red you would put in your
-    ``fzf-header-format``
+    The papis format string is given the additional variable ``c`` which
+    contains the package ``colorama`` in it. Refer to the ``colorama``
+    `documentation <https://github.com/tartley/colorama/blob/master/colorama/ansi.py#L49>`__.
+    to see which colors are available. For instance, if you want the title in
+    red, you would put in your ``fzf-header-format``
 
     .. code:: python
 
         "{c.Fore.RED}{doc[title]}{c.Style.RESET_ALL}"
 
-``fzf`` with a preview window
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+Preview window
+^^^^^^^^^^^^^^
 
-``fzf`` has the disadvantage that it does not support
-multiline output and it matches only against what it shows
-on the screen.
-
-You can go around this issue by composing an ``fzf`` customization.
-The following configuration
+``fzf`` has the disadvantage that it does not support multiline output and
+it matches only against what it shows on the screen. To get around this issue,
+we can try composing a ``fzf`` customization. The following will add a preview
+window to the picker
 
 .. code:: ini
 
@@ -806,83 +864,13 @@ The following configuration
 
     fzf-header-format = {c.Fore.MAGENTA}{doc[title]}{c.Style.RESET_ALL}~~ {c.Fore.CYAN}{doc[author]}{c.Style.RESET_ALL}~~ {c.Fore.YELLOW}«{doc[year]}»{c.Style.RESET_ALL}~~ {c.Fore.YELLOW}{doc[journal]}{c.Style.RESET_ALL}~~ :{doc[tags]}
 
-will have unrestricted titles, author, journal etc fields against which the query will match and it will show
-in the ``fzf`` preview window a tidy description of the currently selected field by replacing the token ``~~``
-by a newline. You can try this out and play with ``fzf`` customizations.
-Please note that ``bottom:wrap:20%%`` has two ``%`` since the config file
-interpolator uses ``%`` as a reserved symbol, so it must be escaped
-by writing two of them.
+This will add unrestricted titles, author, journal etc fields against which the
+query will match and it will show in the ``fzf`` preview window a tidy description
+of the currently selected field by replacing the token ``~~`` by a newline. You
+can try this out and play with ``fzf`` customizations.
 
-Other
------
+.. note::
 
-.. papis-config:: unique-document-keys
-
-    Whenever you add a new document, papis tries to figure out if
-    you have already added this document before. This is partially done
-    checking for some special keys, and checking if they match.
-    Which keys are checked against is decided by this option, which
-    should be formatted as a python list, just as in the default value.
-
-    For instance, if you add a paper with a given ``doi``, and then you
-    add another document with the same ``doi``, then papis will notify
-    you that there is already another document with this ``doi`` because
-    the ``doi`` key is part of the ``unique-document-keys`` option.
-
-.. papis-config:: document-description-format
-
-    ``papis`` sometimes will have to tell you which document it is processing
-    through text, for instance, imagine you are updating a document
-
-    .. code:: yaml
-
-        author: Albert Einstein
-        title: General Relativity
-
-    and papis is doing something with it. Then if your
-    ``document-description-format`` is set to
-    ``{doc[title]} - {doc[author]}``, you will see that papis tells you
-
-    ::
-
-        .....
-        Updating 'General Relativity - Albert Einstein'
-        ...
-
-    so you will know exactly what is going on.
-
-.. papis-config:: sort-field
-
-  As of version ``0.10``, some command line commands have the ``--sort`` option
-  to sort the documents according to a given field. If you set
-  ``sort-field`` in your configuration file, this will sort by default
-  the documents according to this sort field. For instance,
-  if you want your documents by default to be sorted by ``year``, you
-  would set ``sort-field = year``.
-
-.. papis-config:: sort-reverse
-
-    Augments ``sort-field`` by allowing the documents to be sorted in
-    reverse order. For example, when sorting by year, this allows sorting
-    ascendingly or descendingly. This is a boolean option that can be set to
-    ``True`` or ``False``.
-
-.. papis-config:: time-stamp
-
-  Whether or not to add a timestamp to a document when is being added to
-  papis. If documents have a timestamp, then they will be sortable
-  using ``--sort time-added`` option.
-
-.. papis-config:: formatter
-
-    Picks the formatter for templated strings in the configuration file and
-    in various strings presented to the user. Supported formatters are
-
-    * ``"python"``: based on :class:`papis.format.PythonFormatter`.
-    * ``"jinja2"``: based on :class:`papis.format.Jinja2Formatter`.
-
-    Note that the default values of many of the papis configuration settings are
-    based on the Python formatter. These will need to all be specified explicitly
-    if another formatter is chosen.
-
-    **Note** The older (misspelled) version ``"formater"`` is deprecated.
+    Please note that ``bottom:wrap:20%%`` has two ``%`` since the config file
+    interpolator uses ``%`` as a reserved symbol, so it must be escaped
+    by writing two of them.

--- a/doc/source/git.rst
+++ b/doc/source/git.rst
@@ -1,3 +1,5 @@
+.. _git-support:
+
 Git support
 ===========
 

--- a/doc/source/plugins.rst
+++ b/doc/source/plugins.rst
@@ -1,3 +1,5 @@
+.. _plugin-architecture:
+
 Plugin architecture
 ===================
 

--- a/papis/commands/add.py
+++ b/papis/commands/add.py
@@ -562,7 +562,7 @@ def run(paths: List[str],
     help="Download file with importer if available or not",
     default=lambda: papis.config.getboolean("add-download-files"))
 @papis.cli.bool_flag(
-    "--fetch-citations",
+    "--fetch-citations/--no-fetch-citations",
     help="Fetch citations from a DOI (Digital Object Identifier)",
     default=lambda: papis.config.getboolean("add-fetch-citations"))
 def cli(files: List[str],

--- a/papis/defaults.py
+++ b/papis/defaults.py
@@ -44,7 +44,6 @@ settings: Dict[str, Any] = {
     "add-folder-name": "",
     "add-subfolder": "",
     "add-file-name": None,
-    "add-interactive": False,
     "add-edit": False,
     "add-open": False,
     "add-fetch-citations": False,

--- a/papis/defaults.py
+++ b/papis/defaults.py
@@ -44,6 +44,7 @@ settings: Dict[str, Any] = {
     "add-folder-name": "",
     "add-subfolder": "",
     "add-file-name": None,
+    "add-interactive": False,
     "add-edit": False,
     "add-open": False,
     "add-fetch-citations": False,

--- a/papis/defaults.py
+++ b/papis/defaults.py
@@ -16,55 +16,111 @@ def get_default_opener() -> str:
         # NOTE: should work on Linux / FreeBSD / cygwin
         return "xdg-open"
 
+# NOTE: Try to keep these in the same order as in the `default-settings.rst`
+# document in the docs, so they can be easily checked and updated
+
 
 settings: Dict[str, Any] = {
+    # unused or deprecated
+    "add-interactive": False,
+    "mvtool": "mv",
+    "formater": None,
+
+    # general settings
     "local-config-file": ".papis.config",
-    "database-backend": "papis",
-    "default-query-string": ".",
+    "dir-umask": 0o755,
+    "use-git": False,
+    "user-agent": "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_9_3)",
+    "scripts-short-help-regex": ".*papis-short-help: *(.*)",
+    "info-name": "info.yaml",
+    "doc-url-key-name": "doc_url",
+    "default-library": "papers",
+    "format-doc-name": "doc",
+    "match-format": "{doc[tags]}{doc.subfolder}{doc[title]}{doc[author]}{doc[year]}",
+    "header-format": (
+        "<ansired>{doc.html_escape[title]}</ansired>\n"
+        " <ansigreen>{doc.html_escape[author]}</ansigreen>\n"
+        "  <ansiblue>({doc.html_escape[year]})</ansiblue> "
+        "[<ansiyellow>{doc.html_escape[tags]}</ansiyellow>]"
+    ),
+    "header-format-file": None,
+    "info-allow-unicode": True,
+    "unique-document-keys": "['doi','ref','isbn','isbn10','url','doc_url']",
+    "document-description-format": "{doc[title]} - {doc[author]}",
     "sort-field": None,
     "sort-reverse": False,
+    "formatter": "python",
 
+    # tools
     "opentool": get_default_opener(),
-    "dir-umask": 0o755,
     "browser": os.environ.get("BROWSER") or get_default_opener(),
     "picktool": "papis",
-    "mvtool": "mv",
-    "editor": os.environ.get("EDITOR")
-                        or os.environ.get("VISUAL")
-                        or get_default_opener(),
-    "notes-name": "notes.tex",
-    "notes-template": "",
-    "use-cache": True,
-    "cache-dir": None,
-    "use-git": False,
+    "editor": (
+        os.environ.get("EDITOR")
+        or os.environ.get("VISUAL")
+        or get_default_opener()),
+    "file-browser": get_default_opener(),
 
-    "auto-doctor": False,
+    # bibtex
+    "bibtex-journal-key": "journal",
+    "extra-bibtex-keys": "[]",
+    "bibtex-ignore-keys": "[]",
+    "extra-bibtex-types": "[]",
+    "bibtex-unicode": False,
+    "bibtex-export-file": False,
+    "multiple-authors-separator": " and ",
+    "multiple-authors-format": "{au[family]}, {au[given]}",
 
-    "add-confirm": False,
+    # add
+    "ref-format": "{doc[title]:.15} {doc[author]:.6} {doc[year]}",
     "add-folder-name": "",
-    "add-subfolder": "",
     "add-file-name": None,
-    "add-interactive": False,
+    "add-subfolder": "",
+    "add-confirm": False,
     "add-edit": False,
     "add-open": False,
-    "add-fetch-citations": False,
     "add-download-files": True,
+    "add-fetch-citations": False,
+    "auto-doctor": False,
+    "time-stamp": True,
 
-    # papis-doctor configuration
+    # browse
+    "browse-key": "auto",
+    "browse-query-format": "{doc[title]} {doc[author]}",
+    "search-engine": "https://duckduckgo.com",
+
+    # edit
+    "notes-name": "notes.tex",
+    "notes-template": "",
+
+    # doctor
     "doctor-default-checks": ["files", "keys-exist", "duplicated-keys"],
     "doctor-keys-exist-keys": ["title", "author", "author_list", "ref"],
     "doctor-duplicated-keys-keys": ["ref"],
     "doctor-duplicated-values-keys": ["files", "author_list"],
     "doctor-html-codes-keys": ["title", "author", "abstract", "journal"],
     "doctor-html-tags-keys": ["title", "author", "abstract", "journal"],
-    "doctor-key-type-check-separator": None,
     "doctor-key-type-check-keys": ["year:int",
                                    "month:int",
                                    "files:list",
                                    "notes:str",
                                    "author_list:list"],
+    "doctor-key-type-check-separator": None,
 
-    # papis-serve configuration
+    # open
+    "open-mark": False,
+    "mark-key-name": "marks",
+    "mark-format-name": "mark",
+    "mark-header-format": "{mark[name]} - {mark[value]}",
+    "mark-match-format": "{mark[name]} - {mark[value]}",
+    "mark-opener-format": get_default_opener(),
+
+    # serve
+    "serve-empty-query-get-all-documents": False,
+    "serve-default-tag-sorting": "numeric",
+    "serve-timeline-max": 500,
+    "serve-enable-timeline": False,
+    # serve-frameworks
     "serve-user-css": [],
     "serve-user-js": [],
     "serve-font-awesome-css": [("https://cdnjs.cloudflare.com/ajax/"
@@ -92,7 +148,6 @@ settings: Dict[str, Any] = {
     "serve-katex-auto-render-js":
     ("https://cdn.jsdelivr.net/npm/"
      "katex@0.16.4/dist/contrib/auto-render.min.js"),
-
     "serve-ace-urls": [("https://cdnjs.cloudflare.com/ajax/libs/ace/"
                         "1.14.0/ace.min.js"),
                        ("https://cdnjs.cloudflare.com/ajax/libs/ace/"
@@ -114,67 +169,24 @@ settings: Dict[str, Any] = {
                        ("https://cdnjs.cloudflare.com/ajax/libs/ace/"
                         "1.14.0/keybinding-emacs.min.js"),
                        ],
-
-    "serve-empty-query-get-all-documents": False,
-    "serve-default-tag-sorting": "numeric",
-
-    # citations configuration
-    "citations-file-name": "citations.yaml",
-    "cited-by-file-name": "cited-by.yaml",
-
-    # timeline options
-    "serve-timeline-max": 500,
-    "serve-enable-timeline": False,
     "serve-timeline-js": ("https://cdn.knightlab.com/libs/timeline3/"
                           "latest/js/timeline.js"),
     "serve-timeline-css": ("https://cdn.knightlab.com/libs/timeline3/"
                            "latest/css/timeline.css"),
 
-    "browse-key": "auto",
-    "browse-query-format": "{doc[title]} {doc[author]}",
-    "search-engine": "https://duckduckgo.com",
-    "user-agent": "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_9_3)",
-    "scripts-short-help-regex": ".*papis-short-help: *(.*)",
-    "info-name": "info.yaml",
-    "doc-url-key-name": "doc_url",
+    # citations
+    "citations-file-name": "citations.yaml",
+    "cited-by-file-name": "cited-by.yaml",
 
-    "open-mark": False,
-    "mark-key-name": "marks",
-    "mark-format-name": "mark",
-    "mark-header-format": "{mark[name]} - {mark[value]}",
-    "mark-match-format": "{mark[name]} - {mark[value]}",
-    "mark-opener-format": get_default_opener(),
+    # downloaders
+    "downloader-proxy": None,
+    "isbn-service": "openl",
 
-    "file-browser": get_default_opener(),
-    "bibtex-unicode": False,
-    "bibtex-journal-key": "journal",
-    "bibtex-export-file": False,
-    "bibtex-ignore-keys": "[]",
-    "extra-bibtex-keys": "[]",
-    "extra-bibtex-types": "[]",
-    "default-library": "papers",
-    "format-doc-name": "doc",
-    "match-format":
-        "{doc[tags]}{doc.subfolder}{doc[title]}{doc[author]}{doc[year]}",
-    "header-format-file": None,
-    "header-format": (
-        "<ansired>{doc.html_escape[title]}</ansired>\n"
-        " <ansigreen>{doc.html_escape[author]}</ansigreen>\n"
-        "  <ansiblue>({doc.html_escape[year]})</ansiblue> "
-        "[<ansiyellow>{doc.html_escape[tags]}</ansiyellow>]"
-    ),
-
-    "formatter": "python",
-    # FIXME: this is deprecated and should be removed at some point
-    "formater": None,
-    "time-stamp": True,
-    "info-allow-unicode": True,
-    "ref-format": "{doc[title]:.15} {doc[author]:.6} {doc[year]}",
-    "multiple-authors-separator": " and ",
-    "multiple-authors-format": "{au[family]}, {au[given]}",
-    "document-description-format": "{doc[title]} - {doc[author]}",
-    "unique-document-keys": "['doi','ref','isbn','isbn10','url','doc_url']",
-
+    # database
+    "default-query-string": ".",
+    "database-backend": "papis",
+    "use-cache": True,
+    "cache-dir": None,
     "whoosh-schema-fields": "['doi']",
     "whoosh-schema-prototype":
     "{\n"
@@ -199,8 +211,4 @@ settings: Dict[str, Any] = {
                           "«{doc[year]:4}»"
                           "{c.Style.RESET_ALL}"
                           ":{doc[tags]}"),
-
-    # importer / downloader options
-    "downloader-proxy": None,
-    "isbn-service": "openl",
 }


### PR DESCRIPTION
The commits are fairly self-contained, but this mostly 
* updates the config options and removes any references to older values. 
* adds all the `papis serve` settings to the docs, so people can actually change them.
* re-orders the options in `papis/defaults.py` to match the docs.