### PR TITLE
docs: capitalize Papis

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -266,7 +266,7 @@ And many other general interface and robustness improvements.
 * Better notes handling in
   `papis update` ([#404](https://github.com/papis/papis/pull/404)),
   `papis edit` ([#391](https://github.com/papis/papis/pull/391)) and
-  the papis picker ([#319](https://github.com/papis/papis/pull/319)).
+  the Papis picker ([#319](https://github.com/papis/papis/pull/319)).
 * Improvements to BiBTeX export (
   [#412](https://github.com/papis/papis/pull/412)
   [#444](https://github.com/papis/papis/pull/444)
@@ -463,7 +463,7 @@ papis module `papis.git`.
 - The flag `--commit` now has the name `--git`.
 - The flag `--dir` now has the more descriptive name `--subfolder`.
 - The flag `--no-document` has been finally removed.
-- The most notable update is that papis is now able to guess a `doi`
+- The most notable update is that the `papis` commands are now able to guess a `doi`
   or `arxiv` id from a pdf that is being added, so the following could work
 
   ```
@@ -484,7 +484,7 @@ papis module `papis.git`.
 ## `papis export` ##
 
 - The configuration settings `export-text-format` has been removed along with
-  the export --text command. papis now support plugins so you should write your
+  the export --text command. Papis now support plugins so you should write your
   own instead.
 - The flags --bibtex/--json/--yaml of the `export` command have been replaced
   by `export --format=bibtex/json/yaml`
@@ -574,7 +574,7 @@ added into the main source and is installed with it.
 - Remove `xeditor` config parameter
 - Add external picker in api
 
-- Erase all guis from papis main repository, they should be used in external
+- Erase all guis from Papis main repository, they should be used in external
   scripts or projects, [docs](https://papis.readthedocs.io/en/latest/gui.html).
 
 - Fix downloader testing framework.

--- a/HACKING.md
+++ b/HACKING.md
@@ -71,7 +71,7 @@ with the containers (they require either Docker or Podman to run):
 Guidelines for Testing
 ======================
 
-To add tests to the various parts of papis, use the functionality in
+To add tests to the various parts of Papis, use the functionality in
 `papis.testing`. This is documented in the
 [Testing](https://papis.readthedocs.io/en/latest/testing.html) section of the
 docs and more complex examples can be found in the existing `tests` folder.
@@ -115,7 +115,7 @@ Adding Scripts
 --------------
 
 Can add scripts for everyone to share to the folder `examples/scripts` in the
-repository. These scripts will not be shipped with papis, but they are there
+repository. These scripts will not be shipped with Papis, but they are there
 for other users to use and modify.
 
 Adding Importers

--- a/HACKING.md
+++ b/HACKING.md
@@ -193,9 +193,8 @@ These tips can help you figure out which form, `papis` or Papis should be used.
 
 - When referring to the command-line interface, use `papis`, in lowercase and
 with code markup: 
-
   - Incorrect:
-      > The **papis** commands are `add`, `edit`, update`...
+      > The **papis** commands are `add`, `edit`, `update`...
   - Correct:
       > The **`papis`** commands are `add`, `edit`, `update`.
 

--- a/HACKING.md
+++ b/HACKING.md
@@ -158,3 +158,51 @@ from a remote location. They can be implemented in a very similar way:
 
 The downloader can then be added to the `project.entry-points."papis.downloader"`
 section, similarly to an importer.
+
+
+Guidelines for Documentation
+============================
+
+You'll find the source code of the Papis documentation under the `doc/src`
+directory. The documentation uses the Sphinx documentation stack to build the
+manual and HTML pages and, to format the text, the [Sphinx reStrucTured
+markup](https://www.sphinx-doc.org/en/master/usage/restructuredtext/basics.html).
+You'll notice that, under the `doc/source/commands` folder, most files are
+pretty sparse. The reason is that Sphinx populates the documentation
+automatically gathering information from the docstrings and the
+[Click](https://click.palletsprojects.com/) configuration of each command.
+
+
+To document existing or new features
+------------------------------------
+
+- Concise API documentation for a command or module as well as their usage
+examples should be generally placed in each module's source file. Visit the
+`papis/commands/add.py` or `papis/yaml.py` for examples of such use.
+
+- Longer-form texts, such as guides, tutorials or workflows can go to an
+appropriate file under `doc/source/`, and you can also use the
+`examples/scripts` directory to distribute scripts that you think will be
+helpful for other users.
+
+
+Deciding whether to write `papis` or Papis
+------------------------------------------
+
+These tips can help you figure out which form, `papis` or Papis should be used.
+
+- When referring to the command-line interface, use `papis`, in lowercase and
+with code markup: 
+
+  - Incorrect:
+      > The **papis** commands are `add`, `edit`, update`...
+  - Correct:
+      > The **`papis`** commands are `add`, `edit`, `update`.
+
+- When referring to the workflow or project, use uppercase P:
+  - Incorrect:
+      > The YAML files contain the metadata that **papis** uses for search
+      > The documentation for **papis** is built with Sphinx
+  - Correct:
+      > The YAML files contain the metadata that **Papis** uses for search
+      > The documentation for **Papis** is built using Python

--- a/PACKAGING.md
+++ b/PACKAGING.md
@@ -38,7 +38,7 @@ Man pages
 ---------
 
 Papis documentation uses Sphinx, which can also generate man pages. By default,
-we create man pages for all the standard Papis commands and some general
+we create man pages for all the standard `papis` commands and some general
 documentation for the configuration file. These can be generated using
 ```
 make -C doc man
@@ -58,7 +58,7 @@ _PAPIS_COMPLETE=zsh_source papis
 ```
 
 Note that the generated completion files are not static and can pick up any
-custom Papis commands and plugins even after installation.
+custom `Papis` commands and plugins even after installation.
 
 Desktop file
 ------------

--- a/README.rst
+++ b/README.rst
@@ -85,12 +85,12 @@ You can then open the indicated address (``http://localhost:8888``) in your brow
 
 |web_app|
 
-All Papis commands come with help messages:
+All ``papis`` commands come with help messages:
 
 .. code:: bash
 
     papis -h      # General help
-    papis add -h  # Help with a specific Papis command
+    papis add -h  # Help with a specific command
 
 Installation & setup
 --------------------

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -29,7 +29,7 @@ no nice solution of a python library doing this.
 ## YouTube video explaining the main uses of `papis`.
 
 If someone has experience with youtube, it would be nice to have a review
-in youtube explaining the main uses of papis and of her workflow.
+in youtube explaining the main uses of Papis and of her workflow.
 
 ## Implement proxy to download papers. [X]
 

--- a/contrib/papis.desktop
+++ b/contrib/papis.desktop
@@ -1,7 +1,7 @@
 [Desktop Entry]
 Type=Application
 Name=papis-open
-Comment=Launches the papis document opener after picking a library
+Comment=Launches the Papis document opener after picking a library
 Icon=utilities-terminal
 Terminal=true
 Exec=papis --pick-lib open

--- a/doc/source/bibtex.rst
+++ b/doc/source/bibtex.rst
@@ -1,7 +1,7 @@
 Bibtex
 ======
 
-Exporting documents to BibTeX is done in the same way throughout papis.
+Exporting documents to BibTeX is done in the same way throughout Papis.
 However, given the nature of TeX, there are some special corner cases
 to bear in mind when deciding on a workflow.
 
@@ -14,7 +14,7 @@ Unicode output
 If you are using TeX engines like XeTeX or LuaTeX, then you can use unicode
 characters for your BibTeX files as well. This means there is no need to write
 ``\`{a}`` instead of ``à`` in words such as ``apareixerà``. To control the
-output of unicode characters in papis, use the
+output of unicode characters in Papis, use the
 :confval:`bibtex-unicode` setting.
 
 Override keys

--- a/doc/source/citations.rst
+++ b/doc/source/citations.rst
@@ -9,7 +9,7 @@ this ``doi``, or you added information from the ``doi`` when you added the
 document, then chances are that the ``info.yaml`` file has a ``citations``
 key within it.
 
-In this case, papis can actually get metadata from these dois and
+In this case, Papis can actually get metadata from these dois and
 store it in a ``citations.yaml`` file, for references that the document
 has within it.
 
@@ -19,15 +19,15 @@ documentations in order to know more about it.
 
 As of version ``v0.13``, it is also possible to generate a
 ``cited-by.yaml`` file with the information of other papers that cite
-your document. This is done by scanning your papis library for
+your document. This is done by scanning your Papis library for
 documents that cite said document. You can also generate this
 file from the web application or from the ``papis citations`` command.
 
 The citation files try to include always first information already
 existing in the library. This is, before doing any online query,
-papis tries to find the relevant information in your library.
+Papis tries to find the relevant information in your library.
 
-Notice that papis copies most of the metadata to the ``citations.yaml``
+Notice that Papis copies most of the metadata to the ``citations.yaml``
 and ``cited-by.yaml`` files. Even though this might seem quite heavy on
 disk space, as a rule of thumb all the ``citation.yaml`` files of a
 library with 2k papers containing physics papers will amount to only

--- a/doc/source/configuration.rst
+++ b/doc/source/configuration.rst
@@ -162,7 +162,7 @@ Local configuration files
 Papis also offers the possibility of creating local configuration files.
 The name of the local configuration file can be configured with the
 :confval:`local-config-file` setting. The local configuration files
-are looked for in the current directory (where the papis command is issued) or
+are looked for in the current directory (where the ``papis`` command is issued) or
 in the directory of the current library.
 
 For instance, suppose that you are in some project folder ``~/Documents/myproject``
@@ -176,7 +176,7 @@ for your papers, for instance in::
 
     ~/Documents/papers/.papis.config
 
-Then, every time that you use this library papis will also source this
+Then, every time that you use this library Papis will also source this
 configuration file. This can be used as an alternative to adding more configuration
 options in the main configuration file or if you expect this library to be
 used on more machines with different configurations.

--- a/doc/source/database_structure.rst
+++ b/doc/source/database_structure.rst
@@ -52,7 +52,7 @@ and after you are done editing it will update the information for the given
 document in the cache.
 If you go directly to the document and edit the info file without
 passing through the ``papis edit`` command, the cache will not be updated and
-therefore Papis will not`know of these changes, although they will be there.
+therefore Papis will not know of these changes, although they will be there.
 In such cases you will have to *clear the cache*.
 
 Clearing the cache

--- a/doc/source/database_structure.rst
+++ b/doc/source/database_structure.rst
@@ -1,7 +1,7 @@
 The database
 ============
 
-One of the things that makes papis interesting is the fact that
+One of the things that makes Papis interesting is the fact that
 there can be many backends for the database system, including no database.
 
 Right now there are three types of databases that the user can use:
@@ -32,7 +32,7 @@ You can select a database by using the flag :confval:`database-backend`.
 Papis database
 --------------
 
-The fact that there is no database means that papis should crawl through
+The fact that there is no database means that Papis should crawl through
 the library folder and see which folders have an ``info.yaml`` file, which
 is for slow computers (and harddrives) quite bad.
 
@@ -46,13 +46,13 @@ These cache files are stored per default in
 
   ~/.cache/papis/
 
-Notice that most papis commands will update the cache if it has to be the case.
+Notice that most Papis commands will update the cache if it has to be the case.
 For instance the ``edit`` command will let you edit your document's information
 and after you are done editing it will update the information for the given
 document in the cache.
 If you go directly to the document and edit the info file without
-passing through the papis edit command, the cache will not be updated and
-therefore papis will not know of these changes, although they will be there.
+passing through the ``papis edit`` command, the cache will not be updated and
+therefore Papis will not`know of these changes, although they will be there.
 In such cases you will have to *clear the cache*.
 
 Clearing the cache
@@ -142,7 +142,7 @@ what is found in the index. This means that the index can not in general
 have all the information that the info file of the documents includes.
 
 In other words, the whoosh index will store only certain fields from the
-document's info files. The good news is that we can tell papis exactly
+document's info files. The good news is that we can tell Papis exactly
 which fields we want to index. These flags are
 
 - :confval:`whoosh-schema-fields`

--- a/doc/source/database_structure.rst
+++ b/doc/source/database_structure.rst
@@ -46,7 +46,7 @@ These cache files are stored per default in
 
   ~/.cache/papis/
 
-Notice that most Papis commands will update the cache if it has to be the case.
+Notice that most ``papis`` commands will update the cache if it has to be the case.
 For instance the ``edit`` command will let you edit your document's information
 and after you are done editing it will update the information for the given
 document in the cache.

--- a/doc/source/default-settings.rst
+++ b/doc/source/default-settings.rst
@@ -76,7 +76,7 @@ General settings
 
 .. papis-config:: format-doc-name
 
-    This setting controls the name of the document in the papis format strings
+    This setting controls the name of the document in the Papis format strings
     like in format strings such as :confval:`match-format` or
     :confval:`header-format`. For instance, if you are managing
     videos, you might want to set this option to ``vid`` in order to set  the
@@ -159,7 +159,7 @@ General settings
     * ``"python"``: based on :class:`papis.format.PythonFormatter`.
     * ``"jinja2"``: based on :class:`papis.format.Jinja2Formatter`.
 
-    Note that the default values of many of the papis configuration settings are
+    Note that the default values of many of the Papis configuration settings are
     based on the Python formatter. These will need to all be specified explicitly
     if another formatter is chosen.
 
@@ -201,7 +201,7 @@ Tools options
 .. papis-config:: editor
     :default: $EDITOR
 
-    Editor used to edit files in papis, e.g., for the ``papis edit``
+    Editor used to edit files in Papis, e.g., for the ``papis edit``
     command. This will search for the ``$EDITOR`` environment variable or the
     ``$VISUAL`` environment variables to obtain a default if it is not set.
     Otherwise, the default :confval:`opentool` will be used.
@@ -965,7 +965,7 @@ of fzf.
     ``fzf-extra-flags`` and include the colors in the
     :confval:`header-format` as ``ansi`` escape sequences.
 
-    The papis format string is given the additional variable ``c`` which
+    The Papis format string is given the additional variable ``c`` which
     contains the package ``colorama`` in it. Refer to the ``colorama``
     `documentation <https://github.com/tartley/colorama/blob/master/colorama/ansi.py#L49>`__.
     to see which colors are available. For instance, if you want the title in

--- a/doc/source/default-settings.rst
+++ b/doc/source/default-settings.rst
@@ -796,7 +796,7 @@ Databases
     effective when using the ``papis`` backend and disables the storage aspects,
     while keeping the query syntax.
 
-    If the cache is disabled, then every call to Papis commands will have to
+    If the cache is disabled, then every call to ``papis`` commands will have to
     walk the library directory tree to gather all the documents. This can be
     very slow for large libraries.
 

--- a/doc/source/editors.rst
+++ b/doc/source/editors.rst
@@ -16,9 +16,9 @@ original ``vim`` plugin `papis-vim <https://github.com/papis/papis-vim>`__.
 -------
 
 `papis.el <https://github.com/papis/papis.el>`__ is a compatibility layer for
-papis that tries to use as much of the existing packages as possible.
+Papis that tries to use as much of the existing packages as possible.
 In particular it tries to make use also of ``org-ref``
 to try not to reinvent the wheel.
 If you are used to ``org-ref`` or ``org-cite`` it strives
-to work seamless with them and still have your papis
+to work seamless with them and still have your Papis
 library intact.

--- a/doc/source/faq.rst
+++ b/doc/source/faq.rst
@@ -5,7 +5,7 @@ Here are some problems that users have come across often:
 
 - When I remove a folder manually in a library or I synchronize
   the library manually, I do not see the new papers in the library.
-  **Answer**: You probably need to update the cache because papis did not
+  **Answer**: You probably need to update the cache because Papis did not
   know anything about your changes in the library since you did it by yourself.
 
   .. code::

--- a/doc/source/git.rst
+++ b/doc/source/git.rst
@@ -47,7 +47,7 @@ Interplay with other commands
    All other commands assume the repository exists in the directory of the
    current library and their Git functionality will fail otherwise.
 
-Some papis commands give you the opportunity of using Git to manage
+Some Papis commands give you the opportunity of using Git to manage
 changes. For instance, if you are adding a new document, you could use
 the ``--git`` flag to also commit the document into Git like this
 

--- a/doc/source/git.rst
+++ b/doc/source/git.rst
@@ -47,7 +47,7 @@ Interplay with other commands
    All other commands assume the repository exists in the directory of the
    current library and their Git functionality will fail otherwise.
 
-Some Papis commands give you the opportunity of using Git to manage
+Some ``papis`` commands give you the opportunity of using Git to manage
 changes. For instance, if you are adding a new document, you could use
 the ``--git`` flag to also commit the document into Git like this
 
@@ -62,7 +62,7 @@ that, you can push your library to a remote repository by running
 
    papis git push origin main
 
-As expected, other Papis commands like ``update``, ``addto``, ``rename``, ``mv``,
+As expected, other ``papis`` commands like ``update``, ``addto``, ``rename``, ``mv``,
 etc. also offer such functionality, and they all go through the ``--git`` flag.
 
 Updating the library

--- a/doc/source/hooks.rst
+++ b/doc/source/hooks.rst
@@ -1,8 +1,8 @@
 Hooks
 =====
 
-From version ``0.12`` papis has a minimal hook infrastructure.
-Some parts of papis define and run hooks so that users
+From version ``0.12`` Papis has a minimal hook infrastructure.
+Some parts of Papis define and run hooks so that users
 and plugin writers can also tap into this functionality.
 
 A hook is declared in the same way as a plugin, in fact
@@ -14,7 +14,7 @@ they are implemented in the same way within the
 
 Right now the only way to add a hook as a user is using your
 ``config.py`` configuration file, which gets loaded
-when your papis configuration gets loaded.
+when your Papis configuration gets loaded.
 
 As an example you can add a function to the ``on_edit_done``
 hook like

--- a/doc/source/importing.rst
+++ b/doc/source/importing.rst
@@ -13,11 +13,11 @@ for other programs too.
 
 To install this script you can install the project
 `papis-zotero <https://github.com/papis/papis-zotero>`__ and follow the
-instructions therein to import a bibliography file into papis.
+instructions therein to import a bibliography file into Papis.
 
 You can also take a look at the
 `zotero2papis <https://github.com/nicolasshu/zotero2papis>`__ project
 in order to see a different workflow
 and different implementation of a converter script.
 `This <https://nicolasshu.com/zotero_and_papis.html>`__ blogpost
-explains the workflow using papis with zotero and SyncThing.
+explains the workflow using Papis with zotero and SyncThing.

--- a/doc/source/index.rst
+++ b/doc/source/index.rst
@@ -3,7 +3,7 @@
    You can adapt this file completely to your liking, but it should at least
    contain the root `toctree` directive.
 
-Welcome to papis' documentation!
+Welcome to Papis' documentation!
 =================================
 
 Papis is a command-line based document and bibliography manager. Its

--- a/doc/source/index.rst
+++ b/doc/source/index.rst
@@ -1,4 +1,4 @@
-.. papis documentation master file, created by
+.. Papis documentation master file, created by
    sphinx-quickstart on Fri May 12 00:56:29 2017.
    You can adapt this file completely to your liking, but it should at least
    contain the root `toctree` directive.

--- a/doc/source/info_file.rst
+++ b/doc/source/info_file.rst
@@ -3,7 +3,7 @@
 The ``info.yaml`` file
 ======================
 
-At the heart of papis there is the information file. The info file contains
+At the heart of Papis there is the information file. The info file contains
 all information about the documents.
 
 It uses the `YAML <https://yaml.org>`__ syntax to store
@@ -14,7 +14,7 @@ However it will interpret the field ``files`` as the files linked to the
 document for the ``papis open`` command. The ``files`` field
 should be formatted as a YAML list.
 
-For instance, if are storing papers with papis, then you most probably would
+For instance, if are storing papers with Papis, then you most probably would
 like to store author and title in there like this:
 
 .. code:: yaml
@@ -25,7 +25,7 @@ like to store author and title in there like this:
   files:
     - document.pdf
 
-Here we have used the ``files`` field to tell papis that the paper
+Here we have used the ``files`` field to tell Papis that the paper
 has a pdf document attached to it. You can of course attach many other documents
 so that you can open them when you are opening it with the ``papis open``
 command. For instance if you have a paper with supporting information, you

--- a/doc/source/install.rst
+++ b/doc/source/install.rst
@@ -18,7 +18,7 @@ the ``pip`` package manager. Open a terminal and type in
     pip install papis
 
 If you are on GNU/Linux-like systems you might need to type ``sudo`` to install
-papis globally like
+Papis globally like
 
 .. code:: sh
 
@@ -58,7 +58,7 @@ NixOS
 
 If you are running `NixOS <https://nixos.org/>`__ or you have the
 `nix <https://github.com/NixOS/nix>`__ package manager installed, you can install
-papis by running:
+Papis by running:
 
 .. code:: sh
 

--- a/doc/source/install.rst
+++ b/doc/source/install.rst
@@ -10,7 +10,7 @@ Installation
 Using pip
 ---------
 
-The easiest way of installing papis is using the ``PyPI`` repositories and
+The easiest way of installing Papis is using the ``PyPI`` repositories and
 the ``pip`` package manager. Open a terminal and type in
 
 .. code:: sh
@@ -30,7 +30,7 @@ If you prefer installing it locally then simply type
 
     pip install --user papis
 
-You can also **update** papis with ``pip``
+You can also **update** Papis with ``pip``
 
 .. code:: sh
 
@@ -112,7 +112,7 @@ until an official recipe in the main Guix repositories is published.
 From source
 -----------
 
-To install papis from source, you can clone the repository using
+To install Papis from source, you can clone the repository using
 
 .. code:: sh
 

--- a/doc/source/library_structure.rst
+++ b/doc/source/library_structure.rst
@@ -1,15 +1,15 @@
 The library structure
 =====================
 
-One of the things that makes papis interesting is the fact
+One of the things that makes Papis interesting is the fact
 that its library structure is nearly nonexistent.
 
-A papis library is linked to a directory, where all the documents are (and
-possibly sublibraries).  What papis does is simply to go to the library folder
+A Papis library is linked to a directory, where all the documents are (and
+possibly sublibraries).  What Papis does is simply to go to the library folder
 and look for all subfolders that contain a information file, which by default
 is a ``info.yaml`` file.
 
-Every subfolder that has an ``info.yaml`` file in it is a valid papis document.
+Every subfolder that has an ``info.yaml`` file in it is a valid Papis document.
 As an example let us consider the following library
 
 ::
@@ -42,7 +42,7 @@ As an example let us consider the following library
 
 The first thing that you might notice is that there are many folders.
 Just to check that you understand exactly what is a document,
-please think about which of these pdfs is not a valid papis document... That's
+please think about which of these pdfs is not a valid Papis document... That's
 right!, ``folder1/paper.pdf`` is not a valid document since the folder1 does not
 contain any ``info.yaml`` file. You see also that it does not matter how deep the
 folder structure is in your library: you can have a ``physics`` folder in which you
@@ -56,4 +56,4 @@ case, inside the ``info.yaml`` you would have the following ``file`` section
   - document.pdf
   - supplements.pdf
 
-which tells papis that this folder contains two relevant files.
+which tells Papis that this folder contains two relevant files.

--- a/doc/source/papis_id.rst
+++ b/doc/source/papis_id.rst
@@ -1,15 +1,15 @@
 The ``papis_id`` key
 --------------------
 
-Every papis document should have a ``papis_id`` key created at random by
-the papis database. This id should serve as a UUID-type key for the document
+Every Papis document should have a ``papis_id`` key created at random by
+the Papis database. This id should serve as a UUID-type key for the document
 (by default it contains a hash of the document keys and documents with a bit
 of randomness thrown in).
 
 The ``papis_id`` is added automatically when using ``papis add`` or other commands,
 but is not updated after the initial creation of the document. If you manually
 add a document into your library, e.g. by creating an ``info.yaml`` file without
-papis, you will have to clear the library cache in order to trigger a rebuild
+Papis, you will have to clear the library cache in order to trigger a rebuild
 using
 
 .. code:: sh
@@ -23,7 +23,7 @@ without committing the changes (in the case that you are using a git
 repository), so that you can inspect the changes manually.
 
 Please note that if you add a document manually with an existing
-``papis_id`` to your library, papis will not check if there is an
+``papis_id`` to your library, Papis will not check if there is an
 id clash. A clash of ids has a very low probability and can be checked using
 the ``papis doctor`` command.
 

--- a/doc/source/plugins.rst
+++ b/doc/source/plugins.rst
@@ -10,7 +10,7 @@ Papis uses the `stevedore <https://github.com/openstack/stevedore/>`__ library
 for general plugin management. However, other modules are not expected to
 interact with it and instead use the helper wrappers given by ``papis.plugin``.
 
-The different plugins in papis (e.g. ``papis.command``, ``papis.exporter`` etc.)
+The different plugins in Papis (e.g. ``papis.command``, ``papis.exporter`` etc.)
 define a so-called :class:`~stevedore.extension.ExtensionManager`, which loads various
 objects that have been declared as
 `entrypoints <https://packaging.python.org/en/latest/specifications/entry-points/>`__
@@ -49,8 +49,8 @@ be retrieved by name using
     yaml_string = yaml_exporter(mydocs)
 
 Due to the entrypoint mechanism used by ``stevedore``, any third-party package
-can add plugins to papis in this fashion. More information about each type of
-plugin available in papis is given below.
+can add plugins to Papis in this fashion. More information about each type of
+plugin available in Papis is given below.
 
 Exporter
 --------

--- a/doc/source/plugins.rst
+++ b/doc/source/plugins.rst
@@ -161,7 +161,7 @@ return the actual document PDF, we can override the
         return None
 
 Finally, to install the plugin and have it recognized by the extension system
-that papis uses, it needs to be added to ``pyproject.toml``. This can be done with
+that Papis uses, it needs to be added to ``pyproject.toml``. This can be done with
 extending the ``papis.downloader`` entrypoint as follows
 
 .. code:: toml

--- a/doc/source/quick_start.rst
+++ b/doc/source/quick_start.rst
@@ -1,12 +1,12 @@
 Quick start
 ===========
 
-This is a tutorial that should be enough to get you started using papis.  Papis
+This is a tutorial that should be enough to get you started using Papis.  Papis
 tries to be as simple and lightweight as possible, therefore its document model
 should be too as simple as possible.
 
 But before taking a look at its database structure let us show the daily
-usage of papis for a regular user. This tutorial is command-line based, so you
+usage of Papis for a regular user. This tutorial is command-line based, so you
 should be familiar with opening a terminal window on your system and
 do some general operations with it, like creating folders and files.
 
@@ -30,7 +30,7 @@ configuration file is found,
     ~/.config/papis/config
 
 Right now we will open this file for editing and we will create a library.  In
-papis everything should be human-readable and human-editable. So adding a
+Papis everything should be human-readable and human-editable. So adding a
 library is as easy as adding two lines to this configuration file.
 
 Say that you want to create a "papers" library, where you can finally order
@@ -45,7 +45,7 @@ by putting these two lines inside the config file:
 In the above lines we have created a library with the name ``papers`` which is
 located in the directory ``~/Documents/mypapers``.  So all the documents that
 we will be adding to the library will be located inside
-``~/Documents/mypapers``, and nowhere else. Everything that papis needs to take
+``~/Documents/mypapers``, and nowhere else. Everything that Papis needs to take
 care of your ``papers`` library is inside the ``~/Documents/mypapers`` directory,
 self-contained.
 
@@ -80,7 +80,7 @@ And it's done! We have added our first book to the library.
 Let us see how this works exactly. Papis consists of many commands, and one of
 these commands is ``add``. ``add`` itself has many flags, which are options for the
 given command. In the example above we have used the flags ``author`` and
-``title`` to tell papis to use ``Newton`` as the author's name and ``Principia
+``title`` to tell Papis to use ``Newton`` as the author's name and ``Principia
 Mathematica`` as the document's title. You can see all the possible flags
 for the command ``add`` if you use the ``help`` flag, i.e., if you issue the
 following command
@@ -91,7 +91,7 @@ following command
 
 Now you are asking yourself, what happened to the pdf-file? Where is it
 stored?  Is it stored in an obscure database somewhere in my computer? No,
-papis just copied the ``document.pdf`` file into a folder inside the library
+Papis just copied the ``document.pdf`` file into a folder inside the library
 folder ``~/Documents/papers/``. If you now go there, you will see that a folder
 with a weird name has been created. Inside of the folder there is the
 ``document.pdf`` file and another file, ``info.yaml``.
@@ -105,7 +105,7 @@ If you open the ``info.yaml`` file you will see the following contents:
   files:
   - document.pdf
 
-This file is all that papis uses to store the information of your newly added
+This file is all that Papis uses to store the information of your newly added
 document. It is stored in a nicely readable `YAML
 <https://en.wikipedia.org/wiki/YAML>`__ format.
 
@@ -135,7 +135,7 @@ desired paper very easily.
       id="asciicast-hrNaFMh4XwqVpWsGWDi5SASUC" async>
     </script>
 
-Of course papis shines really in other areas, for instance imagine
+Of course Papis shines really in other areas, for instance imagine
 you are browsing this paper
 `prl paper <https://journals.aps.org/prl/abstract/10.1103/PhysRevLett.124.171801/>`__
 and you want to add it to your library, as of version ``v0.9``

--- a/doc/source/scihub.rst
+++ b/doc/source/scihub.rst
@@ -6,7 +6,7 @@ Scihub support
 
 Papis has a script that uses the scihub platform to download scientific
 papers. Due to legal caution the script is not included directly
-as a Papis command, and it has its own PyPi repository.
+as a ``papis`` command, and it has its own PyPi repository.
 
 
 To install it, just type

--- a/doc/source/scihub.rst
+++ b/doc/source/scihub.rst
@@ -6,7 +6,7 @@ Scihub support
 
 Papis has a script that uses the scihub platform to download scientific
 papers. Due to legal caution the script is not included directly
-as a papis command, and it has its own PyPi repository.
+as a Papis command, and it has its own PyPi repository.
 
 
 To install it, just type

--- a/doc/source/scripting.rst
+++ b/doc/source/scripting.rst
@@ -2,7 +2,7 @@ Custom scripts
 ==============
 
 As in `git <https://git-scm.com>`__, you can write custom scripts to
-include them in the command spectrum of papis.
+include them in the command spectrum of Papis.
 
 Example: Mail script
 --------------------
@@ -62,17 +62,17 @@ Then, if you type
 this will create a folder called ``this_paper`` with a selection of a
 document, zip it and send it to whoever you choose to.
 
-Example: Accessing papis from within mutt
+Example: Accessing Papis from within mutt
 -----------------------------------------
 
 You may want to pick documents to attach to your email in ``mutt``
-from the papis interface.
+from the Papis interface.
 
 Add this code to your ``muttrc``
 
 ::
 
-   # # macro to attach paper from papis
+   # # macro to attach paper from Papis
    macro attach,compose \cp \
    "\
    <enter-command>unset wait_key<enter>\                                 # Don't require 'press any key'
@@ -89,17 +89,17 @@ paper to the email, which you can rename to be more descriptive with
 ``R``.
 
 
-Example: Define papis mode in i3wm
+Example: Define Papis mode in i3wm
 ----------------------------------
 
-This is an example of using papis with the window manager `i3`.
+This is an example of using Papis with the window manager `i3`.
 
 ::
 
-  # Enter papis mode
+  # Enter Papis mode
   bindsym $mod+Ctrl+p mode "papis"
 
-  # Define papis mode
+  # Define Papis mode
   mode "papis" {
 
     # open documents

--- a/doc/source/testing.rst
+++ b/doc/source/testing.rst
@@ -99,9 +99,9 @@ manager should be used instead. It also has a corresponding fixture called
 Testing commands
 ----------------
 
-To test Papis commands (such as ``papis add``), we make use of the infrastructure
+To test ``papis`` commands (such as ``papis add``), we make use of the infrastructure
 from :class:`click.testing.CliRunner` and, in particular, the customized
-:class:`papis.testing.PapisRunner`. To run a Papis command as it would be
+:class:`papis.testing.PapisRunner`. To run a ``papis`` command as it would be
 invoked from the command-line, use:
 
 .. code:: python

--- a/doc/source/web-application.rst
+++ b/doc/source/web-application.rst
@@ -1,7 +1,7 @@
 Web Application
 ===============
 
-Since v0.12, papis ships with an experimental, simple yet handy web application.
+Since v0.12, Papis ships with an experimental, simple yet handy web application.
 
 You can start the web application by issuing the following command
 

--- a/flake.nix
+++ b/flake.nix
@@ -218,7 +218,7 @@
               fi
             '';
 
-          # convenience command to build a papis container with docker/podman
+          # convenience command to build a Papis container with docker/podman
           papis-build-container = pkgs.writeShellApplication {
             name = "papis-build-container";
             text =

--- a/papis/api.py
+++ b/papis/api.py
@@ -1,6 +1,6 @@
 """
 This module describes which functions are intended to be used by users to
-create papis scripts.
+create Papis scripts.
 
 .. class:: T
 """

--- a/papis/bibtex.py
+++ b/papis/bibtex.py
@@ -401,7 +401,7 @@ def bibtexparser_entry_to_papis(entry: Dict[str, Any]) -> Dict[str, Any]:
 
 
 def bibtex_to_dict(bibtex: str) -> List[Dict[str, str]]:
-    """Convert a BibTeX file (or string) to a list of papis-compatible dictionaries.
+    """Convert a BibTeX file (or string) to a list of Papis-compatible dictionaries.
 
     This will convert an entry like
 
@@ -534,7 +534,7 @@ def to_bibtex(document: papis.document.Document, *, indent: int = 2) -> str:
       ``"file"`` field to the BibTeX entry, which can be used by e.g. Zotero to
       import documents.
 
-    :param document: a papis document.
+    :param document: a Papis document.
     :param indent: set indentation for the BibTeX fields.
     :returns: a string containing the document metadata in a BibTeX format.
     """

--- a/papis/commands/__init__.py
+++ b/papis/commands/__init__.py
@@ -86,7 +86,7 @@ class AliasedGroup(click.core.Group):
 class Script(NamedTuple):
     """A papis command plugin or script.
 
-    These plugins are made available through the main papis command-line as
+    These plugins are made available through the main Papis command-line as
     subcommands.
     """
 
@@ -99,7 +99,7 @@ class Script(NamedTuple):
 
 
 def get_external_scripts() -> Dict[str, Script]:
-    """Get a mapping of all external scripts that should be registered with papis.
+    """Get a mapping of all external scripts that should be registered with Papis.
 
     An external script is an executable that can be found in the
     :func:`papis.config.get_scripts_folder` folder or in the user's PATH.
@@ -130,7 +130,7 @@ def get_external_scripts() -> Dict[str, Script]:
 
 
 def get_scripts() -> Dict[str, Script]:
-    """Get a mapping of commands that should be registered with papis.
+    """Get a mapping of commands that should be registered with Papis.
 
     This finds all the commands that are registered as entry points in the
     namespace ``"papis.command"``.
@@ -156,7 +156,7 @@ def get_scripts() -> Dict[str, Script]:
 
 
 def get_all_scripts() -> Dict[str, Script]:
-    """Get a mapping of all commands that should be registered with papis.
+    """Get a mapping of all commands that should be registered with Papis.
 
     This includes the results from :func:`get_external_scripts` and
     :func:`get_scripts`. Entrypoint-based scripts take priority, so if an

--- a/papis/commands/__init__.py
+++ b/papis/commands/__init__.py
@@ -84,10 +84,10 @@ class AliasedGroup(click.core.Group):
 
 
 class Script(NamedTuple):
-    """A papis command plugin or script.
+    """A ``papis`` command plugin or script.
 
-    These plugins are made available through the main Papis command-line as
-    subcommands.
+    These plugins are made available through the main ``papis`` command-line
+    interface as subcommands.
     """
 
     #: The name of the command.

--- a/papis/commands/add.py
+++ b/papis/commands/add.py
@@ -1,6 +1,7 @@
 """
-The ``add`` command is one of the central commands of the Papis command-line
-interface. It is a very versatile command with a fair amount of options.
+The ``add`` command is one of the central commands of the ``papis``
+command-line interface It is a very versatile command with a fair amount of
+options.
 
 There are also a few customization settings available for this command, which
 are described on the :ref:`configuration page <add-command-options>` for add.
@@ -137,7 +138,7 @@ class FromFolderImporter(papis.importer.Importer):
 
 class FromLibImporter(papis.importer.Importer):
 
-    """Importer that queries a valid papis library (also paths) and adds files
+    """Importer that queries a valid Papis library (also paths) and adds files
     and data
     """
 

--- a/papis/commands/add.py
+++ b/papis/commands/add.py
@@ -1,5 +1,5 @@
 """
-The ``add`` command is one of the central commands of the papis command-line
+The ``add`` command is one of the central commands of the Papis command-line
 interface. It is a very versatile command with a fair amount of options.
 
 There are also a few customization settings available for this command, which
@@ -44,14 +44,14 @@ Examples
             --from arxiv https://arxiv.org/abs/1712.03134
 
 - If you do not want copy the original PDFs into the library, you can
-  also tell papis to just create a link to them, for example
+  also tell Papis to just create a link to them, for example
 
     .. code:: sh
 
         papis add --link ~/Documents/interesting.pdf \\
             --from doi 10.10763/1.3237134
 
-  will add an entry into the papis library, but the PDF document will remain
+  will add an entry into the Papis library, but the PDF document will remain
   at ``~/Documents/interesting.pdf``. In the document's folder
   there will be a link to ``~/Documents/interesting.pdf`` instead of the
   file itself. Of course you always have to be sure that the
@@ -60,7 +60,7 @@ Examples
 
 - Papis also tries to make sense of the inputs that you have passed
   on the command-line. For instance you could provide only a DOI and
-  papis will figure out if this is indeed a DOI and download available metadata
+  Papis will figure out if this is indeed a DOI and download available metadata
   using Crossref. For example, you can try
 
     .. code:: sh

--- a/papis/commands/cache.py
+++ b/papis/commands/cache.py
@@ -62,7 +62,7 @@ logger = papis.logging.get_logger(__name__)
 @click.help_option("--help", "-h")
 def cli() -> None:
     """
-    Manage the cache or database of a papis library.
+    Manage the cache or database of a Papis library.
     """
 
 

--- a/papis/commands/cache.py
+++ b/papis/commands/cache.py
@@ -12,7 +12,7 @@ This command is also useful for plugin developers.
 Let us suppose that you are editing the YAML file of a document at path
 ``/path/to/info.yaml``.
 If you are editing this file without the machinery of papis
-you might want to make papis be aware of this change by using the ``update``
+you might want to make Papis be aware of this change by using the ``update``
 subcommand. You might do
 
 ::
@@ -28,7 +28,7 @@ or maybe by query
 Furthermore, a noteworthy subcommand is ``update-newer``, which
 updates the cache for those documents whose info file is newer than
 the cache itself.  This subcommand has the same interface as most
-papis commands, so that if you want to check all documents you have to
+``papis`` commands, so that if you want to check all documents you have to
 input
 
 ::

--- a/papis/commands/default.py
+++ b/papis/commands/default.py
@@ -1,5 +1,5 @@
 """
-The papis command-line (without any subcommands) can be used to set configuration
+The ``papis`` command (without any subcommands) can be used to set configuration
 options or select the library.
 
 Examples

--- a/papis/commands/exec.py
+++ b/papis/commands/exec.py
@@ -2,12 +2,12 @@ r"""
 This command is useful to execute Python scripts with the environment of your
 ``papis`` executable.
 
-Often papis is installed in a virtual environment or locally in the user's home
+Often Papis is installed in a virtual environment or locally in the user's home
 directory, and therefore the global Python executable does not have access to
-the papis environment.
+the Papis environment.
 
 This command tries to mend this issue by allowing the user to write a
-Python script and run it using the correct environment where papis is
+Python script and run it using the correct environment where Papis is
 installed.
 
 Examples

--- a/papis/commands/explore.py
+++ b/papis/commands/explore.py
@@ -1,6 +1,6 @@
 """
 This command is mainly used to explore different databases and gather data
-for a project before adding it to the papis libraries.
+for a project before adding it to the Papis libraries.
 
 Examples
 ^^^^^^^^
@@ -75,11 +75,12 @@ file, e.g. the previously created ``docs.yaml``,
         cmd 'firefox {doc[url]}'
 
 In this last example, we read the documents from ``docs.yaml`` and pick a
-document, which we then feed into the ``explore cmd`` command, that accepts
-a papis formatting string to issue a general shell command.  In this case, the
-picked document gets fed into the ``papis scihub`` command which tries to
-download the document using ``scihub``. Also this very document is opened by
-Firefox (in case the document does have a ``url``).
+document, which we then feed into the ``explore cmd`` command.  This command
+accepts a string to issue a general shell command and allows formatting with the
+Papis template syntax.  In this case, the picked document gets fed into the
+``papis scihub`` command which tries to download the document using ``scihub``.
+Also this very document is opened by Firefox (in case the document does have a
+``url``).
 
 Command-line Interface
 ^^^^^^^^^^^^^^^^^^^^^^

--- a/papis/commands/export.py
+++ b/papis/commands/export.py
@@ -79,7 +79,7 @@ def run(documents: List[papis.document.Document], to_format: str) -> str:
     """
     Exports several documents into something else.
 
-    :param documents: A list of papis documents
+    :param documents: A list of Papis documents
     :param to_format: what format to use
     """
     ret_string = (

--- a/papis/commands/init.py
+++ b/papis/commands/init.py
@@ -1,5 +1,5 @@
 r"""
-This command initializes a papis library interactively.
+This command initializes a Papis library interactively.
 
 .. warning::
 

--- a/papis/commands/open.py
+++ b/papis/commands/open.py
@@ -1,5 +1,5 @@
 """
-The ``open`` command is a very important command in the papis workflow.
+The ``open`` command is a very important command in the Papis workflow.
 With it you can open documents, folders or marks.
 
 Marks

--- a/papis/commands/serve.py
+++ b/papis/commands/serve.py
@@ -70,7 +70,7 @@ def ok_html(fun: AnyFn) -> AnyFn:
 class PapisRequestHandler(http.server.BaseHTTPRequestHandler):
 
     """
-    The main request handler of the papis web application.
+    The main request handler of the Papis web application.
     """
 
     def log_message(self, fmt: str, *args: Any) -> None:

--- a/papis/database/cache.py
+++ b/papis/database/cache.py
@@ -52,8 +52,8 @@ def filter_documents(
         search: str = "") -> List[papis.document.Document]:
     """Filter documents. It can be done in a multi core way.
 
-    :param documents: List of papis documents.
-    :param search: Valid papis search string.
+    :param documents: List of Papis documents.
+    :param search: Valid Papis search string.
     :returns: List of filtered documents
 
     >>> document = papis.document.from_data({'author': 'einstein'})

--- a/papis/database/whoosh.py
+++ b/papis/database/whoosh.py
@@ -1,4 +1,4 @@
-"""This is the whoosh interface to papis. For future papis developers
+"""This is the whoosh interface to Papis. For future Papis developers
 here are some considerations.
 
 Whoosh works with 3 main objects, the Index, the Writer and the Schema.
@@ -9,7 +9,7 @@ folders is similar to the cache files of the papis cache database.
 Once the index is created in the mentioned folder, a Schema is initialized,
 which is a declaration of the data prototype of the database, or the
 definition of the table in sql parlance. This is controlled by the
-papis configuration through the `whoosh-schema-prototype`. For instance
+Papis configuration through the `whoosh-schema-prototype`. For instance
 if the database is supposed to only contain the key fields
 ``author``, ``title``, ``year`` and ``tags``, then the
 ``whoosh-schema-prototype`` STRING should look like the following:

--- a/papis/docmatcher.py
+++ b/papis/docmatcher.py
@@ -110,7 +110,7 @@ class DocMatcher:
             >>> DocMatcher.return_if_match(doc) is not None
             True
 
-        :param doc: a papis document to match against.
+        :param doc: a Papis document to match against.
         """
 
         match = None
@@ -197,7 +197,7 @@ def get_regex_from_search(search: str) -> Pattern[str]:
 def parse_query(query_string: str) -> List[ParseResult]:
     """Parse a query string using :mod:`pyparsing`.
 
-    The query language implemented by this function for papis supports strings
+    The query language implemented by this function for Papis supports strings
     of the form::
 
         'hello author : Einstein    title: "Fancy Title: Part 1" tags'

--- a/papis/isbn.py
+++ b/papis/isbn.py
@@ -38,10 +38,10 @@ def get_data(query: str = "",
 
 def data_to_papis(data: Dict[str, Any]) -> Dict[str, Any]:
     """
-    Convert data from isbnlib into papis formatted data.
+    Convert data from isbnlib into Papis formatted data.
 
     :param data: Dictionary with data
-    :returns: Dictionary with papis key names
+    :returns: Dictionary with Papis key names
     """
     _k = papis.document.KeyConversionPair
     key_conversion = [

--- a/papis/logging.py
+++ b/papis/logging.py
@@ -62,7 +62,7 @@ class ColoramaFormatter(logging.Formatter):
         """Format the specified record as text.
 
         This adds color coding to the logging levels, includes the exception
-        into the message, removes the papis namespace from the name, etc. Any
+        into the message, removes the ``papis`` namespace from the name, etc. Any
         formatting of the logging output is made here.
         """
 
@@ -193,10 +193,10 @@ def reset(level: Optional[Union[int, str]] = None,
 
 
 def get_logger(name: Optional[str] = None) -> logging.Logger:
-    """Get a logger instance for the given name under the papis namespace.
+    """Get a logger instance for the given name under the ``papis`` namespace.
 
     :arg name: the provisional name of the logger instance.
-    :returns: a :class:`logging.Logger` under the papis namespace, i.e. with a
+    :returns: a :class:`logging.Logger` under the ``papis`` namespace, i.e. with a
         name such as ``papis.<name>``.
     """
     if name is None or name.startswith("papis."):

--- a/papis/sphinx_ext.py
+++ b/papis/sphinx_ext.py
@@ -10,7 +10,7 @@ This can be included directly into the ``conf.py`` file as a normal extension, i
     ]
 
 It will include a custom :class:`~papis.sphinx_ext.CustomClickDirective` for
-documenting Papis commands and a :class:`~papis.sphinx_ext.PapisConfig` directive
+documenting ``papis`` commands and a :class:`~papis.sphinx_ext.PapisConfig` directive
 for documenting Papis configuration values.
 
 These are included by default when adding it to the ``extensions`` list in your

--- a/papis/utils.py
+++ b/papis/utils.py
@@ -107,7 +107,7 @@ def run(cmd: Sequence[str],
     """Run a given command with :mod:`subprocess`.
 
     This is a simple wrapper around :class:`subprocess.Popen` with custom
-    defaults used to call Papis commands.
+    defaults used to call `papis` commands.
 
     :arg cmd: a sequence of arguments to run, where the first entry is expected
         to be the command name and the remaining entries its arguments.

--- a/papis/web/epubjs.py
+++ b/papis/web/epubjs.py
@@ -23,7 +23,7 @@ def error_message() -> str:
 No installation of epubjs found.
 
 If you want to be able to read and see EPUB files from within
-the papis web applications you need to install epubjs-reader.
+the Papis web applications you need to install epubjs-reader.
 
 You can download the EPUBJS bundle from the url
 

--- a/papis/web/pdfjs.py
+++ b/papis/web/pdfjs.py
@@ -52,7 +52,7 @@ def error_message() -> str:
 No installation of pdfjs found.
 
 If you want to be able to read and see PDF files from within
-the papis web applications you need to install pdfjs.
+the Papis web applications you need to install pdfjs.
 
 You can download the PDFJS bundle from the url
 

--- a/papis/web/search.py
+++ b/papis/web/search.py
@@ -61,7 +61,7 @@ def html(pretitle: str,
          query: str,
          documents: List[papis.document.Document]) -> t.html_tag:
     """
-    Page for querying the papis database and present the results.
+    Page for querying the Papis database and present the results.
     """
     with papis.web.header.main_html_document(pretitle) as result:
         with result.body:

--- a/papis/web/static.py
+++ b/papis/web/static.py
@@ -6,7 +6,7 @@ import papis.config
 
 def static_paths() -> List[str]:
     """
-    This is the static directories where the papis web-application
+    This is the static directories where the Papis web-application
     can access files.
     """
     return [


### PR DESCRIPTION
After the comments in #793, I am hunting Papis written in lowercase in docstrings and comments.

This will track the progress, and also let me spot false positives here too.