### PR TITLE
ci: run nix pytest with `python -m`

### DIFF
--- a/.github/workflows/nix-flake.yml
+++ b/.github/workflows/nix-flake.yml
@@ -23,4 +23,4 @@ jobs:
     - uses: DeterminateSystems/flake-checker-action@main
     - run: nix build
     - run: nix flake check
-    - run: nix develop --command bash -c "pytest -v papis tests"
+    - run: nix develop --command bash -c "python -m pytest -v papis tests"


### PR DESCRIPTION
It doesn't in this case fail without it, but as #786 shows it's sometimes necessary and we don't wanna unnecessarily ask for trouble