### PR TITLE
tests: add a fixture for doctests

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -12,6 +12,7 @@ multiline-quotes = double
 
 [tool:pytest]
 addopts = --doctest-modules
+          --wrap-doctests
           --ignore=papis/downloaders/thesesfr.py
           --cov=papis
           --verbose


### PR DESCRIPTION
This adds a `conftest.py` with a little fixture to the root `papis` folder. It's meant to run the doctests in a clean configuration (not the one in the user's `~/.config/papis`)

@alejandrogallo It's a little hacky to add a test file to the package folder, but it should help users run and pass the tests (if not using a docker container or similar). What do you think?

Fixes #757.