### PR TITLE
setup.py: add jinja2 optional dependency

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -40,7 +40,7 @@
         };
       in
         with pypkgs; [
-          pyyaml
+          arxivpy
           beautifulsoup4
           bibtexparser
           chardet
@@ -50,17 +50,18 @@
           filetype
           habanero
           isbnlib
+          jinja2
           lxml
           prompt_toolkit
           pygments
           pyparsing
           python-doi
           python-slugify
+          pyyaml
           requests
           stevedore
           tqdm
           whoosh
-          arxivpy
         ];
       develop_py_deps = with pypkgs; [
         pip

--- a/setup.py
+++ b/setup.py
@@ -109,12 +109,13 @@ setup(
         # for example:
         # $ pip install -e .[develop]
         "optional": [
+            "Jinja2>=3.0.0",
             "Whoosh>=2.7.4",
         ],
         "develop": [
+            "flake8",
             "flake8-bugbear",
             "flake8-quotes",
-            "flake8",
             "mypy>=0.7",
             "pep8-naming",
             "pylint",


### PR DESCRIPTION
Not quite sure why this wasn't added as an optional dependency, but it should definitely be in there.