### PR TITLE
ci: parse version with python instead of awk

### DIFF
--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -38,15 +38,9 @@ jobs:
       shell: bash
       run: |
         # NOTE: python version follows "X.YdevZ+gHASH" format
-        py_version=$(
-            git describe --tags --dirty \
-            | awk -F '-' '{ printf "%s.dev%s+%s\n", substr($1, 2), $2, $3 }'
-        )
+        py_version=$(python tools/windows/get_version.py python)
         # NOTE: MSI version cannot have letters and is only "X.Y.Z"
-        msi_version=$(
-            git describe --tags --dirty \
-            | awk -F '-' '{ printf "%s.%s", substr($1, 2), $2 }'
-        )
+        msi_version=$(python tools/windows/get_version.py msi)
         sed -i "s/^version =\".*\"/version =\"${py_version}\"/" pyproject.toml
 
         echo "PAPIS_VERSION=${py_version}" >> "$GITHUB_ENV"

--- a/tools/windows/get_version.py
+++ b/tools/windows/get_version.py
@@ -1,0 +1,76 @@
+#!/usr/bin/env python
+
+from packaging.version import Version
+import subprocess
+from typing import Literal
+
+import pytest
+import click
+
+
+Mode = Literal["python", "msi"]
+
+
+def get_version(description: str, mode: Mode) -> str:
+    # When the command returns something like v0.14
+    if "-" in description:
+        raw_version, count, commit_hash = description.split("-")
+    # Otherwise, like v0.14-1-f00b4r
+    else:
+        raw_version = description
+        count = "0"
+        commit_hash = ""
+
+    version = Version(raw_version)
+
+    if mode == "python":
+        # `git describe --tags` returns v.0.14
+        if count == "0":
+            return raw_version
+        # `git describe --tags` returns v0.14-1-f00b4r
+        else:
+            return f"{raw_version}+dev{count}+g{commit_hash}"
+
+    # MSI versions can be either X.Y.Z.W or X.Y.Z-LABEL.W
+    elif mode == "msi":
+        if version.is_prerelease and version.pre is not None:
+            prerelease_id = f"{version.pre[0]}.{version.pre[1]}"
+            # This yields, for example, 0.14.0-rc.1
+            return f"{version.major}.{version.minor}.{version.micro}-{prerelease_id}"
+        else:
+            # 0.14.0.X where X is the commit count after last the tagged commit
+            return f"{version.major}.{version.minor}.{version.micro}.{count}"
+
+
+@pytest.mark.parametrize(
+    "git_description, mode, expected",
+    [
+        # Release commits
+        ("v0.14", "python", "v0.14"),
+        ("v0.14", "msi", "0.14.0.0"),
+        # Release candidates
+        ("v0.14rc3", "python", "v0.14rc3"),
+        ("v0.14rc3", "msi", "0.14.0-rc.3"),
+        # A commit after release
+        ("v0.14-1-g6d2f2957", "python", "v0.14+dev1+gg6d2f2957"),
+        ("v0.14-1-g6d2f2957", "msi", "0.14.0.1"),
+    ],
+)
+def test_get_version(git_description: str, mode: Mode, expected: str) -> None:
+    assert get_version(git_description, mode) == expected
+
+
+@click.command()
+@click.argument("mode", type=click.Choice(["python", "msi"]))
+def main(mode: Mode) -> None:
+    """
+    Return a version compatible with either Python modules or MSI packages.
+    """
+    cmd = "git describe --tags --no-dirty".split()
+    description = subprocess.run(cmd, capture_output=True, text=True)
+    result = get_version(description.stdout, mode)
+    click.echo(result)
+
+
+if __name__ == "__main__":
+    main()

--- a/tools/windows/get_version.py
+++ b/tools/windows/get_version.py
@@ -12,11 +12,11 @@ Mode = Literal["python", "msi"]
 
 
 def get_version(description: str, mode: Mode) -> str:
-    # When the command returns something like v0.14
     if "-" in description:
+        # Expected version like v0.14-1-f00b4r
         raw_version, count, commit_hash = description.split("-")
-    # Otherwise, like v0.14-1-f00b4r
     else:
+        # Otherwise version like v0.14
         raw_version = description
         count = "0"
         commit_hash = ""
@@ -29,7 +29,7 @@ def get_version(description: str, mode: Mode) -> str:
             return raw_version
         # `git describe --tags` returns v0.14-1-f00b4r
         else:
-            return f"{raw_version}+dev{count}+g{commit_hash}"
+            return f"{raw_version}.dev{count}+g{commit_hash}"
 
     # MSI versions can be either X.Y.Z.W or X.Y.Z-LABEL.W
     elif mode == "msi":


### PR DESCRIPTION
This PR addresses the flakiness for the MSI version parsing. I think using this could do the trick.

The version for pre-releases would be in the format of MAJOR.MINOR.MICRO-LABEL.ID such as 0.14.0-rc.3 (like it was an hour ago), whereas for release versions or versions built during CI would be MAJOR.MINOR.MICRO.COUNT such as 0.14.0.0 for cut releases or 0.14.0.42 where 42 corresponds with the 42 in v0.14-**42**-dev000000 like in [this action run](https://github.com/papis/papis/actions/runs/11749836574/job/32736871128?pr=941#step:10:14).

Fixes #940.

Should I change the MSI artifact filenames too so that the filename coincides with the MSI version too?

cc @alexfikl