### PR TITLE
Update dependencies

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,11 +5,15 @@ VERSION NEXT
 
 * Minimum required Python version bumped to 3.8
   ([#552](https://github.com/papis/papis/pull/552)).
-* Move to `pyproject.toml` and removed `setup.py` completely. We use
+* Moved to `pyproject.toml` and removed `setup.py` completely. We use
   [hatchling](https://github.com/pypa/hatch/tree/master/backend) as the build
   backend.
 * Removed [arxiv2bib](https://github.com/nathangrigg/arxiv2bib) in favor of
   [arxiv.py](https://github.com/lukasschwab/arxiv.py).
+* Removed [tqdm](https://github.com/tqdm/tqdm) dependency (using a progress bar
+  from `prompt_toolkit` instead).
+* Made `chardet` an optional dependency. This is an optional dependency of
+  `bs4`, `requests` and `feedparser` and should be installed if possible.
 * Added [markdownify](https://github.com/matthewwithanm/python-markdownify) as
   an optional dependency for the Zenodo downloader.
 

--- a/contrib/python-papis.scm
+++ b/contrib/python-papis.scm
@@ -13,22 +13,6 @@
  (guix build-system python)
  ((guix licenses) #:prefix license:))
 
-(define python-types-tqdm
-  (package
-   (name "python-types-tqdm")
-   (version "4.66.0.2")
-   (source (origin
-            (method url-fetch)
-            (uri (pypi-uri "types-tqdm" version))
-            (sha256
-             (base32
-              "0pylandfajknxprd2y06hxzfihy0cnyvh1gm3775yj0x9kjaalwm"))))
-   (build-system pyproject-build-system)
-   (home-page "https://github.com/python/typeshed")
-   (synopsis "Typing stubs for tqdm")
-   (description "Typing stubs for tqdm")
-   (license #f)))
-
 (define python-types-pyyaml
   (package
    (name "python-types-pyyaml")
@@ -196,7 +180,7 @@ an elegant DOM API.")
                 "02792xxr4mwa17khw6szmpvdlck28sz0npfw57c2rb9dnh0rwvqr"))))
     (build-system pyproject-build-system)
     (arguments '(#:tests? #f))
-    (propagated-inputs (list python-requests python-tqdm))
+    (propagated-inputs (list python-requests))
     (native-inputs (list python-pytest))
     (home-page "https://github.com/sckott/habanero")
     (synopsis "Low Level Client for Crossref Search API")
@@ -232,7 +216,6 @@ an elegant DOM API.")
                           python-requests
                           python-slugify ;added
                           python-stevedore
-                          python-tqdm
                           python-typing-extensions))
  (native-inputs (list python-flake8
                       python-flake8-bugbear
@@ -250,8 +233,7 @@ an elegant DOM API.")
                       python-types-pygments
                       python-types-python-slugify
                       python-types-pyyaml
-                      python-types-requests
-                      python-types-tqdm))
+                      python-types-requests))
  (home-page "https://github.com/papis/papis")
  (synopsis
   "Powerful and highly extensible command-line based document and bibliography manager")

--- a/papis/commands/citations.py
+++ b/papis/commands/citations.py
@@ -99,7 +99,12 @@ def cli(query: str,
                 logger.info("[%d/%d] Fetching citations for '%s'.",
                             i + 1, len(documents),
                             papis.document.describe(document))
-                fetch_and_save_citations(document)
+                try:
+                    fetch_and_save_citations(document)
+                except ValueError as exc:
+                    logger.error("Failed to fetch citations for document: '%s'",
+                                 papis.document.describe(document), exc_info=exc)
+
         if update_from_database:
             if _has_citations_p:
                 logger.info("[%d/%d] Updating citations from library for '%s'.",

--- a/papis/tui/utils.py
+++ b/papis/tui/utils.py
@@ -1,7 +1,10 @@
 import re
-from typing import Optional, List, Callable, Any
+from typing import Optional, List, Callable, Any, Iterable
 
 import click
+
+from papis.api import T
+
 
 # Highlighting style used by pygments. This is a copy of the prompt_toolkit
 # default style, but changed to use ansi colors.
@@ -153,6 +156,33 @@ def prompt(
                                    validate_while_typing=True)
 
     return result or default
+
+
+def progress_bar(iterable: Iterable[T]) -> Iterable[T]:
+    from prompt_toolkit.styles import Style
+    from prompt_toolkit.shortcuts import ProgressBar
+    from prompt_toolkit.shortcuts.progress_bar import formatters
+
+    # NOTE: this style is chosen to make it look like the default tqdm bar
+    style = Style.from_dict({"bar-a": "reverse"})
+    fmt = [
+        formatters.Percentage(),
+        formatters.Bar(start="|", end="|", sym_a=" ", sym_b=" ", sym_c=" "),
+        formatters.Text(" "),
+        formatters.Progress(),
+        formatters.Text(" ["),
+        formatters.TimeElapsed(),
+        formatters.Text("<"),
+        formatters.TimeLeft(),
+        formatters.Text(", "),
+        formatters.IterationsPerSecond(),
+        formatters.Text(" it/s]"),
+        formatters.Text("  "),
+    ]
+
+    with ProgressBar(style=style, formatters=fmt) as pb:
+        for item in pb(iterable):
+            yield item
 
 
 def get_range(range_str: str) -> List[int]:

--- a/papis/utils.py
+++ b/papis/utils.py
@@ -13,13 +13,13 @@ except ImportError:
     HAS_MULTIPROCESSING = False
 
 import papis.config
-import papis.format
-import papis.exceptions
-import papis.importer
-import papis.downloaders
-import papis.document
 import papis.database
 import papis.defaults
+import papis.document
+import papis.downloaders
+import papis.exceptions
+import papis.format
+import papis.importer
 import papis.logging
 
 logger = papis.logging.get_logger(__name__)
@@ -384,16 +384,17 @@ def update_doc_from_data_interactively(
     import copy
     docdata = copy.copy(document)
 
-    import papis.tui.widgets.diff
+    from papis.tui.widgets.diff import diffdict
+
     # do not compare some entries
     docdata.pop("files", None)
     docdata.pop("tags", None)
 
-    document.update(papis.tui.widgets.diff.diffdict(
-                    docdata,
+    diff = diffdict(docdata,
                     data,
                     namea=papis.document.describe(document),
-                    nameb=data_name))
+                    nameb=data_name)
+    document.update(diff)
 
 
 def get_cache_home() -> str:
@@ -559,6 +560,8 @@ def collect_importer_data(
     :param use_files: if *True*, both metadata and files are collected
         from the importers.
     """
+    from papis.tui.utils import confirm
+
     # FIXME: this is here for backwards compatibility and should be removed
     # before we release the next version
     if only_data is not None and use_files is not None:
@@ -597,7 +600,7 @@ def collect_importer_data(
             msg = f"Use this file? (from {importer.name})"
             for f in importer.ctx.files:
                 open_file(f)
-                if batch or papis.tui.utils.confirm(msg):
+                if batch or confirm(msg):
                     ctx.files.append(f)
 
     return ctx

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -307,7 +307,6 @@ module = [
     "markdownify.*",
     "sphinx_click.*",
     "stevedore.*",
-    "typing.re.*",
     "whoosh.*",
 ]
 ignore_missing_imports = true

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -72,14 +72,13 @@ dependencies = [
     "habanero>=0.6",
     "isbnlib>=3.9.1",
     "lxml>=4.3.5",
-    "prompt_toolkit>=2.0.5",
+    "prompt_toolkit>=3.0.5",
     "pygments>=2.2",
     "pyparsing>=2.2",
     "python-doi>=0.1.1",
     "python-slugify>=1.2.6",
     "requests>=2.11.1",
     "stevedore>=1.30",
-    "tqdm>=4.1",
 ]
 
 [project.urls]
@@ -104,7 +103,6 @@ develop = [
     "types-python-slugify",
     "types-PyYAML",
     "types-requests",
-    "types-tqdm",
 ]
 docs = [
     "sphinx>=4",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -61,10 +61,10 @@ classifiers = [
     "Topic :: Utilities",
 ]
 dependencies = [
+    "PyYAML>=3.12",
     "arxiv>=1.0.0",
     "beautifulsoup4>=4.4.1",
     "bibtexparser>=0.6.2,<2",
-    "chardet>=3.0.2",
     "click>=7",
     "colorama>=0.2",
     "dominate",
@@ -77,7 +77,6 @@ dependencies = [
     "pyparsing>=2.2",
     "python-doi>=0.1.1",
     "python-slugify>=1.2.6",
-    "PyYAML>=3.12",
     "requests>=2.11.1",
     "stevedore>=1.30",
     "tqdm>=4.1",
@@ -116,8 +115,9 @@ lsp = [
     "python-lsp-server",
 ]
 optional = [
-    "Whoosh>=2.7.4",
     "Jinja2>=3.0.0",
+    "Whoosh>=2.7.4",
+    "chardet>=3.0.2",
     "markdownify>=0.11.6",
 ]
 windows = [


### PR DESCRIPTION
This cleans up our dependencies a bit. Mainly it removes `tqdm`, since `prompt_toolkit` has a progress bar as well that looks pretty much the same.