### PR TITLE
add convenience commands to nix flake

### DIFF
--- a/HACKING.md
+++ b/HACKING.md
@@ -35,6 +35,7 @@ The docs can be generated with
 ```
 make doc
 ```
+### Containers
 
 To quickly get things up and running, you can also use docker/podman:
 ```
@@ -47,6 +48,16 @@ docker run -v $(pwd):/papis --rm -it papisdev bash
 ```
 
 (or replace `docker` with `podman` if you prefer)
+
+### Nix
+
+If you're using Nix, you can also use the flake and get a development shell up with `nix develop`.
+
+This also gives you access to the following convenience commands to interact with the containers (they require either docker or podman to run):
+
+- `papis-build-container`: build the container
+- `papis-run-container-tests`: run the CI tests in the container
+- `papis-run-container-interactive`: enter the container interactively and populate the library with some test documents
 
 Adding tests
 ------------


### PR DESCRIPTION
I've been wanting a container in which I can try out various commands and see how they work. Which is why I made the below small script number 3 for my development shell. While I was doing that, it seemed logical to also create 1 + 2:

1. `papis-build-container` (builds the container)
2. `papis-run-container-tests` (runs the tests in the container)
3. `papis-run-container-interactive` (drops you into a shell in the container after populating the library)

The commands use `podman` or `docker`, depending on which is in the path.

I could also make these individual scripts so that they would be available for non-nix users, if there is a desire for that.