### PR TITLE
nix: do no try to install lsp server

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -70,11 +70,12 @@
         flake8
         mypy
         pep8-naming
-        pylint
         pytest
         pytest-cov
-        python-lsp-server
-        sphinx_rtd_theme
+        # not used in tests
+        # pylint
+        # python-lsp-server
+        # sphinx_rtd_theme
 
         # not packaged
         # python-coveralls


### PR DESCRIPTION
From looking at a slow run
https://github.com/papis/papis/actions/runs/7848226642/job/21418863808?pr=709
the time seems to be spent building some packages, namely `python-vulture` and `python-pylama`. Hopefully removing them from the develop packages will make the run faster.

Fixes #733.