### PR TITLE
Add extend config settings for doctor

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -152,6 +152,12 @@ Other smaller noteworthy changes:
   ([#695](https://github.com/papis/papis/pull/695))
 * `bibtex-type`: add fixer to automatically convert known document types
   ([#732](https://github.com/papis/papis/pull/732))
+* `html-tags`: be smarter about removing JATS and MML tags in abstracts.
+  ([#881](https://github.com/papis/papis/pull/881)).
+* [#916](https://github.com/papis/papis/pull/916) added configuration keys with
+  and `-extend` suffix to enable appending instead of overwriting existing lists.
+  For example, you should use `doctor-default-checks-extend = ["html-tags"]` to
+  add more default checks.
 
 ### Minor: Plugin helpers ([#680](https://github.com/papis/papis/pull/680) and [#752](https://github.com/papis/papis/pull/752))
 
@@ -231,6 +237,14 @@ this should be fairly automatic.
 * Allow configuration for marked lines margins and make marked and unmarked
   margins span the whole document entry.
   ([#820](https://github.com/papis/papis/pull/820))
+* Be smarter about automatic naming of newly added files.
+  ([#831](https://github.com/papis/papis/pull/831))
+* Add nicer library picker.
+  ([#856](https://github.com/papis/papis/pull/856)).
+* Add an `edit_notes` action to the `fzf` picker.
+  ([#919](https://github.com/papis/papis/pull/919))
+* Add a `browse` action + shortcut to the default pickers.
+  ([#922](https://github.com/papis/papis/pull/922))
 
 ## Bug fixes
 
@@ -253,6 +267,10 @@ this should be fairly automatic.
   ([#693](https://github.com/papis/papis/pull/693))
 * Do not escape verbatim BibTeX fields like `url`
   ([#739](https://github.com/papis/papis/pull/739))
+* Fix loading documents with removed keys.
+  ([#896](https://github.com/papis/papis/pull/896))
+* Use formatter for `multiple-authors-format`.
+  ([#906](https://github.com/papis/papis/pull/906))
 
 VERSION v0.13 (May 7, 2023)
 ===========================

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -99,8 +99,8 @@ string with a separator. You can quickly transform your tags into a list using
 `papis doctor` e.g.
 ```sh
 papis \
-    --set doctor-key-type-check-keys '["tags:list"]' \
-    --set doctor-key-type-check-separator ' ' \
+    --set doctor-key-type-keys '["tags:list"]' \
+    --set doctor-key-type-separator ' ' \
     doctor --fix --all --explain -t key-type QUERY
 ```
 where you may need to change the separator to match your choice.

--- a/doc/source/default-settings.rst
+++ b/doc/source/default-settings.rst
@@ -557,15 +557,35 @@ Doctor options
 
     A list of checks that are performed by default.
 
+.. papis-config:: doctor-default-checks-extend
+    :type: :class:`~typing.List` [:class:`str`]
+
+    A list of checks that extend the default ones from :confval:`doctor-default-checks`.
+    This list extends instead of overwriting the given checks.
+
 .. papis-config:: doctor-keys-missing-keys
 
     A list of keys used by the ``keys-missing`` check. The check will show an
     error if these keys are not present in a document.
 
+.. papis-config:: doctor-keys-missing-keys-extend
+    :type: :class:`~typing.List` [:class:`str`]
+
+    A list of keys that extend the default ones from
+    :confval:`doctor-keys-missing-keys`. This list extends instead of overwriting
+    the given keys.
+
 .. papis-config:: doctor-duplicated-keys-keys
 
     A list of keys used by the ``duplicated-keys`` check. The check will show
     an error if the value of these keys is duplicated across multiple documents.
+
+.. papis-config:: doctor-duplicated-keys-keys-extend
+    :type: :class:`~typing.List` [:class:`str`]
+
+    A list of keys that extend the default ones from
+    :confval:`doctor-duplicated-keys-keys`. This list extends instead of overwriting
+    the given keys.
 
 .. papis-config:: doctor-duplicated-values-keys
 
@@ -574,15 +594,36 @@ Doctor options
    e.g., if a file was mistakenly added multiple times or if a tag already
    exists in the document.
 
+.. papis-config:: doctor-duplicated-values-keys-extend
+    :type: :class:`~typing.List` [:class:`str`]
+
+    A list of keys that extend the default ones from
+    :confval:`doctor-duplicated-values-keys`. This list extends instead of overwriting
+    the given keys.
+
 .. papis-config:: doctor-html-codes-keys
 
     A list of keys used by the ``html-codes`` check. The check will show an error
     if any of the keys contain unwanted HTML codes, e.g. ``&amp;``.
 
+.. papis-config:: doctor-html-codes-keys-extend
+    :type: :class:`~typing.List` [:class:`str`]
+
+    A list of keys that extend the default ones from
+    :confval:`doctor-html-codes-keys`. This list extends instead of overwriting
+    the given keys.
+
 .. papis-config:: doctor-html-tags-keys
 
     A list of keys used by the ``html-tags`` check. The check will show an error
     if any of the keys contain unwanted HTML tags, e.g. ``<div>``.
+
+.. papis-config:: doctor-html-tags-keys-extend
+    :type: :class:`~typing.List` [:class:`str`]
+
+    A list of keys that extend the default ones from
+    :confval:`doctor-html-tags-keys`. This list extends instead of overwriting
+    the given keys.
 
 .. papis-config:: doctor-key-type-keys
 
@@ -591,6 +632,13 @@ Doctor options
    type should be a builtin Python type. For example, this can be
    ``["year:int", "tags:list"]`` to check that the year is an integer and the
    tags are given as a list in a document.
+
+.. papis-config:: doctor-key-type-keys-extend
+    :type: :class:`~typing.List` [:class:`str`]
+
+    A list of keys that extend the default ones from
+    :confval:`doctor-key-type-keys`. This list extends instead of overwriting
+    the given keys.
 
 .. papis-config:: doctor-key-type-separator
     :type: str

--- a/doc/source/default-settings.rst
+++ b/doc/source/default-settings.rst
@@ -584,7 +584,7 @@ Doctor options
     A list of keys used by the ``html-tags`` check. The check will show an error
     if any of the keys contain unwanted HTML tags, e.g. ``<div>``.
 
-.. papis-config:: doctor-key-type-check-keys
+.. papis-config:: doctor-key-type-keys
 
    A list of strings ``key:type`` used by the ``key-type`` check. This
    check will show an error if the key does not have the corresponding type. The
@@ -592,7 +592,7 @@ Doctor options
    ``["year:int", "tags:list"]`` to check that the year is an integer and the
    tags are given as a list in a document.
 
-.. papis-config:: doctor-key-type-check-separator
+.. papis-config:: doctor-key-type-separator
     :type: str
 
     A separator used by the ``key-type`` check fixer. When converting from

--- a/papis/commands/doctor.py
+++ b/papis/commands/doctor.py
@@ -262,9 +262,9 @@ def keys_missing_check(doc: papis.document.Document) -> List[Error]:
     from papis.defaults import NOT_SET
 
     folder = doc.get_main_folder() or ""
-    keys = papis.config.get("doctor-keys-exist-keys")
+    keys = papis.config.get("keys-exist-keys", section="doctor")
     if keys is NOT_SET:
-        keys = papis.config.getlist("doctor-keys-exist-keys")
+        keys = papis.config.getlist("keys-exist-keys", section="doctor")
     else:
         logger.warning("The configuration option 'doctor-keys-exist-keys' "
                        "is deprecated and will be removed in the next version. "
@@ -373,7 +373,7 @@ def duplicated_keys_check(doc: papis.document.Document) -> List[Error]:
     :returns: a :class:`list` of errors, one for each key with a value that already
         exist in the documents from the current query.
     """
-    keys = papis.config.getlist("doctor-duplicated-keys-keys")
+    keys = papis.config.getlist("duplicated-keys-keys", section="doctor")
     folder = doc.get_main_folder() or ""
 
     results: List[Error] = []
@@ -410,7 +410,7 @@ def duplicated_values_check(doc: papis.document.Document) -> List[Error]:
     :returns: a :class:`list` of errors, one for each key with a value that
         has duplicate entries.
     """
-    keys = papis.config.getlist("doctor-duplicated-values-keys")
+    keys = papis.config.getlist("duplicated-values-keys", section="doctor")
     folder = doc.get_main_folder() or ""
 
     def make_fixer(key: str, entries: List[Any]) -> FixFn:
@@ -644,11 +644,12 @@ def get_key_type_check_keys() -> Dict[str, type]:
 
     from papis.defaults import NOT_SET
 
-    key_type_check_keys = papis.config.get("doctor-key-type-check-keys")
+    key_type_check_keys = papis.config.get("key-type-check-keys", section="doctor")
     if key_type_check_keys is NOT_SET:
-        key_type_check_keys = papis.config.getlist("doctor-key-type-keys")
+        key_type_check_keys = papis.config.getlist("key-type-keys", section="doctor")
     else:
-        key_type_check_keys = papis.config.getlist("doctor-key-type-check-keys")
+        key_type_check_keys = papis.config.getlist("key-type-check-keys",
+                                                   section="doctor")
         logger.warning("The configuration option 'doctor-key-type-check-keys' "
                        "is deprecated and will be removed in the next version. "
                        "Use 'doctor-key-type-keys' instead.")
@@ -684,9 +685,9 @@ def key_type_check(doc: papis.document.Document) -> List[Error]:
     folder = doc.get_main_folder() or ""
 
     # NOTE: the separator can be quoted so that it can force whitespace
-    separator = papis.config.get("doctor-key-type-check-separator")
+    separator = papis.config.get("key-type-check-separator", section="doctor")
     if separator is NOT_SET:
-        separator = papis.config.get("doctor-key-type-separator")
+        separator = papis.config.get("key-type-separator", section="doctor")
     else:
         logger.warning("The configuration option 'doctor-key-type-check-separator' "
                        "is deprecated and will be removed in the next version. "
@@ -787,7 +788,7 @@ def html_codes_check(doc: papis.document.Document) -> List[Error]:
 
         return fixer
 
-    for key in papis.config.getlist("doctor-html-codes-keys"):
+    for key in papis.config.getlist("html-codes-keys", section="doctor"):
         value = doc.get(key)
         if value is None:
             continue
@@ -872,7 +873,7 @@ def html_tags_check(doc: papis.document.Document) -> List[Error]:
 
         return fixer
 
-    for key in papis.config.getlist("doctor-html-tags-keys"):
+    for key in papis.config.getlist("html-tags-keys", section="doctor"):
         value = doc.get(key)
         if value is None:
             logger.debug("Key '%s' not found in document: '%s'",
@@ -925,7 +926,7 @@ def gather_errors(documents: List[papis.document.Document],
     :returns: a list of all the errors gathered from the documents.
     """
     if not checks:
-        checks = papis.config.getlist("doctor-default-checks")
+        checks = papis.config.getlist("default-checks", section="doctor")
 
     for check in checks:
         if check not in REGISTERED_CHECKS:
@@ -1064,7 +1065,7 @@ def run(doc: papis.document.Document,
 @papis.cli.query_argument()
 @papis.cli.sort_option()
 @click.option("-t", "--checks", "_checks",
-              default=lambda: papis.config.getlist("doctor-default-checks"),
+              default=lambda: papis.config.getlist("default-checks", section="doctor"),
               multiple=True,
               type=click.Choice(registered_checks_names()
                                 + list(DEPRECATED_CHECK_NAMES)),

--- a/papis/config.py
+++ b/papis/config.py
@@ -357,11 +357,11 @@ def general_get(key: str,
 
     # Check data type for setting getter method
     method: Callable[[Any, Any], Any]
-    if data_type == int:
+    if data_type is int:
         method = config.getint
-    elif data_type == float:
+    elif data_type is float:
         method = config.getfloat
-    elif data_type == bool:
+    elif data_type is bool:
         method = config.getboolean
     else:
         method = config.get

--- a/papis/config.py
+++ b/papis/config.py
@@ -405,10 +405,16 @@ def general_get(key: str,
             value = method(section_name, key_name)
 
     if value is None:
-        try:
-            return default_settings[section or global_section][key]
-        except KeyError as exc:
-            raise papis.exceptions.DefaultSettingValueMissing(qualified_key) from exc
+        if section is not None:
+            section_settings = default_settings.get(section, {})
+            if key in section_settings:
+                return section_settings[key]
+
+        general_settings = default_settings.get(global_section, {})
+        if qualified_key in general_settings:
+            return general_settings[qualified_key]
+
+        raise papis.exceptions.DefaultSettingValueMissing(qualified_key)
 
     return value
 

--- a/papis/defaults.py
+++ b/papis/defaults.py
@@ -107,11 +107,17 @@ settings: Dict[str, Any] = {
 
     # doctor
     "doctor-default-checks": ["files", "biblatex-required-keys", "bibtex-type", "refs"],
+    "doctor-default-checks-extend": [],
     "doctor-keys-missing-keys": ["title", "author", "author_list", "ref"],
+    "doctor-keys-missing-keys-extend": [],
     "doctor-duplicated-keys-keys": ["ref"],
+    "doctor-duplicated-keys-keys-extend": [],
     "doctor-duplicated-values-keys": ["files", "author_list"],
+    "doctor-duplicated-values-keys-extend": [],
     "doctor-html-codes-keys": ["title", "author", "abstract", "journal"],
+    "doctor-html-codes-keys-extend": [],
     "doctor-html-tags-keys": ["title", "author", "abstract", "journal"],
+    "doctor-html-tags-keys-extend": [],
     "doctor-key-type-keys": ["year:int",
                              "month:int",
                              "files:list",
@@ -128,6 +134,7 @@ settings: Dict[str, Any] = {
                              "publisher:str",
                              "title:str",
                              "shorttitle:str"],
+    "doctor-key-type-keys-extend": [],
     "doctor-key-type-separator": None,
 
     # open

--- a/papis/defaults.py
+++ b/papis/defaults.py
@@ -20,12 +20,16 @@ def get_default_opener() -> str:
 # document in the docs, so they can be easily checked and updated
 
 
+NOT_SET = object()
+
 settings: Dict[str, Any] = {
     # unused or deprecated
     "add-interactive": False,
     "mvtool": "mv",
-    "formater": None,
-    "doctor-keys-exist-keys": None,
+    "formater": NOT_SET,
+    "doctor-keys-exist-keys": NOT_SET,
+    "doctor-key-type-check-keys": NOT_SET,
+    "doctor-key-type-check-separator": NOT_SET,
 
     # general settings
     "local-config-file": ".papis.config",
@@ -108,23 +112,23 @@ settings: Dict[str, Any] = {
     "doctor-duplicated-values-keys": ["files", "author_list"],
     "doctor-html-codes-keys": ["title", "author", "abstract", "journal"],
     "doctor-html-tags-keys": ["title", "author", "abstract", "journal"],
-    "doctor-key-type-check-keys": ["year:int",
-                                   "month:int",
-                                   "files:list",
-                                   "notes:str",
-                                   "author_list:list",
-                                   "doi:str",
-                                   "ref:str",
-                                   "isbn:str",
-                                   "author:str",
-                                   "journal:str",
-                                   "note:str",
-                                   "tags:list",
-                                   "type:str",
-                                   "publisher:str",
-                                   "title:str",
-                                   "shorttitle:str"],
-    "doctor-key-type-check-separator": None,
+    "doctor-key-type-keys": ["year:int",
+                             "month:int",
+                             "files:list",
+                             "notes:str",
+                             "author_list:list",
+                             "doi:str",
+                             "ref:str",
+                             "isbn:str",
+                             "author:str",
+                             "journal:str",
+                             "note:str",
+                             "tags:list",
+                             "type:str",
+                             "publisher:str",
+                             "title:str",
+                             "shorttitle:str"],
+    "doctor-key-type-separator": None,
 
     # open
     "open-mark": False,

--- a/papis/format.py
+++ b/papis/format.py
@@ -256,13 +256,16 @@ def get_formatter(name: Optional[str] = None) -> Formatter:
         mgr = papis.plugin.get_extension_manager(FORMATTER_EXTENSION_NAME)
 
         if name is None:
+            from papis.defaults import NOT_SET
+
             # FIXME: remove this special handling when we don't need to support
             # the deprecated 'formater' configuration setting
             value = papis.config.get("formater")
-            if value is None:
+            if value is NOT_SET:
                 name = papis.config.getstring("formatter")
             else:
-                logger.warning("The configuration option 'formater' is deprecated. "
+                logger.warning("The configuration option 'formater' is deprecated "
+                               "and will be removed in the next version. "
                                "Use 'formatter' instead.")
                 name = str(value)
 

--- a/tests/test_doctor.py
+++ b/tests/test_doctor.py
@@ -212,53 +212,53 @@ def test_key_type_check(tmp_config: TemporaryConfiguration) -> None:
         })
 
     # check: invalid setting parsing
-    papis.config.set("doctor-key-type-check-keys", ["year = WithoutColon"])
+    papis.config.set("doctor-key-type-keys", ["year = WithoutColon"])
     errors = key_type_check(doc)
     assert not errors
 
-    papis.config.set("doctor-key-type-check-keys", ["year:NotBuiltin"])
+    papis.config.set("doctor-key-type-keys", ["year:NotBuiltin"])
     errors = key_type_check(doc)
     assert not errors
 
     # check: incorrect type
-    papis.config.set("doctor-key-type-check-keys", ["year:int"])
+    papis.config.set("doctor-key-type-keys", ["year:int"])
     error, = key_type_check(doc)
     assert error.payload == "year"
 
     # check: correct type
-    papis.config.set("doctor-key-type-check-keys", ["  author_list :    list"])
+    papis.config.set("doctor-key-type-keys", ["  author_list :    list"])
     errors = key_type_check(doc)
     assert not errors
 
     # check: fix int
-    papis.config.set("doctor-key-type-check-keys", ["year:int"])
+    papis.config.set("doctor-key-type-keys", ["year:int"])
     error, = key_type_check(doc)
     assert error.payload == "year"
     error.fix_action()
     assert doc["year"] == 2023
 
     # check: fix list
-    papis.config.set("doctor-key-type-check-separator", " ")
-    papis.config.set("doctor-key-type-check-keys", ["projects:list"])
+    papis.config.set("doctor-key-type-separator", " ")
+    papis.config.set("doctor-key-type-keys", ["projects:list"])
     error, = key_type_check(doc)
     assert error.payload == "projects"
     error.fix_action()
     assert doc["projects"] == ["test-key-project"]
 
-    papis.config.set("doctor-key-type-check-keys", ["tags:list"])
+    papis.config.set("doctor-key-type-keys", ["tags:list"])
     error, = key_type_check(doc)
     assert error.payload == "tags"
     error.fix_action()
     assert doc["tags"] == ["test-key-tag-1", "test-key-tag-2", "test-key-tag-3"]
 
-    papis.config.set("doctor-key-type-check-separator", ",")
+    papis.config.set("doctor-key-type-separator", ",")
     doc["tags"] = "test-key-tag-1,test-key-tag-2    ,  test-key-tag-3"
     error, = key_type_check(doc)
     assert error.payload == "tags"
     error.fix_action()
     assert doc["tags"] == ["test-key-tag-1", "test-key-tag-2", "test-key-tag-3"]
 
-    papis.config.set("doctor-key-type-check-keys", ["tags:str"])
+    papis.config.set("doctor-key-type-keys", ["tags:str"])
     error, = key_type_check(doc)
     assert error.payload == "tags"
     error.fix_action()


### PR DESCRIPTION
This adds a `doctor-default-checks-extend` to `doctor-default-checks` (and same for other options) to allow users to extend instead of overwrite the various lists of keys and checks in there.

TODO:
* [X] Add some tests to make sure everything works.
* [X] Add to CHANGELOG.

cc @jghauser @apraga 