### PR TITLE
fix docs for update and tag command

### DIFF
--- a/doc/source/commands/tag.rst
+++ b/doc/source/commands/tag.rst
@@ -1,0 +1,4 @@
+Tag
+---
+.. automodule:: papis.commands.tag
+

--- a/papis/commands/tag.py
+++ b/papis/commands/tag.py
@@ -4,14 +4,14 @@ This command allows users to add and remove tags to documents in their library.
 Examples
 ^^^^^^^^
 
-- To add a tag use the `--add` (or `--append`/`-p`) option:
+- To add a tag use the ``--add`` (or ``--append``/``-p``) option:
 
     .. code:: sh
 
         papis tag --add TAG1 --add TAG2 QUERY
 
   This will add TAG1 and TAG2 to a document matched by QUERY. You can repeat
-  `--add` as many times as you need. The query is any query supported by papis.
+  ``--add`` as many times as you need. The query is any query supported by papis.
   If the query matches more than one document, Papis' picker will be started to
   let you pick the document from those matched (just as with Papis' other
   commands).
@@ -19,27 +19,27 @@ Examples
   Tags are only added if they do not already exist, which is to say that the
   same tag cannot exist more than once in a given document.
 
-- To remove a tag use the `--remove` (or `-r`) option:
+- To remove a tag use the ``--remove`` (or ``-r``) option:
 
     .. code:: sh
 
         papis tag --remove TAG1 QUERY
 
   This removes TAG1 from the document. If it didn't exist before, nothing
-  happens. You can use `--remove` as many times as you like to remove multiple
+  happens. You can use ``--remove`` as many times as you like to remove multiple
   tags.
 
-- Use `--drop` (or `-d`) to remove all tags:
+- Use ``--drop`` (or ``-d``) to remove all tags:
 
     .. code:: sh
 
         papis tag --drop --add TAG1 QUERY
 
   This removes all tags from the document and then adds TAG1. You can of course
-  also use `--drop` by itself to simply remove all tags without adding new
+  also use ``--drop`` by itself to simply remove all tags without adding new
   ones.
 
-- Use `--all` (or `-a`) with any of the other options to apply the tagging
+- Use ``--all`` (or ``-a``) with any of the other options to apply the tagging
   operation to all matching documents:
 
     .. code:: sh
@@ -50,6 +50,7 @@ Examples
   picker to let you choose one.
 
 """
+
 from typing import List, Optional, Tuple, Any, Dict
 
 import click

--- a/papis/commands/tag.py
+++ b/papis/commands/tag.py
@@ -49,6 +49,12 @@ Examples
   This adds TAG1 to all documents matching the QUERY rather than opening the
   picker to let you choose one.
 
+Command-line Interface
+^^^^^^^^^^^^^^^^^^^^^^
+
+.. click:: papis.commands.tag:cli
+    :prog: papis tag
+
 """
 
 from typing import List, Optional, Tuple, Any, Dict

