### PR TITLE
config: handle percents in file paths

### DIFF
--- a/doc/source/configuration.rst
+++ b/doc/source/configuration.rst
@@ -155,6 +155,26 @@ all the options and more extensive descriptions)
     browse-query-format = {doc[first_name]} {doc[last_name]}
     add-open = False
 
+.. note::
+
+   Papis uses the standard :class:`~configparser.ConfigParser` to read and write
+   configuration options. It also allows interpolation of values
+   (using :class:`~configparser.BasicInterpolation`) so that previous values
+   can be referred back to. For example, one can do
+
+   .. code:: ini
+
+        [DEFAULT]
+        basedir = /path/to/libraries
+
+        [papers]
+        dir = %(basedir)s/papers
+
+        [books]
+        dir = %(basedir)s/books
+
+   Interpolation variables are looked for in the current section and in the
+   standard ``DEFAULT`` section.
 
 Local configuration files
 -------------------------

--- a/papis/commands/addto.py
+++ b/papis/commands/addto.py
@@ -162,7 +162,7 @@ def cli(query: str,
     document = docs[0]
 
     if file_name is not None:  # Use args if set
-        papis.config.set("add-file-name", file_name)
+        papis.config.set("add-file-name", papis.config.escape_interp(file_name))
 
     try:
         run(document, files + urls, git=git, link=link)

--- a/papis/commands/edit.py
+++ b/papis/commands/edit.py
@@ -108,7 +108,7 @@ def cli(query: str,
         return
 
     if editor is not None:
-        papis.config.set("editor", editor)
+        papis.config.set("editor", papis.config.escape_interp(editor))
 
     for document in documents:
         if notes:

--- a/papis/commands/open.py
+++ b/papis/commands/open.py
@@ -95,7 +95,7 @@ def run(document: papis.document.Document,
         folder: bool = False,
         mark: bool = False) -> None:
     if opener is not None:
-        papis.config.set("opentool", opener)
+        papis.config.set("opentool", papis.config.escape_interp(opener))
 
     _doc_folder = document.get_main_folder()
     if _doc_folder is None:
@@ -136,7 +136,7 @@ def run(document: papis.document.Document,
                         papis.document.from_data(mark_dict[0]),
                         doc_key=_mark_name)
                     logger.info("Setting opener to '%s'.", opener)
-                    papis.config.set("opentool", opener)
+                    papis.config.set("opentool", papis.config.escape_interp(opener))
         files = document.get_files()
         if not files:
             logger.error("The chosen document has no files attached: '%s'.",
@@ -169,7 +169,7 @@ def cli(query: str, doc_folder: Tuple[str, ...], tool: str, folder: bool,
         mark: bool) -> None:
     """Open document from a given library"""
     if tool:
-        papis.config.set("opentool", tool)
+        papis.config.set("opentool", papis.config.escape_interp(tool))
 
     documents = papis.cli.handle_doc_folder_query_all_sort(query,
                                                            doc_folder,

--- a/papis/config.py
+++ b/papis/config.py
@@ -312,7 +312,15 @@ def set(key: str, value: Any, section: Optional[str] = None) -> None:
     if not config.has_section(section):
         config.add_section(section)
 
-    config[section][key] = str(value)
+    try:
+        config[section][key] = str(value)
+    except ValueError as exc:
+        logger.error("Failed to set the key '%s' in section '%s' with value '%s'.",
+                     key, section, value)
+        logger.error("If the value contains a '%', this should be properly "
+                     "escaped (using a double percent '%%') or the proper "
+                     "interpolation syntax should be used (i.e. '%(other_key)').",
+                     exc_info=exc)
 
 
 def general_get(key: str,

--- a/papis/testing.py
+++ b/papis/testing.py
@@ -614,6 +614,8 @@ def resource_cache(request: SubRequest) -> ResourceCache:
 
 
 def pytest_addoption(parser: Parser) -> None:
+    parser.addoption("--papis-enable-logging", action="store_true",
+                     help="Enable logging while running tests")
     parser.addoption("--papis-tmp-doctests", action="store_true",
                      help="Use a temporary configuration file for doctests")
     parser.addoption("--papis-tmp-xdg-home", action="store_true",
@@ -626,6 +628,10 @@ def pytest_configure(config: Config) -> None:
         # a chance to construct a TemporaryConfiguration. We set XDG_CONFIG_HOME
         # here first to avoid them picking up any sort of user configuration.
         os.environ["XDG_CONFIG_HOME"] = tempfile.gettempdir()
+
+    if config.getoption("--papis-enable-logging"):
+        import papis.logging
+        papis.logging.setup()
 
     config.addinivalue_line(
         "markers",

--- a/tests/commands/test_edit.py
+++ b/tests/commands/test_edit.py
@@ -17,7 +17,9 @@ def get_mock_script(name: str) -> str:
 
     script = os.path.join(os.path.dirname(__file__), "scripts.py")
 
-    return "{} {} {}".format(sys.executable, script, name)
+    from papis.config import escape_interp
+
+    return escape_interp("{} {} {}".format(sys.executable, script, name))
 
 
 @pytest.mark.library_setup(settings={
@@ -66,7 +68,8 @@ def test_edit_cli(tmp_library: TemporaryLibrary) -> None:
         cli,
         ["--all", "--editor", ls, "krishnamurti"])
     assert result.exit_code == 0
-    assert papis.config.get("editor") == get_mock_script("ls")
+    assert (papis.config.escape_interp(papis.config.get("editor"))
+            == get_mock_script("ls"))
 
     # check --notes
     notes_name = papis.config.get("notes-name")
@@ -76,7 +79,8 @@ def test_edit_cli(tmp_library: TemporaryLibrary) -> None:
         cli,
         ["--all", "--editor", get_mock_script("echo"), "--notes", "krishnamurti"])
     assert result.exit_code == 0
-    assert papis.config.get("editor") == get_mock_script("echo")
+    assert (papis.config.escape_interp(papis.config.get("editor"))
+            == get_mock_script("echo"))
 
     db = papis.database.get()
     doc, = db.query_dict({"author": "Krishnamurti"})

--- a/tests/commands/test_open.py
+++ b/tests/commands/test_open.py
@@ -4,11 +4,24 @@ import pytest
 
 from papis.testing import TemporaryLibrary, PapisRunner
 
-script = os.path.join(os.path.dirname(__file__), "scripts.py")
+
+def get_mock_script(name: str) -> str:
+    """Constructs a command call for a command mocked by ``scripts.py``.
+
+    :param name: the name of the command, e.g. ``ls`` or ``echo``.
+    :returns: a string of the command
+    """
+    import sys
+
+    script = os.path.join(os.path.dirname(__file__), "scripts.py")
+
+    from papis.config import escape_interp
+
+    return escape_interp("{} {} {}".format(sys.executable, script, name))
 
 
 @pytest.mark.library_setup(settings={
-    "file-browser": "{} {} echo".format(sys.executable, script)
+    "file-browser": get_mock_script("echo")
     })
 def test_open_cli(tmp_library: TemporaryLibrary) -> None:
     from papis.commands.open import cli
@@ -35,7 +48,7 @@ def test_open_cli(tmp_library: TemporaryLibrary) -> None:
     # Use a mock scriptlet
     result = cli_runner.invoke(
         cli,
-        ["--tool", "{} {} echo".format(sys.executable, script),
+        ["--tool", get_mock_script("echo"),
          "--mark", "--all", "Krishnamurti"])
     assert result.exit_code == 0
 

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -13,7 +13,7 @@ def test_get_cache_home(tmp_config: TemporaryConfiguration, monkeypatch) -> None
     assert get_cache_home() == os.path.join(tmp_config.tmpdir, "papis")
     with tempfile.TemporaryDirectory(dir=tmp_config.tmpdir) as d:
         tmp = os.path.join(d, "blah")
-        papis.config.set("cache-dir", tmp)
+        papis.config.set("cache-dir", papis.config.escape_interp(tmp))
         assert get_cache_home() == tmp
 
 


### PR DESCRIPTION
This fixes the tests so that they work when the temporary path contains a `%`. It also adds a nicer error message in `papis.config.set`.

@hseg If you have a chance to test this, that would be great! I tried running the whole test suite with a percent in the tmpdir and it worked for me.

Fixes #850.