### PR TITLE
commands.init: improve first-time usage and messages

### DIFF
--- a/papis/commands/default.py
+++ b/papis/commands/default.py
@@ -175,7 +175,9 @@ def generate_profile_writing_function(profiler: "cProfile.Profile",
     help="Use number of processors for multicore functionalities in papis",
     type=str,
     default=None)
-def run(verbose: bool,
+@click.pass_context
+def run(ctx: click.Context,
+        verbose: bool,
         profile: str,
         config: str,
         lib: str,
@@ -232,10 +234,18 @@ def run(verbose: bool,
                 local_config_path,
                 papis.config.get_configuration())
     else:
-        logger.error(
-            "Library '%s' does not have any folders attached to it. Please "
-            "create and add the required paths to the configuration file.",
-            library)
+        config_file = papis.config.get_config_file()
+        if os.path.exists(config_file):
+            logger.error(
+                "Library '%s' does not have any folders attached to it. Please "
+                "create and add the required paths to the configuration file.",
+                library)
+        elif ctx.invoked_subcommand != "init":
+            logger.warning("No configuration file exists at '%s'.", config_file)
+            logger.warning("Create a configuration file and define your "
+                           "libraries before using papis. You can use "
+                           "'papis init /path/to/my/library' for a quick "
+                           "interactive setup.")
 
     # read in configuration from command-line
     sections = papis.config.get_configuration().sections()

--- a/papis/commands/default.py
+++ b/papis/commands/default.py
@@ -220,21 +220,22 @@ def run(verbose: bool,
     papis.config.set_lib_from_name(lib)
     library = papis.config.get_lib()
 
-    if not library.paths:
-        raise RuntimeError(
-            f"Library '{lib}' does not have any existing folders attached to it. "
-            "Please define and create the paths in the configuration file"
-            )
-
-    # Now the library should be set, let us check if there is a
-    # local configuration file there, and if there is one, then
-    # merge its contents
-    local_config_file = papis.config.getstring("local-config-file")
-    for path in library.paths:
-        local_config_path = os.path.expanduser(os.path.join(path, local_config_file))
-        papis.config.merge_configuration_from_path(
-            local_config_path,
-            papis.config.get_configuration())
+    if library.paths:
+        # Now the library should be set, let us check if there is a
+        # local configuration file there, and if there is one, then
+        # merge its contents
+        local_config_file = papis.config.getstring("local-config-file")
+        for path in library.paths:
+            local_config_path = os.path.expanduser(
+                os.path.join(path, local_config_file))
+            papis.config.merge_configuration_from_path(
+                local_config_path,
+                papis.config.get_configuration())
+    else:
+        logger.error(
+            "Library '%s' does not have any folders attached to it. Please "
+            "create and add the required paths to the configuration file.",
+            library)
 
     # read in configuration from command-line
     sections = papis.config.get_configuration().sections()

--- a/papis/commands/init.py
+++ b/papis/commands/init.py
@@ -100,9 +100,9 @@ def cli(dir_path: Optional[str]) -> None:
         if not papis.tui.utils.confirm("Do you want to continue?"):
             return
     else:
-        logger.info("Using config file: '%s'.", config_file)
+        logger.info("Initializing a new config file: '%s'.", config_file)
 
-    logger.info("Setting library location.")
+    logger.info("Setting library location:")
     dir_path = os.getcwd() if dir_path is None else dir_path
     library_name = papis.tui.utils.prompt(
         "Name of the library",

--- a/papis/commands/init.py
+++ b/papis/commands/init.py
@@ -104,11 +104,23 @@ def cli(dir_path: Optional[str]) -> None:
 
     logger.info("Setting library location:")
     dir_path = os.getcwd() if dir_path is None else dir_path
+
+    # FIXME: this is necessary because incorrectly configured libraries still
+    # show up in `papis.config.get_libs()`. We need better handling of missing
+    # libraries or ill-configured libraries.
+    known_libraries = []
+    for libname in papis.config.get_libs():
+        lib = papis.config.get_lib_from_name(libname)
+        if lib.paths and all(os.path.exists(path) for path in lib.paths):
+            known_libraries.append(libname)
+
     library_name = papis.tui.utils.prompt(
         "Name of the library",
         default=os.path.basename(dir_path),
-        bottom_toolbar="Known libraries: '{}'".format(
-            "', '".join(papis.config.get_libs())))
+        bottom_toolbar=(
+            "Known libraries: '{}'".format("', '".join(known_libraries))
+            if known_libraries else "No currently configured libraries")
+        )
 
     if library_name not in config:
         config[library_name] = {}

--- a/papis/commands/init.py
+++ b/papis/commands/init.py
@@ -127,13 +127,18 @@ def cli(dir_path: Optional[str]) -> None:
     local["dir"] = library_path
 
     logger.info("Setting library custom options.")
-    for setting, help_string in INIT_PROMPTS:
-        local[setting] = papis.tui.utils.prompt(
-            setting,
-            default=str(local.get(setting, defaults.get(setting))),
-            bottom_toolbar=help_string)
+    if papis.tui.utils.confirm("Want to add some standard settings?", yes=False):
+        for setting, help_string in INIT_PROMPTS:
+            local[setting] = papis.tui.utils.prompt(
+                setting,
+                default=str(local.get(setting, defaults.get(setting))),
+                bottom_toolbar=help_string)
 
     if papis.tui.utils.confirm("Do you want to save?"):
+        config_folder = papis.config.get_config_folder()
+        if not os.path.exists(config_folder):
+            os.makedirs(config_folder)
+
         with open(config_file, "w") as configfile:
             config.write(configfile)
 

--- a/papis/commands/init.py
+++ b/papis/commands/init.py
@@ -78,7 +78,7 @@ INIT_PROMPTS = [
 @click.argument(
     "dir_path",
     required=False,
-    type=click.Path(),
+    type=click.Path(file_okay=False),
     default=None,
     metavar="<LIBRARY DIRECTORY>",
     nargs=1,

--- a/papis/config.py
+++ b/papis/config.py
@@ -97,8 +97,6 @@ class Configuration(configparser.ConfigParser):
         # if no sections were actually read, add default ones
         if not self.sections():
             self.include_defaults()
-            with open(self.file_location, "w") as configfile:
-                self.write(configfile)
 
         # ensure the general section and default-library exist in the config
         if GENERAL_SETTINGS_NAME not in self:

--- a/papis/database/cache.py
+++ b/papis/database/cache.py
@@ -144,7 +144,7 @@ class Database(papis.database.base.Database):
             import pickle
             with open(cache_path, "rb") as fd:
                 self.documents = pickle.load(fd)
-        else:
+        elif self.get_dirs():
             logger.info("Indexing library. This might take a while...")
             folders: List[str] = sum(
                 [papis.utils.get_folders(d) for d in self.get_dirs()],
@@ -155,6 +155,9 @@ class Database(papis.database.base.Database):
                 self.maybe_compute_id(doc)
             if use_cache:
                 self.save()
+        else:
+            self.documents = []
+
         logger.debug("Loaded %d documents.", len(self.documents))
         return self.documents
 


### PR DESCRIPTION
This should fix some issues when working with a new configuration file:
* Calling `papis add --help` (and all other) no longer shows a traceback, but a nicer error message.
* `papis init` can be used without crashing horribly too.
* Removed logging messages in `Configuration.initialize` because they weren't showing up correctly anyway.

Fixes #697.