### PR TITLE
doc: add a 30s quickstart

### DIFF
--- a/doc/source/index.rst
+++ b/doc/source/index.rst
@@ -16,9 +16,16 @@ Papis: Command-line Bibliography Manager
       :link-type: ref
       :class-card: getting-started
 
-    .. grid-item-card:: :material-regular:`rocket_launch;2em` Quick Guide
+
+    .. grid-item-card:: :material-regular:`rocket_launch;2em` Quick start
       :columns: 12 6 6 4
-      :link: quick-guide
+      :link: quick-start 
+      :link-type: ref
+      :class-card: getting-started
+
+    .. grid-item-card:: :material-regular:`library_books;2em` Tutorial 
+      :columns: 12 6 6 4
+      :link: tutorial
       :link-type: ref
       :class-card: getting-started
 
@@ -103,7 +110,8 @@ extend Papis' features or integrate it with other software.
    :caption: Getting started
 
    install
-   quick_guide
+   quick_start
+   tutorial
    configuration
    info_file
    library_structure

--- a/doc/source/quick_start.rst
+++ b/doc/source/quick_start.rst
@@ -1,0 +1,38 @@
+.. _quick-start:
+
+Quick start
+===========
+
+Papis in 30s !
+
+Add a document from a DOI (recommended)
+
+.. code:: bash
+
+    papis add --from doi 10.1145/2430532.2364520
+
+Import a bibtex file into papis
+
+.. code:: bash
+
+    papis read biblio.bib import -a 
+
+Edit a document, add a note, open a file can be done through many commands. For example
+
+.. code:: bash
+
+    papis browse 
+
+shcw all the bibliography. `Enter` will open the URL but 
+
+- `ctrl-e` edits the metada
+- `ctrl-q` adds a note.
+- `ctrl-o` open the PDF (if it exists). 
+
+Results can be filtered interactively by typing a few words or beforehand:
+
+.. code:: bash
+
+    papis browse tags:haskell
+
+More can be found in the :ref:`tutorial`.

--- a/doc/source/tutorial.rst
+++ b/doc/source/tutorial.rst
@@ -1,9 +1,9 @@
-.. _quick-guide:
+.. _Tutorial:
 
-Quick guide
-===========
+Tutorial
+========
 
-In this quick guide, we'll create a library, download a couple documents, and
+In this tutorial, we'll create a library, download a couple documents, and
 then work on them by opening, tagging, updating, exporting, and organising them.
 In doing so, you will be introduced to the ``papis`` command and number of its
 subcommands. These subcommands (which we'll simply call "commands" from now on)


### PR DESCRIPTION
With the new quick guide, I felt a shorter version was needed with papis explained in 30s.
The presentation is a bit opinionated as I focused on the picker
Quick guide is moved to a tutorial.
The doc compiles locally. Any feedback is appreciated :)