### PR TITLE
 commands.addto: add expected suffix

### DIFF
--- a/papis/commands/addto.py
+++ b/papis/commands/addto.py
@@ -56,7 +56,10 @@ def run(document: papis.document.Document,
         raise DocumentFolderNotFound(papis.document.describe(document))
 
     from papis.utils import create_identifier
-    suffix = create_identifier(skip=len(document.get_files()))
+
+    nfiles = len(document.get_files())
+    gen_suffix = create_identifier(skip=nfiles - 1)
+    suffix = "" if nfiles == 0 else next(gen_suffix)
 
     from papis.downloaders import download_document
     from papis.commands.add import get_file_name
@@ -78,7 +81,7 @@ def run(document: papis.document.Document,
         new_filename = get_file_name(
             document,
             local_in_file_path,
-            suffix=next(suffix)
+            suffix=suffix
         )
         out_file_path = os.path.join(doc_folder, new_filename)
         new_file_list.append(new_filename)
@@ -106,6 +109,8 @@ def run(document: papis.document.Document,
             os.unlink(tmp_file.name)
             tmp_file = None
 
+        suffix = next(gen_suffix)
+
     if "files" not in document:
         document["files"] = []
 
@@ -113,7 +118,6 @@ def run(document: papis.document.Document,
     papis.api.save_doc(document)
 
     if git:
-
         for r in new_file_list + [document.get_info_file()]:
             papis.git.add(doc_folder, r)
         papis.git.commit(

--- a/papis/utils.py
+++ b/papis/utils.py
@@ -245,7 +245,7 @@ def create_identifier(input_list: Optional[str] = None, skip: int = 0) -> Iterat
     to ensure uniqueness.
 
     :param input_list: list to iterate over
-    :param skip: number of identifiers to skip.
+    :param skip: number of identifiers to skip (negative integers are set to 0).
 
     >>> import string
     >>> m = create_identifier(string.ascii_lowercase)
@@ -262,7 +262,7 @@ def create_identifier(input_list: Optional[str] = None, skip: int = 0) -> Iterat
             for s in product(inputs, repeat=n):
                 yield "".join(s)
 
-    yield from islice(ids(), skip, None)
+    yield from islice(ids(), max(skip, 0), None)
 
 
 def clean_document_name(doc_path: str, is_path: bool = True) -> str:

--- a/tests/commands/test_addto.py
+++ b/tests/commands/test_addto.py
@@ -4,6 +4,25 @@ import papis.database
 from papis.testing import TemporaryLibrary, PapisRunner
 
 
+def test_addto_run_no_files(tmp_library: TemporaryLibrary) -> None:
+    import papis.config
+
+    papis.config.set("add-file-name", "{doc[author]}-{doc[title]}")
+
+    from papis.commands.addto import run
+
+    db = papis.database.get()
+    doc, = db.query_dict({"author": "popper"})
+    assert len(doc.get_files()) == 0
+
+    inputfile = tmp_library.create_random_file("pdf")
+    run(doc, [inputfile])
+
+    files = doc.get_files()
+    assert len(files) == 1
+    assert os.path.basename(files[0]) == "k.-popper-the-open-society.pdf"
+
+
 def test_addto_run(tmp_library: TemporaryLibrary, nfiles: int = 5) -> None:
     from papis.commands.addto import run
 


### PR DESCRIPTION
In `addto` we would always add the previous suffix incorrectly, e.g. if there's no file it would add an `-a`, if there's one file it would add a `-b`, etc.

xref: https://github.com/papis/papis/discussions/762#discussion-6294918