### PR TITLE
Remove magic-nix-cache-action from ci

### DIFF
--- a/.github/workflows/nix-flake.yml
+++ b/.github/workflows/nix-flake.yml
@@ -19,12 +19,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v4
-    # - uses: cachix/install-nix-action@v22
-    #   with:
-    #     github_access_token: ${{ secrets.GITHUB_TOKEN }}
-    # - uses: DeterminateSystems/magic-nix-cache-action@v3
     - uses: DeterminateSystems/nix-installer-action@main
-    - uses: DeterminateSystems/magic-nix-cache-action@main
     - uses: DeterminateSystems/flake-checker-action@main
     - run: nix build
     - run: nix flake check


### PR DESCRIPTION
The cache action does not seem to be available anymore according to https://determinate.systems/posts/magic-nix-cache-free-tier-eol/. I'm not sure if there's an alternative, but for now this just removes it..

cc @f0rki @jghauser 