### PR TITLE
Fix: masterthesis should be mastersthesis

### DIFF
--- a/papis/arxiv.py
+++ b/papis/arxiv.py
@@ -86,7 +86,7 @@ def arxiv_to_papis(result: "arxiv.Result") -> Dict[str, Any]:
             if "phd" in comment:
                 data["type"] = "phdthesis"
             elif "master" in comment:
-                data["type"] = "masterthesis"
+                data["type"] = "mastersthesis"
             else:
                 data["type"] = "thesis"
 

--- a/papis/bibtex.py
+++ b/papis/bibtex.py
@@ -46,7 +46,7 @@ bibtex_standard_types = frozenset([
 bibtex_type_aliases = {
     "conference": "inproceedings",
     "electronic": "online",
-    "masterthesis": "thesis",
+    "mastersthesis": "thesis",
     "phdthesis": "thesis",
     "techreport": "report",
     "www": "online",

--- a/papis/hayagriva.py
+++ b/papis/hayagriva.py
@@ -113,7 +113,7 @@ BIBTEX_TO_HAYAGRIVA_TYPE_MAP = {
     # type aliases (Section 2.1.2)
     "conference": "conference",
     "electronic": "web",
-    "masterthesis": "thesis",
+    "mastersthesis": "thesis",
     "phdthesis": "thesis",
     "techreport": "report",
     "www": "web",


### PR DESCRIPTION
This was fixed in #561 and got back in :(

cc @amine-aboufirass