### PR TITLE
commands.bibtex: some general cleanup

### DIFF
--- a/doc/source/bibtex.rst
+++ b/doc/source/bibtex.rst
@@ -1,4 +1,4 @@
-Bibtex
+BibTeX
 ======
 
 Exporting documents to BibTeX is done in the same way throughout Papis.

--- a/papis/bibtex.py
+++ b/papis/bibtex.py
@@ -358,7 +358,7 @@ class Importer(papis.importer.Importer):
 def explorer(ctx: click.core.Context, bibfile: str) -> None:
     """Import documents from a BibTeX file.
 
-    This explorer be used as
+    This explorer can be used as
 
     .. code:: sh
 

--- a/papis/commands/bibtex.py
+++ b/papis/commands/bibtex.py
@@ -179,7 +179,9 @@ def _add(ctx: click.Context,
          query: str,
          _all: bool,
          refs_file: Optional[str]) -> None:
-    """Add a reference to the BibTeX file."""
+    """Add documents from the library to the BibTeX file"""
+    from papis.api import get_documents_in_lib, pick_doc
+
     docs = []
 
     if refs_file:
@@ -205,9 +207,9 @@ def _add(ctx: click.Context,
 
         logger.info("Found %d documents for %d references.", found, len(references))
     else:
-        docs = papis.api.get_documents_in_lib(search=query)
+        docs = get_documents_in_lib(search=query)
         if not _all:
-            docs = list(papis.api.pick_doc(docs))
+            docs = list(pick_doc(docs))
 
     ctx.obj["documents"].extend(docs)
 

--- a/papis/commands/bibtex.py
+++ b/papis/commands/bibtex.py
@@ -182,10 +182,10 @@ if BIBTEX_EXPLORER:
     type=click.Path(exists=True),
     default=None)
 @click.pass_context
-def _add(ctx: click.Context,
-         query: str,
-         _all: bool,
-         refs_file: Optional[str]) -> None:
+def cli_add(ctx: click.Context,
+            query: str,
+            _all: bool,
+            refs_file: Optional[str]) -> None:
     """Add documents from the library to the BibTeX file"""
     from papis.api import get_documents_in_lib, pick_doc
 
@@ -233,8 +233,8 @@ def _add(ctx: click.Context,
               type=str,
               multiple=True)
 @click.pass_context
-def _update(ctx: click.Context, _all: bool,
-            fromdb: bool, todb: bool, keys: List[str]) -> None:
+def cli_update(ctx: click.Context, _all: bool,
+               fromdb: bool, todb: bool, keys: List[str]) -> None:
     """Update documents from and to the library"""
     if fromdb and todb:
         logger.error("Cannot pass both '--from' and '--to'.")
@@ -296,7 +296,7 @@ def _update(ctx: click.Context, _all: bool,
 @cli.command("open")
 @click.help_option("-h", "--help")
 @click.pass_context
-def _open(ctx: click.Context) -> None:
+def cli_open(ctx: click.Context) -> None:
     """Open a document using the default application."""
     from papis.api import pick_doc
 
@@ -334,9 +334,9 @@ def _open(ctx: click.Context) -> None:
               type=(str, str),)
 @papis.cli.all_option()
 @click.pass_context
-def _edit(ctx: click.Context,
-          set_tuples: List[Tuple[str, str]],
-          _all: bool) -> None:
+def cli_edit(ctx: click.Context,
+             set_tuples: List[Tuple[str, str]],
+             _all: bool) -> None:
     """
     Edit documents by adding keys or opening an editor.
 
