### PR TITLE
Confirm when adding files

### DIFF
--- a/papis/commands/update.py
+++ b/papis/commands/update.py
@@ -531,7 +531,7 @@ def cli(
                             matching_importers.append(importer)
 
             imported = papis.utils.collect_importer_data(
-                matching_importers, batch=batch, only_data=True
+                matching_importers, batch=batch, use_files=False
             )
             if "ref" in imported.data:
                 logger.debug(

--- a/papis/paths.py
+++ b/papis/paths.py
@@ -296,6 +296,20 @@ def _make_unique_folder(out_folder_path: PathLike) -> str:
     return out_folder_path_suffix
 
 
+def _make_unique_file(filename: PathLike) -> str:
+    if not os.path.exists(filename):
+        return str(filename)
+
+    suffix = unique_suffixes()
+    basename, ext = os.path.splitext(filename)
+
+    out_file_name = f"{basename}-{next(suffix)}{ext}"
+    while os.path.exists(out_file_name):
+        out_file_name = f"{basename}-{next(suffix)}{ext}"
+
+    return out_file_name
+
+
 def get_document_unique_folder(
         doc: DocumentLike,
         dirname: PathLike, *,

--- a/papis/utils.py
+++ b/papis/utils.py
@@ -518,12 +518,11 @@ def collect_importer_data(
     only do the aggregation.
 
     :param batch: if *True*, overwrite data from previous importers, otherwise
-        ask the user to manually merge.
+        ask the user to manually merge. Note that files are always kept, even
+        if they potentially contain duplicates.
     :param use_files: if *True*, both metadata and files are collected
         from the importers.
     """
-    from papis.tui.utils import confirm
-
     # FIXME: this is here for backwards compatibility and should be removed
     # before we release the next version
     if only_data is not None and use_files is not None:
@@ -559,11 +558,7 @@ def collect_importer_data(
                         importer.name,
                         "\n\t".join(importer.ctx.files))
 
-            msg = f"Use this file? (from {importer.name})"
-            for f in importer.ctx.files:
-                open_file(f)
-                if batch or confirm(msg):
-                    ctx.files.append(f)
+            ctx.files.extend(importer.ctx.files)
 
     return ctx
 


### PR DESCRIPTION
This updates how `papis add` works when adding files:
* Files from importers are all included. Before, each importer asked for confirmation for each file.
* The `--open` flag opens files before they're added to the document for checking. Before, it would open them afterwards.
* The `--confirm` flag asks the user to add the file after it's been opened. Before, it would only ask for confirmation on downloaded files.

This way, when `--no-open` and `--no-confirm` is set, the files are just added without opening anything, as expected. Before, `collected_importer_data` would still open them up annoyingly.

xref: #956.