### PR TITLE
commands.doctor: rename keys-exist to keys-missing

### DIFF
--- a/doc/source/default-settings.rst
+++ b/doc/source/default-settings.rst
@@ -557,9 +557,9 @@ Doctor options
 
     A list of checks that are performed by default.
 
-.. papis-config:: doctor-keys-exist-keys
+.. papis-config:: doctor-keys-missing-keys
 
-    A list of keys used by the ``keys-exist`` check. The check will show an
+    A list of keys used by the ``keys-missing`` check. The check will show an
     error if these keys are not present in a document.
 
 .. papis-config:: doctor-duplicated-keys-keys

--- a/papis/defaults.py
+++ b/papis/defaults.py
@@ -102,7 +102,7 @@ settings: Dict[str, Any] = {
     "notes-template": "",
 
     # doctor
-    "doctor-default-checks": ["files", "keys-missing", "duplicated-keys"],
+    "doctor-default-checks": ["files", "biblatex-required-keys", "bibtex-type", "refs"],
     "doctor-keys-missing-keys": ["title", "author", "author_list", "ref"],
     "doctor-duplicated-keys-keys": ["ref"],
     "doctor-duplicated-values-keys": ["files", "author_list"],

--- a/papis/defaults.py
+++ b/papis/defaults.py
@@ -25,6 +25,7 @@ settings: Dict[str, Any] = {
     "add-interactive": False,
     "mvtool": "mv",
     "formater": None,
+    "doctor-keys-exist-keys": None,
 
     # general settings
     "local-config-file": ".papis.config",
@@ -101,8 +102,8 @@ settings: Dict[str, Any] = {
     "notes-template": "",
 
     # doctor
-    "doctor-default-checks": ["files", "keys-exist", "duplicated-keys"],
-    "doctor-keys-exist-keys": ["title", "author", "author_list", "ref"],
+    "doctor-default-checks": ["files", "keys-missing", "duplicated-keys"],
+    "doctor-keys-missing-keys": ["title", "author", "author_list", "ref"],
     "doctor-duplicated-keys-keys": ["ref"],
     "doctor-duplicated-values-keys": ["files", "author_list"],
     "doctor-html-codes-keys": ["title", "author", "abstract", "journal"],

--- a/tests/commands/test_add.py
+++ b/tests/commands/test_add.py
@@ -89,7 +89,7 @@ def test_add_auto_doctor_run(tmp_library: TemporaryLibrary) -> None:
     paths = []
 
     # add document with auto-doctor on
-    papis.config.set("doctor-default-checks", ["keys-exist", "key-type", "refs"])
+    papis.config.set("doctor-default-checks", ["keys-missing", "key-type", "refs"])
     run(paths, data=data, auto_doctor=True)
 
     # check that all the broken fields are fixed

--- a/tests/test_doctor.py
+++ b/tests/test_doctor.py
@@ -29,10 +29,10 @@ def test_files_check(tmp_config: TemporaryConfiguration) -> None:
         assert "non-existent-file" not in doc["files"]
 
 
-def test_keys_check(tmp_config: TemporaryConfiguration) -> None:
-    from papis.commands.doctor import keys_exist_check
+def test_keys_missing_check(tmp_config: TemporaryConfiguration) -> None:
+    from papis.commands.doctor import keys_missing_check
 
-    papis.config.set("doctor-keys-exist-keys",
+    papis.config.set("doctor-keys-missing-keys",
                      ["ref", "author", "author_list", "title"])
 
     doc = papis.document.from_data({
@@ -40,15 +40,15 @@ def test_keys_check(tmp_config: TemporaryConfiguration) -> None:
         "author": "Sanger, F. and Nicklen, S. and Coulson, A. R.",
         })
 
-    error1, error2 = keys_exist_check(doc)
+    error1, error2 = keys_missing_check(doc)
     assert error1.payload == "ref" or error2.payload == "ref"
     assert error1.payload == "author_list" or error2.payload == "author_list"
 
 
-def test_keys_check_authors(tmp_config: TemporaryConfiguration) -> None:
-    from papis.commands.doctor import keys_exist_check
+def test_keys_missing_check_authors(tmp_config: TemporaryConfiguration) -> None:
+    from papis.commands.doctor import keys_missing_check
 
-    papis.config.set("doctor-keys-exist-keys", ["author_list", "author"])
+    papis.config.set("doctor-keys-missing-keys", ["author_list", "author"])
     full_doc = papis.document.from_data(
         {
             "title": "DNA sequencing with chain-terminating inhibitors",
@@ -61,12 +61,12 @@ def test_keys_check_authors(tmp_config: TemporaryConfiguration) -> None:
     )
 
     doc = full_doc.copy()
-    errors = keys_exist_check(doc)
+    errors = keys_missing_check(doc)
     assert not errors
 
     # check author -> author_list
     del doc["author_list"]
-    error, = keys_exist_check(doc)
+    error, = keys_missing_check(doc)
 
     error.fix_action()
     assert doc["author_list"][0]["family"] == "Doe"
@@ -78,7 +78,7 @@ def test_keys_check_authors(tmp_config: TemporaryConfiguration) -> None:
     doc = full_doc.copy()
     del doc["author"]
 
-    error, = keys_exist_check(doc)
+    error, = keys_missing_check(doc)
     error.fix_action()
     assert doc["author"] == "Doe, John and Doe, Jane"
 


### PR DESCRIPTION
This renames the `keys-exist` check to `keys-missing` with a bunch of deprecation warnings.

@jghauser What do you think about this? Should we also change the default to `biblatex-required-keys` for smarter missing key reporting?

Fixes #849.