### PR TITLE
Add PyPI release job

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -56,14 +56,30 @@ jobs:
     - uses: actions/checkout@v4
       with:
         fetch-depth: 0
+
     - uses: actions/setup-python@v5
       with:
         python-version: '3.12'
+
     - id: dist
-      uses: casperdcl/deploy-pypi@v2
-      with:
-        build: true
-        upload: false
+      run: |
+        # NOTE: need to make the wheels first so that the sdist doesn't add the
+        # extra generated `CHANGELOG-LATEST.md` file.
+        bash tools/make-wheels.sh
+        python tools/extract-changelog.py CHANGELOG.md -o CHANGELOG-LATEST.md
+
     - if: github.event_name == 'push' && startsWith(github.ref, 'refs/tags')
-      name: Publish package to PyPI
+      name: Publish Package to PyPI
       uses: pypa/gh-action-pypi-publish@release/v1
+
+    - if: github.event_name == 'push' && startsWith(github.ref, 'refs/tags')
+      name: Publish a GitHub Release
+      uses: softprops/action-gh-release@v2
+      with:
+        prerelease: ${{ contains(github.ref, 'rc') }}
+        name: Version ${{ github.ref_name }}
+        body: CHANGELOG-LATEST.md
+        files: |
+          dist/*.tar.gz
+          dist/*.whl
+        fail_on_unmatched_files: true

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -1,8 +1,10 @@
 name: CI
 
 on:
+  workflow_dispatch:
   push:
     branches: [ "main", "ci-*" ]
+    tags: [ 'v**' ]
   pull_request:
     branches: [ "main" ]
   schedule:
@@ -41,3 +43,27 @@ jobs:
       if: success() || failure()
       run: make ci-test
       shell: bash
+
+  pypi-release:
+    needs: [build]
+    name: PyPI Release
+    environment: pypi
+    permissions:
+      contents: write
+      id-token: write
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v4
+      with:
+        fetch-depth: 0
+    - uses: actions/setup-python@v5
+      with:
+        python-version: '3.12'
+    - id: dist
+      uses: casperdcl/deploy-pypi@v2
+      with:
+        build: true
+        upload: false
+    - if: github.event_name == 'push' && startsWith(github.ref, 'refs/tags')
+      name: Publish package to PyPI
+      uses: pypa/gh-action-pypi-publish@release/v1

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,4 @@
-VERSION NEXT
-============
+# VERSION NEXT
 
 ## Dependency changes
 
@@ -272,8 +271,7 @@ this should be fairly automatic.
 * Use formatter for `multiple-authors-format`.
   ([#906](https://github.com/papis/papis/pull/906))
 
-VERSION v0.13 (May 7, 2023)
-===========================
+# VERSION v0.13 (May 7, 2023)
 
 ## Features
 
@@ -386,8 +384,7 @@ And many other general interface and robustness improvements.
 * Fix crash on trying to add a duplicate document ([#510](https://github.com/papis/papis/pull/510)).
 * Fix many typos ([#540](https://github.com/papis/papis/pull/540)).
 
-VERSION v0.12 (May 23, 2022)
-============================
+# VERSION v0.12 (May 23, 2022)
 
 Many issues were resolved and new (and old) contributors
 made the following changes possible.
@@ -442,8 +439,7 @@ Check out the
 ## Community
 - usage of github discussions and #papis channel on libera.
 
-VERSION v0.11 (October 17, 2020)
-================================
+# VERSION v0.11 (October 17, 2020)
 
 ## `papis explore`
 - Add `add` command to simply add documents retrieved.
@@ -480,9 +476,7 @@ VERSION v0.11 (October 17, 2020)
 - Add an `ads` handler to jump into the `ads` website of the paper
   using a doi.
 
-
-VERSION v0.10 (May 2, 2020)
-===========================
+# VERSION v0.10 (May 2, 2020)
 
 - Fix several bugs.
 - Typecheck the whole codebase
@@ -514,10 +508,7 @@ VERSION v0.10 (May 2, 2020)
   in that folder or in all folders matching a given query introduced by
   `--pick`.
 
-
-
-VERSION v0.9 (October 21, 2019)
-===============================
+# VERSION v0.9 (October 21, 2019)
 
 ## Plugin architecture ##
 
@@ -626,14 +617,12 @@ papis module `papis.git`.
   been added. Now you will be able to retrieve information
   from many more websites by by virtue of the metadata of html websites.
 
-VERSION v0.8.1 (February 27, 2019)
-==================================
+# VERSION v0.8.1 (February 27, 2019)
 
 - Change default colors for `header_formater`.
 - Update `prompt_toolkit` version to `2.0.5`.
 
-VERSION v0.8 (February 26, 2019)
-================================
+# VERSION v0.8 (February 26, 2019)
 
 One of the main developments for version `0.8` is to make `papis` less
 dependent on `PyPi`, for which some important dependencies have been

--- a/tools/extract-changelog.py
+++ b/tools/extract-changelog.py
@@ -1,0 +1,35 @@
+import pathlib
+from typing import Optional
+
+
+def main(filename: pathlib.Path, *, outfile: Optional[pathlib.Path] = None) -> int:
+    if not filename.exists():
+        print(f"ERROR: Filename does not exist: '{filename}'")
+        return 1
+
+    with open(filename, encoding="utf-8") as inf:
+        contents = inf.read()
+
+    result = contents.split("\n# ")
+    if not result:
+        print(f"ERROR: Could not find any sections in file: '{filename}'")
+        return 1
+
+    if outfile is not None:
+        with open(outfile, "w", encoding="utf-8") as outf:
+            print(result[0].strip(), file=outf)
+    else:
+        print(result[0].strip())
+
+    return 0
+
+
+if __name__ == "__main__":
+    import argparse
+
+    parser = argparse.ArgumentParser()
+    parser.add_argument("changelog", default="CHANGELOG.md", type=pathlib.Path)
+    parser.add_argument("-o", "--outfile", default=None, type=pathlib.Path)
+    args = parser.parse_args()
+
+    raise SystemExit(main(args.changelog, outfile=args.outfile))

--- a/tools/make-wheels.sh
+++ b/tools/make-wheels.sh
@@ -2,7 +2,7 @@
 set -ex
 
 DIST_DIR=dist
-DIST_ENV=distenv
+DIST_ENV=.venv
 
 # create a virtual environment for the build
 rm -rf "$DIST_ENV"
@@ -10,7 +10,7 @@ python -m venv --system-site-packages "$DIST_ENV"
 source "$DIST_ENV/bin/activate"
 
 # install build dependencies
-python -m pip install --upgrade pip hatchling wheel build twine
+python -m pip install --upgrade pip hatchling wheel build
 python -m pip install .
 python -m pip install .[docs]
 
@@ -21,12 +21,4 @@ make -C doc man ENV="$DIST_ENV"
 
 rm -rf ${DIST_DIR}
 rm -rf doc/build/man/_static/
-python -m build --sdist --skip-dependency-check --no-isolation .
-
-# upload to pypi
-read -p 'Do you want to push to PyPI? (y/N)' -n 1 -r
-echo
-if [[ $REPLY =~ ^[Yy]$ ]]; then
-  twine upload ${DIST_DIR}/*.tar.gz
-fi
-REPLY= # unset REPLY after using it
+python -m build --skip-dependency-check .


### PR DESCRIPTION
This mostly uses the tutorial from here
https://packaging.python.org/en/latest/guides/publishing-package-distribution-releases-using-github-actions-ci-cd-workflows/

To work for actual releases, it needs:
* A `pypi` environment on Github: https://docs.github.com/en/actions/managing-workflow-runs-and-deployments/managing-deployments/managing-environments-for-deployment
* Adding the Github repo as a "trusted publisher" on PyPI: https://docs.pypi.org/trusted-publishers/adding-a-publisher/

I think we can add a step here to also make a Github release at the same time, but that would require a bit of scripting to get the changelog from `CHANGELOG.md`. Should be doable though.

@alejandrogallo @jghauser 