### PR TITLE
pick: add nicer library picker

### DIFF
--- a/doc/source/default-settings.rst
+++ b/doc/source/default-settings.rst
@@ -196,6 +196,12 @@ General settings
     replacing spaces or other non-letter characters). By default this is the
     hyphen ``"-"`` but it could, e.g., also be the underscore ``"_"``.
 
+.. papis-config:: library-header-format
+
+    The format of a library when shown in a picker, e.g. when using
+   ``papis --pick-lib export --all``. The format takes a dictionary named
+   ``library`` with the keys *name*, *dir*, and *paths*.
+
 Tools options
 -------------
 

--- a/papis/commands/default.py
+++ b/papis/commands/default.py
@@ -215,7 +215,7 @@ def run(ctx: click.Context,
 
     # read in configuration from current library
     if pick_lib:
-        picked_libs = papis.pick.pick(papis.api.get_libraries())
+        picked_libs = papis.pick.pick_library()
         if picked_libs:
             lib = picked_libs[0]
 

--- a/papis/defaults.py
+++ b/papis/defaults.py
@@ -53,6 +53,10 @@ settings: Dict[str, Any] = {
     "doc-paths-lowercase": True,
     "doc-paths-extra-chars": "",
     "doc-paths-word-separator": "-",
+    "library-header-format": (
+        "<ansired>{library[name]}</ansired>"
+        " <ansiblue>{library[paths]}</ansiblue>"
+    ),
 
     # tools
     "opentool": get_default_opener(),

--- a/papis/pick.py
+++ b/papis/pick.py
@@ -1,6 +1,6 @@
 import os
 from abc import ABC, abstractmethod
-from typing import Any, Callable, TypeVar, Generic, Sequence, Type, List
+from typing import Any, Callable, TypeVar, Generic, Sequence, Type, Optional, List
 
 import papis.config
 import papis.document
@@ -138,3 +138,26 @@ def pick_subfolder_from_lib(lib: str) -> List[str]:
     folders = sorted(set(folders))
 
     return pick(folders)
+
+
+def pick_library(libs: Optional[List[str]] = None) -> List[str]:
+    """Pick a library from the current configuration.
+
+    :arg libs: a list of libraries to pick from.
+    """
+    if libs is None:
+        libs = papis.api.get_libraries()
+
+    header_format = papis.config.getstring("library-header-format")
+
+    def header_filter(lib: str) -> str:
+        library = papis.config.get_lib_from_name(lib)
+        return papis.format.format(header_format, {
+            "name": library.name,
+            "dir": library.paths[0],
+            "paths": library.paths
+            }, doc_key="library")
+
+    return pick(libs,
+                header_filter=header_filter,
+                match_filter=str)


### PR DESCRIPTION
This adds a little wrapper to pick libraries (e.g. `papis --pick-lib add`) with more color. On my dark terminal it looks something like this

![Screenshot_20240519_175742](https://github.com/papis/papis/assets/777240/7afb7863-7799-4bb4-9a63-410ec1c976bd)

@jghauser I'm not sure if there is any other nice information we could display about the libraries. Any thoughts?