### PR TITLE
Improve flake

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -13,8 +13,8 @@
   }:
     flake-utils.lib.eachDefaultSystem (system: let
       pkgs = nixpkgs.legacyPackages.${system};
-      python = pkgs.python311;
-      pypkgs = pkgs.python311Packages;
+      python = pkgs.python3;
+      pypkgs = pkgs.python3Packages;
       lib = pkgs.lib;
 
       runtime_py_deps = let
@@ -159,7 +159,7 @@
             python --version
             python -m venv .venv
             source .venv/bin/activate
-            pip install -e .[develop,optional]
+            pip install -e ".[develop,optional]"
           '';
         };
       };


### PR DESCRIPTION
I'm quite new to nix, so not sure if this is correct. I'd love some input from fellow nix users @f0rki or @alejandrogallo.

This PR would solve 2 things:

1. I've been installing papis on my system via the flake and that worked for a while. However, at some point it broke:

```
error: builder for '/nix/store/cxcc2ihfxipsjpy3r8fxrqvz0zdph283-python3.10-papis-0.13.drv' failed with exit code 1;
       last 10 log lines:
       > Running phase: updateAutotoolsGnuConfigScriptsPhase
       > Running phase: configurePhase
       > no configure script, doing nothing
       > Running phase: buildPhase
       > Executing setuptoolsBuildPhase
       > Traceback (most recent call last):
       >   File "/build/khp02d3wb2lb6z0nb5wa2d21p46fhzkm-source/nix_run_setup", line 3, in <module>
       >     import setuptools
       > ModuleNotFoundError: No module named 'setuptools'
       > /nix/store/bknngadwym46j65qs14ic2w79rpav888-stdenv-linux/setup: line 1582: pop_var_context: head of shell_variables not a function context
       For full logs, run 'nix log /nix/store/cxcc2ihfxipsjpy3r8fxrqvz0zdph283-python3.10-papis-0.13.drv'.
error: 1 dependencies of derivation '/nix/store/b2zsv768g1w4nkw96zbq1l333zm2yx86-home-manager-path.drv' failed to build
error: 1 dependencies of derivation '/nix/store/kqngvvg8fr749v5hc2q587xxmdsjb0j2-home-manager-path.drv' failed to build
error: 1 dependencies of derivation '/nix/store/8rqs5bzg01mxyjs8q5zlrbgmq86hlnr8-home-manager-generation.drv' failed to build
error: 1 dependencies of derivation '/nix/store/m1j6c8gnz9h7rzbqdxqz8n0li6jwqbjp-activatable-home-manager-generation.drv' failed to build
error: 1 dependencies of derivation '/nix/store/5wbaxbm05y3n0g38wr9rx2gy8fmlfbj8-deploy-rs-check-activate.drv' failed to build
```

My guess is that it's because my `nixpkgs-unstable` uses another python version, or at least the error goes away if I refer to `python3` rather than `python310`. 

2. Whenever I enter the development shell I get the following message:
```
Python 3.10.13

Usage:   
  pip install [options] <requirement specifier> [package-index-options] ...
  pip install [options] -r <requirements file> [package-index-options] ...
  pip install [options] [-e] <vcs project url> ...
  pip install [options] [-e] <local project path> ...
  pip install [options] <archive url/path> ...

-e option requires 1 argument
```
I think it's because of some missing quotes around `.[develop,optional]`

I've been using papis with this version of the flake for a couple of months and it seems to be working alright so far.