### PR TITLE
Call `ref_cleanup()` function when `papis --set ref` is called

### DIFF
--- a/papis/commands/update.py
+++ b/papis/commands/update.py
@@ -196,6 +196,8 @@ def run_set(
                 "Document files renamed in the info.yaml file. This does not "
                 "rename any files on disk."
             )
+        elif key == "ref" and isinstance(value, str):
+            document[key] = papis.bibtex.ref_cleanup(value)
         else:
             document[key] = value
 


### PR DESCRIPTION
When I was calling `papis -l update --all --set ref '{doc[author_list][0][family]!l}_{doc[year]}_{doc[title]!l:0.3S}'`, I noticed that `doc[title]` had spaces in it that were not being cleaned up. This seemed like the appropriate fix, since `ref_cleanup()` is called other times when `ref` is being set.