### PR TITLE
picker: some minor improvements for marking entries

### DIFF
--- a/papis/tui/__init__.py
+++ b/papis/tui/__init__.py
@@ -15,6 +15,7 @@ def get_default_settings() -> PapisConfigType:
         "message_toolbar_style": "bg:ansiyellow fg:ansiblack",
         "options_list.selected_margin_style": "bg:ansiblack fg:ansigreen",
         "options_list.unselected_margin_style": "bg:ansiwhite",
+        "options_list.marked_margin_style": "bg:ansiblack fg:ansiwhite",
         "error_toolbar_style": "bg:ansired fg:ansiblack",
 
         "move_down_key": "down",

--- a/papis/tui/app.py
+++ b/papis/tui/app.py
@@ -366,6 +366,9 @@ class Picker(Application, Generic[Option]):  # type: ignore
                 "options_list.unselected_margin": config.getstring(
                     "options_list.unselected_margin_style", section="tui"
                 ),
+                "options_list.marked_margin": config.getstring(
+                    "options_list.marked_margin_style", section="tui"
+                ),
                 "error_toolbar": config.getstring(
                     "error_toolbar_style", section="tui"
                 ),

--- a/papis/tui/widgets/list.py
+++ b/papis/tui/widgets/list.py
@@ -122,8 +122,12 @@ class OptionsList(ConditionalContainer, Generic[Option]):
                 < self.options_headers_linecount[self.current_index]):
             return [("class:options_list.selected_margin", "|")]
         else:
-            marked_clines = [self.index_to_line(i) for i in self.marks]
-            if line in marked_clines:
+            marked_lines = []
+            for index in self.marks:
+                start_line = self.index_to_line(index)
+                end_line = start_line + self.options_headers_linecount[index]
+                marked_lines.extend([line for line in range(start_line, end_line)])
+            if line in marked_lines:
                 return [("class:options_list.marked_margin", "#")]
             else:
                 return [("class:options_list.unselected_margin", " ")]


### PR DESCRIPTION
One of the things that I found a bit unintuitive in the picker was that marked lines only had one marker on the first line. That is alright but I find it a bit more straightforward if the marker is applied to the whole entry, as many lines as that might span.

Also, while both selected and unselected margins can be configured, marked margins can not. I use the marker quite often, so i want a clearer picture of what I have marked.

This PR introduces:

- configurable marked line margin style: allows setting the style of a marked entry's margin ![image](https://github.com/papis/papis/assets/464625/3a82545b-c688-4d47-b805-71949fb02c6c)
- markers span the whole line range for an entry instead of just the first line. ![image](https://github.com/papis/papis/assets/464625/bea14ba2-fe96-4398-b7ca-057e74a39ef3)

While the first point is straightforward, for the second feature I expanded the list comprehension into a `for` loop to make it a bit more readable. I could turn it into a list comprehension if desired.

These are super simple changes, but I think the end result looks a bit more intuitive. What do you think?