### PR TITLE
Support custom context for importers

### DIFF
--- a/papis/importer.py
+++ b/papis/importer.py
@@ -83,7 +83,7 @@ class Importer:
         if not name:
             name = type(self).__module__.split(".")[-1]
 
-        self.ctx: Context = ctx or Context()
+        self.ctx: Context = ctx
         self.uri: str = uri
         self.name: str = name
         self.logger = papis.logging.get_logger(f"papis.importer.{self.name}")

--- a/tests/test_importer.py
+++ b/tests/test_importer.py
@@ -23,6 +23,34 @@ def test_context() -> None:
     assert not ctx
 
 
+def test_custom_context_importer() -> None:
+    from papis.importer import Context, Importer
+
+    class CustomContext(Context):
+        def __init__(self) -> None:
+            super().__init__()
+            self.extra = ""
+
+    class CustomContextImporter(Importer):
+        ctx: CustomContext
+
+        def __init__(self, uri: str = "", **kwargs: Any) -> None:
+            super().__init__(uri=uri, name="SimpleImporter", ctx=CustomContext())
+
+        @classmethod
+        def match(cls, uri: str) -> "CustomContextImporter":
+            importer = CustomContextImporter(uri=uri, ctx=CustomContext())
+            return importer
+
+        def fetch(self) -> None:
+            self.ctx.extra = "foobar"
+
+    importer = CustomContextImporter()
+    assert importer.ctx.extra == ""
+    importer.fetch()
+    assert importer.ctx.extra == "foobar"
+
+
 def test_cache() -> None:
     from papis.importer import Importer, cache
 


### PR DESCRIPTION
Hi!

I noticed during my PR for Zenodo that, in order for an `Importer` to store stuff that had to survive different calls (say, `fetch`, then `match` or whatever), you had to add custom attributes into `self`. That's what `arxiv` [is currently doing](https://github.com/papis/papis/blob/b3ada0efcf16c2d0272c5f79858659629634a22b/papis/arxiv.py#L346).

In [this comment](https://github.com/papis/papis/pull/770#discussion_r1518578728) it was proposed that perhaps there should be a way to let Importers store additional attributes.

Is that what `Context` is for?

In my importer, [you can see](https://github.com/papis/papis/pull/770/files#diff-740a873f36cf874d9d4c3f9842878e2c79d241f52f7510defd1857ac8a8b7e9fR146) I try to use the context to store data that is for internal use.

But the current importer implementation fails to use a custom Context: it will let you pass a subclassed `Context`  into the importer constructor, but it won't pass [the check in line 86](https://github.com/papis/papis/blob/b3ada0efcf16c2d0272c5f79858659629634a22b/papis/importer.py#L86), because a new context will be empty by default, failing the truth check. Thus, a new `Context` is created into `self.ctx`, ignoring the one passed as argument.

I think this check is not necessary, because a default `Context` is assigned into `self.ctx` in case there wasn't one passed as argument. Or I might be missing a reason?