### PR TITLE
tests/mock_sed: use same interpreter as the one `pytest` is running

### DIFF
--- a/tests/commands/test_edit.py
+++ b/tests/commands/test_edit.py
@@ -1,4 +1,5 @@
 import os
+import sys
 import pytest
 
 import papis.database
@@ -9,7 +10,7 @@ script = os.path.join(os.path.dirname(__file__), "scripts.py")
 
 
 @pytest.mark.library_setup(settings={
-    "editor": "python {} sed".format(script)
+    "editor": "{} {} sed".format(sys.executable, script)
     })
 def test_edit_run(tmp_library: TemporaryLibrary) -> None:
     import papis.config


### PR DESCRIPTION
When testing #813 I found a minor bug that happened on Windows during testing in CI or in my machine with a vanilla Windows installation.

The venv with uv is not global, so `test_edit_run` fails because the mock sed program does not have the necessary papis dependency, not being aware of the local venv.

With this PR, the interpreter is made to be the one that runs during CI (using `sys.executable`), having access to all the runtime dependencies.