--- a/papis/commands/update.py
+++ b/papis/commands/update.py
@@ -1,6 +1,6 @@
 """
 This command allows you to update the document metadata stored in the
-`info.yaml` file. With it, you can either change individual values manually
+``info.yaml`` file. With it, you can either change individual values manually
 or update a document with information automatically retrieved from a variety
 of sources.
 
@@ -9,8 +9,8 @@ expressions can be used. See below examples for more information. The command
 also tries to sanitise filenames so that they don't contain any problematic
 characters.
 
-Normally, `papis update` will abort on encountering an error. If you want to
-skip errors and apply as many changes as possible, use the `--batch` flag.
+Normally, ``papis update`` will abort on encountering an error. If you want to
+skip errors and apply as many changes as possible, use the ``--batch`` flag.
 
 Examples
 ^^^^^^^^
@@ -31,7 +31,7 @@ Examples
 
         papis update --set author_list "[{'family': 'Einstein', 'given': 'Albert'}]"
 
-  As you can see, `papis update` tries to parse the input string as a python
+  As you can see, ``papis update`` tries to parse the input string as a python
   expression (such as a list or dictionary). When this succeeds, as in the above
   example where we're setting a dictionary, it's the parsed expression that is
   used to update the metadata.
@@ -44,7 +44,7 @@ Examples
         papis update --all --set journal "Mass and Energy" "journal:'Energy and Mass'"
 
 
-  The `--all` flag means that the tag is applied to all documents that match the
+  The ``--all`` flag means that the tag is applied to all documents that match the
   query, rather than allowing you to pick one individual document to update.
 
 - Update a document automatically and interactively (searching by DOI in
@@ -69,11 +69,11 @@ Examples
 
         papis update --set author "{doc[author]}, Albert" Einstein
 
-  The `papis update` command tries to format input strings using the configured
+  The ``papis update`` command tries to format input strings using the configured
   formatter. Here, it is used to get the existing author "Albert" and then add
   the string ", Einstein" to end up with "Einstein, Albert"
 
-- The above can also be achieved with the `--append` option:
+- The above can also be achieved with the ``--append`` option:
 
     .. code:: sh
 
@@ -91,7 +91,7 @@ Examples
     doesn't yet exist, it will be created. All duplicate items will be removed
     from the list.
 
-- To remove an item from a list, use `--remove`:
+- To remove an item from a list, use ``--remove``:
 
     .. code:: sh
 
@@ -99,7 +99,7 @@ Examples
 
     If the tag "physics" is in the list of tags, this command removes it.
 
-- To remove a key-value pair entirely, use `--drop`:
+- To remove a key-value pair entirely, use ``--drop``:
 
     .. code:: sh
 
@@ -107,15 +107,15 @@ Examples
 
     This removes the all tags.
 
-- There is also a convenience option `--rename` if you want to rename
-  a list item. It's equivalent to doing `--remove` and `--append` sequentially.
+- There is also a convenience option ``--rename`` if you want to rename
+  a list item. It's equivalent to doing ``--remove`` and ``--append`` sequentially.
 
     .. code:: sh
 
         papis update --rename tags physics philosophy
 
   This renames the tag 'physics' to 'philosophy'. Note that this option being a
-  combination of `--remove` and `--append`, it will append the desired values
+  combination of ``--remove`` and ``--append``, it will append the desired values
   even if the value to be removed didn't exist. Thus, the above command will add
   the tag "philosophy" even if the tag "physics" didn't exist before the
   operation.
@@ -168,7 +168,7 @@ def run_set(
     key_types: Dict[str, type],
 ) -> None:
     """
-    Processes a list of `to_set` tuples and applies the resulting changes to the
+    Processes a list of ``to_set`` tuples and applies the resulting changes to the
     input document. Each tuple is (KEY, VALUE) and results in setting the KEY to
     the VALUE in the document.
     """
@@ -207,7 +207,7 @@ def run_append(
     batch: bool,
 ) -> bool:
     """
-    Processes a list of `to_append` tuples and applies the resulting changes
+    Processes a list of ``to_append`` tuples and applies the resulting changes
     to the input document. Each tuple is (KEY, VALUE) and results in appending
     the VALUE to the KEY item.
 
@@ -261,7 +261,7 @@ def run_remove(
     document: papis.document.DocumentLike, to_remove: List[Tuple[str, str]], batch: bool
 ) -> bool:
     """
-    Processes a list of `to_remove` tuples and applies the resulting changes
+    Processes a list of ``to_remove`` tuples and applies the resulting changes
     to the input document. Each tuple is (KEY, VALUE) and results in removing
     the VALUE from the KEY item.
 
@@ -301,9 +301,9 @@ def run_remove(
 
 def run_drop(document: papis.document.DocumentLike, to_remove: List[str]) -> None:
     """
-    Processes a list of `to_drop` strings and applies the resulting changes
+    Processes a list of ``to_drop`` strings and applies the resulting changes
     to the input document. Each string is a KEY whose value is set to None
-    (and then later in `run()` dropped from the document entirely).
+    (and then later in ``run()`` dropped from the document entirely).
 
     """
     for key in to_remove:
@@ -321,7 +321,7 @@ def run_rename(
     batch: bool,
 ) -> bool:
     """
-    Processes a list of `to_rename` tuples and applies the resulting changes
+    Processes a list of ``to_rename`` tuples and applies the resulting changes
     to the input document. Each tuple is (KEY, VALUE_OLD, VALUE_NEW) and results in
     rename the KEY's VALUE_OLD to VALUE_NEW.
 


### PR DESCRIPTION
I realised the tag and update docstrings didn't use rst synatx. Also the stub to create docs from the tag docstrings were missing.