### PR TITLE
fix(thesesfr): update to support the new API

### DIFF
--- a/papis/downloaders/thesesfr.py
+++ b/papis/downloaders/thesesfr.py
@@ -5,7 +5,10 @@ import papis.downloaders.base
 
 
 class Downloader(papis.downloaders.Downloader):
-    """Retrieve documents from `theses.fr <https://theses.fr/en/>`__"""
+    """Retrieve documents from `theses.fr <https://theses.fr/en/>`__
+
+    API Documentation: https://api.gouv.fr/documentation/scanR
+    """
 
     def __init__(self, url: str) -> None:
         super().__init__(url, name="thesesfr", expected_document_extension="pdf")

--- a/papis/downloaders/thesesfr.py
+++ b/papis/downloaders/thesesfr.py
@@ -18,39 +18,17 @@ class Downloader(papis.downloaders.Downloader):
             return None
 
     def get_identifier(self) -> Optional[str]:
-        """
-        >>> d = Downloader("https://www.theses.fr/2014TOU30305")
-        >>> d.get_identifier()
-        '2014TOU30305'
-        >>> d = Downloader("https://www.theses.fr/2014TOU30305.bib/?asdf=2")
-        >>> d.get_identifier()
-        '2014TOU30305'
-        >>> d = Downloader("2014TOU30305")
-        >>> d.get_identifier()
-        '2014TOU30305'
-        """
         if match := re.match(r".*?(\d{4}[a-zA-Z]{3,}\d+)", self.uri):
             return match.group(1)
         else:
             return None
 
     def get_document_url(self) -> Optional[str]:
-        """
-        >>> d = Downloader("https://theses.fr/2019REIMS014")
-        >>> d.get_document_url()
-        'https://theses.fr/api/v1/document/2019REIMS014'
-        """
-
         baseurl = "https://theses.fr/api/v1/document"
         identifier = self.get_identifier()
         return f"{baseurl}/{identifier}"
 
     def get_bibtex_url(self) -> Optional[str]:
-        """
-        >>> d = Downloader("https://www.theses.fr/2014TOU30305")
-        >>> d.get_bibtex_url()
-        'https://www.theses.fr/2014TOU30305.bib'
-        """
         url = f"https://www.theses.fr/{self.get_identifier()}.bib"
         self.logger.debug("Using BibTeX URL: '%s'.", url)
         return url

--- a/papis/downloaders/thesesfr.py
+++ b/papis/downloaders/thesesfr.py
@@ -12,13 +12,17 @@ class Downloader(papis.downloaders.Downloader):
 
     @classmethod
     def match(cls, url: str) -> Optional[papis.downloaders.Downloader]:
-        if re.match(r".*theses.fr.*|\d{4}[a-zA-Z]{3,}\d+", url):
+        # ID format ("nnt" in french). Not specified in the docs, but it's
+        # the pattern that all the published theses until now follow.
+        # https://documentation.abes.fr/aidetheses/thesesfr/index.html
+        if re.match(r"(?:https?://(:?www\.)?theses\.fr/)?(\d{4}[A-Z]{3,5}\d{3,5})",
+                    url):
             return Downloader(url)
         else:
             return None
 
     def get_identifier(self) -> Optional[str]:
-        if match := re.match(r".*?(\d{4}[a-zA-Z]{3,}\d+)", self.uri):
+        if match := re.search(r"(\d{4}[A-Z]{3,5}\d{3,5})", self.uri):
             return match.group(1)
         else:
             return None

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -240,7 +240,6 @@ addopts = [
     "--wrap-doctests",
     "--tmp-xdg-config-home",
     "--doctest-modules",
-    "--ignore=papis/downloaders/thesesfr.py",
     "--cov=papis",
 ]
 doctest_optionflags = ["NORMALIZE_WHITESPACE", "ELLIPSIS"]

--- a/tests/downloaders/test_thesesfr.py
+++ b/tests/downloaders/test_thesesfr.py
@@ -1,9 +1,10 @@
 import pytest
 
+from papis.testing import TemporaryConfiguration
 from papis.downloaders.thesesfr import Downloader
 
 
-def test_match():
+def test_match(tmp_config: TemporaryConfiguration):
     valid_urls = [
         "https://www.theses.fr/2014TOU30305",
         "2014TOU30305",
@@ -26,7 +27,7 @@ def test_match():
         ("2014TOU", None),
     ],
 )
-def test_get_identifier(query: str, expected: str):
+def test_get_identifier(query: str, expected: str, tmp_config: TemporaryConfiguration):
     d = Downloader(query)
     actual = d.get_identifier()
     assert actual == expected
@@ -56,7 +57,7 @@ def test_get_document_url(query: str, expected: str):
         ),
     ],
 )
-def test_get_bibtex_url(query: str, expected: str):
+def test_get_bibtex_url(query: str, expected: str, tmp_config: TemporaryConfiguration):
     d = Downloader(query)
     actual = d.get_bibtex_url()
     assert actual == expected

--- a/tests/downloaders/test_thesesfr.py
+++ b/tests/downloaders/test_thesesfr.py
@@ -1,0 +1,62 @@
+import pytest
+
+from papis.downloaders.thesesfr import Downloader
+
+
+def test_match():
+    valid_urls = [
+        "https://www.theses.fr/2014TOU30305",
+        "2014TOU30305",
+        "https://www.theses.fr/2014TOU30305.bib/?asdf=2",
+    ]
+    invalid_urls = ["http://google.com", "2014TOU", "ASDF"]
+    for url in valid_urls:
+        assert isinstance(Downloader.match(url), Downloader)
+
+    for url in invalid_urls:
+        assert Downloader.match(url) is None
+
+
+@pytest.mark.parametrize(
+    ("query", "expected"),
+    [
+        ("https://www.theses.fr/2014TOU30305", "2014TOU30305"),
+        ("https://www.theses.fr/2014TOU30305.bib/?asdf=2", "2014TOU30305"),
+        ("2014TOU30305", "2014TOU30305"),
+        ("2014TOU", None),
+    ],
+)
+def test_get_identifier(query: str, expected: str):
+    d = Downloader(query)
+    actual = d.get_identifier()
+    assert actual == expected
+
+
+@pytest.mark.parametrize(
+    ("query", "expected"),
+    [
+        (
+            "https://theses.fr/2019REIMS014",
+            "https://theses.fr/api/v1/document/2019REIMS014",
+        )
+    ],
+)
+def test_get_document_url(query: str, expected: str):
+    d = Downloader(query)
+    actual = d.get_document_url()
+    assert actual == expected
+
+
+@pytest.mark.parametrize(
+    ("query", "expected"),
+    [
+        (
+            "https://www.theses.fr/2014TOU30305",
+            "https://www.theses.fr/2014TOU30305.bib",
+        ),
+    ],
+)
+def test_get_bibtex_url(query: str, expected: str):
+    d = Downloader(query)
+    actual = d.get_bibtex_url()
+    assert actual == expected


### PR DESCRIPTION
That `--ignore` line in the pytest config made me sad. I went to see what happened with that downloader. I fixed the tests and the downloader so we can now read more French.

As a small bonus, you can now also download files using only the id: `papis add 2019REIMS014`.