### PR TITLE
defaults: do not force isbn type

### DIFF
--- a/papis/defaults.py
+++ b/papis/defaults.py
@@ -110,7 +110,6 @@ settings: Dict[str, Any] = {
                                    "author_list:list",
                                    "doi:str",
                                    "ref:str",
-                                   "isbn:str",
                                    "author:str",
                                    "journal:str",
                                    "note:str",


### PR DESCRIPTION
@jghauser This removes the expected type for `isbn` since there seem to be quite a few documents in my library where it's a list. Those documents have e.g. an ISBN for the hardcover and an ISBN for the e-book version and they we both added from Google Books (or something, not sure?).

I'm not sure if this is better fixed in the library, i.e. only one ISBN should be kept. What do you think?