### PR TITLE
feat/hayagriva editor list

### DIFF
--- a/papis/hayagriva.py
+++ b/papis/hayagriva.py
@@ -131,7 +131,9 @@ PAPIS_TO_HAYAGRIVA_KEY_CONVERSION_MAP = [
     _k("author_list", [{"key": "author", "action": lambda a: to_hayagriva_authors(a)}]),
     _k("year", [{"key": "date", "action": None}]),
     _k("date", [{"key": "date", "action": None}]),
-    _k("editor", [papis.document.EmptyKeyConversion]),
+    _k("editor", [{"key": "editor", "action": lambda a:
+                   to_hayagriva_authors(papis.document.split_authors_name([a]))}]),
+    _k("editor_list", [{"key": "editor", "action": lambda a: to_hayagriva_authors(a)}]),
     _k("publisher", [papis.document.EmptyKeyConversion]),
     _k("location", [papis.document.EmptyKeyConversion]),
     _k("venue", [{"key": "location", "action": None}]),

--- a/papis/testing.py
+++ b/papis/testing.py
@@ -126,7 +126,7 @@ PAPIS_TEST_DOCUMENTS = [
         "pages": "56-71",
         "publisher": "Scranton Publishing",
         "ref": "scott2008that",
-        "title": "That is What She Said: The Art of Office Banter",
+        "title": "That is What She Said. The Art of Office Banter",
         "type": "incollection",
         "year": "2008",
         "_test_files": 1
@@ -139,7 +139,7 @@ PAPIS_TEST_DOCUMENTS = [
         "pages": "15-30",
         "publisher": "Schrute Farms Publishing",
         "ref": "schrute2020beet",
-        "title": "Beet Identity: Unraveling the Mysteries of Schrute Farms Secret Crop",
+        "title": "Beet Identity. Unraveling the Mysteries of Schrute Farms Secret Crop",
         "type": "incollection",
         "year": "2020",
         "_test_files": 1

--- a/papis/testing.py
+++ b/papis/testing.py
@@ -117,6 +117,33 @@ PAPIS_TEST_DOCUMENTS = [
         "year": 2019,
         "_test_files": 1
     },
+    {
+        "address": "Scranton, PA, USA",
+        "author": "Scott, Michael",
+        "booktitle": "Humor in the Workplace",
+        "editor_list": [{"family": "Halpert", "given": "Jim"},
+                        {"family": "Beesly", "given": "Pam"}],
+        "pages": "56-71",
+        "publisher": "Scranton Publishing",
+        "ref": "scott2008that",
+        "title": "That is What She Said: The Art of Office Banter",
+        "type": "incollection",
+        "year": "2008",
+        "_test_files": 1
+    },
+    {
+        "address": "Scranton, PA, USA",
+        "author": "Schrute, Dwight K.",
+        "booktitle": "Beets: The Ultimate Guide to Beet Farming",
+        "editor": "Martin, Angela",
+        "pages": "15-30",
+        "publisher": "Schrute Farms Publishing",
+        "ref": "schrute2020beet",
+        "title": "Beet Identity: Unraveling the Mysteries of Schrute Farms Secret Crop",
+        "type": "incollection",
+        "year": "2020",
+        "_test_files": 1
+    },
 ]
 
 

--- a/tests/commands/test_export.py
+++ b/tests/commands/test_export.py
@@ -145,7 +145,7 @@ def test_export_folder_all_cli(tmp_library: TemporaryLibrary) -> None:
 
     import glob
     dirs = glob.glob(os.path.join(outdir, "*"))
-    assert len(dirs) == 6
+    assert len(dirs) == 8
 
     for d in dirs:
         assert os.path.exists(d)

--- a/tests/test_haragriva.py
+++ b/tests/test_haragriva.py
@@ -1,9 +1,11 @@
 import os
 
+import pytest
+
 from papis.testing import TemporaryLibrary
 
 
-def test_exporter(tmp_library: TemporaryLibrary) -> None:
+def test_simple(tmp_library: TemporaryLibrary) -> None:
     import papis.database
 
     db = papis.database.get()
@@ -18,3 +20,18 @@ def test_exporter(tmp_library: TemporaryLibrary) -> None:
     expected = yaml_to_data(filename)
 
     assert result == expected
+
+
+@pytest.mark.parametrize(("author", "editor_count"), [("schrute", 1), ("scott", 2)])
+def test_parent_editors(author: str,
+                        editor_count: int,
+                        tmp_library: TemporaryLibrary) -> None:
+    import papis.database
+    from papis.hayagriva import to_hayagriva
+
+    db = papis.database.get()
+
+    doc, = db.query_dict({"author": author})
+    result = to_hayagriva(doc)
+    assert "parent" in result.keys()
+    assert len(result["parent"]["editor"]) == editor_count


### PR DESCRIPTION
Fixes #789

I made it so we always output a list for the editors and now we also support `editor_list`. Making a list will also make the yaml easier to visually browse.