### PR TITLE
papis.format: redefine Jinja2Formatter to enable easy template extension in config.py

### DIFF
--- a/papis/config.py
+++ b/papis/config.py
@@ -134,7 +134,12 @@ class Configuration(configparser.ConfigParser):
         configpy = get_configpy_file()
         if os.path.exists(configpy):
             with open(configpy) as fd:
-                exec(fd.read(), globals())  # add user's defs to global name space
+                # NOTE: this includes the `globals()` so that the user config.py
+                # can add entries to the global namespace. This was motivated
+                # by adding filters to `Jinja2Formatter.env`, which may be separated
+                # into multiple functions that would not be found otherwise.
+                #   https://github.com/papis/papis/pull/930
+                exec(fd.read(), globals())
 
 
 def get_default_settings() -> PapisConfigType:

--- a/papis/config.py
+++ b/papis/config.py
@@ -134,7 +134,7 @@ class Configuration(configparser.ConfigParser):
         configpy = get_configpy_file()
         if os.path.exists(configpy):
             with open(configpy) as fd:
-                exec(fd.read(), globals())
+                exec(fd.read(), globals())  # add user's defs to global name space
 
 
 def get_default_settings() -> PapisConfigType:

--- a/papis/config.py
+++ b/papis/config.py
@@ -134,7 +134,7 @@ class Configuration(configparser.ConfigParser):
         configpy = get_configpy_file()
         if os.path.exists(configpy):
             with open(configpy) as fd:
-                exec(fd.read())
+                exec(fd.read(), globals())
 
 
 def get_default_settings() -> PapisConfigType:

--- a/papis/format.py
+++ b/papis/format.py
@@ -8,8 +8,10 @@ import papis.logging
 
 try:
     from jinja2.environment import Environment
-except ImportError:
-    pass
+except ImportError as e:
+    exc = e
+else:
+    exc = None
 
 logger = papis.logging.get_logger(__name__)
 
@@ -207,19 +209,17 @@ class Jinja2Formatter(Formatter):
         "{{ doc.isbn | default('ISBN-NONE', true) }}"
     """
 
-    env: Environment = Environment()
+    if not exc:
+        env: Environment = Environment() # type: ignore
+    else:
+        logger.error(
+            "The 'jinja2' formatter requires the 'jinja' library. "
+            "To use this functionality install it using e.g. "
+            "'pip install jinja2'.", exc_info=exc)
+        raise exc
 
     def __init__(self) -> None:
         super().__init__()
-
-        try:
-            import jinja2       # noqa: F401
-        except ImportError as exc:
-            logger.error(
-                "The 'jinja2' formatter requires the 'jinja' library. "
-                "To use this functionality install it using e.g. "
-                "'pip install jinja2'.", exc_info=exc)
-            raise exc
 
     def format(self,
                fmt: str,

--- a/papis/format.py
+++ b/papis/format.py
@@ -220,6 +220,7 @@ class Jinja2Formatter(Formatter):
 
     def __init__(self) -> None:
         super().__init__()
+        self.env.shared = True
 
     def format(self,
                fmt: str,

--- a/papis/format.py
+++ b/papis/format.py
@@ -1,6 +1,5 @@
 import string
-from functools import lru_cache
-from typing import Any, Dict, Optional
+from typing import Any, ClassVar, Dict, Optional
 
 import papis.config
 import papis.plugin
@@ -173,19 +172,6 @@ class PythonFormatter(Formatter):
                 raise FormatFailedError(fmt) from exc
 
 
-@lru_cache(maxsize=None)
-def jinja_environment() -> Any:
-    try:
-        from jinja2.environment import Environment
-        return Environment()
-    except ImportError as e:
-        logger.error(
-            "The 'jinja2' formatter requires the 'jinja2' library. "
-            "To use this functionality install it using e.g. "
-            "'pip install jinja2'.", exc_info=e)
-        raise e
-
-
 class Jinja2Formatter(Formatter):
     """Construct a string using `Jinja2 <https://palletsprojects.com/p/jinja/>`__
     templates.
