### PR TITLE
commands.doctor: also support weirdly uppercased HTML codes

### DIFF
--- a/tests/test_doctor.py
+++ b/tests/test_doctor.py
@@ -271,7 +271,7 @@ def test_html_codes_check(tmp_config: TemporaryConfiguration) -> None:
     errors = html_codes_check(doc)
     assert not errors
 
-    for amp in ("&amp;", "&#38;", "&#x26;"):
+    for amp in ("&amp;", "&#38;", "&#x26;", "&Amp;"):
         doc["title"] = (
             "DNA sequencing with chain-terminating inhibitors {} stuff"
             .format(amp))


### PR DESCRIPTION
As stated, this allows the `html-codes` doctor check to also fix weirdly uppercased codes like `&Amp;`. Not sure how I managed to get one of those, but it's a pretty easy fix..