### PR TITLE
add slugify configuration options

### DIFF
--- a/doc/source/default-settings.rst
+++ b/doc/source/default-settings.rst
@@ -165,35 +165,31 @@ General settings
 
     **Note** The older (misspelled) version ``"formater"`` is deprecated.
 
-.. papis-config:: slugify-lowercase
+.. papis-config:: doc-paths-lowercase
     :type: bool
 
     This setting controls whether capital letters in a (generated or specified)
     document path should be lowercased before the path is created.
 
-    **Note:** Lowercasing happens *before* removing disallowed characters.
-    If you disable it without allowing uppercase letters they will simply
-    disappear from document paths!
-
-.. papis-config:: slugify-regex-pattern
+.. papis-config:: doc-paths-extra-chars
     :type: str
 
-    This setting defines the set of *disallowed* characters for document paths.
-    It must be a valid regular expression matching all disallowed characters.
-    The default value disallows all characters except lowercase letters and
-    numbers (and dots for file extensions).
+    By default document paths in Papis libraries can contain only a limited set
+    of characters. This is mainly to exclude characters that are invalid for
+    file paths on any operating system or possibly unprintable. Allowed
+    characters are:
 
-    Possible alternative values are:
+    * latin letters (a to z)
+    * arabic digits (0 to 9)
+    * dots (for file extensions)
+    * directory separators (usually ``/`` on UNIX-like systems and ``\\``
+      on Windows)
 
-    * ``r"[^a-zA-Z0-9.]+"``: Don't filter out uppercase letters from the path.
-    * ``r"[^a-z0-9._]+"``: Don't filter out underscores from the path.
+    This setting allows to append additional characters to this set. It expects
+    a string containing all additional valid characters. A possible value would
+    be ``"_"`` to allow underscores in document paths.
 
