### PR TITLE
Fix tests picking up config.py

### DIFF
--- a/papis/database/cache.py
+++ b/papis/database/cache.py
@@ -66,8 +66,8 @@ def filter_documents(
 
     """
     papis.docmatcher.DocMatcher.set_search(search)
-    papis.docmatcher.DocMatcher.parse()
     papis.docmatcher.DocMatcher.set_matcher(match_document)
+    papis.docmatcher.DocMatcher.parse()
 
     logger.debug("Filtering %d docs (search '%s').", len(documents), search)
 

--- a/papis/docmatcher.py
+++ b/papis/docmatcher.py
@@ -88,7 +88,7 @@ class DocMatcher:
     matcher: ClassVar[Optional[MatcherCallable]] = None
     #: A format string (defaulting to :confval:`match-format`) used
     #: to match the parsed search results if no document key is present.
-    match_format: ClassVar[str] = papis.config.getstring("match-format")
+    match_format: ClassVar[str] = ""
 
     @classmethod
     def return_if_match(
@@ -135,6 +135,7 @@ class DocMatcher:
             >>> DocMatcher.search
             'author:Hummel'
         """
+
         cls.search = search
 
     @classmethod
@@ -169,7 +170,10 @@ class DocMatcher:
         """
         if search is None:
             search = cls.search
+
+        cls.match_format = papis.config.getstring("match-format")
         cls.parsed_search = parse_query(search)
+
         return cls.parsed_search
 
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -237,6 +237,8 @@ packages = ["papis"]
 
 [tool.pytest.ini_options]
 addopts = [
+    "--wrap-doctests",
+    "--tmp-xdg-config-home",
     "--doctest-modules",
     "--ignore=papis/downloaders/thesesfr.py",
     "--cov=papis",

--- a/tests/database/test_papis.py
+++ b/tests/database/test_papis.py
@@ -1,19 +1,17 @@
 import os
 
-import papis.config
-import papis.database
-from papis.database.cache import Database
-
 import pytest
 from papis.testing import TemporaryLibrary
 
 
 @pytest.mark.library_setup(settings={"database-backend": "papis"})
 def test_database_query(tmp_library: TemporaryLibrary) -> None:
+    import papis.database
+
     db = papis.database.get()
     db.initialize()
 
-    assert isinstance(db, Database)
+    assert isinstance(db, papis.database.Database)
     assert db.get_backend_name() == "papis"
 
     docs = db.query(".")
@@ -27,8 +25,10 @@ def test_database_query(tmp_library: TemporaryLibrary) -> None:
 
 @pytest.mark.library_setup(settings={"database-backend": "papis"})
 def test_database_reload(tmp_library: TemporaryLibrary) -> None:
+    import papis.database
+
     db = papis.database.get()
-    assert isinstance(db, Database)
+    assert isinstance(db, papis.database.Database)
 
     ndocs = len(db.get_all_documents())
     db.save()
@@ -40,8 +40,10 @@ def test_database_reload(tmp_library: TemporaryLibrary) -> None:
 
 @pytest.mark.library_setup(settings={"database-backend": "papis"})
 def test_database_missing(tmp_library: TemporaryLibrary) -> None:
+    import papis.database
+
     db = papis.database.get()
-    assert isinstance(db, Database)
+    assert isinstance(db, papis.database.Database)
 
     docs = db.get_all_documents()
     doc = docs[0]
@@ -54,8 +56,10 @@ def test_database_missing(tmp_library: TemporaryLibrary) -> None:
 
 
 def test_filter_documents() -> None:
+    from papis.document import from_data
     from papis.database.cache import filter_documents
-    document = papis.document.from_data({"author": "einstein"})
+
+    document = from_data({"author": "einstein"})
 
     assert len(filter_documents([document], search="einstein")) == 1
     assert len(filter_documents([document], search="author : ein")) == 1
@@ -64,6 +68,8 @@ def test_filter_documents() -> None:
 
 @pytest.mark.library_setup(settings={"database-backend": "papis"})
 def test_cache_path(tmp_library: TemporaryLibrary) -> None:
+    import papis.database
+
     db = papis.database.get()
     _ = db.get_documents()
 

--- a/tests/test_docmatcher.py
+++ b/tests/test_docmatcher.py
@@ -1,21 +1,25 @@
 import os
 import yaml
 from functools import partial
-from typing import Any, List, Optional, Pattern, Tuple
+from typing import Any, List, Optional, Pattern, Tuple, TYPE_CHECKING
 
-import papis.document
 from papis.testing import TemporaryConfiguration
 
+if TYPE_CHECKING:
+    from papis.document import Document
 
-def get_docs() -> List[papis.document.Document]:
+
+def get_docs() -> List["Document"]:
+    from papis.document import from_data
+
     yamlfile = os.path.join(os.path.dirname(__file__), "data", "licl.yaml")
     with open(yamlfile) as f:
-        return [papis.document.from_data(data) for data in yaml.safe_load_all(f)]
+        return [from_data(data) for data in yaml.safe_load_all(f)]
 
 
 def docmatcher_matcher(
         res: Tuple[bool, int],
-        document: papis.document.Document,
+        document: "Document",
         search: Pattern[str],
         match_format: Optional[str] = None,
         doc_key: Optional[str] = None,


### PR DESCRIPTION
@jghauser This should hopefully fix the issues you were seeing. I added a `~/.config/papis/config.py` with just `raise RuntimeError` and it's never loaded now. 

* The first commit adds a little hack so that we don't hit this anymore, by setting `XDG_CONFIG_HOME=/tmp` before any tests run. This is under a `--tmp-xdg-config-home` flag so that we can check if any test breaks things.
* The second commit fixes our tests so that they don't call `papis.config` before we have a chance to construct a `TemporaryConfiguration`.

The second commit should make it so that the tests still work even if we don't add the `--tmp-xdg-config-home` flag to `pyproject.toml`. Let me know if you get a chance to test it!

Fixes #784.