### PR TITLE
document: Clear dictionary before loading data

### DIFF
--- a/papis/document.py
+++ b/papis/document.py
@@ -451,6 +451,7 @@ class Document(Dict[str, Any]):
                 "Error reading info file at '%s'. Please check it!",
                 self.get_info_file(), exc_info=exc)
         else:
+            self.clear()
             self.update(data)
 
 


### PR DESCRIPTION
Clear current data (if any) in the document before loading new data in document.load().  This avoids an edge case where a document is being updated, and a key is removed.

Closes #895 