### PR TITLE
papis.config: add configuration ref-word-separator

### DIFF
--- a/doc/source/default-settings.rst
+++ b/doc/source/default-settings.rst
@@ -203,7 +203,7 @@ General settings
     replacing spaces or other non-letter characters). By default this is the
     underscore ``"_"`` but it could, e.g., also be the hyphen ``"-"``.
 
-    The ref is used as the bibtex key when creating bibtex format bibliographies.
+    The ``ref`` is used as the citation key when creating BibTeX format bibliographies.
     Therefore, characters ``" # ' ( ) , = { } %`` are not recommended for use as
     separators because neither ``bibtex`` nor ``biber`` can process them.
 

--- a/doc/source/default-settings.rst
+++ b/doc/source/default-settings.rst
@@ -196,6 +196,17 @@ General settings
     replacing spaces or other non-letter characters). By default this is the
     hyphen ``"-"`` but it could, e.g., also be the underscore ``"_"``.
 
+.. papis-config:: ref-word-separator
+    :type: str
+
+    This setting defines the separator between words in ref keys (usually
+    replacing spaces or other non-letter characters). By default this is the
+    underscore ``"_"`` but it could, e.g., also be the hyphen ``"-"``.
+
+    The ref is used as the bibtex key when creating bibtex format bibliographies.
+    Therefore, characters ``" # ' ( ) , = { } %`` are not recommended for use as
+    separators because neither ``bibtex`` nor ``biber`` can process them.
+
 .. papis-config:: library-header-format
 
     The format of a library when shown in a picker, e.g. when using

--- a/papis/bibtex.py
+++ b/papis/bibtex.py
@@ -465,7 +465,6 @@ def ref_cleanup(ref: str) -> str:
     ref = slugify.slugify(ref,
                           lowercase=False,
                           word_boundary=False,
-                          separator="_",
                           regex_pattern=ref_allowed_characters)
 
     return str(ref).strip()

--- a/papis/bibtex.py
+++ b/papis/bibtex.py
@@ -465,6 +465,7 @@ def ref_cleanup(ref: str) -> str:
     ref = slugify.slugify(ref,
                           lowercase=False,
                           word_boundary=False,
+                          separator=papis.config.getstring("ref-word-separator"),
                           regex_pattern=ref_allowed_characters)
 
     return str(ref).strip()

--- a/papis/defaults.py
+++ b/papis/defaults.py
@@ -58,6 +58,7 @@ settings: Dict[str, Any] = {
     "doc-paths-lowercase": True,
     "doc-paths-extra-chars": "",
     "doc-paths-word-separator": "-",
+    "ref-word-separator": "_",
     "library-header-format": (
         "<ansired>{library[name]}</ansired>"
         " <ansiblue>{library[paths]}</ansiblue>"


### PR DESCRIPTION
Changes:

1. introduced a configuration option `ref-word-separator` (default "_")
2. I just think enforcing a word separator in refs is too opinionated ("-" looks better in the latex context)

I'm open to alternative ways of doing this, but I reckon other approaches would require more invasive revision of tests.