### PR TITLE
remove openfile from collect_importer_data

### DIFF
--- a/papis/utils.py
+++ b/papis/utils.py
@@ -561,7 +561,6 @@ def collect_importer_data(
 
             msg = f"Use this file? (from {importer.name})"
             for f in importer.ctx.files:
-                open_file(f)
                 if batch or confirm(msg):
                     ctx.files.append(f)
 


### PR DESCRIPTION
So for some reason, in the `collect_importer_data` function in `utils.py`, when a pdf from arxiv is download it is always opened. This overwrites the `add-open` configuration and the `--open / --no-open` args for `papis add`. I removed the line.