### PR TITLE
sphinx_ext: do not require linkcode

### DIFF
--- a/doc/source/conf.py
+++ b/doc/source/conf.py
@@ -31,6 +31,7 @@ extensions = [
     "sphinx.ext.intersphinx",
     "sphinx.ext.todo",
     "sphinx.ext.linkcode",
+    "sphinx_click.ext",
     "papis.sphinx_ext",
 ]
 

--- a/papis/sphinx_ext.py
+++ b/papis/sphinx_ext.py
@@ -218,7 +218,6 @@ def remove_module_docstring(app: application.Sphinx,
 def setup(app: application.Sphinx) -> Dict[str, Any]:
     from sphinx.util.docfields import Field
 
-    app.setup_extension("sphinx.ext.linkcode")
     app.setup_extension("sphinx_click.ext")
 
     app.add_directive("click", CustomClickDirective, override=True)


### PR DESCRIPTION
Plugins using this may not use `linkcode`, so it's not nice to require it.