### PR TITLE
ci: use uv

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -25,6 +25,11 @@ jobs:
       with:
         python-version: ${{ matrix.python-version }}
 
+    - name: Install uv
+      uses: yezz123/setup-uv@v4
+      with:
+        uv-venv: "venv"
+
     - name: Install dependencies
       run: make ci-install
       shell: bash

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -24,11 +24,16 @@ jobs:
       with:
         python-version: "3.12"
 
+    - name: Install uv
+      uses: yezz123/setup-uv@v4
+      with:
+        uv-venv: "venv"
+
     - name: Install dependencies
       shell: bash
       run: |
         make ci-install
-        pip install '.[windows]'
+        uv pip install '.[windows]'
 
     - name: Set version in pyproject.toml, MSI and environment
       shell: bash

--- a/tests/commands/test_edit.py
+++ b/tests/commands/test_edit.py
@@ -1,4 +1,5 @@
 import os
+import sys
 import pytest
 
 import papis.database
@@ -9,7 +10,7 @@ script = os.path.join(os.path.dirname(__file__), "scripts.py")
 
 
 @pytest.mark.library_setup(settings={
-    "editor": "python {} sed".format(script)
+    "editor": "{} {} sed".format(sys.executable, script)
     })
 def test_edit_run(tmp_library: TemporaryLibrary) -> None:
     import papis.config

--- a/tools/ci-install.sh
+++ b/tools/ci-install.sh
@@ -2,5 +2,5 @@
 
 set -o errexit -o noglob -o pipefail
 
-python -m pip install --upgrade pip hatchling wheel
-python -m pip install --editable '.[develop,docs,optional]'
+uv pip install --upgrade pip hatchling wheel
+uv pip install --editable '.[develop,docs,optional]'


### PR DESCRIPTION
Hi! This is a companion PR to the discussion in #812. I have been using `uv` for some months now and would like to pitch for inclusion in the CI pipelines here.

With this PR, we can significantly cut the time that it takes to install dependencies during CI. For instance, with the current setup, installing deps on Ubuntu takes around 20 seconds. With this PR it would be around 3-6 seconds. In Windows, installing the deps takes around one minute. With this PR, the time is halved too, resulting in around 20 seconds.

For this, a 3rd party action is used. I have personally reviewed the code there and it doesn't do anything sketchy.

If you want to see it in action with Papis, it's been running [on my fork](https://github.com/kiike/papis/actions/workflows/main.yml).

When testing this PR I also found a minor bug that happened on Windows during testing in CI. The venv with uv is not global, so `test_edit_run` fails because the mock `sed` program does not have the necessary `papis` dependency since it looks in the global venv. With this PR, the interpreter is assured to be the one that runs during CI (using `sys.executable`), having access to all the runtime dependencies.

