### PR TITLE
docs: update testing docs

### DIFF
--- a/HACKING.md
+++ b/HACKING.md
@@ -9,6 +9,11 @@ Coding Style
 * Follow the [PEP8 style guide](https://www.python.org/dev/peps/pep-0008/)
 * Try and run tests locally before submitting a new PR.
 
+Issues
+------
+
+You can open issues in the [GitHub issue tracker](https://github.com/papis/papis/issues).
+
 Development
 -----------
 
@@ -26,19 +31,20 @@ make pytest
 ```
 which runs the full test suite and doctests for `papis`. To run the tests exactly
 as they are set up on the Github Actions CI use
-```
+```bash
 make ci-install
 make ci-test
 ```
 
 The docs can be generated with
-```
+```bash
 make doc
 ```
+
 ### Containers
 
-To quickly get things up and running, you can also use docker/podman:
-```
+To quickly get things up and running, you can also use Docker:
+```bash
 # build the image
 docker build -t papisdev .
 # to run the CI tests
@@ -51,16 +57,19 @@ docker run -v $(pwd):/papis --rm -it papisdev bash
 
 ### Nix
 
-If you're using Nix, you can also use the flake and get a development shell up with `nix develop`.
+If you're using Nix, you can also use the included `flake.nix` and get a
+development shell up with `nix develop`.
 
-This also gives you access to the following convenience commands to interact with the containers (they require either docker or podman to run):
+This also gives you access to the following convenience commands to interact
+with the containers (they require either Docker or Podman to run):
 
-- `papis-build-container`: build the container
-- `papis-run-container-tests`: run the CI tests in the container
-- `papis-run-container-interactive`: enter the container interactively and populate the library with some test documents
+* `papis-build-container`: build the container.
+* `papis-run-container-tests`: run the CI tests in the container.
+* `papis-run-container-interactive`: enter the container interactively and
+  populate the library with some test documents.
 
-Adding tests
-------------
+Guidelines for Testing
+======================
 
 To add tests to the various parts of papis, use the functionality in
 `papis.testing`. This is documented in the
@@ -74,23 +83,8 @@ make ci-test
 make ci-lint
 ```
 
-Issues
-------
-
-You can open issues in the [GitHub issue tracker](https://github.com/papis/papis/issues).
-
-Version Numbering
------------------
-
-The versioning scheme generally follows semantic versioning. That is, we
-have three numbers, `A.B.C`, where:
-
-* `A` changes on a rewrite
-* `B` changes when major configuration incompatibilities occur
-* `C` changes with each release (bug fixes..)
-
-Extending Papis
-===============
+Guidelines for Extending Papis
+==============================
 
 Adding Configuration Options
 ----------------------------

--- a/PACKAGING.md
+++ b/PACKAGING.md
@@ -4,13 +4,24 @@ Guidelines for Packaging
 These are some loose notes about packing Papis meant to highlight the different
 components that are available and not to require a particular format.
 
+Version Numbering
+-----------------
+
+The versioning scheme generally follows semantic versioning. That is, we
+have three numbers, `A.B.C`, where:
+
+* `A` changes on a rewrite or other major changes in the library or command-line.
+* `B` changes when major configuration incompatibilities occur or major features
+  are added.
+* `C` changes with each release (bug fixes).
+
 Dependencies
-============
+------------
 
 See `pyproject.toml` for a complete list of dependencies and minimum versions.
 
 Wheels
-======
+------
 
 Papis uses the standard `pyproject.toml`-based format using `hatchling` as a
 build backend. Wheels can be generated using
@@ -24,7 +35,7 @@ python -m build --skip-dependency-check .
 ```
 
 Man pages
-=========
+---------
 
 Papis documentation uses Sphinx, which can also generate man pages. By default,
 we create man pages for all the standard Papis commands and some general
@@ -37,7 +48,7 @@ The resulting man pages can then be found in `doc/build/man` and should be insta
 in appropriate locations.
 
 Shell completions
-=================
+-----------------
 
 Papis uses `click` for its command-line parsing. To generate completions, use
 ```
@@ -50,6 +61,6 @@ Note that the generated completion files are not static and can pick up any
 custom Papis commands and plugins even after installation.
 
 Desktop file
-============
+------------
 
 There is a desktop file in `contrib/papis.desktop`.

--- a/doc/source/testing.rst
+++ b/doc/source/testing.rst
@@ -76,6 +76,26 @@ manager should be used instead. It also has a corresponding fixture called
 
         assert tmp_library.libname == papis.config.get_lib_name()
 
+.. warning::
+
+   If the user also has a `~/.config/papis/config.py`, this is always read and
+   inserted into the Papis global scope using :func:`eval`. This cannot be handled
+   in a clean fashion by ``TemporaryConfiguration``, so a new ``pytest`` flag
+   was introduced to point to an empty configuration before the tests are loaded.
+   It can be used like (and is enabled by default in ``pyproject.toml``)::
+
+        python -m pytest --papis-tmp-xdg-home tests
+
+.. warning::
+
+   The doctests also try to load the global user configuration and cannot easily
+   use the ``TemporaryConfiguration`` context manager or the associated fixture.
+   To deal with this an ``autouse=True`` fixture is introduced. It can be used
+   like (and is enabled by default in ``pyproject.toml``)::
+
+        python -m pytest --papis-tmp-doctests papis
+
+
 Testing commands
 ----------------
 

--- a/papis/testing.py
+++ b/papis/testing.py
@@ -490,7 +490,7 @@ def _doctest_tmp_config(request: SubRequest) -> Iterator[None]:
     """A fixture for doctests to ensure that they run in a clean environment.
 
     This fixture is enabled automatically for all doctests using the
-    ``--wrap-doctests`` command-line flag.
+    ``--papis-tmp-doctests`` command-line flag.
     """
     # NOTE: taken from https://stackoverflow.com/a/46991331
     doctest_plugin = request.config.pluginmanager.getplugin("doctest")
@@ -498,7 +498,7 @@ def _doctest_tmp_config(request: SubRequest) -> Iterator[None]:
     # NOTE: this should only run for papis doctests
     if (
             isinstance(request.node, doctest_plugin.DoctestItem)
-            and request.config.getoption("--wrap-doctests")):
+            and request.config.getoption("--papis-tmp-doctests")):
         with TemporaryConfiguration():
             yield
     else:
@@ -577,15 +577,14 @@ def resource_cache(request: SubRequest) -> ResourceCache:
 
 
 def pytest_addoption(parser: Parser) -> None:
-    parser.addoption("--wrap-doctests", dest="wrap_doctests", action="store_true",
+    parser.addoption("--papis-tmp-doctests", action="store_true",
                      help="Use a temporary configuration file for doctests")
-    parser.addoption("--tmp-xdg-config-home", dest="tmp_xdg_config_home",
-                     action="store_true",
+    parser.addoption("--papis-tmp-xdg-home", action="store_true",
                      help="Set XDG_CONFIG_HOME to a temporary directory")
 
 
 def pytest_configure(config: Config) -> None:
-    if config.getoption("--tmp-xdg-config-home"):
+    if config.getoption("--papis-tmp-xdg-home"):
         # NOTE: some Papis modules call papis.config even before the tests have
         # a chance to construct a TemporaryConfiguration. We set XDG_CONFIG_HOME
         # here first to avoid them picking up any sort of user configuration.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -237,8 +237,8 @@ packages = ["papis"]
 
 [tool.pytest.ini_options]
 addopts = [
-    "--wrap-doctests",
-    "--tmp-xdg-config-home",
+    "--papis-tmp-doctests",
+    "--papis-tmp-xdg-home",
     "--doctest-modules",
     "--ignore=papis/downloaders/thesesfr.py",
     "--cov=papis",


### PR DESCRIPTION
This adds some additional warnings to the testing docs to mention the new flags that enable running the tests in a clean environment.

@jghauser Added some more context to `docs/source/testing.rst` about those flags and why they're there. Let me know if you think anything else would be helpful to mention! I also renamed them to make it clear they're papis-specific.

xref: #786 #758.