@@ -382,7 +382,7 @@ def _edit(ctx: click.Context,
 @click.help_option("-h", "--help")
 @click.option("-k", "--key", default=None, help="doi, url, ...")
 @click.pass_context
-def _browse(ctx: click.Context, key: Optional[str]) -> None:
+def cli_browse(ctx: click.Context, key: Optional[str]) -> None:
     """Browse a document in the document list."""
     from papis.api import pick_doc
 
@@ -403,7 +403,7 @@ def _browse(ctx: click.Context, key: Optional[str]) -> None:
 @cli.command("rm")
 @click.help_option("-h", "--help")
 @click.pass_context
-def _rm(ctx: click.Context) -> None:
+def cli_rm(ctx: click.Context) -> None:
     """Remove a document from the documents list."""
     click.echo("Sorry, TODO...")
 
@@ -412,7 +412,7 @@ def _rm(ctx: click.Context) -> None:
 @click.help_option("-h", "--help")
 @click.option("-o", "--out", help="Output ref to a file", default=None)
 @click.pass_context
-def _ref(ctx: click.Context, out: Optional[str]) -> None:
+def cli_ref(ctx: click.Context, out: Optional[str]) -> None:
     """Print the reference for a document."""
     from papis.api import pick_doc
 
@@ -439,7 +439,7 @@ def _ref(ctx: click.Context, out: Optional[str]) -> None:
     required=True, type=click.Path())
 @papis.cli.bool_flag("-f", "--force", help="Do not ask for confirmation when saving")
 @click.pass_context
-def _save(ctx: click.Context, bibfile: str, force: bool) -> None:
+def cli_save(ctx: click.Context, bibfile: str, force: bool) -> None:
     """Save the documents in the BibTeX format."""
     docs = ctx.obj["documents"]
 
@@ -465,7 +465,7 @@ def _save(ctx: click.Context, bibfile: str, force: bool) -> None:
               required=True)
 @papis.cli.bool_flag("-r", "--reverse", help="Reverse the sort order")
 @click.pass_context
-def _sort(ctx: click.Context, key: Optional[str], reverse: bool) -> None:
+def cli_sort(ctx: click.Context, key: Optional[str], reverse: bool) -> None:
     """Sort the documents in the BibTeX file."""
     docs = ctx.obj["documents"]
     ctx.obj["documents"] = sorted(docs,
@@ -484,7 +484,7 @@ def _sort(ctx: click.Context, key: Optional[str], reverse: bool) -> None:
               default=None,
               type=str)
 @click.pass_context
-def _unique(ctx: click.Context, key: str, o: Optional[str]) -> None:
+def cli_unique(ctx: click.Context, key: str, o: Optional[str]) -> None:
     """Remove duplicate BibTeX entries."""
     docs = ctx.obj["documents"]
     unique_docs = []
@@ -532,7 +532,7 @@ def _unique(ctx: click.Context, key: str, o: Optional[str]) -> None:
               default=("doi", "url", "year", "title", "author"),
               type=str)
 @click.pass_context
-def _doctor(ctx: click.Context, key: List[str]) -> None:
+def cli_doctor(ctx: click.Context, key: List[str]) -> None:
     """
     Check BibTeX file for correctness.
 
@@ -561,7 +561,7 @@ def _doctor(ctx: click.Context, key: List[str]) -> None:
               help="Text file to check for references",
               multiple=True, required=True, type=str)
 @click.pass_context
-def _filter_cited(ctx: click.Context, _files: List[str]) -> None:
+def cli_filter_cited(ctx: click.Context, _files: List[str]) -> None:
     """
     Filter cited documents from the BibTeX file.
 
@@ -591,7 +591,7 @@ def _filter_cited(ctx: click.Context, _files: List[str]) -> None:
               help="Text file to check for references",
               multiple=True, required=True, type=str)
 @click.pass_context
-def _iscited(ctx: click.Context, _files: List[str]) -> None:
+def cli_iscited(ctx: click.Context, _files: List[str]) -> None:
     """
     Check which documents are not cited.
 
@@ -623,7 +623,7 @@ def _iscited(ctx: click.Context, _files: List[str]) -> None:
 @click.option("-o", "--out", help="Out folder to export", default=None)
 @papis.cli.all_option()
 @click.pass_context
-def _import(ctx: click.Context, out: Optional[str], _all: bool) -> None:
+def cli_import(ctx: click.Context, out: Optional[str], _all: bool) -> None:
     """
     Import documents from a BibTeX file to the current library.
 

