### PR TITLE
default: tags should be a list

### DIFF
--- a/papis/defaults.py
+++ b/papis/defaults.py
@@ -119,6 +119,7 @@ settings: Dict[str, Any] = {
                                    "author:str",
                                    "journal:str",
                                    "note:str",
+                                   "tags:list",
                                    "type:str",
                                    "publisher:str",
                                    "title:str",


### PR DESCRIPTION
With the new tag command, add only works if it's a list. papis doctor should fix that by default.

Thanks