### PR TITLE
feat(rename): allow batch and auto-renaming from pattern

### DIFF
--- a/papis/commands/rename.py
+++ b/papis/commands/rename.py
@@ -56,8 +56,6 @@ Command-line Interface
     :prog: papis rename
 """
 
-
-import os
 from typing import Optional, Tuple, List
 
 import click
@@ -80,6 +78,8 @@ logger = papis.logging.get_logger(__name__)
 
 def run(document: papis.document.Document,
         new_name: str, git: bool = False) -> None:
+    import os
+
     db = papis.database.get()
     folder = document.get_main_folder()
 

--- a/papis/commands/rename.py
+++ b/papis/commands/rename.py
@@ -128,6 +128,12 @@ def cli(query: str,
         doc_folder: Tuple[str, ...],
         sort_reverse: bool) -> None:
     """Rename document folders"""
+    if not folder_name:
+        logger.warning("No folder name format specified, so no documents can be "
+                       "renamed. Set either the configuration option "
+                       "'add-folder-name' or use the '--folder-name' flag.")
+        return
+
     documents = papis.cli.handle_doc_folder_query_all_sort(query,
                                                            doc_folder,
                                                            sort_field,

--- a/papis/commands/rename.py
+++ b/papis/commands/rename.py
@@ -120,7 +120,6 @@ def prepare_run(operations: List[Tuple[papis.document.Document, str]],
 @papis.cli.bool_flag("--batch", "-b", default=False, help="Batch mode, do not prompt")
 @papis.cli.bool_flag("--regenerate", "-r", default=False,
                      help="Regenerate the folder name from the configured patttern")
-@papis.cli.bool_flag("--slugify", "-s", default=False, help="Slugify the folder name")
 @click.help_option("--help", "-h")
 @papis.cli.all_option()
 @papis.cli.query_argument()
@@ -132,7 +131,6 @@ def cli(query: str,
         regenerate: bool,
         _all: bool,
         batch: bool,
-        slugify: bool,
         sort_field: Optional[str],
         doc_folder: Tuple[str, ...],
         sort_reverse: bool) -> None:
@@ -155,8 +153,7 @@ def cli(query: str,
         current_name = document.get_main_folder_name()
         if regenerate:
             new_name = papis.format.format(folder_name_pattern, document)
-            if slugify:
-                new_name = papis.utils.clean_document_name(new_name)
+            new_name = papis.utils.clean_document_name(new_name)
 
             if batch:
                 logger.info("Renaming '%s' into '%s'", current_name, new_name)

--- a/papis/commands/rename.py
+++ b/papis/commands/rename.py
@@ -1,15 +1,13 @@
 """
-The ``rename`` is one of the facilities of Papis to suit the naming
-of folders to your liking.  Functioning without interaction, thanks to the
-``--batch`` mode, or with interaction when executed without flags, it can rename
-the folders that contain your documents, optionally committing the changes to Git.
+The ``rename`` command is used to rename document folders based on
+a provided format or using :confval:`add-folder-name`.
 
 
 Examples
 ^^^^^^^^
 
-- Manually rename all folders matching a query. ``papis`` will prompt for the
-  new folder name, being the current name the default.
+- Manually rename all folders for documents matching a query. ``papis`` will
+  prompt for the new folder name, with the current name as a default.
 
    .. code:: sh
 
@@ -25,7 +23,7 @@ Examples
 
         papis rename --regenerate author:"Rick Astley"
 
-- Same, without asking for confirmation.
+- Rename folders without asking for confirmation using ``--batch``.
 
    .. code:: sh
 
@@ -134,7 +132,7 @@ def cli(query: str,
         sort_field: Optional[str],
         doc_folder: Tuple[str, ...],
         sort_reverse: bool) -> None:
