### PR TITLE
docs: improve how configuration values are handled

### DIFF
--- a/doc/source/bibtex.rst
+++ b/doc/source/bibtex.rst
@@ -15,7 +15,7 @@ If you are using TeX engines like XeTeX or LuaTeX, then you can use unicode
 characters for your BibTeX files as well. This means there is no need to write
 ``\`{a}`` instead of ``à`` in words such as ``apareixerà``. To control the
 output of unicode characters in papis, use the
-:ref:`config-settings-bibtex-unicode` setting.
+:confval:`bibtex-unicode` setting.
 
 Override keys
 -------------
@@ -44,5 +44,5 @@ Ignore keys
 -----------
 
 If you do not want to export certain keys to the BibTeX file,
-like the ``abstract``, you might use the :ref:`config-settings-bibtex-ignore-keys`
+like the ``abstract``, you might use the :confval:`bibtex-ignore-keys`
 setting to omit them in the exporting process.

--- a/doc/source/configuration.rst
+++ b/doc/source/configuration.rst
@@ -76,7 +76,7 @@ all the options and more extensive descriptions)
 
    Many configuration options use special formatted strings that can depend on
    the document that is being worked on. When using these, make sure to also
-   set the :ref:`config-settings-formatter` to your desired choice. Below, we
+   set the :confval:`formatter` to your desired choice. Below, we
    are using the default ``python`` formatter that is based on :meth:`str.format`.
 
 .. code:: ini
@@ -161,7 +161,7 @@ Local configuration files
 
 Papis also offers the possibility of creating local configuration files.
 The name of the local configuration file can be configured with the
-:ref:`config-settings-local-config-file` setting. The local configuration files
+:confval:`local-config-file` setting. The local configuration files
 are looked for in the current directory (where the papis command is issued) or
 in the directory of the current library.
 

--- a/doc/source/database_structure.rst
+++ b/doc/source/database_structure.rst
@@ -27,8 +27,7 @@ you will have ample performance with the two first options.
 However if you're reaching higher numbers,
 you'll probably want to use the ``Whoosh`` backend for very good performance.
 
-You can select a database by using the flag
-:ref:`database-backend <config-settings-database-backend>`.
+You can select a database by using the flag :confval:`database-backend`.
 
 Papis database
 --------------
@@ -146,8 +145,8 @@ In other words, the whoosh index will store only certain fields from the
 document's info files. The good news is that we can tell papis exactly
 which fields we want to index. These flags are
 
-- :ref:`whoosh-schema-fields <config-settings-whoosh-schema-fields>`
-- :ref:`whoosh-schema-prototype <config-settings-whoosh-schema-prototype>`
+- :confval:`whoosh-schema-fields`
+- :confval:`whoosh-schema-prototype`
 
 The prototype is for advanced users. If you just want to, say, include
 the publisher to the fields that you can search in, then you can put

--- a/doc/source/default-settings.rst
+++ b/doc/source/default-settings.rst
@@ -23,7 +23,7 @@ General settings
 
     Then, you can share your library (through e.g. Dropbox or a network drive)
     and have the same settings for the library across machines, e.g. to generate
-    consistent references with :ref:`config-settings-ref-format`. In this setup,
+    consistent references with :confval:`ref-format`. In this setup,
     whenever Fulano uses that library, their Papis calls will also read the
     configuration settings and use the same settings.
 
@@ -77,10 +77,10 @@ General settings
 .. papis-config:: format-doc-name
 
     This setting controls the name of the document in the papis format strings
-    like in format strings such as :ref:`config-settings-match-format` or
-    :ref:`config-settings-header-format`. For instance, if you are managing
+    like in format strings such as :confval:`match-format` or
+    :confval:`header-format`. For instance, if you are managing
     videos, you might want to set this option to ``vid`` in order to set  the
-    :ref:`config-settings-header-format` to
+    :confval:`header-format` to
 
     .. code:: ini
 
@@ -92,7 +92,7 @@ General settings
     and in the ``papis`` database backend. For example, if the ``match-format``
     is set to ``{doc[year]} {doc[author]}``, then words from the title will not
     match the document, only using the year or the author will work. It is
-    recommended to set this to all the keys used by :ref:`config-settings-header-format`,
+    recommended to set this to all the keys used by :confval:`header-format`,
     so that any visible information can be matched.
 
 .. papis-config:: header-format
@@ -102,7 +102,7 @@ General settings
 
 .. papis-config:: header-format-file
 
-    If the :ref:`config-settings-header-format` grows too complex, it can be
+    If the :confval:`header-format` grows too complex, it can be
     stored in a separate file. This option should give the path to that file (in
     which case the ``header-format`` option will be ignored). For example, this
     can be set to
@@ -145,7 +145,7 @@ General settings
 
 .. papis-config:: sort-reverse
 
-    A setting that augments :ref:`config-settings-sort-field` by allowing the
+    A setting that augments :confval:`sort-field` by allowing the
     documents to be sorted in reverse order. Most commands support a ``--reverse``
     flag that uses this setting as a default value.
 
@@ -202,7 +202,7 @@ Tools options
     Editor used to edit files in papis, e.g., for the ``papis edit``
     command. This will search for the ``$EDITOR`` environment variable or the
     ``$VISUAL`` environment variables to obtain a default if it is not set.
-    Otherwise, the default :ref:`config-settings-opentool` will be used.
+    Otherwise, the default :confval:`opentool` will be used.
 
 .. papis-config:: file-browser
 
@@ -287,11 +287,11 @@ BibTeX options
     which for the author ``{"family": "Einstein", "given": "Albert"}`` would
     construct the string ``Einstein -- Albert``. In most circumstances, multiple
     authors are then concatenated together using
-    :ref:`config-settings-multiple-authors-separator`.
+    :confval:`multiple-authors-separator`.
 
 .. papis-config:: multiple-authors-separator
 
-    A string used with :ref:`config-settings-multiple-authors-format` to
+    A string used with :confval:`multiple-authors-format` to
     concatenate multiple authors, e.g. into the ``authors`` document key.
     By default, this is set to ``and``, which is the separator used by
     BibTeX in its so-called *name-lists*.
@@ -364,7 +364,7 @@ Add options
     :type: str
 
     Set the default file name for newly added documents, similarly to
-    :ref:`config-settings-add-folder-name`. If it is not set, the names of the
+    :confval:`add-folder-name`. If it is not set, the names of the
     files will be cleaned and taken *as-is*.
 
 .. papis-config:: add-subfolder
@@ -440,8 +440,8 @@ Browse options
       ``https://ui.adsabs.harvard.edu/abs/<DOI>``.
     * ``"auto"``: automatically pick between ``url``, ``doi`` and ``isbn``
       (first existing key is chosen).
-    * ``"search-engine"``: the :ref:`config-settings-search-engine` is used
-      to search for the contents of :ref:`config-settings-browse-query-format`.
+    * ``"search-engine"``: the :confval:`search-engine` is used
+      to search for the contents of :confval:`browse-query-format`.
 
     If the required keys are not found in the document (e.g. the DOI or the
     ISBN), the key will fallback to the ``"search-engine"`` case.
@@ -449,7 +449,7 @@ Browse options
 .. papis-config:: browse-query-format
 
     The query string that is to be searched for in the ``papis browse`` command
-    whenever a search engine is used (see :ref:`config-settings-browse-key`).
+    whenever a search engine is used (see :confval:`browse-key`).
 
 .. papis-config:: search-engine
 
@@ -465,7 +465,7 @@ Edit options
 
     In ``papis edit`` you can edit notes about the document. ``notes-name``
     is the default name of the notes file. The ``notes-name`` is formatted by the
-    :ref:`config-settings-formatter`, so that the filename of notes can be
+    :confval:`formatter`, so that the filename of notes can be
     dynamically defined, e.g.:
 
     .. code:: ini
@@ -477,7 +477,7 @@ Edit options
     When editing notes for the first time, a preliminary notes file will be
     generated based on a template. The path to this template is specified by
     ``notes-template``. The template will then be formatted by
-    :ref:`config-settings-formatter`. This can be useful to enforce the same
+    :confval:`formatter`. This can be useful to enforce the same
     style in the notes for all documents.
 
     Default value is set to the empty ``""``, which will return an empty notes
@@ -566,8 +566,8 @@ Open options
 .. papis-config:: mark-format-name
 
     This is the name of the mark to be passed to
-    :ref:`config-settings-mark-header-format` and other such settings, similarly
-    to :ref:`config-settings-format-doc-name`. For example, if we want to set
+    :confval:`mark-header-format` and other such settings, similarly
+    to :confval:`format-doc-name`. For example, if we want to set
     it to ``m``, then other settings must be consistent, e.g.
 
     .. code:: ini
@@ -578,14 +578,14 @@ Open options
 .. papis-config:: mark-header-format
 
     This is the format of the mark when shown in a picker, similarly to
-    :ref:`config-settings-header-format`. This can be changed to allow for
+    :confval:`header-format`. This can be changed to allow for
     more complex marks. However, by default, we just assume that each mark is
     of the form ``{"name": <NAME>, "value": <VALUE>}``.
 
 .. papis-config:: mark-match-format
 
     Format in which the mark name has to match the user input, similarly to
-    :ref:`config-settings-match-format`.
+    :confval:`match-format`.
 
 .. papis-config:: mark-opener-format
 
@@ -622,7 +622,7 @@ Serve (Web App) options
 
 .. papis-config:: serve-enable-timeline
 
-    If *True*, the :ref:`config-settings-time-stamp` of documents is used to
+    If *True*, the :confval:`time-stamp` of documents is used to
     create a timeline for when the documents were added.
 
 .. papis-config:: serve-timeline-max
@@ -748,7 +748,7 @@ Databases
 
         default-query-string = author:"John Smith"
 
-    would do the trick. Note that each :ref:`config-settings-database-backend`
+    would do the trick. Note that each :confval:`database-backend`
     will have a different search query, so this setting is specific to the
     default ``papis`` backend.
 
@@ -936,7 +936,7 @@ of fzf.
     Format for the entries for fzf.
     Notice that if you want colors you should add the ``--ansi`` flag to
     ``fzf-extra-flags`` and include the colors in the
-    :ref:`config-settings-header-format` as ``ansi`` escape sequences.
+    :confval:`header-format` as ``ansi`` escape sequences.
 
     The papis format string is given the additional variable ``c`` which
     contains the package ``colorama`` in it. Refer to the ``colorama``

--- a/doc/source/default-settings.rst
+++ b/doc/source/default-settings.rst
@@ -361,6 +361,7 @@ Add options
     be a duplicate, a suffix ``-a``, ``-b``, etc. is added to the names.
 
 .. papis-config:: add-file-name
+    :type: str
 
     Set the default file name for newly added documents, similarly to
     :ref:`config-settings-add-folder-name`. If it is not set, the names of the
@@ -528,6 +529,7 @@ Doctor options
    tags are given as a list in a document.
 
 .. papis-config:: doctor-key-type-check-separator
+    :type: str
 
     A separator used by the ``key-type`` check fixer. When converting from
     :class:`str` to :class:`list`, it is used to split the string into a list,
@@ -720,11 +722,14 @@ Downloaders
 -----------
 
 .. papis-config:: downloader-proxy
+    :type: str
 
     There is the possibility of download papers using a proxy. We use :mod:`requests`
     to handle web queries, which has extensive documentation on how to use
     proxies
     `here <https://docs.python-requests.org/en/latest/user/advanced/#proxies>`__.