-    **Note:** Allowing uppercase letters here will not yield the desired result
-    unless lowercasing is also turned off. Otherwise all uppercase letters are
-    lowercased before filtering happens and no uppercase letters will appear
-    in the path anyway.
-
-.. papis-config:: slugify-separator
+.. papis-config:: doc-paths-word-separator
     :type: str
 
     This setting defines the separator between words in document paths (usually

--- a/doc/source/default-settings.rst
+++ b/doc/source/default-settings.rst
@@ -165,6 +165,41 @@ General settings
 
     **Note** The older (misspelled) version ``"formater"`` is deprecated.
 
+.. papis-config:: slugify-lowercase
+    :type: bool
+
+    This setting controls whether capital letters in a (generated or specified)
+    document path should be lowercased before the path is created.
+
+    **Note:** Lowercasing happens *before* removing disallowed characters.
+    If you disable it without allowing uppercase letters they will simply
+    disappear from document paths!
+
+.. papis-config:: slugify-regex-pattern
+    :type: str
+
+    This setting defines the set of *disallowed* characters for document paths.
+    It must be a valid regular expression matching all disallowed characters.
+    The default value disallows all characters except lowercase letters and
+    numbers (and dots for file extensions).
+
+    Possible alternative values are:
+
+    * ``r"[^a-zA-Z0-9.]+"``: Don't filter out uppercase letters from the path.
+    * ``r"[^a-z0-9._]+"``: Don't filter out underscores from the path.
+
+    **Note:** Allowing uppercase letters here will not yield the desired result
+    unless lowercasing is also turned off. Otherwise all uppercase letters are
+    lowercased before filtering happens and no uppercase letters will appear
+    in the path anyway.
+
+.. papis-config:: slugify-separator
+    :type: str
+
+    This setting defines the separator between words in document paths (usually
+    replacing spaces or other non-letter characters). By default this is the
+    hyphen ``"-"`` but it could, e.g., also be the underscore ``"_"``.
+
 Tools options
 -------------
 

--- a/papis/defaults.py
+++ b/papis/defaults.py
@@ -50,6 +50,9 @@ settings: Dict[str, Any] = {
     "sort-field": None,
     "sort-reverse": False,
     "formatter": "python",
+    "slugify-lowercase": True,
+    "slugify-regex-pattern": r"[^a-z0-9.]+",
+    "slugify-separator": "-",
 
     # tools
     "opentool": get_default_opener(),

--- a/papis/defaults.py
+++ b/papis/defaults.py
@@ -50,9 +50,9 @@ settings: Dict[str, Any] = {
     "sort-field": None,
     "sort-reverse": False,
     "formatter": "python",
-    "slugify-lowercase": True,
-    "slugify-regex-pattern": r"[^a-z0-9.]+",
-    "slugify-separator": "-",
+    "doc-paths-lowercase": True,
+    "doc-paths-extra-chars": "",
+    "doc-paths-word-separator": "-",
 
     # tools
     "opentool": get_default_opener(),

--- a/papis/utils.py
+++ b/papis/utils.py
@@ -285,11 +285,15 @@ def clean_document_name(doc_path: str, is_path: bool = True) -> str:
         doc_path = os.path.basename(doc_path)
 
     import slugify
-    regex_pattern = r"[^a-z0-9.]+"
+    lowercase = papis.config.getbool("slugify-lowercase")
+    regex_pattern = papis.config.getstring("slugify-regex-pattern")
+    separator = papis.config.getstring("slugify-separator")
     return str(slugify.slugify(
         doc_path,
         word_boundary=True,
-        regex_pattern=regex_pattern))
+        separator=separator,
+        regex_pattern=regex_pattern,
+        lowercase=lowercase))
 
 
 def locate_document_in_lib(document: papis.document.Document,

--- a/papis/utils.py
+++ b/papis/utils.py
@@ -285,9 +285,11 @@ def clean_document_name(doc_path: str, is_path: bool = True) -> str:
         doc_path = os.path.basename(doc_path)
 
     import slugify
-    lowercase = papis.config.getbool("slugify-lowercase")
+    lowercase = papis.config.getboolean("slugify-lowercase")
     regex_pattern = papis.config.getstring("slugify-regex-pattern")
     separator = papis.config.getstring("slugify-separator")
+    if lowercase is None:
+        lowercase = True
     return str(slugify.slugify(
         doc_path,
         word_boundary=True,

--- a/papis/utils.py
+++ b/papis/utils.py
@@ -285,11 +285,19 @@ def clean_document_name(doc_path: str, is_path: bool = True) -> str:
         doc_path = os.path.basename(doc_path)
 
     import slugify
-    lowercase = papis.config.getboolean("slugify-lowercase")
-    regex_pattern = papis.config.getstring("slugify-regex-pattern")
-    separator = papis.config.getstring("slugify-separator")
+
+    lowercase = papis.config.getboolean("doc-paths-lowercase")
+    extra_chars = papis.config.getstring("doc-paths-extra-chars")
+    separator = papis.config.getstring("doc-paths-word-separator")
+
     if lowercase is None:
         lowercase = True
+
+    if lowercase is True:
+        regex_pattern = fr"[^a-z0-9.{extra_chars}]+"
+    else:
+        regex_pattern = fr"[^a-zA-Z0-9.{extra_chars}]+"
+
     return str(slugify.slugify(
         doc_path,
         word_boundary=True,

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -132,6 +132,40 @@ def test_slugify(tmp_config: TemporaryConfiguration) -> None:
     assert clean_document_name("الامير الصغير.pdf") == "lmyr-lsgyr.pdf"
 
 
+def test_slugify_config(tmp_config: TemporaryConfiguration) -> None:
+    import papis.config
+
+    from papis.utils import clean_document_name
+
+    papis.config.set("doc-paths-lowercase", "False")
+    assert (
+        clean_document_name("{{] __ }}Albert )(*& $ß $+_ Einstein (*]")
+        == "Albert-ss-Einstein"
+    )
+
+    papis.config.set("doc-paths-extra-chars", "_")
+    assert (
+        clean_document_name("{{] __ }}Albert )(*& $ß $+_ Einstein (*]")
+        == "__-Albert-ss-_-Einstein"
+    )
+    assert (
+        clean_document_name("{{] __Albert )(*& $ß $+_ Einstein (*]")
+        == "__Albert-ss-_-Einstein"
+    )
+
+    papis.config.set("doc-paths-word-separator", "_")
+    assert (
+        clean_document_name("{{] __ }}Albert )(*& $ß $+_ Einstein (*]")
+        == "___Albert_ss___Einstein"
+    )
+
+    papis.config.set("doc-paths-lowercase", "True")
+    assert (
+        clean_document_name("{{] __ }}Albert )(*& $ß $+_ Einstein (*]")
+        == "___albert_ss___einstein"
+    )
+
+
 def test_yaml_unicode_dump(tmp_config: TemporaryConfiguration) -> None:
     from papis.crossref import get_data
 


### PR DESCRIPTION
This adds three options to configure the behaviour of slugify when cleaning document paths:

- ``slugify-lowercase``
- ``slugify-regex-pattern``
- ``slugify-separator``

Their effects mostly follow the respective arguments to ``python-slugify``. Hopefully appropriate documentation about this is added to ``default-settings.rst``.

As this is my first PR for this project any feedback is welcome and greatly appreciated!