### PR TITLE
Use command-line filename when renaming

### DIFF
--- a/papis/commands/add.py
+++ b/papis/commands/add.py
@@ -283,7 +283,9 @@ def run(paths: List[str],
     # rename all the given file names
     from papis.paths import symlink, rename_document_files
 
-    renamed_file_list = rename_document_files(tmp_document, in_document_paths)
+    renamed_file_list = rename_document_files(
+        tmp_document, in_document_paths,
+        file_name_format=file_name)
 
     import shutil
 
@@ -298,7 +300,8 @@ def run(paths: List[str],
             papis.utils.open_file(in_file_path)
 
         if not batch and confirm and not papis.tui.utils.confirm(
-                f"Add file '{os.path.basename(in_file_path)}' to document?"):
+                f"Add file '{os.path.basename(in_file_path)}' "
+                f"(renamed to '{os.path.basename(out_file_path)}') to document?"):
             continue
 
         if link:

--- a/papis/commands/addto.py
+++ b/papis/commands/addto.py
@@ -49,6 +49,7 @@ logger = papis.logging.get_logger(__name__)
 
 def run(document: papis.document.Document,
         filepaths: List[str],
+        file_name: Optional[str] = None,
         link: bool = False,
         git: bool = False) -> None:
     doc_folder = document.get_main_folder()
@@ -58,7 +59,9 @@ def run(document: papis.document.Document,
     import shutil
     from papis.paths import symlink, rename_document_files
 
-    new_file_list = rename_document_files(document, filepaths)
+    new_file_list = rename_document_files(
+        document, filepaths, file_name_format=file_name
+    )
 
     for in_file_path, out_file_name in zip(filepaths, new_file_list):
         out_file_path = os.path.join(doc_folder, out_file_name)
@@ -130,10 +133,7 @@ def cli(query: str,
 
     document = docs[0]
 
-    if file_name is not None:  # Use args if set
-        papis.config.set("add-file-name", papis.config.escape_interp(file_name))
-
     try:
-        run(document, files + urls, git=git, link=link)
+        run(document, files + urls, file_name=file_name, git=git, link=link)
     except Exception as exc:
         logger.error("Failed to add files.", exc_info=exc)

--- a/tests/commands/test_add.py
+++ b/tests/commands/test_add.py
@@ -151,12 +151,14 @@ def test_add_folder_name_cli(tmp_library: TemporaryLibrary) -> None:
     cli_runner = PapisRunner()
 
     filename = tmp_library.create_random_file()
+    _, ext = os.path.splitext(filename)
     result = cli_runner.invoke(
         cli,
         ["--set", "author", "Aristotel",
          "--set", "title", "The apology of Socrates",
          "--batch",
-         "--folder-name", "the-apology",
+         "--folder-name", "test-the-apology",
+         "--file-name", f"test-the-apology{ext}",
          filename])
     assert result.exit_code == 0
 
@@ -165,8 +167,13 @@ def test_add_folder_name_cli(tmp_library: TemporaryLibrary) -> None:
 
     folder = doc.get_main_folder()
     assert folder is not None
-    assert os.path.basename(folder) == "the-apology"
-    assert len(doc.get_files()) == 1
+    assert os.path.basename(folder) == "test-the-apology"
+
+    files = doc.get_files()
+    assert len(files) == 1
+
+    basename, _ = os.path.splitext(os.path.basename(files[0]))
+    assert os.path.basename(files[0]) == f"test-the-apology{ext}"
 
 
 def test_add_from_folder_cli(tmp_library: TemporaryLibrary,


### PR DESCRIPTION
In some previous refactorings, the value passed on `papis add --file-name FILENAME` didn't get used when actually renaming the document files. The value from the config was always used instead, which is why this probably wasn't caught..

Fixes #963.