+    This value should give a URL that can be used as a proxy for both HTTP
+    and HTTPS.
 
 .. papis-config:: isbn-service
 

--- a/doc/source/default-settings.rst
+++ b/doc/source/default-settings.rst
@@ -296,6 +296,31 @@ BibTeX options
     By default, this is set to ``and``, which is the separator used by
     BibTeX in its so-called *name-lists*.
 
+.. _bibtex-command-options:
+
+BibTeX command options
+^^^^^^^^^^^^^^^^^^^^^^
+
+.. papis-config:: default-read-bibfile
+    :section: bibtex
+
+    A path to a BibTex file that should be automatically read when using the
+    ``papis bibtex`` command. This should be equivalent to using
+    ``papis bibtex read file.bib`` when used with :confval:`auto-read`.
+
+.. papis-config:: default-save-bibfile
+    :section: bibtex
+
+    A path to a BibTex file that should be automatically saved when using the
+    ``papis bibtex`` command. This should be equivalent to using
+    ``papis bibtex save file.bib``.
+
+.. papis-config:: auto-read
+    :section: bibtex
+
+    A flag used in conjunction with :confval:`default-read-bibfile` to
+    automatically read a BibTeX file.
+
 .. _add-command-options:
 
 Add options

--- a/doc/source/developer_reference.rst
+++ b/doc/source/developer_reference.rst
@@ -121,6 +121,12 @@ Developer API reference
 .. automodule:: papis.plugin
     :members:
 