@@ -216,11 +202,35 @@ class Jinja2Formatter(Formatter):
         "{{ doc.isbn | default('ISBN-NONE', true) }}"
     """
 
-    env = jinja_environment()
+    env: ClassVar[Any] = None
+    """The ``jinja2`` Environment used by the formatter. This should be obtained
+    with :meth:`~Jinja2Formatter.get_environment()` (cached) and modified as
+    required (e.g. by adding filters).
+    """
 
     def __init__(self) -> None:
         super().__init__()
-        self.env.shared = True
+
+        try:
+            import jinja2  # noqa: F401
+        except ImportError as exc:
+            logger.error(
+                "The 'jinja2' formatter requires the 'jinja2' library. "
+                "To use this functionality install it using e.g. "
+                "'pip install jinja2'.", exc_info=exc)
+            raise exc
+
+    @classmethod
+    def get_environment(cls, *, force: bool = False) -> Any:
+        if cls.env is None or force:
+            from jinja2 import Environment
+
+            # NOTE: this will kindly autoescape apostrophes otherwise
+            env = Environment(autoescape=False)
+            env.shared = True
+            cls.env = env
+
+        return cls.env
 
     def format(self,
                fmt: str,
@@ -236,9 +246,10 @@ class Jinja2Formatter(Formatter):
             doc = papis.document.from_data(doc)
 
         doc_name = doc_key or self.default_doc_name
+        env = self.get_environment()
+
         try:
-            tmpl = self.env.from_string(fmt)
-            return str(tmpl.render(**{doc_name: doc}, **additional))
+            return str(env.from_string(fmt).render(**{doc_name: doc}, **additional))
         except Exception as exc:
             if default is not None:
                 logger.warning("Could not format string '%s' for document '%s'",

--- a/papis/format.py
+++ b/papis/format.py
@@ -210,7 +210,7 @@ class Jinja2Formatter(Formatter):
     """
 
     if not exc:
-        env: Environment = Environment() # type: ignore
+        env: Environment = Environment()  # type: ignore
     else:
         logger.error(
             "The 'jinja2' formatter requires the 'jinja' library. "

--- a/papis/format.py
+++ b/papis/format.py
@@ -9,9 +9,9 @@ import papis.logging
 try:
     from jinja2.environment import Environment
 except ImportError as e:
-    exc = e
+    exc: Optional[ImportError] = e
 else:
-    exc = None
+    exc: Optional[ImportError] = None
 
 logger = papis.logging.get_logger(__name__)
 


### PR DESCRIPTION
Changes:

1. minimally redefine `Jinja2Formatter` to expose the jinja environment as a class variable so it can be easily accessed by the user config and freely modified
2. this environment is used to create template instances directly instead of using the jinja2 Template class.
3. when a `Jinja2Formatter` is initialized the env is "shared" so all format strings should share the same env just as they did before (this claim needs more verification)
4. call configpy with `exec(fd.read(), globals())` instead of `exec(fd.read())`

The main change is (4). From reading https://docs.python.org/3/library/functions.html#exec this should be a fully back-compatible change, but I'm not sure.

This is necessary to allow any reasonably complicated custom function to be registered with the Jinja2Formatter environment (easily, at least). Executing config.py in the top level namespace ensures all functions defined within are discoverable by the formatter. This is very much simpler than any alternative.

I was able to use these changes to implement (near enough) `bibtex-generate-autokey` from emacs' `bibtex.el` -- in my opinion, the best key generator I've used.

**USE CAUTION WHEN RUNNING FOREIGN CODE OF ANY KIND**. Here's a Gist of my config.py:
https://gist.github.com/pmiam/25b4232e9990cb251167bee7868e849b

I originally wrote this at the head of alexfikl's #711 branch, but it can stand alone.