### PR TITLE
ci: build windows executables

### DIFF
--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -2,7 +2,7 @@ name: Build Windows release
 
 on:
   push:
-    branches: [ "main", "ci-*", "feat/windows"]
+    branches: [ "main", "ci-*"]
   pull_request:
     branches: [ "main" ]
 
@@ -13,11 +13,29 @@ jobs:
       matrix:
         os: [ubuntu-latest]
         python-version: ['3.12']
-      fail-fast: false
+      fail-fast: true
 
     steps:
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@v4.1.2
+      with:
+        fetch-depth: 0
 
+    - name: Get short commit ref
+      run: |
+        version=$(
+            git describe --tags --dirty \
+            | sed -e 's/^v//' -e 's/\([^-]*-g\)/r\1/;s/-/./g'
+          )
+        echo "PAPIS_VERSION=$version" >> "$GITHUB_ENV"
+        
+
+    - name: Set version in pyproject.toml
+      run: |
+        set -x \
+        sed -i \
+          "s/^version =/version = \"${{env.PAPIS_VERSION}}\"/" \
+          pyproject.toml
+    
     - name: Build Windows binary
       run: |
         docker run -v ${{github.workspace}}:/src \
@@ -28,5 +46,5 @@ jobs:
     - name: Publish binary as artifact
       uses: actions/upload-artifact@v4
       with:
-        name: workspace_artifacts
+        name: papis-${{env.PAPIS_VERSION}}
         path: ${{ github.workspace }}/dist/papis.exe

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -1,0 +1,32 @@
+name: Build Windows release
+
+on:
+  push:
+    branches: [ "main", "ci-*", "feat/windows"]
+  pull_request:
+    branches: [ "main" ]
+
+jobs:
+  build-windows-release:
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        os: [ubuntu-latest]
+        python-version: ['3.12']
+      fail-fast: false
+
+    steps:
+    - uses: actions/checkout@v4
+
+    - name: Build Windows binary
+      run: |
+        docker run -v ${{github.workspace}}:/src \
+         -e PIP_GROUPS=windows,develop \
+         -e SPECFILE=scripts/windows/papis.spec \
+         ghcr.io/kiike/pyinstaller-windows:latest
+    
+    - name: Publish binary as artifact
+      uses: actions/upload-artifact@v4
+      with:
+        name: workspace_artifacts
+        path: ${{ github.workspace }}/dist/papis.exe

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -3,6 +3,11 @@ name: Build Windows release
 on:
   push:
     tags: ["v.*"]
+    branches:
+      - main
+      - "*windows*"
+  pull_request:
+      branches: [ "main" ]
 
 jobs:
   build-windows-release:

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -11,7 +11,7 @@ jobs:
       fail-fast: true
 
     steps:
-    - uses: actions/checkout@v4.1.2
+    - uses: actions/checkout@v4
       with:
         fetch-depth: 0
 

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -10,9 +10,6 @@ jobs:
   build-windows-release:
     runs-on: ubuntu-latest
     strategy:
-      matrix:
-        os: [ubuntu-latest]
-        python-version: ['3.12']
       fail-fast: true
 
     steps:
@@ -20,20 +17,16 @@ jobs:
       with:
         fetch-depth: 0
 
-    - name: Get short commit ref
+    - name: Set version in pyproject.toml and environment
       run: |
+        set -x
         version=$(
             git describe --tags --dirty \
-            | sed -e 's/^v//' -e 's/\([^-]*-g\)/r\1/;s/-/./g'
+            | sed -e 's/^v//' -e 's/\([^-]*-g\)/dev\1/;s/-g.*//g'
           )
         echo "PAPIS_VERSION=$version" >> "$GITHUB_ENV"
-        
-
-    - name: Set version in pyproject.toml
-      run: |
-        set -x \
         sed -i \
-          "s/^version =/version = \"${{env.PAPIS_VERSION}}\"/" \
+          "s/^version =/version =\"${{env.PAPIS_VERSION}}\"/" \
           pyproject.toml
     
     - name: Build Windows binary

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -2,9 +2,7 @@ name: Build Windows release
 
 on:
   push:
-    branches: [ "main", "ci-*"]
-  pull_request:
-    branches: [ "main" ]
+    tags: ["v.*"]
 
 jobs:
   build-windows-release:
@@ -26,9 +24,9 @@ jobs:
           )
         echo "PAPIS_VERSION=$version" >> "$GITHUB_ENV"
         sed -i \
-          "s/^version =/version =\"${version}\"/" \
+          "s/^version =\".*\"/version =\"${version}\"/" \
           pyproject.toml
-    
+            
     - name: Build Windows binary
       run: |
         docker run -v ${{github.workspace}}:/src \

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -26,7 +26,7 @@ jobs:
           )
         echo "PAPIS_VERSION=$version" >> "$GITHUB_ENV"
         sed -i \
