### PR TITLE
Fix spelling errors

### DIFF
--- a/.codespell-ignore
+++ b/.codespell-ignore
@@ -1,0 +1,8 @@
+aci
+annote
+formater
+hart
+ist
+selv
+shs
+theses

--- a/Makefile
+++ b/Makefile
@@ -48,6 +48,14 @@ mypy:								## Run mypy (type annotations)
 	$(PYTHON) -m mypy papis
 .PHONY: mypy
 
+codespell:							## Run codespell (spellchecking)
+	@codespell --summary \
+		--skip build --skip resources --skip data --skip LTWA.json \
+		--uri-ignore-words-list '*' \
+		--ignore-words .codespell-ignore \
+		contrib doc examples papis scripts tests tools
+.PHONY: codespell
+
 ci-install:							## Install dependencies like on the CI
 	bash tools/ci-install.sh
 .PHONY: ci-install

--- a/examples/scripts/papis-abbrev
+++ b/examples/scripts/papis-abbrev
@@ -72,7 +72,7 @@ try:
 except FileNotFoundError:
     LTWA_ABBREVS = {}
 
-# List of short words that are ommited in abbreviations
+# List of short words that are omitted in abbreviations
 ABBREV_IGNORE_WORDS = frozenset([
     # en
     "of", "in", "the", "and", "part",

--- a/examples/scripts/papis-check
+++ b/examples/scripts/papis-check
@@ -55,7 +55,7 @@ papis.config.register_default_settings({
 
 
 def check_files(document: papis.document.Document) -> bool:
-    """Check for the exsitence of the document's files.
+    """Check for the existence of the document's files.
 
     :returns: *False* if some file does not exist, *True* otherwise
 

--- a/examples/scripts/papis-mail
+++ b/examples/scripts/papis-mail
@@ -20,7 +20,7 @@ if [[ ! -e ${folder_name} ]]; then
   exit 1
 fi
 
-echo "Ziping folder (${folder_name} => ${zip_name})"
+echo "Zipping folder (${folder_name} => ${zip_name})"
 zip -r "${zip_name}" "${folder_name}"
 
 ${mail_agent} -a "${zip_name}"

--- a/papis/arxiv.py
+++ b/papis/arxiv.py
@@ -160,7 +160,7 @@ def pdf_to_arxivid(
 
     :param filepath: Path to the pdf file
     :param maxlines: Maximum number of lines that should be checked
-        For some documnets, it would spend a long time trying to look for
+        For some documents, it would spend a long time trying to look for
         a arxivid, and arxivids in the middle of documents don't tend to be the
         correct arxivid of the document.
     :returns: arxivid or None

--- a/papis/commands/default.py
+++ b/papis/commands/default.py
@@ -240,7 +240,7 @@ def run(verbose: bool,
     sections = papis.config.get_configuration().sections()
     for pair in set_list:
         # NOTE: search for a matching section so that we can overwrite entries
-        # from the command-line as well (the section takes precendence)
+        # from the command-line as well (the section takes precedence)
         key, value, section = pair[0], pair[1], None
         for s in sections:
             if key.startswith(s):

--- a/papis/database/base.py
+++ b/papis/database/base.py
@@ -107,11 +107,11 @@ class Database(ABC):
 
     def maybe_compute_id(self, doc: papis.document.Document) -> None:
         """
-        Compute a papis id for the document doc.
-        If the document has already an id, then ignore the document,
-        and it *will not check for duplications*.
-        Otherwise it will try to create a new id that is unique in this
-        database and update the document yaml accordignly.
+        Compute a Papis ID for the document doc.
+
+        If the document already has an ID, then the document is skipped (without
+        checking for duplicates). Otherwise try to create a new ID that is
+        unique in this database and update the document YAML accordingly.
         """
         key_name = papis.id.key_name()
         if key_name in doc:

--- a/papis/document.py
+++ b/papis/document.py
@@ -499,7 +499,7 @@ def dump(document: Document) -> str:
 
     data = dict(document)
 
-    # NOTE: poping some usually very long and unhelpful fields
+    # NOTE: popping some usually very long and unhelpful fields
     data.pop("citations", None)
     data.pop("abstract", None)
     data.pop("papis_id", None)

--- a/papis/sphinx_ext.py
+++ b/papis/sphinx_ext.py
@@ -86,7 +86,7 @@ class PapisConfig(Directive):
     optional_arguments: int = 3
     #: Number of required arguments to the directive.
     required_arguments: int = 1
-    #: A descrption of the arguments, mapping names to validator functions.
+    #: A description of the arguments, mapping names to validator functions.
     option_spec: Dict[str, type] = {"default": str, "section": str, "type": str}
     add_index: int = True
 

--- a/papis/utils.py
+++ b/papis/utils.py
@@ -436,7 +436,7 @@ def get_matching_importer_or_downloader(
     :param download_files: if *True*, importers and downloaders also try to
         download files (PDFs, etc.) instead of just metadata.
     """
-    # FIXME: this is here for backwards compatiblity and should be removed
+    # FIXME: this is here for backwards compatibility and should be removed
     # before we release the next version
     if only_data is not None and download_files is not None:
         raise ValueError("Cannot pass both 'only_data' and 'download_files'")
@@ -506,7 +506,7 @@ def get_matching_importer_by_name(
     :param download_files: if *True*, importers and downloaders also try to
         download files (PDFs, etc.) instead of just metadata.
     """
-    # FIXME: this is here for backwards compatiblity and should be removed
+    # FIXME: this is here for backwards compatibility and should be removed
     # before we release the next version
     if only_data is not None and download_files is not None:
         raise ValueError("Cannot pass both 'only_data' and 'download_files'")
@@ -559,7 +559,7 @@ def collect_importer_data(
     :param use_files: if *True*, both metadata and files are collected
         from the importers.
     """
-    # FIXME: this is here for backwards compatiblity and should be removed
+    # FIXME: this is here for backwards compatibility and should be removed
     # before we release the next version
     if only_data is not None and use_files is not None:
         raise ValueError("Cannot pass both 'only_data' and 'use_files'")

--- a/tests/commands/test_cache.py
+++ b/tests/commands/test_cache.py
@@ -59,7 +59,7 @@ def test_rm_add_update(tmp_library: TemporaryLibrary) -> None:
 
     # update
     ###################################################
-    # NOTE: modifying `doc` diretly may modify the version in the database, so
+    # NOTE: modifying `doc` directly may modify the version in the database, so
     # this modifies the info file behind its back completely to check the update
     doc_dict = {**dict(doc), "cache": "test-update"}
     papis.yaml.data_to_yaml(doc.get_info_file(), doc_dict, allow_unicode=True)

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -76,7 +76,7 @@ def test_locate_document(tmp_config: TemporaryConfiguration) -> None:
         from_data(
             {
                 "doi": "10.123/12afad12",
-                "author": "noone really",
+                "author": "no one really",
                 "title": "Hello world"
             }
         ),
@@ -92,7 +92,7 @@ def test_locate_document(tmp_config: TemporaryConfiguration) -> None:
     found_doc = locate_document(doc, docs)
     assert found_doc is None
 
-    doc = from_data({"author": "noone really"})
+    doc = from_data({"author": "no one really"})
     found_doc = locate_document(doc, docs)
     assert found_doc is None
 


### PR DESCRIPTION
This adds a simple codespell target to the Makefile and fixes all the spelling errors that it reports. There's just a few though, so not a big change.