### PR TITLE
Align code structure of epubjs.py and pdfjs.py

### DIFF
--- a/papis/web/epubjs.py
+++ b/papis/web/epubjs.py
@@ -1,15 +1,45 @@
 import os.path
+import urllib.parse
 
 import dominate.tags as t
 
 import papis.web.html as wh
 import papis.web.static
 
-VIEWER_PATH = "epubjs-reader/reader/index.html"
 EPUBJS_URL = "https://github.com/futurepress/epubjs-reader"
+VIEWER_PATH = "epubjs-reader/reader/index.html"
 
 
-def detect_local_installation() -> bool:
+def widget(unquoted_file_path: str) -> None:
+    """
+    Widget for epub files.
+    """
+
+    _file_path = urllib.parse.quote(unquoted_file_path, safe="")
+
+    viewer_path = f"/static/{VIEWER_PATH}?bookPath={_file_path}"
+
+    with wh.flex("center"):
+        with t.div(cls="btn-group", role="group"):
+            with t.a(href=viewer_path,
+                     cls="btn btn-outline-success",
+                     target="_blank"):
+                wh.icon_span("square-arrow-up-right", "Open in new window")
+            with t.a(href=unquoted_file_path,
+                     cls="btn btn-outline-success",
+                     target="_blank"):
+                wh.icon_span("download", "Download")
+
+    if detect_epubjs():
+        t.iframe(src=viewer_path,
+                 style="resize: vertical",
+                 width="100%",
+                 height="800")
+    else:
+        t.pre(error_message(), cls="alert alert-warning")
+
+
+def detect_epubjs() -> bool:
     for path in papis.web.static.static_paths():
         viewer = os.path.join(path, VIEWER_PATH)
         if os.path.exists(viewer):
@@ -37,30 +67,3 @@ On linux and mac you can simply run the following lines
     mkdir -p ~/.config/papis/web/
     git clone {EPUBJS_URL} ~/.config/papis/web/epubjs-reader
     """
-
-
-def widget(unquoted_file_path: str) -> None:
-    """
-    Widget for epub files.
-    """
-
-    viewer_path = f"/static/{VIEWER_PATH}?bookPath={unquoted_file_path}"
-
-    with wh.flex("center"):
-        with t.div(cls="btn-group", role="group"):
-            with t.a(href=viewer_path,
-                     cls="btn btn-outline-success",
-                     target="_blank"):
-                wh.icon_span("square-arrow-up-right", "Open in new window")
-            with t.a(href=unquoted_file_path,
-                     cls="btn btn-outline-success",
-                     target="_blank"):
-                wh.icon_span("download", "Download")
-
-    if detect_local_installation():
-        t.iframe(src=viewer_path,
-                 style="resize: vertical",
-                 width="100%",
-                 height="800")
-    else:
-        t.pre(error_message(), cls="alert alert-warning")

--- a/papis/web/pdfjs.py
+++ b/papis/web/pdfjs.py
@@ -1,4 +1,4 @@
-import os
+import os.path
 import urllib.parse
 
 import dominate.tags as t
@@ -11,8 +11,12 @@ PDFJS_URL = ("https://github.com/mozilla/pdf.js/releases/download/"
 VIEWER_PATH = "pdfjs/web/viewer.html"
 
 
-def widget(_unquoted_file_path: str) -> None:
-    _file_path = urllib.parse.quote(_unquoted_file_path, safe="")
+def widget(unquoted_file_path: str) -> None:
+    """
+    Widget for pdf files.
+    """
+
+    _file_path = urllib.parse.quote(unquoted_file_path, safe="")
 
     viewer_path = (f"/static/{VIEWER_PATH}?file={_file_path}")
 
@@ -21,22 +25,19 @@ def widget(_unquoted_file_path: str) -> None:
             with t.a(href=viewer_path,
                      cls="btn btn-outline-success",
                      target="_blank"):
-                wh.icon_span(
-                    "square-arrow-up-right",
-                    "Open in new window")
-            with t.a(href=_unquoted_file_path,
+                wh.icon_span("square-arrow-up-right", "Open in new window")
+            with t.a(href=unquoted_file_path,
                      cls="btn btn-outline-success",
                      target="_blank"):
-                wh.icon_span("download",
-                             "Download")
+                wh.icon_span("download", "Download")
+
     if detect_pdfjs():
         t.iframe(src=viewer_path,
                  style="resize: vertical",
                  width="100%",
                  height="800")
     else:
-        t.pre(papis.web.pdfjs.error_message(),
-              cls="alert alert-warning")
+        t.pre(error_message(), cls="alert alert-warning")
 
 
 def detect_pdfjs() -> bool:
@@ -48,6 +49,7 @@ def detect_pdfjs() -> bool:
 
 
 def error_message() -> str:
+    """Error message for when there is no pdfjs installation"""
     return f"""
 No installation of pdfjs found.
 


### PR DESCRIPTION
Following up on
https://github.com/papis/papis/issues/946#issuecomment-2473620039, I realigned
the code for `epubjs` and `pdfjs`, in case it's useful.