-          "s/^version =/version =\"${{env.PAPIS_VERSION}}\"/" \
+          "s/^version =/version =\"${version}\"/" \
           pyproject.toml
     
     - name: Build Windows binary

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -6,7 +6,7 @@ on:
 
 jobs:
   build-windows-release:
-    runs-on: ubuntu-latest
+    runs-on: windows-latest
     strategy:
       fail-fast: true
 
@@ -16,6 +16,7 @@ jobs:
         fetch-depth: 0
 
     - name: Set version in pyproject.toml and environment
+      shell: bash
       run: |
         set -x
         version=$(
@@ -26,13 +27,14 @@ jobs:
         sed -i \
           "s/^version =\".*\"/version =\"${version}\"/" \
           pyproject.toml
-            
+    
+    - name: Install dependencies
+      run: make ci-install && pip install '.[windows]'
+      shell: bash
+
     - name: Build Windows binary
       run: |
-        docker run -v ${{github.workspace}}:/src \
-         -e PIP_GROUPS=windows,develop \
-         -e SPECFILE=scripts/windows/papis.spec \
-         ghcr.io/kiike/pyinstaller-windows:latest
+        pyinstaller --clean scripts/windows/papis.spec
     
     - name: Publish binary as artifact
       uses: actions/upload-artifact@v4

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -120,6 +120,9 @@ optional = [
     "Jinja2>=3.0.0",
     "markdownify>=0.11.6",
 ]
+windows = [
+    "pyinstaller"
+]
 
 [project.scripts]
 papis = "papis.commands.default:run"

--- a/scripts/windows/papis.spec
+++ b/scripts/windows/papis.spec
@@ -1,0 +1,44 @@
+# -*- mode: python ; coding: utf-8 -*-
+from PyInstaller.utils.hooks import collect_all
+
+datas = []
+binaries = []
+hiddenimports = []
+tmp_ret = collect_all('papis')
+datas += tmp_ret[0]; binaries += tmp_ret[1]; hiddenimports += tmp_ret[2]
+
+
+a = Analysis(
+    ['run.py'],
+    pathex=[],
+    binaries=binaries,
+    datas=datas,
+    hiddenimports=hiddenimports,
+    hookspath=[],
+    hooksconfig={},
+    runtime_hooks=[],
+    excludes=[],
+    noarchive=False,
+)
+pyz = PYZ(a.pure)
+
+exe = EXE(
+    pyz,
+    a.scripts,
+    a.binaries,
+    a.datas,
+    [],
+    name='papis',
+    debug=False,
+    bootloader_ignore_signals=False,
+    strip=False,
+    upx=True,
+    upx_exclude=[],
+    runtime_tmpdir=None,
+    console=True,
+    disable_windowed_traceback=False,
+    argv_emulation=False,
+    target_arch=None,
+    codesign_identity=None,
+    entitlements_file=None,
+)

--- a/scripts/windows/run.py
+++ b/scripts/windows/run.py
@@ -1,0 +1,6 @@
+import sys
+
+from papis.commands.default import run
+
+
+sys.exit(run())


### PR DESCRIPTION
This pull requests allows for creating Papis one-file binaries that can be run under Windows without needing the Python toolchain installed.

Right now it works OK, a bit slower compared to a one file+support dir, but maybe this is alright. Besides changing the version identifier so it mentions the commit ID that triggered the rebuild, I tried to touch the minimal things to build this:

- the pyproject.toml now has a windows dependency group that is used by the action. If needed, I could move it to the action, but here it's a bit more explicit if somebody wants to build this on-prem.
- there is a new action workflow now, called "Build windows release". Right now, it will run on PR and pushes on main, allowing to test binaries for commits that trigger these events. This action needs two more pieces, which I forked from other repos on GitHub:
  - a docker container that uses WINE to compile the program. The recipe to build the container and the `papis.exe` are in the indicated repos. Nothing is uploaded from me, but instead ran from artifacts.
  - an action that uses this docker container
- the script that is executed by pyinstaller is like the default one that is executed when you pip-install the program. Just a couple lines shorter.

Now, I don't have a dev certificate, so the executables are not signed. Unfortunately, this means that Windows Defender can trigger false positives and block the program. It happened to me for a build but not another. The reason is PyInstaller, which is used by malware too.

I've gone down a PyInstaller rabbit hole and apparently we can build the bootloader for the executable. That might help in that regard. But code signing would be better maybe.

As for this PR, it's ready to be merged, and the improvements to using Papis, like #745, would reflect on this windows artifact. Do we have stats on the artifact downloads? Maybe it could help see if this effort is actually beneficial.

Partly fixes #780 