### PR TITLE
Add zenodo entrypoint

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -199,6 +199,7 @@ setup(
             "pdf2doi=papis.crossref:DoiFromPdfImporter",
             "pmid=papis.pubmed:Importer",
             "yaml=papis.yaml:Importer",
+            "zenodo=papis.zenodo:Importer",
         ],
         "papis.picker": [
             "fzf=papis.fzf:Picker",


### PR DESCRIPTION
@kiike Tried to play around a bit with the Zenodo importer and noticed it didn't have an entrypoint set. How did you test it?

Also found a little bug: the filename from Zenodo could be a relative path e.g. `username/filename.zip`, in which case just writing the file wouldn't work because the folder does not exist. I modified it to just use the basename instead. 