+``papis.sphinx_ext``
+--------------------
+
+.. automodule:: papis.sphinx_ext
+    :members:
+
 ``papis.testing``
 -----------------
 

--- a/doc/source/git.rst
+++ b/doc/source/git.rst
@@ -5,7 +5,7 @@ Git support
 
 Papis is made to work well with `git <https://git-scm.com/>`__ and has
 functionality in most of its command to interact with it. This functionality
-can be turned on by default by using the :ref:`config-settings-use-git`
+can be turned on by default by using the :confval:`use-git`
 configuration setting. This guide gives a description of a possible workflow
 for using Git with Papis. This is not the only workflow, but it is the most
 obvious.

--- a/papis/bibtex.py
+++ b/papis/bibtex.py
@@ -81,7 +81,7 @@ biblatex_software_types = frozenset([
 
 #: A set of known BibLaTeX types (as described in Section 2.1 of the `manual`_).
 #: These types are a union of the types above and can be extended with
-#: :ref:`config-settings-extra-bibtex-types`.
+#: :confval:`extra-bibtex-types`.
 bibtex_types = (
     bibtex_standard_types
     | frozenset(bibtex_type_aliases)
@@ -152,7 +152,7 @@ biblatex_software_keys = frozenset([
 
 #: A set of known BibLaTeX fields (as described in Section 2.2 of the `manual`_).
 #: These fields are a union of the above fields and can be extended with
-#: extended with :ref:`config-settings-extra-bibtex-keys`.
+#: extended with :confval:`extra-bibtex-keys`.
 bibtex_keys = (
     bibtex_standard_keys
     | frozenset(bibtex_key_aliases)
@@ -279,7 +279,7 @@ bibtex_key_converter: Dict[str, str] = {
 }
 
 #: A set of BibLaTeX fields to ignore when exporting from the Papis database.
-#: These can be extended with :ref:`config-settings-bibtex-ignore-keys`.
+#: These can be extended with :confval:`bibtex-ignore-keys`.
 bibtex_ignore_keys = (
     frozenset(["file"])
     | frozenset(papis.config.getlist("bibtex-ignore-keys"))
@@ -472,7 +472,7 @@ def create_reference(doc: Dict[str, Any], force: bool = False) -> str:
     to create one, otherwise the existing key is returned. When creating a new
     reference:
 
-    * the :ref:`config-settings-ref-format` key is used, if available,
+    * the :confval:`ref-format` key is used, if available,
     * the document DOI is used, if available,
     * a string is constructed from the document data (author, title, etc.).
 
@@ -526,11 +526,11 @@ def to_bibtex(document: papis.document.Document, *, indent: int = 2) -> str:
     are exported, while other keys are ignored (see :data:`bibtex_ignore_keys`)
     with the following rules:
 
-    * :ref:`config-settings-bibtex-unicode` is used to control whether the
+    * :confval:`bibtex-unicode` is used to control whether the
       field values can contain unicode characters.
-    * :ref:`config-settings-bibtex-journal-key` is used to define the field
+    * :confval:`bibtex-journal-key` is used to define the field
       name for the journal.
-    * :ref:`config-settings-bibtex-export-file` is used to also add a
+    * :confval:`bibtex-export-file` is used to also add a
       ``"file"`` field to the BibTeX entry, which can be used by e.g. Zotero to
       import documents.
 

--- a/papis/citations.py
+++ b/papis/citations.py
@@ -179,7 +179,7 @@ def fetch_and_save_citations(doc: papis.document.Document) -> None:
 
 def get_citations_file(doc: papis.document.Document) -> Optional[str]:
     """Get the document's citation file path (see
-    :ref:`config-settings-citations-file-name`).
+    :confval:`citations-file-name`).
 
     :returns: an absolute path to the citations file for *doc*.
     """
@@ -222,7 +222,7 @@ def get_citations(doc: papis.document.Document) -> Citations:
 
 
 def get_cited_by_file(doc: papis.document.Document) -> Optional[str]:
-    """Get the documents cited-by file (see :ref:`config-settings-cited-by-file-name`).
+    """Get the documents cited-by file (see :confval:`cited-by-file-name`).
 
     :returns: an absolute path to the cited-by file for *doc*.
     """

--- a/papis/commands/add.py
+++ b/papis/commands/add.py
@@ -170,7 +170,7 @@ def get_file_name(
         base_name_limit: int = 150) -> str:
     """Generate a file name for the document.
 
-    This function uses :ref:`config-settings-add-file-name` to generate a file
+    This function uses :confval:`add-file-name` to generate a file
     name for the *original_filepath* based on the document data. If the document
     does not provide the necessary keys, the original file name will be preserved
     (mostly as is).

--- a/papis/commands/bibtex.py
+++ b/papis/commands/bibtex.py
@@ -29,8 +29,10 @@ Local configuration file
 
 If you are working in a local folder where you have a ``bib`` file called
 ``main.bib``, you can avoid adding the repetitive ``read main.bib`` and
-``save main.bib`` by writing a local configuration file ``.papis.config`` for
-``papis bibtex`` to read and write automatically. This file should contain::
+``save main.bib`` by using the configuration values described in the
+:ref:`documentation <bibtex-command-options>`. You can create a local
+configuration file ``.papis.config`` for ``papis bibtex`` to read and write
+automatically. This file should contain::
 
     [bibtex]
     default-read-bibfile = main.bib

--- a/papis/commands/browse.py
+++ b/papis/commands/browse.py
@@ -7,14 +7,14 @@ to open it in a browser.  Also if it has a ``doc_url`` key, or a DOI, it will tr
 to compose URLs out of these to open it.
 
 If none of the above work, then it will try to use a search engine with the
-document's information (using the :ref:`config-settings-browse-query-format`
+document's information (using the :confval:`browse-query-format`
 configuration option).  You can select which search engine you want to use
-with the :ref:`config-settings-search-engine` setting.
+with the :confval:`search-engine` setting.
 
 Examples
 ^^^^^^^^
 
-By default, it will use the configuration option :ref:`config-settings-browse-key`
+By default, it will use the configuration option :confval:`browse-key`
 to try and form an URL to browse. You can bypass this option using the ``-k``
 flag issuing the command
 

--- a/papis/commands/doctor.py
+++ b/papis/commands/doctor.py
@@ -18,23 +18,23 @@ implemented
 * ``bibtex-type``: checks that the document type matches a known BibLaTeX type
   from :data:`papis.bibtex.bibtex_types`.
 * ``duplicated-keys``: checks that the keys provided by
-  :ref:`config-settings-doctor-duplicated-keys-keys` are not present in multiple
+  :confval:`doctor-duplicated-keys-keys` are not present in multiple
   documents. This is mainly meant to be used to check the ``ref`` key or other
   similar keys that are meant to be unique.
 * ``duplicated-values``: checks if the keys provided by
-  :ref:`config-settings-doctor-duplicated-values-keys` have any duplicated
+  :confval:`doctor-duplicated-values-keys` have any duplicated
   values. The keys are expected to be lists, e.g. ``files``.
 * ``files``: checks whether all the document files exist on the filesystem.
 * ``html-codes``: checks that no HTML codes (e.g. ``&amp;``) appear in the keys
-  provided by :ref:`config-settings-doctor-html-codes-keys`.
+  provided by :confval:`doctor-html-codes-keys`.
 * ``html-tags``: checks that no HTML or XML tags (e.g. ``<a>``) appear in the keys
-  provided by :ref:`config-settings-doctor-html-tags-keys`.
+  provided by :confval:`doctor-html-tags-keys`.
 * ``key-type``: checks the type of keys provided by
-  :ref:`config-settings-doctor-key-type-check-keys`, e.g. year should be an ``int``.
+  :confval:`doctor-key-type-check-keys`, e.g. year should be an ``int``.
   Lists can be automatically fixed (by splitting or joining) using the
-  :ref:`config-settings-doctor-key-type-check-separator` setting.
+  :confval:`doctor-key-type-check-separator` setting.
 * ``keys-exist``: checks that the keys provided by
-  :ref:`config-settings-doctor-keys-exist-keys` exist in the document.
+  :confval:`doctor-keys-exist-keys` exist in the document.
 * ``refs``: checks that the document has a valid reference (i.e. one that would
   be accepted by BibTeX and only contains valid characters).
 
@@ -188,7 +188,7 @@ def register_check(name: str, check: CheckFn) -> None:
     Register a new check.
 
     Registered checks are recognized by ``papis`` and can be used by users
-    in their configuration files through :ref:`config-settings-doctor-default-checks`
+    in their configuration files through :confval:`doctor-default-checks`
     or on the command line through the ``--checks`` flag.
     """
     REGISTERED_CHECKS[name] = Check(name=name, operate=check)
@@ -254,7 +254,7 @@ KEYS_EXIST_CHECK_NAME = "keys-exist"
 def keys_exist_check(doc: papis.document.Document) -> List[Error]:
     """
     Checks whether the keys provided in the configuration
-    option :ref:`config-settings-doctor-keys-exist-keys` exit in the document
+    option :confval:`doctor-keys-exist-keys` exit in the document
     and are non-empty.
 
     :returns: a :class:`list` of errors, one for each key that does not exist.
@@ -304,7 +304,7 @@ REFS_CHECK_NAME = "refs"
 def refs_check(doc: papis.document.Document) -> List[Error]:
     """
     Checks that a ref exists and if not it tries to create one
-    according to the :ref:`config-settings-ref-format` configuration option.
+    according to the :confval:`ref-format` configuration option.
 
     :returns: an error if the reference does not exist or contains invalid
         characters (as required by BibTeX).
@@ -360,7 +360,7 @@ DUPLICATED_KEYS_NAME = "duplicated-keys"
 def duplicated_keys_check(doc: papis.document.Document) -> List[Error]:
     """
     Check for duplicated keys in the list given by the
-    :ref:`config-settings-doctor-duplicated-keys-keys` configuration option.
+    :confval:`doctor-duplicated-keys-keys` configuration option.
 
     :returns: a :class:`list` of errors, one for each key with a value that already
         exist in the documents from the current query.
@@ -396,7 +396,7 @@ DUPLICATED_VALUES_NAME = "duplicated-values"
 
 def duplicated_values_check(doc: papis.document.Document) -> List[Error]:
     """
-    Check if the keys given by :ref:`config-settings-doctor-duplicated-values-keys`
+    Check if the keys given by :confval:`doctor-duplicated-values-keys`
     contain any duplicate entries. These keys are expected to be lists of items.
 
     :returns: a :class:`list` of errors, one for each key with a value that
@@ -624,9 +624,9 @@ def key_type_check(doc: papis.document.Document) -> List[Error]:
     """
     Check document keys have expected types.
 
-    The :ref:`config-settings-doctor-key-type-check-keys` configuration entry
+    The :confval:`doctor-key-type-check-keys` configuration entry
     defines a mapping of keys and their expected types. If the desired type is
-    a list, the :ref:`config-settings-doctor-key-type-check-separator` setting
+    a list, the :confval:`doctor-key-type-check-separator` setting
     can be used to split an existing string (and, similarly, if the desired type
     is a string, it can be used to join a list of items).
 
@@ -722,7 +722,7 @@ HTML_CODES_CHECK_NAME = "html-codes"
 
 def html_codes_check(doc: papis.document.Document) -> List[Error]:
     """
-    Checks that the keys in :ref:`config-settings-doctor-html-codes-keys`
+    Checks that the keys in :confval:`doctor-html-codes-keys`
     configuration options do not contain any HTML codes like ``&amp;`` etc.
 
     :returns: a :class:`list` of errors, one for each key that contains HTML codes.
@@ -763,7 +763,7 @@ HTML_TAGS_REGEX = re.compile(r"<.*?>")
 
 def html_tags_check(doc: papis.document.Document) -> List[Error]:
     """
-    Checks that the keys in :ref:`config-settings-doctor-html-tags-keys`
+    Checks that the keys in :confval:`doctor-html-tags-keys`
     configuration options do not contain any HTML tags like ``<href>`` etc.
 
     :returns: a :class:`list` of errors, one for each key that contains HTML codes.
@@ -827,7 +827,7 @@ def gather_errors(documents: List[papis.document.Document],
     unrecongnized checks are automatically skipped.
 
     :param checks: a list of checks to run over the documents. If not provided,
-        the default :ref:`config-settings-doctor-default-checks` are used.
+        the default :confval:`doctor-default-checks` are used.
     :returns: a list of all the errors gathered from the documents.
     """
     if not checks:

--- a/papis/commands/edit.py
+++ b/papis/commands/edit.py
@@ -1,6 +1,6 @@
 """
 This command edits the :ref:`info.yaml file <info-file>` of the documents.
-The editor used is defined by the :ref:`config-settings-editor` configuration
+The editor used is defined by the :confval:`editor` configuration
 setting.
 
 Command-line Interface

--- a/papis/commands/list.py
+++ b/papis/commands/list.py
@@ -120,7 +120,7 @@ def list_plugins(show_paths: bool = False,
             if verbose:
                 lines = [line for line in str(check.operate.__doc__).split("\n\n")
                          if line]
-                line = re.sub(r":ref:`config-settings-(.*)`", r"'\1'", lines[0].strip())
+                line = re.sub(r":confval:`(.*)`", r"'\1'", lines[0].strip())
                 results.append(f"    {line}")
         return results
 

--- a/papis/commands/open.py
+++ b/papis/commands/open.py
@@ -54,7 +54,7 @@ Examples
 
         papis open -d bohm
 
-  The file browser used is given by the :ref:`config-settings-file-browser` setting.
+  The file browser used is given by the :confval:`file-browser` setting.
 
 - Open a mark defined in the info file
 

--- a/papis/docmatcher.py
+++ b/papis/docmatcher.py
@@ -86,7 +86,7 @@ class DocMatcher:
     #: A :class:`MatcherCallable` used to match the document to the
     #: :attr:`parsed_search`.
     matcher: ClassVar[Optional[MatcherCallable]] = None
-    #: A format string (defaulting to :ref:`config-settings-match-format`) used
+    #: A format string (defaulting to :confval:`match-format`) used
     #: to match the parsed search results if no document key is present.
     match_format: ClassVar[str] = papis.config.getstring("match-format")
 

--- a/papis/document.py
+++ b/papis/document.py
@@ -144,8 +144,8 @@ def keyconversion_to_data(conversions: Sequence[KeyConversionPair],
 def author_list_to_author(data: Dict[str, Any]) -> str:
     """Convert a list of authors into a single author string.
 
-    This uses the :ref:`config-settings-multiple-authors-separator` and the
-    :ref:`config-settings-multiple-authors-format` settings to construct the
+    This uses the :confval:`multiple-authors-separator` and the
+    :confval:`multiple-authors-format` settings to construct the
     concatenated authors.
 
     :param data: a :class:`dict` that contains an ``"author_list"`` key to
@@ -525,7 +525,7 @@ def delete(document: Document) -> None:
 def describe(document: Union[Document, Dict[str, Any]]) -> str:
     """
     :returns: a string description of the current document using
-        :ref:`config-settings-document-description-format`.
+        :confval:`document-description-format`.
     """
     return papis.format.format(
         papis.config.getstring("document-description-format"),

--- a/papis/format.py
+++ b/papis/format.py
@@ -45,7 +45,7 @@ class Formatter:
         :param fmt: a format string understood by the formatter.
         :param doc: an object convertible to a document.
         :param doc_key: the name of the document in the format string. By
-            default, this falls back to :ref:`config-settings-format-doc-name`.
+            default, this falls back to :confval:`format-doc-name`.
         :param default: an optional string to use as a default value if the
             formatting fails. If no default is given, a :exc:`FormatFailedError`
             will be raised.
@@ -62,7 +62,7 @@ class PythonFormatter(Formatter):
     (*str.format* based) format string.
 
     This formatter is named ``"python"`` and can be set using the
-    :ref:`config-settings-formatter` setting in the configuration file. The
+    :confval:`formatter` setting in the configuration file. The
     formatted string has access to the ``doc`` variable, that is always a
     :class:`papis.document.Document`. A string using this formatter can look
     like
@@ -110,7 +110,7 @@ class Jinja2Formatter(Formatter):
     templates.
 
     This formatter is named ``"jinja2"`` and can be set using the
-    :ref:`config-settings-formatter` setting in the configuration file. The
+    :confval:`formatter` setting in the configuration file. The
     formatted string has access to the ``doc`` variable, that is always a
     :class:`papis.document.Document`. A string using this formatter can look
     like
@@ -181,7 +181,7 @@ def get_formatter(name: Optional[str] = None) -> Formatter:
     will return the same formatter.
 
     :param name: the name of the desired formatter, by default this uses
-        the value of :ref:`config-settings-formatter`.
+        the value of :confval:`formatter`.
     """
     global FORMATTER
 

--- a/papis/notes.py
+++ b/papis/notes.py
@@ -23,7 +23,7 @@ def notes_path(doc: papis.document.Document) -> str:
     """Get the path to the notes file corresponding to *doc*.
 
     If the document does not have attached notes, a filename is constructed (using
-    the :ref:`config-settings-notes-name` setting) in the document's main folder.
+    the :confval:`notes-name` setting) in the document's main folder.
 
     :returns: a absolute filename that corresponds to the attached notes for
         *doc* (this file does not necessarily exist).
@@ -43,7 +43,7 @@ def notes_path_ensured(doc: papis.document.Document) -> str:
 
     If the notes do not exist, a new file is created using :func:`notes_path`
     and filled with the contents of the template given by the
-    :ref:`config-settings-notes-template` configuration option.
+    :confval:`notes-template` configuration option.
 
     :returns: an absolute filename that corresponds to the attached notes for *doc*.
     """

--- a/papis/pick.py
+++ b/papis/pick.py
@@ -64,7 +64,7 @@ def pick(items: Sequence[T],
     """Load a :class:`Picker` plugin and select a subset of *items*.
 
     The arguments to this function match those of :meth:`Picker.__call__`. The
-    specific picker is chosen through the :ref:`config-settings-picktool`
+    specific picker is chosen through the :confval:`picktool`
     configuration option.
 
     :returns: a subset of *items* that were picked.
@@ -91,10 +91,10 @@ def pick_doc(
         ) -> List[papis.document.Document]:
     """Pick from a sequence of *documents* using :func:`pick`.
 
-    This function uses the :ref:`config-settings-header-format-file` setting
-    or, if not available, the :ref:`config-settings-header-format` setting
+    This function uses the :confval:`header-format-file` setting
+    or, if not available, the :confval:`header-format` setting
     to construct a *header_filter* for the picker. It also uses the configuration
-    setting :ref:`config-settings-match-format` to construct a *match_filter*.
+    setting :confval:`match-format` to construct a *match_filter*.
 
     :arg documents: a sequence of documents.
     :returns: a subset of *documents* that was picked.

--- a/papis/sphinx_ext.py
+++ b/papis/sphinx_ext.py
@@ -24,6 +24,9 @@ class PapisConfig(Directive):
     add_index: int = True
 
     def run(self) -> Any:
+        # NOTE: these are imported to register additional config settings
+        import papis.commands.bibtex    # noqa: F401
+
         from papis.config import get_general_settings_name, get_default_settings
 
         default_settings = get_default_settings()

--- a/papis/sphinx_ext.py
+++ b/papis/sphinx_ext.py
@@ -1,0 +1,137 @@
+import os
+import sys
+import docutils
+from typing import Any, Callable, Dict, List, Optional
+
+from sphinx import application
+from sphinx_click.ext import ClickDirective
+from docutils.parsers.rst import Directive
+
+
+class CustomClickDirective(ClickDirective):     # type: ignore[misc]
+    def run(self) -> Any:
+        sections = super().run()
+
+        # NOTE: just remove the title section so we can add our own
+        return sections[0].children[1:]
+
+
+class PapisConfig(Directive):
+    has_content: bool = True
+    optional_arguments: int = 3
+    required_arguments: int = 1
+    option_spec: Dict[str, type] = {"default": str, "section": str, "description": str}
+    add_index: int = True
+
+    def run(self) -> Any:
+        from papis.config import get_general_settings_name, get_default_settings
+
+        default_settings = get_default_settings()
+        key = self.arguments[0]
+
+        section = self.options.get("section", get_general_settings_name())
+        default = self.options.get(
+            "default",
+            default_settings.get(section, {}).get(key, "<missing>"))
+
+        lines = []
+        lines.append("")
+        lines.append(".. _config-{section}-{key}:".format(section=section, key=key))
+        lines.append("")
+        lines.append("`{key} <#config-{section}-{key}>`__"
+                     .format(section=section, key=key))
+
+        if "\n" in str(default):
+            lines.append("    - **Default**: ")
+            lines.append("        .. code::")
+            lines.append("")
+            for lindef in default.split("\n"):
+                lines.append(3 * "    " + lindef)
+        else:
+            lines.append("    - **Default**: ``{value!r}``"
+                         .format(value=default))
+        lines.append("")
+
+        view = docutils.statemachine.ViewList(lines)
+        self.content = view + self.content  # type: ignore[has-type]
+
+        node = docutils.nodes.paragraph()
+        node.document = self.state.document
+        self.state.nested_parse(self.content, self.content_offset, node)
+
+        return node.children
+
+
+def make_link_resolve(
+        github_project_url: str,
+        revision: str) -> Callable[[str, Dict[str, Any]], Optional[str]]:
+    def linkcode_resolve(domain: str, info: Dict[str, Any]) -> Optional[str]:
+        url = None
+        if domain != "py" or not info["module"]:
+            return url
+
+        modname = info["module"]
+        objname = info["fullname"]
+
+        mod = sys.modules.get(modname)
+        if not mod:
+            return url
+
+        obj = mod
+        for part in objname.split("."):
+            try:
+                obj = getattr(obj, part)
+            except Exception:
+                return url
+
+        import inspect
+
+        try:
+            filepath = "{}.py".format(os.path.join(*obj.__module__.split(".")))
+        except Exception:
+            return url
+
+        if filepath is None:
+            return url
+
+        try:
+            source, lineno = inspect.getsourcelines(obj)
+        except Exception:
+            return url
+        else:
+            linestart, linestop = lineno, lineno + len(source) - 1
+
+        return (
+            "{}/blob/{}/{}#L{}-L{}"
+            .format(github_project_url, revision, filepath, linestart, linestop)
+        )
+
+    return linkcode_resolve
+
+
+def remove_module_docstring(app: application.Sphinx,
+                            what: str,
+                            name: str,
+                            obj: object,
+                            options: Any,
+                            lines: List[str]) -> None:
+    # NOTE: this is used to remove the module documentation for commands so that
+    # we can show the module members in the `Developer API Reference` section
+    # without the tutorial / examples parts.
+    if what == "module" and ".commands." in name and options.get("members"):
+        del lines[:]
+
+
+def setup(app: application.Sphinx) -> Dict[str, Any]:
+    app.setup_extension("sphinx.ext.linkcode")
+    app.setup_extension("sphinx_click.ext")
+
+    app.add_directive("click", CustomClickDirective, override=True)
+    app.add_directive("papis-config", PapisConfig)
+
+    app.connect("autodoc-process-docstring", remove_module_docstring)
+
+    return {
+        "parallel_read_safe": True,
+        "parallel_write_safe": True,
+    }

--- a/papis/utils.py
+++ b/papis/utils.py
@@ -37,8 +37,8 @@ def get_session() -> "requests.Session":
     """Create a :class:`requests.Session` for ``papis``.
 
     This session has the expected ``User-Agent`` (see
-    :ref:`config-settings-user-agent`), proxy (see
-    :ref:`config-settings-downloader-proxy`) and other settings used
+    :confval:`user-agent`), proxy (see
+    :confval:`downloader-proxy`) and other settings used
     for ``papis``. It is recommended to use it instead of creating a
     :class:`requests.Session` at every call site.
     """
@@ -171,7 +171,7 @@ def general_open(file_name: str,
 
     :param file_name: a file path to open.
     :param key: a key in the configuration file to determine the opener used,
-        e.g. :ref:`config-settings-opentool`.
+        e.g. :confval:`opentool`.
     :param default_opener: an existing executable that can be used to open the
         file given by *file_name*. By default, the opener given by
         *key*, if any, or the default ``papis`` opener are used.
@@ -202,7 +202,7 @@ def general_open(file_name: str,
 
 
 def open_file(file_path: str, wait: bool = True) -> None:
-    """Open file using the configured :ref:`config-settings-opentool`.
+    """Open file using the configured :confval:`opentool`.
 
     :param file_path: a file path to open.
     :param wait: if *True* wait for the process to finish, otherwise detach the
@@ -217,7 +217,7 @@ def get_folders(folder: str) -> List[str]:
     This is the main indexing routine. It looks inside *folder* and crawls
     the whole directory structure in search of subfolders containing an ``info``
     file. The name of the file must match the configured
-    :ref:`config-settings-info-name`.
+    :confval:`info-name`.
 
     :param folder: root folder to look into.
     :returns: List of folders containing an ``info`` file.
@@ -296,7 +296,7 @@ def locate_document_in_lib(document: papis.document.Document,
                            library: Optional[str] = None) -> papis.document.Document:
     """Locate a document in a library.
 
-    This function uses the :ref:`config-settings-unique-document-keys`
+    This function uses the :confval:`unique-document-keys`
     to determine if the current document matches any document in the library.
     The first document for which a key matches exactly will be returned.
 
@@ -331,7 +331,7 @@ def locate_document(
         ) -> Optional[papis.document.Document]:
     """Locate a *document* in a list of *documents*.
 
-    This function uses the :ref:`config-settings-unique-document-keys`
+    This function uses the :confval:`unique-document-keys`
     to determine if the current document matches any document in the list.
     The first document for which a key matches exactly will be returned.
 
@@ -399,7 +399,7 @@ def update_doc_from_data_interactively(
 def get_cache_home() -> str:
     """Get default cache directory.
 
-    This will retrieve the :ref:`config-settings-cache-dir` configuration setting.
+    This will retrieve the :confval:`cache-dir` configuration setting.
     It is ``XDG`` standard compatible.
 
     :returns: the absolute path for the cache main folder.

--- a/setup.cfg
+++ b/setup.cfg
@@ -55,3 +55,6 @@ ignore_missing_imports = True
 
 [mypy-whoosh.*]
 ignore_missing_imports = True
+
+[mypy-sphinx_click.*]
+ignore_missing_imports = True


### PR DESCRIPTION
This improves how configuration values are handled in the docs:
* It adds a new directive `:confval:` that's used by the wrapping `papis-config` directive to render the configuration values in a nicer way.
* Adds a `type: ...` entry to each config to show what type we expect it to be.
* They can now be referenced normally using `:confval:<name>` just like `:class:` or `:func:` roles.

It also moves the Sphinx directives from `docs/source/conf.py` to `papis/sphinx_ext.py` so that they can be used by external plugins without copy-pasting them. And for some pretty pictures before and after:

Before:
<img src="https://github.com/papis/papis/assets/777240/3b53fc15-304c-4bdf-977a-c6e6bc346178" width=600></img>

After:
<img src="https://github.com/papis/papis/assets/777240/725d91fa-0f82-4e25-8b7a-c9c164d5f9cf" width=600></img>
