### PR TITLE
tests(windows): fix remaining "unixisms" that break some tests

### DIFF
--- a/papis/commands/add.py
+++ b/papis/commands/add.py
@@ -90,7 +90,6 @@ Command-line Interface
 
 import os
 import re
-import sys
 from typing import List, Any, Optional, Dict, Tuple
 
 import click
@@ -418,17 +417,7 @@ def run(paths: List[str],
 
         if link:
             in_file_abspath = os.path.abspath(in_file_path)
-            try:
-                logger.info("[SYMLINK] '%s' to '%s'.", in_file_abspath,
-                            tmp_end_filepath)
-                os.symlink(in_file_abspath, tmp_end_filepath)
-            except OSError as e:
-                missing_privilege_error = 1314
-                if sys.platform == "win32" and e.winerror == missing_privilege_error:
-                    logger.error("Failed to link due to insufficient permissions.  You "
-                                 "can try again after enabling the 'Developer mode' "
-                                 "and restarting.")
-                raise
+            papis.utils.symlink(in_file_abspath, tmp_end_filepath)
         elif move:
             logger.info("[MV] '%s' to '%s'.", in_file_path, tmp_end_filepath)
             shutil.copy(in_file_path, tmp_end_filepath)

--- a/papis/commands/add.py
+++ b/papis/commands/add.py
@@ -90,6 +90,7 @@ Command-line Interface
 
 import os
 import re
+import sys
 from typing import List, Any, Optional, Dict, Tuple
 
 import click
@@ -417,8 +418,17 @@ def run(paths: List[str],
 
         if link:
             in_file_abspath = os.path.abspath(in_file_path)
-            logger.info("[SYMLINK] '%s' to '%s'.", in_file_abspath, tmp_end_filepath)
-            os.symlink(in_file_abspath, tmp_end_filepath)
+            try:
+                logger.info("[SYMLINK] '%s' to '%s'.", in_file_abspath,
+                            tmp_end_filepath)
+                os.symlink(in_file_abspath, tmp_end_filepath)
+            except OSError as e:
+                missing_privilege_error = 1314
+                if sys.platform == "win32" and e.winerror == missing_privilege_error:
+                    logger.error("Failed to link due to insufficient permissions.  You "
+                                 "can try again after enabling the 'Developer mode' "
+                                 "and restarting.")
+                raise
         elif move:
             logger.info("[MV] '%s' to '%s'.", in_file_path, tmp_end_filepath)
             shutil.copy(in_file_path, tmp_end_filepath)

--- a/papis/commands/add.py
+++ b/papis/commands/add.py
@@ -417,6 +417,7 @@ def run(paths: List[str],
 
         if link:
             in_file_abspath = os.path.abspath(in_file_path)
+            logger.info("[SYMLINK] '%s' to '%s'.", in_file_abspath, tmp_end_filepath)
             papis.utils.symlink(in_file_abspath, tmp_end_filepath)
         elif move:
             logger.info("[MV] '%s' to '%s'.", in_file_path, tmp_end_filepath)

--- a/papis/commands/addto.py
+++ b/papis/commands/addto.py
@@ -98,8 +98,7 @@ def run(document: papis.document.Document,
 
         if link:
             in_file_abspath = os.path.abspath(in_file_path)
-            logger.debug("[SYMLINK] '%s' to '%s'.", in_file_abspath, out_file_path)
-            os.symlink(in_file_abspath, out_file_path)
+            papis.utils.symlink(in_file_abspath, out_file_path)
         else:
             import shutil
             logger.info("[CP] '%s' to '%s'.", local_in_file_path, out_file_path)

--- a/papis/commands/addto.py
+++ b/papis/commands/addto.py
@@ -98,6 +98,7 @@ def run(document: papis.document.Document,
 
         if link:
             in_file_abspath = os.path.abspath(in_file_path)
+            logger.info("[SYMLINK] '%s' to '%s'.", in_file_abspath, out_file_path)
             papis.utils.symlink(in_file_abspath, out_file_path)
         else:
             import shutil

--- a/papis/commands/mv.py
+++ b/papis/commands/mv.py
@@ -34,8 +34,12 @@ def run(document: papis.document.Document,
     if not folder:
         raise DocumentFolderNotFound(papis.document.describe(document))
 
-    papis.utils.run((["git"] if git else []) + ["mv", folder, new_folder_path],
-                    cwd=folder)
+    if git:
+        papis.utils.run(["git", "mv", folder, new_folder_path],
+                        cwd=folder)
+    else:
+        import shutil
+        shutil.move(folder, new_folder_path)
 
     db = papis.database.get()
     db.delete(document)

--- a/papis/commands/mv.py
+++ b/papis/commands/mv.py
@@ -14,6 +14,7 @@ from typing import Optional, Tuple
 import click
 
 import papis.config
+import papis.git
 import papis.utils
 import papis.database
 import papis.document
@@ -35,8 +36,7 @@ def run(document: papis.document.Document,
         raise DocumentFolderNotFound(papis.document.describe(document))
 
     if git:
-        papis.utils.run(["git", "mv", folder, new_folder_path],
-                        cwd=folder)
+        papis.git.mv(folder, new_folder_path)
     else:
         import shutil
         shutil.move(folder, new_folder_path)

--- a/papis/utils.py
+++ b/papis/utils.py
@@ -34,6 +34,8 @@ A = TypeVar("A")
 #: Invariant :class:`typing.TypeVar`
 B = TypeVar("B")
 
+ERROR_PRIVILEGE_NOT_HELD = 1314
+
 
 def get_session() -> "requests.Session":
     """Create a :class:`requests.Session` for ``papis``.
@@ -649,10 +651,9 @@ def symlink(source: str, destination: str) -> None:
         logger.debug("[SYMLINK] '%s' to '%s'.", source, destination)
         os.symlink(source, destination)
     except OSError as exc:
-        windows_missing_privilege_error = 1314
-        if sys.platform == "win32" and exc.winerror == windows_missing_privilege_error:
+        if sys.platform == "win32" and exc.winerror == ERROR_PRIVILEGE_NOT_HELD:
             # https://learn.microsoft.com/en-us/windows/win32/debug/system-error-codes--1300-1699-
-            logger.error("Failed to link due to insufficient permissions.  You "
-                         "can try again after enabling the 'Developer mode' "
-                         "and restarting.", exc_info=exc)
-            raise
+            raise OSError(exc.errno,
+                          "Failed to link due to insufficient permissions. You "
+                          "can try again after enabling the 'Developer mode' "
+                          "and restarting.", exc.filename, exc.winerror, exc.filename2)

--- a/papis/utils.py
+++ b/papis/utils.py
@@ -648,7 +648,6 @@ def symlink(source: str, destination: str) -> None:
     :param destination: the name of the new symbolic link, pointing to `source`.
     """
     try:
-        logger.debug("[SYMLINK] '%s' to '%s'.", source, destination)
         os.symlink(source, destination)
     except OSError as exc:
         if sys.platform == "win32" and exc.winerror == ERROR_PRIVILEGE_NOT_HELD:

--- a/papis/utils.py
+++ b/papis/utils.py
@@ -633,3 +633,26 @@ def is_relative_to(path: str, other: str) -> bool:
             return not os.path.relpath(path, start=other).startswith("..")
         except ValueError:
             return False
+
+
+def symlink(source: str, destination: str) -> None:
+    """Creates a symbolic link named ``destination`` that points to ``source``.
+
+    On Windows, Developer Mode can be enabled to allow unprivileged users to
+    allow creation of symlinks.  Failing to do so will raise an OSError exception,
+    with error code 1314.
+
+    :param source: the existing file that `destination` points to
+    :param destination: the name of the new symbolic link, pointing to `source`.
+    """
+    try:
+        logger.debug("[SYMLINK] '%s' to '%s'.", source, destination)
+        os.symlink(source, destination)
+    except OSError as exc:
+        windows_missing_privilege_error = 1314
+        if sys.platform == "win32" and exc.winerror == windows_missing_privilege_error:
+            # https://learn.microsoft.com/en-us/windows/win32/debug/system-error-codes--1300-1699-
+            logger.error("Failed to link due to insufficient permissions.  You "
+                         "can try again after enabling the 'Developer mode' "
+                         "and restarting.", exc_info=exc)
+            raise

--- a/tests/commands/scripts.py
+++ b/tests/commands/scripts.py
@@ -17,6 +17,11 @@ def echo(filename: str) -> None:
     print("Attempted to open '{}'".format(filename))
 
 
+def ls(filename: str) -> None:
+    # NOTE: This function is used by 'test_edit_cli' and 'test_run_run'
+    print(filename)
+
+
 if __name__ == "__main__":
     cmd, filename = sys.argv[-2:]
 
@@ -26,6 +31,8 @@ if __name__ == "__main__":
             sed_replace(filename)
         elif cmd == "echo":
             echo(filename)
+        elif cmd == "ls":
+            ls(filename)
         else:
             ret = 1
     except Exception:

--- a/tests/commands/test_add.py
+++ b/tests/commands/test_add.py
@@ -1,6 +1,7 @@
 import re
 import os
 import pytest
+import sys
 
 import papis.config
 import papis.document
@@ -189,6 +190,7 @@ def test_add_set_cli(tmp_library: TemporaryLibrary) -> None:
     assert not doc.get_files()
 
 
+@pytest.mark.xfail(sys.platform == "win32", reason="Developer mode not enabled")
 def test_add_link_cli(tmp_library: TemporaryLibrary) -> None:
     from papis.commands.add import cli
     cli_runner = PapisRunner()

--- a/tests/commands/test_edit.py
+++ b/tests/commands/test_edit.py
@@ -1,16 +1,22 @@
 import os
-import sys
+
 import pytest
 
 import papis.database
 
 from papis.testing import TemporaryLibrary, PapisRunner
 
-script = os.path.join(os.path.dirname(__file__), "scripts.py")
+
+def get_mock_script(commandlet: str) -> str:
+    import sys
+
+    script = os.path.join(os.path.dirname(__file__), "scripts.py")
+
+    return "{} {} {}".format(sys.executable, script, commandlet)
 
 
 @pytest.mark.library_setup(settings={
-    "editor": "{} {} sed".format(sys.executable, script)
+    "editor": get_mock_script("sed")
     })
 def test_edit_run(tmp_library: TemporaryLibrary) -> None:
     import papis.config
@@ -31,7 +37,7 @@ def test_edit_run(tmp_library: TemporaryLibrary) -> None:
 
 
 @pytest.mark.library_setup(settings={
-    "editor": "echo",
+    "editor": get_mock_script("echo")
     })
 def test_edit_cli(tmp_library: TemporaryLibrary) -> None:
     from papis.commands.edit import cli
@@ -50,11 +56,12 @@ def test_edit_cli(tmp_library: TemporaryLibrary) -> None:
     assert result.exit_code == 0
 
     # check --all
+    ls = get_mock_script("ls")
     result = cli_runner.invoke(
         cli,
-        ["--all", "--editor", "ls", "krishnamurti"])
+        ["--all", "--editor", ls, "krishnamurti"])
     assert result.exit_code == 0
-    assert papis.config.get("editor") == "ls"
+    assert papis.config.get("editor") == get_mock_script("ls")
 
     # check --notes
     notes_name = papis.config.get("notes-name")
@@ -62,9 +69,9 @@ def test_edit_cli(tmp_library: TemporaryLibrary) -> None:
 
     result = cli_runner.invoke(
         cli,
-        ["--all", "--editor", "echo", "--notes", "krishnamurti"])
+        ["--all", "--editor", get_mock_script("echo"), "--notes", "krishnamurti"])
     assert result.exit_code == 0
-    assert papis.config.get("editor") == "echo"
+    assert papis.config.get("editor") == get_mock_script("echo")
 
     db = papis.database.get()
     doc, = db.query_dict({"author": "Krishnamurti"})

--- a/tests/commands/test_edit.py
+++ b/tests/commands/test_edit.py
@@ -7,12 +7,17 @@ import papis.database
 from papis.testing import TemporaryLibrary, PapisRunner
 
 
-def get_mock_script(commandlet: str) -> str:
+def get_mock_script(name: str) -> str:
+    """Constructs a command call for a command mocked by ``scripts.py``.
+
+    :param name: the name of the command, e.g. ``ls`` or ``echo``.
+    :returns: a string of the command
+    """
     import sys
 
     script = os.path.join(os.path.dirname(__file__), "scripts.py")
 
-    return "{} {} {}".format(sys.executable, script, commandlet)
+    return "{} {} {}".format(sys.executable, script, name)
 
 
 @pytest.mark.library_setup(settings={

--- a/tests/commands/test_open.py
+++ b/tests/commands/test_open.py
@@ -8,7 +8,7 @@ script = os.path.join(os.path.dirname(__file__), "scripts.py")
 
 
 @pytest.mark.library_setup(settings={
-    "file-browser": "echo"
+    "file-browser": "{} {} echo".format(sys.executable, script)
     })
 def test_open_cli(tmp_library: TemporaryLibrary) -> None:
     from papis.commands.open import cli
@@ -32,9 +32,11 @@ def test_open_cli(tmp_library: TemporaryLibrary) -> None:
         catch_exceptions=True)
     assert result.exit_code == 0
 
+    # Use a mock scriptlet
     result = cli_runner.invoke(
         cli,
-        ["--tool", "python {} echo".format(script), "--mark", "--all", "Krishnamurti"])
+        ["--tool", "{} {} echo".format(sys.executable, script),
+         "--mark", "--all", "Krishnamurti"])
     assert result.exit_code == 0
 
 

--- a/tests/commands/test_open.py
+++ b/tests/commands/test_open.py
@@ -45,5 +45,5 @@ def test_open_windows_cli(tmp_library: TemporaryLibrary) -> None:
 
     result = cli_runner.invoke(
         cli,
-        ["--tool", 'cmd.exe /c start ""', "--all", "Krishnamurti"])
+        ["--tool", "cmd.exe /c type", "--all", "Krishnamurti"])
     assert result.exit_code == 0

--- a/tests/commands/test_run.py
+++ b/tests/commands/test_run.py
@@ -1,3 +1,6 @@
+import os
+import sys
+
 import pytest
 import papis.config
 
@@ -8,7 +11,9 @@ def test_run_run(tmp_library: TemporaryLibrary) -> None:
     from papis.commands.run import run
 
     libdir, = papis.config.get_lib_dirs()
-    run(libdir, command=["ls"])
+    # Use a mock scriptlet
+    script = os.path.join(os.path.dirname(__file__), "scripts.py")
+    run(libdir, command=[sys.executable, script, "ls"])
 
     with pytest.raises(FileNotFoundError):
         run(libdir, command=["nonexistent"])


### PR DESCRIPTION
When I was developing an earlier PR, I wanted to test it on a vanilla installation of Windows, just to make sure no config could pollute the results.

Turns out, some tests fail on this kind of setup. Even with a benign but creepy Windows error popup during `tests/commands/open`.
![image](https://github.com/papis/papis/assets/464625/37ef9c2c-bcc2-4fd4-958a-42e6f542a707)

Some reasons for the failing tests:

- symlinks no functional unless "developer mode is active" (I guess CI never sees this because it's running a modified build)
- typical unix commands such as `mv`, `echo` or `mv` not present in vanilla Windows.

Some details of this PR:

- It actually contains a fix that is present on a commit of #810, so I'll remove it from there.
- I want to explain the user why symlinks don't work if we get an exception.
- I'm sad to make `["git"] if git else []) + ["mv", folder, new_folder_path]` go, being so clever. I hope using `shutils` is OK.
- the add via symlink test is marked as xfail, just in case it succeeds.
- `script.py` now has `ls` too.

Looking forward to your feedback! I think this PR getting in will make it a bit more polished when a new user tries the 0.14 release on Windows, wants to contribute, and tests pass on a fresh install!