-    """Rename an entry"""
+    """Rename document folders"""
     documents = papis.cli.handle_doc_folder_query_all_sort(query,
                                                            doc_folder,
                                                            sort_field,

--- a/papis/commands/rename.py
+++ b/papis/commands/rename.py
@@ -79,6 +79,7 @@ logger = papis.logging.get_logger(__name__)
 def run(document: papis.document.Document,
         new_name: str, git: bool = False) -> None:
     import os
+    import shutil
 
     db = papis.database.get()
     folder = document.get_main_folder()
@@ -93,13 +94,14 @@ def run(document: papis.document.Document,
         logger.warning("Path '%s' already exists.", new_folder_path)
         return
 
-    papis.utils.run((["git"] if git else []) + ["mv", folder, new_folder_path],
-                    cwd=folder)
-
     if git:
+        papis.utils.run(["git", "mv", folder, new_folder_path],
+                        cwd=folder)
         papis.git.commit(
             new_folder_path,
             f"Rename from '{folder}' to '{new_name}'")
+    else:
+        shutil.move(folder, new_folder_path)
 
     db.delete(document)
     logger.debug("New document folder: '%s'.", new_folder_path)

--- a/papis/commands/rename.py
+++ b/papis/commands/rename.py
@@ -7,7 +7,7 @@ Command-line Interface
 """
 
 import os
-from typing import Optional, Tuple
+from typing import Optional, Tuple, List
 
 import click
 
@@ -56,6 +56,13 @@ def run(document: papis.document.Document,
     db.add(document)
 
 
+def prepare_run(operations: List[Tuple[papis.document.Document, str]],
+                git: bool
+                ) -> None:
+    for document, new_name in operations:
+        run(document, new_name, git)
+
+
 @click.command("rename")
 @papis.cli.bool_flag("--batch", "-b", default=False, help="Batch mode, do not prompt")
 @papis.cli.bool_flag("--slugify", "-s", default=False, help="Slugify the folder name")
@@ -90,6 +97,7 @@ def cli(query: str,
     if regenerate:
         folder_name_pattern = papis.config.getstring("add-folder-name")
 
+    renames = []
     for document in documents:
         current_name = document.get_main_folder_name()
         if regenerate:
@@ -107,4 +115,6 @@ def cli(query: str,
                 ">",
                 default=current_name or "")
 
-        run(document, new_name, git=git)
+        renames.append((document, new_name))
+
+    prepare_run(renames, git)

--- a/papis/commands/rename.py
+++ b/papis/commands/rename.py
@@ -1,10 +1,63 @@
 """
+The ``rename`` is one of the facilities of Papis to suit the naming
+of folders to your liking.  Functioning without interaction, thanks to the
+``--batch`` mode, or with interaction when executed without flags, it can rename
+the folders that contain your documents, optionally committing the changes to Git.
+
+
+Examples
+^^^^^^^^
+
+- Manually rename all folders matching a query. ``papis`` will prompt for the
+  new folder name, being the current name the default.
+
+   .. code:: sh
+
+        papis rename author:"Rick Astley"
+
+- Rename picked folders that match a query and automatically ``--regenerate``
+  the names following the pattern provided by the ``add-folder-name``
+  configuration option. It will ask for confirmation before each rename. It
+  doesn't slugify the names, so if the pattern results in "Rick Astley - Never
+  Gonna Give You Up", that will be the final folder name.
+
+   .. code:: sh
+
+        papis rename --regenerate author:"Rick Astley"
+
+- Same, without asking for confirmation.
+
+   .. code:: sh
+
+        papis rename -r --batch author:"Rick Astley"
+
+- The folder names can be slugified too with the ``--slugify`` flag. This avoids
+  uppercase or special characters, among others.  This can make it easier to type
+  the names into a terminal, share them via a web or to make the folder names
+  more portable.
+
+   .. code:: sh
+
+        papis rename -rb --slugify author:"Rick Astley"
+
+- There is also an option to avoid picking the entries, ``--all``. This is
+  a flag that should be used with caution, especially when used along with
+  ``--batch``, since it will make ``papis rename`` act on all matching documents.
+  To rename all matched folders with a name generated from config, "slugifying"
+  the names and asking for confirmation before each rename:
+
+   .. code:: sh
+
+        papis rename -rbs --all author:"Rick Astley"
+
+
 Command-line Interface
 ^^^^^^^^^^^^^^^^^^^^^^
 
 .. click:: papis.commands.rename:cli
     :prog: papis rename
 """
+
 
 import os
 from typing import Optional, Tuple, List
@@ -65,9 +118,9 @@ def prepare_run(operations: List[Tuple[papis.document.Document, str]],
 
 @click.command("rename")
 @papis.cli.bool_flag("--batch", "-b", default=False, help="Batch mode, do not prompt")
-@papis.cli.bool_flag("--slugify", "-s", default=False, help="Slugify the folder name")
 @papis.cli.bool_flag("--regenerate", "-r", default=False,
                      help="Regenerate the folder name from the configured patttern")
+@papis.cli.bool_flag("--slugify", "-s", default=False, help="Slugify the folder name")
 @click.help_option("--help", "-h")
 @papis.cli.all_option()
 @papis.cli.query_argument()
@@ -83,7 +136,7 @@ def cli(query: str,
         sort_field: Optional[str],
         doc_folder: Tuple[str, ...],
         sort_reverse: bool) -> None:
-    """Rename entry"""
+    """Rename an entry"""
     documents = papis.cli.handle_doc_folder_query_all_sort(query,
                                                            doc_folder,
                                                            sort_field,

--- a/papis/commands/rename.py
+++ b/papis/commands/rename.py
@@ -2,51 +2,49 @@
 The ``rename`` command is used to rename document folders based on
 a provided format or using :confval:`add-folder-name`.
 
+It will (except when run with ``--all``) bring up the picker with a list of
+documents that match the query. In the picker, you can select one or more
+documents and then initiate renaming by pressing enter. Folder names are cleaned,
+so that various characters (white spaces, punctuation, capital letters, and some
+others) are automatically converted.
+
 Examples
 ^^^^^^^^
 
-- Manually rename all folders for documents matching a query. ``papis`` will
-  prompt for the new folder name, with the current name as a default.
+- Rename folders for documents whose author is "Rick Astley". You can then either
+  enter a new folder name or accept Papis' suggestion. The suggested folder name
+  will be generated according to :confval:`add-folder-name` or, if this option
+  isn't set, the current folder name.
 
    .. code:: sh
 
         papis rename author:"Rick Astley"
 
-- Rename picked folders that match a query and automatically ``--folder-name``
-  the names following the pattern provided by the ``add-folder-name``
-  configuration option. It will ask for confirmation before each rename. It
-  doesn't slugify the names, so if the pattern results in "Rick Astley - Never
-  Gonna Give You Up", that will be the final folder name.
+- You can use ``--folder-name`` to pass in your desired name. This option
+  supports Papis formatting patterns. You will be asked for confirmation
+  before the folder is renamed.
 
    .. code:: sh
 
-        papis rename --folder-name author:"Rick Astley"
+        papis rename --folder-name "{doc[author]}-never-gonna" author:"Rick Astley"
 
-- Rename folders without asking for confirmation using ``--batch``.
+  This will give you a folder named "rick-astley-never-gonna".
 
-   .. code:: sh
 
-        papis rename -r --batch author:"Rick Astley"
-
-- The folder names can be slugified too with the ``--slugify`` flag. This avoids
-  uppercase or special characters, among others.  This can make it easier to type
-  the names into a terminal, share them via a web or to make the folder names
-  more portable.
+- To stop Papis from asking for confirmation, use the ``--batch`` flag:
 
    .. code:: sh
 
-        papis rename -rb --slugify author:"Rick Astley"
+        papis rename --batch author:"Rick Astley"
 
-- There is also an option to avoid picking the entries, ``--all``. This is
-  a flag that should be used with caution, especially when used along with
-  ``--batch``, since it will make ``papis rename`` act on all matching documents.
-  To rename all matched folders with a name generated from config, "slugifying"
-  the names and asking for confirmation before each rename:
+- If you want to rename all documents without narrowing down your selection in
+  the picker, you can use the ``--all`` flag. Be careful when combining this
+  with ``--batch``, as you might end up renaming a lot folders without
+  confirmation:
 
    .. code:: sh
 
-        papis rename -rbs --all author:"Rick Astley"
-
+        papis rename --all author:"Rick Astley"
 
 Command-line Interface
 ^^^^^^^^^^^^^^^^^^^^^^

--- a/papis/git.py
+++ b/papis/git.py
@@ -9,6 +9,16 @@ import papis.logging
 logger = papis.logging.get_logger(__name__)
 
 
+def add(path: str, resource: str) -> None:
+    """Adds changes in the *path* to the git index with a *message*.
+
+    :param path: a folder with an existing git repository.
+    :param resource: a resource (e.g. ``info.yaml`` file) to add to the index.
+    """
+    logger.info("Adding '%s'.", path)
+    papis.utils.run(["git", "add", resource], cwd=path)
+
+
 def commit(path: str, message: str) -> None:
     """Commits changes in the *path* with a *message*.
 
@@ -19,14 +29,15 @@ def commit(path: str, message: str) -> None:
     papis.utils.run(["git", "commit", "-m", message], cwd=path)
 
 
-def add(path: str, resource: str) -> None:
-    """Adds changes in the *path* to the git index with a *message*.
+def mv(from_path: str, to_path: str) -> None:
+    """Renames (moves) the path *from_path* to *to_path*.
 
-    :param path: a folder with an existing git repository.
-    :param resource: a resource (e.g. ``info.yaml`` file) to add to the index.
+    :param from_path: path to be moved (the source).
+    :param to_path: destination where *from_path* is moved. If this is in the
+        same parent directory as *from_path*, it is a simple rename.
     """
-    logger.info("Adding '%s'.", path)
-    papis.utils.run(["git", "add", resource], cwd=path)
+    logger.info("Moving '%s' to '%s'.", from_path, to_path)
+    papis.utils.run(["git", "mv", from_path, to_path], cwd=from_path)
 
 
 def remove(path: str, resource: str,
@@ -56,6 +67,17 @@ def add_and_commit_resource(path: str, resource: str, message: str) -> None:
     """
     add(path, resource)
     commit(path, message)
+
+
+def mv_and_commit_resource(from_path: str, to_path: str, message: str) -> None:
+    """Moves *from_path* and commits the change.
+
+    :param from_path: path to be moved (the source).
+    :param to_path: destination where *from_path* is moved.
+    :param message: a commit message.
+    """
+    mv(from_path, to_path)
+    commit(to_path, message)
 
 
 def add_and_commit_resources(path: str,

--- a/tests/commands/test_rename.py
+++ b/tests/commands/test_rename.py
@@ -22,6 +22,12 @@ def test_rename_run(tmp_library: TemporaryLibrary) -> None:
 
 
 def test_regenerate_name(tmp_library: TemporaryLibrary) -> None:
+    # Avoids disabling loading windll on Windows if Sphinx is also detected
+    # see https://github.com/prompt-toolkit/python-prompt-toolkit/blob/465ab02854763fafc0099a2e38a56328c1cb0625/src/prompt_toolkit/output/win32.py#L30  # noqa
+    import sys
+    if "sphinx.ext.autodoc" in sys.modules:
+        sys.modules.pop("sphinx.ext.autodoc")
+
     from papis.commands.rename import cli
     from papis.testing import PapisRunner
 
@@ -36,6 +42,11 @@ def test_regenerate_name(tmp_library: TemporaryLibrary) -> None:
 def test_batch_regenerate_name(tmp_library: TemporaryLibrary,
                                caplog) -> None:
     import logging
+
+    # See comment on previous function
+    import sys
+    if "sphinx.ext.autodoc" in sys.modules:
+        sys.modules.pop("sphinx.ext.autodoc")
 
     from papis.commands.rename import cli
     from papis.testing import PapisRunner

--- a/tests/commands/test_rename.py
+++ b/tests/commands/test_rename.py
@@ -51,8 +51,12 @@ def test_rename_single_entry(regenerate: List,
         print(prompt)
         return default
 
+    def dumb_confirm(prompt, *_) -> bool:
+        print(prompt)
+        return True
+
     with monkeypatch.context() as m:
-        m.setattr(papis.tui.utils, "confirm", lambda prompt, *_: print(prompt))
+        m.setattr(papis.tui.utils, "confirm", dumb_confirm)
         m.setattr(papis.tui.utils, "prompt", dumb_prompt)
         result = runner.invoke(cli, args)
         assert substring in result.output

--- a/tests/commands/test_rename.py
+++ b/tests/commands/test_rename.py
@@ -1,7 +1,7 @@
 import os
 
 import papis.database
-from papis.testing import TemporaryLibrary, TemporaryConfiguration
+from papis.testing import TemporaryLibrary
 
 
 def test_rename_run(tmp_library: TemporaryLibrary) -> None:
@@ -21,13 +21,11 @@ def test_rename_run(tmp_library: TemporaryLibrary) -> None:
     assert os.path.exists(doc.get_main_folder())
 
 
-def test_regenerate_name(tmp_library: TemporaryLibrary,
-                         tmp_config: TemporaryConfiguration,
-                         ) -> None:
-    from click.testing import CliRunner
+def test_regenerate_name(tmp_library: TemporaryLibrary) -> None:
     from papis.commands.rename import cli
+    from papis.testing import PapisRunner
 
-    runner = CliRunner(mix_stderr=False)
+    runner = PapisRunner()
 
     magic_string = "Test42"
     papis.config.set("add-folder-name", magic_string)
@@ -36,14 +34,13 @@ def test_regenerate_name(tmp_library: TemporaryLibrary,
 
 
 def test_batch_regenerate_name(tmp_library: TemporaryLibrary,
-                               tmp_config: TemporaryConfiguration,
                                caplog) -> None:
     import logging
 
-    from click.testing import CliRunner
     from papis.commands.rename import cli
+    from papis.testing import PapisRunner
 
-    runner = CliRunner(mix_stderr=False)
+    runner = PapisRunner()
 
     docs = papis.database.get().get_all_documents()
     magic_string = "Test42"
@@ -52,4 +49,4 @@ def test_batch_regenerate_name(tmp_library: TemporaryLibrary,
         runner.invoke(cli, ["--all", "--regenerate", "--batch"])
         assert len(caplog.records) == len(docs)
         for record in caplog.records:
-            assert magic_string in record.text
+            assert magic_string in record.message

--- a/tests/commands/test_rename.py
+++ b/tests/commands/test_rename.py
@@ -1,8 +1,11 @@
 import os
 
+from _pytest.logging import LogCaptureFixture
 from _pytest.monkeypatch import MonkeyPatch
 
+import papis.config
 import papis.database
+
 from papis.testing import TemporaryLibrary
 
 
@@ -26,79 +29,96 @@ def test_rename_run(tmp_library: TemporaryLibrary) -> None:
 def test_folder_name_flag(tmp_library: TemporaryLibrary,
                           monkeypatch: MonkeyPatch,
                           ) -> None:
-    import re
-
-    from papis.commands.rename import cli
-    from papis.testing import PapisRunner
-
-    def dumb_confirm(prompt, *_) -> bool:
-        print(prompt)
-        return True
-
-    runner = PapisRunner()
-    first_doc_id = papis.database.get().get_all_documents()[0]["papis_id"]
-    query = f"papis_id:{first_doc_id}"
     papis.config.set("add-folder-name", "{doc[papis_id]}")
 
-    new_name_re = re.compile(r"Rename .* into (.*)\?")
+    from papis.commands.rename import cli
+    from papis.testing import PapisRunner
+
+    runner = PapisRunner()
+    db = papis.database.get()
+
+    doc, *_ = db.get_all_documents()
+    papis_id = doc["papis_id"]
+
+    old_folder_name = doc.get_main_folder()
+    assert os.path.exists(old_folder_name)
 
     with monkeypatch.context() as m:
-        m.setattr(papis.tui.utils, "confirm", dumb_confirm)
+        m.setattr(papis.tui.utils, "confirm", lambda *args, **kwargs: True)
 
         # Check that the document will be renamed according to the default pattern
-        result = runner.invoke(cli, [query])
-        new_name = new_name_re.match(result.output).group(1)
-        assert new_name == first_doc_id
+        result = runner.invoke(
+            cli,
+            [f"papis_id:{papis_id}"])
+
+        doc, = db.query_dict({"papis_id": papis_id})
+        assert result.exit_code == 0
+        assert os.path.basename(doc.get_main_folder()) == papis_id
+        assert os.path.exists(doc.get_main_folder())
+        assert not os.path.exists(old_folder_name)
 
         # Check that we can override the default pattern
-        result = runner.invoke(cli, ["--folder-name", "magicstring42", query])
-        new_name = new_name_re.match(result.output).group(1)
-        assert new_name == "magicstring42"
+        result = runner.invoke(
+            cli,
+            ["--folder-name", "magicstring42", f"papis_id:{papis_id}"])
+
+        doc, = db.query_dict({"papis_id": papis_id})
+        assert result.exit_code == 0
+        assert os.path.basename(doc.get_main_folder()) == "magicstring42"
+        assert os.path.exists(doc.get_main_folder())
 
 
-def test_rename_batch(tmp_library: TemporaryLibrary, caplog) -> None:
-    import logging
+def test_rename_batch(tmp_library: TemporaryLibrary) -> None:
+    papis.config.set("add-folder-name", "magic-string-42-{doc[papis_id]}")
 
     from papis.commands.rename import cli
     from papis.testing import PapisRunner
 
     runner = PapisRunner()
+    runner.invoke(
+        cli,
+        ["--all", "--batch"])
 
     docs = papis.database.get().get_all_documents()
-    magic_string = "magic-string42"
-    papis.config.set("add-folder-name", magic_string + "-{doc[papis_id]}")
-    with caplog.at_level(logging.INFO):
-        runner.invoke(cli, ["--all", "--batch"])
-        assert len(caplog.records) == len(docs)
-        for record in caplog.records:
-            assert magic_string in record.message
+    for doc in docs:
+        folder = doc.get_main_folder()
+
+        assert os.path.exists(folder)
+        assert os.path.basename(folder).startswith("magic-string-42")
 
 
-def test_rename_no_matching_documents(tmp_library: TemporaryLibrary, caplog) -> None:
-    import logging
+def test_rename_no_matching_documents(tmp_library: TemporaryLibrary,
+                                      caplog: LogCaptureFixture) -> None:
+    from papis.commands.rename import cli
+    from papis.testing import PapisRunner
 
+    with caplog.at_level("WARNING", logger="papis"):
+        runner = PapisRunner()
+        runner.invoke(
+            cli,
+            ["--all", "--batch", "url:https://youtu.be/dQw4w9WgXcQ"])
+
+        warning, = caplog.records
+        assert warning.levelname == "WARNING"
+        assert warning.message == "No documents retrieved"
+
+
+def test_duplicate_new_names(tmp_library: TemporaryLibrary,
+                             caplog: LogCaptureFixture) -> None:
     from papis.commands.rename import cli
     from papis.testing import PapisRunner
 
     runner = PapisRunner()
-    args = ["--all", "--folder-name", "--batch", "url:https://youtu.be/dQw4w9WgXcQ"]
-    with caplog.at_level(logging.INFO):
-        runner.invoke(cli, args)
+    doc_count = len(papis.database.get().get_all_documents())
 
-        warnings = [r for r in caplog.records if r.levelno == logging.WARN]
-        assert len(warnings) == 1
+    with caplog.at_level("WARNING", logger="papis"):
+        runner.invoke(
+            cli,
+            ["--all", "--folder-name", "same-name", "--batch"])
 
-
-def test_duplicate_new_names(tmp_library: TemporaryLibrary, caplog) -> None:
-    import logging
-
-    from papis.commands.rename import cli
-    from papis.testing import PapisRunner
-
-    docs = papis.database.get().get_all_documents()
-    runner = PapisRunner()
-    with caplog.at_level(logging.WARN):
-        runner.invoke(cli, ["--all", "--folder-name", "same_name", "--batch"])
-        warnings = [r for r in caplog.records if r.levelno == logging.WARN]
         # First document will rename, but all others should raise a warning
-        assert len(warnings) == len(docs) - 1
+        assert len(caplog.records) == doc_count - 1
+        assert all(
+            os.path.basename(record.args[0]) == "same-name"
+            for record in caplog.records
+            )

--- a/tests/commands/test_rename.py
+++ b/tests/commands/test_rename.py
@@ -26,7 +26,7 @@ def test_rename_run(tmp_library: TemporaryLibrary) -> None:
 
 
 @pytest.mark.parametrize(["regenerate", "substring"],
-                         [[False, "Enter new folder name"], [True, "MAGIC_STRING"]])
+                         [[False, "Enter new folder name"], [True, "magic-string42"]])
 def test_rename_single_entry(regenerate: List,
                              substring: str,
                              tmp_library: TemporaryLibrary,
@@ -67,36 +67,13 @@ def test_rename_batch(tmp_library: TemporaryLibrary, caplog) -> None:
     runner = PapisRunner()
 
     docs = papis.database.get().get_all_documents()
-    magic_string = "Test42"
+    magic_string = "magic-string42"
     papis.config.set("add-folder-name", magic_string + "-{doc[papis_id]}")
     with caplog.at_level(logging.INFO):
         runner.invoke(cli, ["--all", "--regenerate", "--batch"])
         assert len(caplog.records) == len(docs)
         for record in caplog.records:
             assert magic_string in record.message
-
-
-def test_rename_and_slugify(tmp_library: TemporaryLibrary, caplog) -> None:
-    import logging
-    import re
-
-    from papis.commands.rename import cli
-    from papis.testing import PapisRunner
-
-    runner = PapisRunner()
-
-    docs = papis.database.get().get_all_documents()
-    papis.config.set("add-folder-name", "{doc[author]}-{doc[title]}")
-    with caplog.at_level(logging.INFO):
-        runner.invoke(cli, ["--all", "--regenerate", "--batch", "--slugify"])
-        assert len(caplog.records) == len(docs)
-        for record in caplog.records:
-            # Check that no filenames contain uppercase characters, punctuation
-            # or spaces
-            pattern = re.compile("Renaming.*into '([a-z-]+)'")
-            if match := pattern.match(record.message):
-                new_name = match.group(1)
-                assert "-" in new_name
 
 
 def test_rename_no_matching_documents(tmp_library: TemporaryLibrary, caplog) -> None:

--- a/tests/commands/test_rename.py
+++ b/tests/commands/test_rename.py
@@ -1,8 +1,7 @@
 import os
 
 import papis.database
-
-from papis.testing import TemporaryLibrary
+from papis.testing import TemporaryLibrary, TemporaryConfiguration
 
 
 def test_rename_run(tmp_library: TemporaryLibrary) -> None:
@@ -20,3 +19,37 @@ def test_rename_run(tmp_library: TemporaryLibrary) -> None:
     doc, = db.query_dict({"title": old_title})
     assert doc.get_main_folder_name() == new_name
     assert os.path.exists(doc.get_main_folder())
+
+
+def test_regenerate_name(tmp_library: TemporaryLibrary,
+                         tmp_config: TemporaryConfiguration,
+                         ) -> None:
+    from click.testing import CliRunner
+    from papis.commands.rename import cli
+
+    runner = CliRunner(mix_stderr=False)
+
+    magic_string = "Test42"
+    papis.config.set("add-folder-name", magic_string)
+    result = runner.invoke(cli, ["--all", "--regenerate"])
+    assert magic_string in result.output
+
+
+def test_batch_regenerate_name(tmp_library: TemporaryLibrary,
+                               tmp_config: TemporaryConfiguration,
+                               caplog) -> None:
+    import logging
+
+    from click.testing import CliRunner
+    from papis.commands.rename import cli
+
+    runner = CliRunner(mix_stderr=False)
+
+    docs = papis.database.get().get_all_documents()
+    magic_string = "Test42"
+    papis.config.set("add-folder-name", magic_string + "-{doc[papis_id]}")
+    with caplog.at_level(logging.INFO):
+        runner.invoke(cli, ["--all", "--regenerate", "--batch"])
+        assert len(caplog.records) == len(docs)
+        for record in caplog.records:
+            assert magic_string in record.text

--- a/tests/commands/test_rename.py
+++ b/tests/commands/test_rename.py
@@ -90,6 +90,8 @@ def test_rename_batch(tmp_library: TemporaryLibrary) -> None:
 
 def test_rename_no_matching_documents(tmp_library: TemporaryLibrary,
                                       caplog: LogCaptureFixture) -> None:
+    papis.config.set("add-folder-name", "{doc[papis_id]}")
+
     from papis.commands.rename import cli
     from papis.testing import PapisRunner
 

--- a/tests/commands/test_rename.py
+++ b/tests/commands/test_rename.py
@@ -75,9 +75,10 @@ def test_rename_batch(tmp_library: TemporaryLibrary) -> None:
     from papis.testing import PapisRunner
 
     runner = PapisRunner()
-    runner.invoke(
+    result = runner.invoke(
         cli,
         ["--all", "--batch"])
+    assert result.exit_code == 0
 
     docs = papis.database.get().get_all_documents()
     for doc in docs:
@@ -94,9 +95,10 @@ def test_rename_no_matching_documents(tmp_library: TemporaryLibrary,
 
     with caplog.at_level("WARNING", logger="papis"):
         runner = PapisRunner()
-        runner.invoke(
+        result = runner.invoke(
             cli,
             ["--all", "--batch", "url:https://youtu.be/dQw4w9WgXcQ"])
+        assert result.exit_code == 0
 
         warning, = caplog.records
         assert warning.levelname == "WARNING"
@@ -112,9 +114,10 @@ def test_duplicate_new_names(tmp_library: TemporaryLibrary,
     doc_count = len(papis.database.get().get_all_documents())
 
     with caplog.at_level("WARNING", logger="papis"):
-        runner.invoke(
+        result = runner.invoke(
             cli,
             ["--all", "--folder-name", "same-name", "--batch"])
+        assert result.exit_code == 0
 
         # First document will rename, but all others should raise a warning
         assert len(caplog.records) == doc_count - 1

--- a/tests/commands/test_rename.py
+++ b/tests/commands/test_rename.py
@@ -1,4 +1,7 @@
 import os
+import sys
+
+import pytest
 
 import papis.database
 from papis.testing import TemporaryLibrary
@@ -21,13 +24,8 @@ def test_rename_run(tmp_library: TemporaryLibrary) -> None:
     assert os.path.exists(doc.get_main_folder())
 
 
+@pytest.mark.skipif(sys.platform == "win32", reason="prompt_toolkit won't work in CI")
 def test_regenerate_name(tmp_library: TemporaryLibrary) -> None:
-    # Avoids disabling loading windll on Windows if Sphinx is also detected
-    # see https://github.com/prompt-toolkit/python-prompt-toolkit/blob/465ab02854763fafc0099a2e38a56328c1cb0625/src/prompt_toolkit/output/win32.py#L30  # noqa
-    import sys
-    if "sphinx.ext.autodoc" in sys.modules:
-        sys.modules.pop("sphinx.ext.autodoc")
-
     from papis.commands.rename import cli
     from papis.testing import PapisRunner
 
@@ -39,14 +37,10 @@ def test_regenerate_name(tmp_library: TemporaryLibrary) -> None:
     assert magic_string in result.output
 
 
+@pytest.mark.skipif(sys.platform == "win32", reason="prompt_toolkit won't work in CI")
 def test_batch_regenerate_name(tmp_library: TemporaryLibrary,
                                caplog) -> None:
     import logging
-
-    # See comment on previous function
-    import sys
-    if "sphinx.ext.autodoc" in sys.modules:
-        sys.modules.pop("sphinx.ext.autodoc")
 
     from papis.commands.rename import cli
     from papis.testing import PapisRunner


### PR DESCRIPTION
When I develop a feature, I try to dogfood, so sometimes I end up using default values of config options such as `add-folder-name`, thus creating folders that don't end up like I like. `papis rename` can rename entries but is now pretty limited.

With this WIP pull request, I am trying to make `papis rename` a bit more powerful:

- allow selecting multiple entries with the picker
- selecting all entries matching a query, for mass renaming of folders
- optional slugify of names
- rename without confirmation
- rename using the generated folder name

It's taking form:

With slug enabled:
```
 papis rename -arsb "black hole"
[INFO] commands.rename: Renaming 'raju-2024-howdoesinformationemerge' into 'test-2024-how-does-information-emerge-from-a-black-hole'
[INFO] commands.rename: Renaming 'macedo-2024-thermodynamicsandquasinormalmodes' into 'test-2024-thermodynamics-and-quasinormal-modes-of-the-dymnikova-black-hole-in-higher-dimensions'
[INFO] commands.rename: Renaming 'ressler-2024-blackhole-diskinteractionsin' into 'test-2024-black-hole-disk-interactions-in-magnetically-arrested-active-galactic-nuclei-general-relativistic-magnetohydrodynamic-simulations-using-a-time-dependent-binary-metric'
```

Without:
```
 papis rename -arb "black hole"
[INFO] commands.rename: Renaming 'test-2024-how-does-information-emerge-from-a-black-hole' into 'Test 2024 How does information emerge from a black hole?'
[INFO] commands.rename: Renaming 'test-2024-thermodynamics-and-quasinormal-modes-of-the-dymnikova-black-hole-in-higher-dimensions' into 'Test 2024 Thermodynamics and Quasinormal Modes of the Dymnikova Black Hole in Higher Dimensions'
[INFO] commands.rename: Renaming 'test-2024-black-hole-disk-interactions-in-magnetically-arrested-active-galactic-nuclei-general-relativistic-magnetohydrodynamic-simulations-using-a-time-dependent-binary-metric' into 'Test 2024 Black Hole-Disk Interactions in Magnetically Arrested Active Galactic Nuclei: General Relativistic Magnetohydrodynamic Simulations Using A Time-Dependent, Binary Metric'
```

Picking files:
```
 papis rename -rbs "black hole"
#How does information emerge from a black hole?
  Raju, Suvrat
   (2024) []
#Thermodynamics and Quasinormal Modes of the Dymnikova Black Hole in Higher Dimensions
  Macêdo, M. H. and Furtado, J. and Alencar, G. and Landim, R. R.
   (2024) []
|Black Hole-Disk Interactions in Magnetically Arrested Active Galactic Nuclei: General Relat
| Ressler, Sean M. and Combi, Luciano and Li, Xinyu and Ripperda, Bart and Yang, Huan
|  (2024) []

[INFO] commands.rename: Renaming 'Test 2024 How does information emerge from a black hole?' into 'test-2024-how-does-information-emerge-from-a-black-hole'
[INFO] commands.rename: Renaming 'Test 2024 Thermodynamics and Quasinormal Modes of the Dymnikova Black Hole in Higher Dimensions' into 'test-2024-thermodynamics-and-quasinormal-modes-of-the-dymnikova-black-hole-in-higher-dimensions'
```
What do you think?