### PR TITLE
format: Add default value to convert_field

### DIFF
--- a/papis/format.py
+++ b/papis/format.py
@@ -100,7 +100,7 @@ class _PythonStringFormatter(string.Formatter):
             from papis.paths import normalize_path
             return normalize_path(str(value))
 
-        return super().convert_field(value, conversion)
+        return super().convert_field(value, conversion or "s")
 
 
 class PythonFormatter(Formatter):


### PR DESCRIPTION
0eff41a5c6deffdea5a7023511e432b25a6fba34 made `conversion` an
`Optional[str]`, but the builtin `Formatter.convert_field` expects an
`str`. To restore correctness, we need to supply a default argument.

Set the default to `'s'` (string conversion), but perhaps something else is more
appropriate here? Untested, just made `mypy` stop complaining.
