### PR TITLE
crossref: implement fetch_data in terms of fetch

### DIFF
--- a/papis/crossref.py
+++ b/papis/crossref.py
@@ -493,6 +493,9 @@ class Downloader(papis.downloaders.Downloader):
 
         return self._doi
 
+    def fetch_data(self) -> None:
+        self.fetch()
+
     def fetch(self) -> None:
         if not self.doi:
             return


### PR DESCRIPTION
The `crossref.Downloader` was buggy because it didn't call `fetch` from `fetch_data`. This meant that running
```
papis add https://doi.org/10.1029/WR022i010p01404
```
wouldn't actually download any data because it was running the default `Downloader.fetch_data`.