### PR TITLE
Fix importing and exporting of institutional authors

### DIFF
--- a/papis/bibtex.py
+++ b/papis/bibtex.py
@@ -512,6 +512,29 @@ def create_reference(doc: Dict[str, Any], force: bool = False) -> str:
     return ref_cleanup(ref)
 
 
+def author_list_to_author(author_list: List[Dict[str, Any]]) -> str:
+    if not author_list:
+        return ""
+
+    result = []
+    fmt = "{au[family]}, {au[given]}"
+
+    for author in author_list:
+        family = author.get("family")
+        given = author.get("given")
+        if family and given:
+            result.append(fmt.format(au=author))
+        elif family:
+            result.append(f"{{{family}}}")
+        elif given:
+            result.append(f"{{{given}}}")
+        else:
+            # NOTE: empty author, just skip it
+            pass
+
+    return " and ".join(result)
+
+
 def to_bibtex_multiple(documents: List[papis.document.Document]) -> Iterator[str]:
     for doc in documents:
         bib = to_bibtex(doc)
@@ -600,6 +623,8 @@ def to_bibtex(document: papis.document.Document, *, indent: int = 2) -> str:
                 logger.warning(
                     "'journal-key' key '%s' is not present for ref '%s'.",
                     journal_key, document["ref"])
+        elif bib_key == "author" and "author_list" in document:
+            bib_value = author_list_to_author(document["author_list"])
 
         override_key = f"{bib_key}_latex"
         if override_key in document:

--- a/papis/bibtex.py
+++ b/papis/bibtex.py
@@ -394,9 +394,9 @@ def bibtexparser_entry_to_papis(entry: Dict[str, Any]) -> Dict[str, Any]:
             }]),
         _k("author", [{
             "key": "author_list",
-            "action": lambda author: papis.document.split_authors_name([
-                latex_to_unicode(author)
-                ], separator="and")
+            "action": lambda author: (
+                papis.document.split_authors_name([author], separator="and")
+                )
             }]),
     ]
 

--- a/papis/document.py
+++ b/papis/document.py
@@ -254,7 +254,9 @@ def split_author_name(author: str) -> Dict[str, Any]:
     given = " ".join(parts["first"])
     family = " ".join(parts["von"] + parts["last"] + parts["jr"])
 
-    return {"family": family, "given": given}
+    from bibtexparser.latexenc import latex_to_unicode
+
+    return {"family": latex_to_unicode(family), "given": latex_to_unicode(given)}
 
 
 def split_authors_name(authors: Union[str, List[str]],


### PR DESCRIPTION
As shown in #885, some entries only have a single name author. This improves the handling of such entries by:
* Not doing `latex_to_unicode` on the whole author field. This removed the extra "{}" around an entry and confused "splitauthor" to think there are multiple names there.
* Adding a custom `author_list_to_author` for BibTeX so that we can handle author names in a smarter way. Now where there's a missing family or given name, it just uses `{name}` (with the curly braces, so that a roundtrip gives the same result).

Fixes #885. 