### PR TITLE
isbn: force book type for data from isbnlib

### DIFF
--- a/papis/isbn.py
+++ b/papis/isbn.py
@@ -59,8 +59,15 @@ def data_to_papis(data: Dict[str, Any]) -> Dict[str, Any]:
         ]
 
     data = {k.lower(): data[k] for k in data}
-    return papis.document.keyconversion_to_data(
+    result = papis.document.keyconversion_to_data(
         key_conversion, data, keep_unknown_keys=True)
+
+    # NOTE: 'isbnlib' does not give a type at all, so we can't know if this is
+    # a proceeding or any other book-like format. Also, 'isbnlib' always uses
+    # the 'book' type when converting to BibTeX, so we'll do the same.
+    result["type"] = "book"
+
+    return result
 
 
 @click.command("isbn")

--- a/tests/resources/isbn/test_isbn_1_out.json
+++ b/tests/resources/isbn/test_isbn_1_out.json
@@ -11,5 +11,6 @@
     "language": "en",
     "publisher": "R.T. Edwards",
     "title": "An introduction to multigrid methods",
+    "type": "book",
     "year": "2004"
 }


### PR DESCRIPTION
The `isbn` importer did not set a type for the document because `isbnlib` does not provide one. This forces all documents to be books, since that's what `isbnlib` does too in its BibTeX exporter.