### PR TITLE
feat: tweak document file naming

### DIFF
--- a/papis/downloaders/__init__.py
+++ b/papis/downloaders/__init__.py
@@ -1,6 +1,5 @@
 import re
 import os
-import pathlib
 import tempfile
 from typing import List, Optional, Any, Sequence, Type, Dict, Union, TYPE_CHECKING
 

--- a/tests/downloaders/test_utils.py
+++ b/tests/downloaders/test_utils.py
@@ -1,5 +1,9 @@
-from papis.downloaders import get_available_downloaders, get_matching_downloaders
+import os
+from typing import Optional
 
+import pytest
+
+from papis.downloaders import get_available_downloaders, get_matching_downloaders
 from papis.testing import TemporaryConfiguration
 
 
@@ -16,3 +20,30 @@ def test_get_downloader(tmp_config: TemporaryConfiguration) -> None:
     assert down is not None
     assert len(down) >= 1
     assert down[0].name == "arxiv"
+
+
+@pytest.mark.parametrize(("url", "expected_file_name", "ext"), [
+    (
+        "https://arxiv.org/pdf/2408.03952",
+        "2408.03952v1.pdf",
+        None
+    ),
+    (
+        "https://arxiv.org/bibtex/2408.03952",
+        "2408.03952.bib",
+        ".bib"
+    ),
+    (
+        "https://github.com/",
+        "github.com.html",
+        None
+    )
+    ])
+def test_download_document(tmp_config: TemporaryConfiguration,
+                           url: str,
+                           expected_file_name: str,
+                           ext: Optional[str]) -> None:
+    from papis.downloaders import download_document
+
+    local_file_name = download_document(url, expected_document_extension=ext)
+    assert os.path.basename(local_file_name) == expected_file_name

--- a/tests/test_paths.py
+++ b/tests/test_paths.py
@@ -212,13 +212,14 @@ def test_rename_document_files(tmp_config: TemporaryConfiguration) -> None:
     assert new_files == ["x-1913-niels-bohr.pdf", "x-1913-niels-bohr.md"]
 
     # check that correct suffixes are added base on existing files
-    doc["files"] = [
+    doc["files"] = rename_document_files(doc, [
         tmp_config.create_random_file("pdf"),
         tmp_config.create_random_file("pdf"),
         tmp_config.create_random_file("text", suffix=".md"),
-    ]
+        ])
 
     new_files = rename_document_files(doc, [
+        tmp_config.create_random_file("pdf"),
         tmp_config.create_random_file("pdf"),
         tmp_config.create_random_file("text", suffix=".md"),
         tmp_config.create_random_file("djvu"),
@@ -226,6 +227,20 @@ def test_rename_document_files(tmp_config: TemporaryConfiguration) -> None:
 
     assert new_files == [
         "1913-niels-bohr-b.pdf",
+        "1913-niels-bohr-c.pdf",
         "1913-niels-bohr-a.md",
         "1913-niels-bohr.djvu",
+        ]
+
+    # check that files are left alone when no 'file_name_format' is given
+    orig_files = [
+        tmp_config.create_random_file("pdf"),
+        tmp_config.create_random_file("text", suffix=".md"),
+        tmp_config.create_random_file("djvu"),
+        ]
+    new_files = rename_document_files(doc, orig_files, file_name_format=False)
+
+    from papis.paths import normalize_path
+    assert new_files == [
+        normalize_path(os.path.basename(filename)) for filename in orig_files
         ]

--- a/tests/test_paths.py
+++ b/tests/test_paths.py
@@ -98,7 +98,7 @@ def test_get_document_file_name(tmp_library: TemporaryLibrary) -> None:
 
     papis.config.set(
         "add-file-name",
-        "{doc[title]} {doc[author]} {doc[yeary]}"
+        "{doc[title]} {doc[author]} {doc[year]}"
     )
 
     # check file name generation
@@ -188,3 +188,44 @@ def test_get_document_folder(tmp_library: TemporaryLibrary) -> None:
     folder_name = get_document_folder(doc, tmp_library.libdir,
                                       folder_name_format="../{doc[author]}")
     assert re.match(r"\w{32}", os.path.basename(folder_name))[0] == doc["papis_id"]
+
+
+def test_rename_document_files(tmp_config: TemporaryConfiguration) -> None:
+    import papis.config
+
+    papis.config.set("add-file-name", "{doc[year]} {doc[author]}")
+
+    from papis.paths import rename_document_files
+
+    doc = {
+        "author": "Niels Bohr",
+        "title": "On the constitution of atoms and molecules",
+        "year": 1913,
+    }
+
+    # check no existing files: no suffix should be added
+    new_files = rename_document_files(doc, [
+        tmp_config.create_random_file("pdf"),
+        tmp_config.create_random_file("text", suffix=".md"),
+        ], file_name_format="x {doc[year]} {doc[author]}")
+
+    assert new_files == ["x-1913-niels-bohr.pdf", "x-1913-niels-bohr.md"]
+
+    # check that correct suffixes are added base on existing files
+    doc["files"] = [
+        tmp_config.create_random_file("pdf"),
+        tmp_config.create_random_file("pdf"),
+        tmp_config.create_random_file("text", suffix=".md"),
+    ]
+
+    new_files = rename_document_files(doc, [
+        tmp_config.create_random_file("pdf"),
+        tmp_config.create_random_file("text", suffix=".md"),
+        tmp_config.create_random_file("djvu"),
+        ])
+
+    assert new_files == [
+        "1913-niels-bohr-b.pdf",
+        "1913-niels-bohr-a.md",
+        "1913-niels-bohr.djvu",
+        ]


### PR DESCRIPTION
This tries to be a bit smarter about adding suffixes to files in `papis add` and `papis addto`. Namely:
* Unifies the two with a new function `papis.paths.rename_document_files`.
* Makes files with different extensions not get a suffix, e.g. if one adds `file.pdf` and `file.md` it will now not rename them like `<something>.pdf` and `<something>-a.md` (with the `a` suffix).