### PR TITLE
ci: add 3.13-dev to the tests

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -15,7 +15,7 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest, macos-latest, windows-latest]
-        python-version: ['3.8', '3.9', '3.10', '3.11', '3.12']
+        python-version: ['3.8', '3.9', '3.10', '3.11', '3.12', '3.13-dev']
       fail-fast: false
 
     steps:

--- a/papis/commands/serve.py
+++ b/papis/commands/serve.py
@@ -6,7 +6,6 @@ import urllib.parse
 from typing import Any, List, Optional, Tuple, Callable, Dict
 
 import functools
-import cgi
 import collections
 import tempfile
 
@@ -319,10 +318,8 @@ class PapisRequestHandler(http.server.BaseHTTPRequestHandler):
                 )
         return doc
 
-    def _get_form(self, method: str = "POST") -> cgi.FieldStorage:
-        return cgi.FieldStorage(fp=self.rfile,
-                                headers=self.headers,
-                                environ={"REQUEST_METHOD": method})
+    def _get_form(self, method: str = "POST") -> Any:
+        return None
 
     def update_notes(self, libname: str, papis_id: str) -> None:
         doc = self._get_document(libname, papis_id)

--- a/papis/downloaders/__init__.py
+++ b/papis/downloaders/__init__.py
@@ -234,7 +234,7 @@ class Downloader(papis.importer.Importer):
             return self._soup
 
         import bs4
-        self._soup = bs4.BeautifulSoup(self._get_body(), features="lxml")
+        self._soup = bs4.BeautifulSoup(self._get_body())
 
         return self._soup
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -71,7 +71,6 @@ dependencies = [
     "filetype>=1.0.1",
     "habanero>=0.6",
     "isbnlib>=3.9.1",
-    "lxml>=4.3.5",
     "prompt_toolkit>=3.0.5",
     "pygments>=2.2",
     "pyparsing>=2.2",


### PR DESCRIPTION
Just running the CI with the current Python 3.13alpha4 to see what breaks.