--- a/papis/commands/bibtex.py
+++ b/papis/commands/bibtex.py
@@ -1,14 +1,25 @@
 r"""
-This command helps interacting with BibTeX ``bib`` files in your LaTeX projects.
+This command is used for interacting with BibTeX ``bib`` files in your LaTeX projects.
+
+It is meant to be used when the BibTeX file is a companion to your Papis library.
+Then, ``papis bibtex`` can be used to add, remove, update, and generally clean
+the file using information from the library.
 
 Examples
 ^^^^^^^^
 
-You can use it for opening some papers by calling::
+You can use it for opening some papers from the BibTeX file by calling
+
+.. code:: sh
 
     papis bibtex read new_papers.bib open
 
-or to add papers to the BibTeX file by calling::
+This is done by matching the entry in the BibTeX file with a document in your
+library and then opening the correspond files. If no document can be found in
+the library, then the file cannot be opened, of course. To add papers to the
+BibTeX file (from the current library) you can call
+
+.. code:: sh
 
     papis bibtex             \
         read new_papers.bib  \ # Read bib file
@@ -16,13 +27,20 @@ or to add papers to the BibTeX file by calling::
         add -q heisenberg    \ # Pick a doc with query 'heisenberg' from library
         save new_papers.bib    # Save in new_papers.bib
 
-or to update some information that was modified in papis'
-:ref:`YAML files <info-file>` by calling::
+To update some information that was modified in Papis'
+:ref:`YAML files <info-file>`, you can call
+
+.. code:: sh
 
     papis bibtex            \
         read new_papers.bib \ # Read bib file
         update -f           \ # Update what has been read from papis library
         save new_papers.bib   # save everything to new_papers.bib, overwriting
+
+.. note::
+
+    Reading, adding, and then saving documents in this fashion will re-export
+    them and may change the formatting of your BibTeX file.
 
 Local configuration file
 ^^^^^^^^^^^^^^^^^^^^^^^^
@@ -72,7 +90,7 @@ to the project's ``Makefile`` like
 Vim integration
 ^^^^^^^^^^^^^^^
 
-This command can also be easily used from vim with these simple lines
+This command can also be easily used from Vim with these simple lines
 
 .. code:: vim
 

--- a/papis/commands/bibtex.py
+++ b/papis/commands/bibtex.py
@@ -230,7 +230,7 @@ def _update(ctx: click.Context, _all: bool,
     picked_doc = None
     if not _all:
         picked_docs = pick_doc(docs)
-        if picked_docs is None or picked_docs[0] is None:
+        if not picked_docs or not picked_docs[0]:
             logger.warning(papis.strings.no_documents_retrieved_message)
             return
 
@@ -269,6 +269,8 @@ def _update(ctx: click.Context, _all: bool,
                     libdoc.clear()
                     libdoc.update(doc)
                     save_doc(libdoc)
+
+        logger.info("")
 
     ctx.obj["documents"] = docs
 

--- a/papis/commands/explore.py
+++ b/papis/commands/explore.py
@@ -131,6 +131,15 @@ def get_explorer_mgr() -> "ExtensionManager":
     return papis.plugin.get_extension_manager(EXPLORER_EXTENSION_NAME)
 
 
+def get_explorer_by_name(name: str) -> Optional[click.Command]:
+    try:
+        mgr = get_explorer_mgr()
+        plugin: click.Command = mgr[name].plugin
+        return plugin
+    except KeyError:
+        return None
+
+
 @click.command("lib")
 @click.pass_context
 @click.help_option("--help", "-h")


### PR DESCRIPTION
I used the `papis bibtex` command recently and did some small cleanups along the way. Some small functionality changes as well:
* `papis bibtex update --to`: actually implement this flag, but haven't tested it.
* `papis bibtex open`: shows a nicer error message instead of raising an exception on failure.