### PR TITLE
config: use platformdirs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,8 @@ VERSION NEXT
   `bs4`, `requests` and `feedparser` and should be installed if possible.
 * Added [markdownify](https://github.com/matthewwithanm/python-markdownify) as
   an optional dependency for the Zenodo downloader.
+* Added [platformdirs](https://github.com/platformdirs/platformdirs) dependency
+  for platform-specific config locations.
 
 ## Features
 

--- a/papis/database/cache.py
+++ b/papis/database/cache.py
@@ -13,11 +13,11 @@ import papis.logging
 logger = papis.logging.get_logger(__name__)
 
 
-def get_cache_file_name(directory: str) -> str:
+def get_cache_file_name(libpaths: str) -> str:
     """Create a cache file name out of the path of a given directory.
 
-    :param directory: Folder name to be used as a seed for the cache name.
-    :returns: Name for the cache file.
+    :param libpaths: folder names to be used as a seed for the cache name.
+    :returns: a name for the cache file specific to *libpaths*.
 
     >>> get_cache_file_name('path/to/my/lib')
     'a8c689820a94babec20c5d6269c7d488-lib'
@@ -26,24 +26,20 @@ def get_cache_file_name(directory: str) -> str:
     """
     import hashlib
     return "{}-{}".format(
-        hashlib.md5(directory.encode()).hexdigest(),
-        os.path.basename(directory))
+        hashlib.md5(libpaths.encode()).hexdigest(),
+        os.path.basename(libpaths))
 
 
-def get_cache_file_path(directory: str) -> str:
-    """Get the full path to the cache file
+def get_cache_file_path(libpaths: str) -> str:
+    """Get the full path to the cache file.
 
-    :param directory: Library folder
-
-    >>> import os; os.environ["XDG_CACHE_HOME"] = '/tmp'
-    >>> os.path.basename(get_cache_file_path('blah/papers'))
-    'c39177eca0eaea2e21134b0bd06631b6-papers'
+    :param libpaths: a cache file specific for the given library paths.
     """
-    cache_name = get_cache_file_name(directory)
-    folder = os.path.expanduser(
-        os.path.join(papis.utils.get_cache_home(), "database"))
+    cache_name = get_cache_file_name(libpaths)
+    folder = os.path.join(papis.utils.get_cache_home(), "database")
     if not os.path.exists(folder):
         os.makedirs(folder)
+
     return os.path.join(folder, cache_name)
 
 

--- a/papis/database/whoosh.py
+++ b/papis/database/whoosh.py
@@ -2,9 +2,9 @@
 here are some considerations.
 
 Whoosh works with 3 main objects, the Index, the Writer and the Schema.
-The indices are stored in a folder which by default is in
-``$XDG_CACHE_HOME/papis/whoosh``. The name of the indices
-folders is similar to the cache files of the papis cache database.
+The indices are stored in a subfolder of :func:`~papis.utils.get_cache_home`.
+The name of the indices folders is similar to the cache files of the papis
+cache database.
 
 Once the index is created in the mentioned folder, a Schema is initialized,
 which is a declaration of the data prototype of the database, or the

--- a/papis/utils.py
+++ b/papis/utils.py
@@ -12,6 +12,8 @@ try:
 except ImportError:
     HAS_MULTIPROCESSING = False
 
+import platformdirs
+
 import papis.config
 import papis.database
 import papis.defaults
@@ -401,21 +403,16 @@ def get_cache_home() -> str:
     """Get default cache directory.
 
     This will retrieve the :confval:`cache-dir` configuration setting.
-    It is ``XDG`` standard compatible.
+    If not provided, a platform-dependent cache folder is chosen instead.
 
     :returns: the absolute path for the cache main folder.
     """
     cachedir = papis.config.get("cache-dir")
-
     if cachedir is None:
-        xdg_cache_dir = os.environ.get("XDG_CACHE_HOME")
-        if xdg_cache_dir:
-            cachedir = os.path.join(xdg_cache_dir, "papis")
-        else:
-            cachedir = os.path.join("~", ".cache", "papis")
+        cachedir = os.environ.get("PAPIS_CACHE_DIR")
+        if cachedir is None:
+            cachedir = platformdirs.user_cache_dir("papis")
 
-    # ensure the directory exists
-    cachedir = os.path.expanduser(cachedir)
     if not os.path.exists(cachedir):
         os.makedirs(cachedir)
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -72,6 +72,7 @@ dependencies = [
     "habanero>=0.6",
     "isbnlib>=3.9.1",
     "lxml>=4.3.5",
+    "platformdirs>=4.0.0",
     "prompt_toolkit>=3.0.5",
     "pygments>=2.2",
     "pyparsing>=2.2",

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -31,40 +31,9 @@ def test_get_config_paths(tmp_config: TemporaryConfiguration) -> None:
     assert papis.config.get_scripts_folder() == scriptsdir
 
 
-@pytest.mark.skipif(sys.platform != "linux", reason="uses linux paths")
 def test_get_config_home(tmp_config: TemporaryConfiguration, monkeypatch) -> None:
     import papis.config
-
-    with monkeypatch.context() as m:
-        m.delenv("XDG_CONFIG_HOME", raising=False)
-        assert re.match(r".+config", papis.config.get_config_home()) is not None
-
-
-@pytest.mark.skipif(sys.platform != "linux", reason="uses linux paths")
-def test_get_config_dirs(tmp_config: TemporaryConfiguration, monkeypatch) -> None:
-    import tempfile
-    import papis.config
-    tmpdir = tempfile.gettempdir()
-
-    with monkeypatch.context() as m:
-        m.setenv("XDG_CONFIG_HOME", tmpdir)
-        m.delenv("XDG_CONFIG_DIRS", raising=False)
-
-        dirs = papis.config.get_config_dirs()
-        assert os.environ.get("XDG_CONFIG_DIRS") is None
-        assert len(dirs) == 2
-        assert os.path.join(tmpdir, "papis") == dirs[0]
-
-    with monkeypatch.context() as m:
-        m.setenv("XDG_CONFIG_DIRS", "/etc/:/usr/local/etc")
-        m.setenv("XDG_CONFIG_HOME", os.path.expanduser("~"))
-
-        dirs = papis.config.get_config_dirs()
-        assert len(dirs) == 4
-        assert os.path.abspath("/etc/papis") == os.path.abspath(dirs[0])
-        assert os.path.abspath("/usr/local/etc/papis") == os.path.abspath(dirs[1])
-        assert os.path.expanduser("~/papis") == os.path.abspath(dirs[2])
-        assert os.path.expanduser("~/.papis") == os.path.abspath(dirs[3])
+    assert re.match(r".+papis", papis.config.get_config_home()) is not None
 
 
 def test_set(tmp_config: TemporaryConfiguration) -> None:
@@ -78,39 +47,35 @@ def test_set(tmp_config: TemporaryConfiguration) -> None:
 
 def test_get(tmp_config: TemporaryConfiguration) -> None:
     import papis.config
-    general_name = papis.config.get_general_settings_name()
+    section = papis.config.get_general_settings_name()
     libname = papis.config.get_lib_name()
 
     papis.config.set("test_get", "value1")
     assert papis.config.get("test_get") == "value1"
-    assert papis.config.get("test_get", section=general_name) == "value1"
+    assert papis.config.get("test_get", section=section) == "value1"
 
     papis.config.set("test_get", "value42", section=libname)
     assert papis.config.get("test_get") == "value42"
     assert papis.config.get("test_get", section=libname) == "value42"
-    assert papis.config.get("test_get", section=general_name) == "value1"
+    assert papis.config.get("test_get", section=section) == "value1"
 
     papis.config.set("test_getint", "42")
     assert papis.config.getint("test_getint") == 42
-    assert papis.config.getint("test_getint", section=general_name) == 42
-    assert isinstance(papis.config.getint("test_getint", section=general_name),
-                      int
-                      )
+    assert papis.config.getint("test_getint", section=section) == 42
+    assert isinstance(papis.config.getint("test_getint", section=section), int)
 
     papis.config.set("test_getfloat", "3.14")
     assert papis.config.getfloat("test_getfloat") == 3.14
-    assert papis.config.getfloat("test_getfloat", section=general_name) == 3.14
-    assert isinstance(papis.config.getfloat("test_getfloat", section=general_name),
-                      float
-                      )
+    assert papis.config.getfloat("test_getfloat", section=section) == 3.14
+    assert isinstance(papis.config.getfloat("test_getfloat", section=section), float)
 
     papis.config.set("test_getbool", "True")
     assert papis.config.getboolean("test_getbool") is True
-    assert papis.config.getboolean("test_getbool", section=general_name) is True
+    assert papis.config.getboolean("test_getbool", section=section) is True
 
     papis.config.set("test_getbool", "False")
     assert papis.config.getboolean("test_getbool") is False
-    assert papis.config.getboolean("test_getbool", section=general_name) is False
+    assert papis.config.getboolean("test_getbool", section=section) is False
 
     import papis.exceptions
     with pytest.raises(papis.exceptions.DefaultSettingValueMissing):

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -6,26 +6,11 @@ import tempfile
 from papis.testing import TemporaryConfiguration
 
 
-@pytest.mark.skipif(sys.platform != "linux", reason="uses linux paths")
 def test_get_cache_home(tmp_config: TemporaryConfiguration, monkeypatch) -> None:
     import papis.config
     from papis.utils import get_cache_home
-    tmpdir = tempfile.gettempdir()
 
-    with monkeypatch.context() as m:
-        m.delenv("XDG_CACHE_HOME", raising=False)
-        assert get_cache_home() == os.path.join(os.path.expanduser("~/.cache"), "papis")
-
-    with monkeypatch.context() as m:
-        m.setenv("XDG_CACHE_HOME", os.path.expanduser("~/.cache"))
-        assert get_cache_home() == os.path.join(os.environ["XDG_CACHE_HOME"], "papis")
-
-    with monkeypatch.context() as m:
-        m.setenv("XDG_CACHE_HOME", os.path.join(tmpdir, ".cache"))
-
-        assert get_cache_home() == os.path.join(tmpdir, ".cache", "papis")
-        assert os.path.exists(get_cache_home())
-
+    assert get_cache_home() == os.path.join(tmp_config.tmpdir, "papis")
     with tempfile.TemporaryDirectory(dir=tmp_config.tmpdir) as d:
         tmp = os.path.join(d, "blah")
         papis.config.set("cache-dir", tmp)


### PR DESCRIPTION
This switches to using [platformdirs](https://platformdirs.readthedocs.io/en/latest/) for all our "getting a standard path" functions. This will mainly improves the situation on other platforms, i.e.
* On Windows the configuration should go in `%USERPROFILE%\AppData\Local\$appauthor\$appname`
* On macOS the configuration should go in `~/Library/Application Support/$appname/$version`

To help with migrating:
* config: When loading a config, it checks if the previous XDG-based `config_folder` exists and copies it over with a warning.
* cache: Nothing is done here, since we can just regenerate the cache and nothing is lost. It's not too hard to copy over older caches, so I'm open to suggestions.

On Linux, this shouldn't change anything at all really, so if someone with a different OS can chime in, that would be very appreciated!