### PR TITLE
Try Python 3.13 now that it's out

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -9,6 +9,10 @@ on:
     # 17:00 on Friday (UTC)
     - cron: "00 17 * * 5"
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
 jobs:
   build:
     runs-on: ${{ matrix.os }}

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -15,7 +15,7 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest, macos-latest, windows-latest]
-        python-version: ['3.8', '3.9', '3.10', '3.11', '3.12']
+        python-version: ['3.8', '3.9', '3.10', '3.11', '3.12', '3.13']
       fail-fast: false
 
     steps:

--- a/.github/workflows/nix-flake.yml
+++ b/.github/workflows/nix-flake.yml
@@ -9,6 +9,10 @@ on:
     # 17:00 on Friday (UTC)
     - cron: "00 17 * * 5"
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
 jobs:
   test-nix-flake:
     runs-on: ubuntu-latest

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -9,6 +9,10 @@ on:
   pull_request:
       branches: [ "main" ]
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
 jobs:
   build-windows-release:
     runs-on: windows-latest

--- a/PACKAGING.md
+++ b/PACKAGING.md
@@ -1,7 +1,7 @@
 Guidelines for Packaging
 ========================
 
-These are some loose notes about packing Papis meant to highlight the different
+These are some loose notes about packaging Papis meant to highlight the different
 components that are available and not to require a particular format.
 
 Version Numbering
@@ -23,7 +23,7 @@ See `pyproject.toml` for a complete list of dependencies and minimum versions.
 Wheels
 ------
 
-Papis uses the standard `pyproject.toml`-based format using `hatchling` as a
+Papis uses the standard `pyproject.toml`-based format and `hatchling` as a
 build backend. Wheels can be generated using
 ```
 python -m build --wheel --skip-dependency-check .

--- a/papis/commands/serve.py
+++ b/papis/commands/serve.py
@@ -36,7 +36,7 @@ AnyFn = Callable[..., Any]
 try:
     # NOTE: the cgi module is being removed in python 3.13, so we add our own
     # little copy of FieldStorage when it's not available
-    from cgi import FieldStorage
+    from cgi import FieldStorage  # type: ignore[import-not-found,unused-ignore]
 except ImportError:
     from email.message import Message
     from dataclasses import dataclass, field

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -58,6 +58,7 @@ classifiers = [
     "Programming Language :: Python :: 3.10",
     "Programming Language :: Python :: 3.11",
     "Programming Language :: Python :: 3.12",
+    "Programming Language :: Python :: 3.13",
     "Topic :: Utilities",
 ]
 dependencies = [

--- a/tools/create-docker-image.py
+++ b/tools/create-docker-image.py
@@ -48,7 +48,7 @@ if __name__ == "__main__":
     parser = argparse.ArgumentParser()
     parser.add_argument(
         "-p", "--python-version", help="Python version",
-        choices=[f"{major}.{minor}" for major, minor in zip(repeat(3), range(8, 13))],
+        choices=[f"{major}.{minor}" for major, minor in zip(repeat(3), range(8, 14))],
         default="3.12")
     parser.add_argument("dockerfile", type=pathlib.Path, default="Dockerfile")
     parser.add_argument(

--- a/tools/test-all-py-versions-in-docker.sh
+++ b/tools/test-all-py-versions-in-docker.sh
@@ -7,7 +7,7 @@ fi
 
 set -ex
 
-for pyversion in 3.8 3.9 3.10 3.11 3.12; do
+for pyversion in 3.8 3.9 3.10 3.11 3.12 3.13; do
     "$CTRT" build \
         --build-arg "PYTHON_VERSION=$pyversion" \
         -t "papisdev:$pyversion" \


### PR DESCRIPTION
This adds Python 3.13 to `pyproject.toml` and in all the testing scripts.