### PR TITLE
Shortcut to browse_documents in pickers

### DIFF
--- a/papis/fzf.py
+++ b/papis/fzf.py
@@ -47,6 +47,19 @@ class Command(ABC, Generic[T]):
         pass
 
 
+class Browse(Command[T]):
+    regex = re.compile(r"browse ([\d ]+)")
+    command = "become(echo browse {+n})"
+    key = "enter"
+
+    def run(self, docs: List[T]) -> List[T]:
+        from papis.commands.browse import run
+        for doc in docs:
+            if isinstance(doc, papis.document.Document):
+                run(doc)
+        return []
+
+
 class Choose(Command[T]):
     regex = re.compile(r"choose ([\d ]+)")
     command = "become(echo choose {+n})"
@@ -114,7 +127,7 @@ class Picker(papis.pick.Picker[T]):
                 f"Found 'fzf' version {version} but "
                 f"version >={MIN_FZF_VERSION} is required")
 
-        commands: List[Command[T]] = [Choose(), Open(), Edit(), EditNote()]
+        commands: List[Command[T]] = [Browse(), Choose(), Open(), Edit(), EditNote()]
 
         bindings = (
             [c.binding() for c in commands]

--- a/papis/tui/__init__.py
+++ b/papis/tui/__init__.py
@@ -23,6 +23,7 @@ def get_default_settings() -> PapisConfigType:
         "move_down_while_info_window_active_key": "c-n",
         "move_up_while_info_window_active_key": "c-p",
         "focus_command_line_key": "tab",
+        "browse_document_key": "c-b",
         "edit_document_key": "c-e",
         "edit_notes_key": "c-q",
         "open_document_key": "c-o",

--- a/papis/tui/app.py
+++ b/papis/tui/app.py
@@ -68,6 +68,10 @@ def get_keys_info() -> Dict[str, KeyInfo]:
                     config.getstring("focus_command_line_key", section="tui"),
                 "help": "Focus command line prompt",
             },
+            "browse_document_key": {
+                "key": config.getstring("browse_document_key", section="tui"),
+                "help": "Browse currently selected document",
+            },
             "edit_document_key": {
                 "key": config.getstring("edit_document_key", section="tui"),
                 "help": "Edit currently selected document",
@@ -230,6 +234,14 @@ def get_commands(app: "Picker[Any]") -> Tuple[List[Command], KeyBindings]:
             thread.join()
 
         app.renderer.clear()
+
+    @kb.add(keys_info["browse_document_key"]["key"],      # type: ignore[misc]
+            filter=has_focus(app.options_list.search_buffer))
+    def browse(event: Union[Command, KeyPressEvent]) -> None:
+        from papis.commands.browse import run
+        docs = app.get_selection()
+        for doc in docs:
+            run(doc)
 
     @kb.add(keys_info["edit_document_key"]["key"],      # type: ignore[misc]
             filter=has_focus(app.options_list.search_buffer))


### PR DESCRIPTION
I often have to browse multiple entrie so a shortcut is welcome.

Not tested on fzf.