### PR TITLE
Add basic CSL exporting

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # VERSION NEXT (TDB)
 
+## Dependency Changes
+
+- The [citeproc-py](https://github.com/citeproc-py/citeproc-py) library is now
+  required for CSL exporter support.
+
 ## Features
 
 ### Major: Improved formatter support ([#711](https://github.com/papis/papis/pull/711))
@@ -24,6 +29,22 @@ order in the configuration file. If no formatter is provided for a formatted
 string of this type, then it will fall back to the default formatter set by the
 `formatter` setting. All default settings are now clearly marked as using the
 `python` formatter, so they no longer need to be rewritten when changing formatters.
+
+### Major: Support for CSL citation export ([#976](https://github.com/papis/papis/pull/976))
+
+A new exporter has been added that supports the popular CSL (Citation Style
+Language) through the [citeproc-py](https://github.com/citeproc-py/citeproc-py)
+library. Not all styles are supported, but we hope that this will quickly improve.
+
+The citation style can be set in the configuration file using
+```ini
+csl-style = "harvard1"
+csl-formatter = "plain"
+```
+or on the command-line as
+```bash
+papis --set csl-style harvard1 export --format csl <QUERY>
+```
 
 # VERSION 0.14.1 (March 1, 2025)
 

--- a/doc/source/default-settings.rst
+++ b/doc/source/default-settings.rst
@@ -213,6 +213,21 @@ General settings
    ``papis --pick-lib export --all``. The format takes a dictionary named
    ``library`` with the keys *name*, *dir*, and *paths*.
 
+.. papis-config:: csl-style
+
+    The CSL style name used by the CSL exporter. For a list of styles and their
+    naming see the `Zotero Style Repository <https://www.zotero.org/styles>`__.
+    This setting can also be a path to a local file that describes the style.
+    User styles can be placed in the ``styles`` subfolder of the Papis configuration
+    folder so that they are recognized just by their name.
+
+.. papis-config:: csl-formatter
+
+   The formatter used by the CSL exporter. Currently supported formatters are
+   "plain", "html" and "rst". Note that these are different to the Papis formatter
+   and are just used to add style to the resulting citation (e.g. marking titles
+   as italic).
+
 Tools options
 -------------
 

--- a/papis/commands/export.py
+++ b/papis/commands/export.py
@@ -82,9 +82,15 @@ def run(documents: List[papis.document.Document], to_format: str) -> str:
     :param documents: A list of Papis documents
     :param to_format: what format to use
     """
-    ret_string = (
-        papis.plugin.get_extension_manager(EXPORTER_EXTENSION_NAME)[to_format]
-        .plugin(document for document in documents))
+    try:
+        ret_string = (
+            papis.plugin.get_extension_manager(EXPORTER_EXTENSION_NAME)[to_format]
+            .plugin(document for document in documents))
+    except KeyError as exc:
+        logger.error("Failed to load '%s' exporter. Cannot export to this format.",
+                     to_format, exc_info=exc)
+        return ""
+
     return str(ret_string)
 
 
@@ -137,7 +143,7 @@ def cli(query: str,
 
     ret_string = run(documents, to_format=fmt)
 
-    if ret_string is not None and not folder:
+    if ret_string and not folder:
         if out is not None:
             logger.info("Dumping to '%s'.", out)
             with open(out, "a+") as fd:

--- a/papis/csl.py
+++ b/papis/csl.py
@@ -1,0 +1,224 @@
+import os
+from contextlib import suppress
+from typing import Any, Dict, List, Optional
+
+from citeproc.source import BibliographySource, Date, Name, Reference
+from citeproc.source.bibtex import BibTeX
+
+import papis.config
+import papis.logging
+from papis.document import Document
+
+logger = papis.logging.get_logger(__name__)
+
+#: URL from which to download styles from if not available locally.
+ZOTERO_CSL_STYLE_URL = "https://www.zotero.org/styles/{}"
+
+#: Subfolder in the Papis configuration folder where styles are stored.
+CSL_STYLES_FOLDER = "styles"
+
+
+def get_styles_folder() -> str:
+    return os.path.join(papis.config.get_config_folder(), CSL_STYLES_FOLDER)
+
+
+def _download_style(name: str) -> None:
+    if name.endswith(".csl"):
+        name = name[:-4]
+
+    styles_folder = get_styles_folder()
+    style_path = os.path.join(styles_folder, f"{name}.csl")
+    if os.path.exists(style_path):
+        return
+
+    from papis.utils import get_session
+
+    with get_session() as session:
+        response = session.get(ZOTERO_CSL_STYLE_URL.format(name),
+                               allow_redirects=True)
+
+    if not response.ok:
+        logger.error("Could not download style '%s'. (HTTPS status: %s %d)",
+                     name, response.reason, response.status_code)
+        return
+
+    if not os.path.exists(styles_folder):
+        os.mkdir(styles_folder)
+
+    with open(style_path, mode="wb") as fout:
+        fout.write(response.content)
+
+    logger.info("Style '%s' downloaded to '%s'.", name, style_path)
+
+
+def _parse_date(doc: Document) -> Optional[Date]:
+    """Extract a date from a document."""
+
+    if "year" not in doc:
+        return None
+
+    try:
+        year = int(doc["year"])
+    except ValueError:
+        return None
+
+    date = {"year": year}
+    if "month" in doc:
+        month = doc["month"]
+        if isinstance(month, int):
+            if 1 <= month <= 12:
+                date["month"] = month
+        elif isinstance(month, str):
+            month = month.strip().lower()
+            try:
+                date["month"] = BibTeX.MONTHS.index(month[:3]) + 1
+            except ValueError:
+                try:
+                    date["month"] = int(month)
+                except ValueError:
+                    pass
+
+    return Date(**date)
+
+
+def to_csl(doc: Document) -> Dict[str, Any]:
+    """Convert a document into a dictionary of keys supported by :mod:`citeproc`.
+
+    This function only converts keys that are supported, while other keys in the
+    document are ignored.
+    """
+
+    # FIXME: we're using the fields from citeproc to make sure that we're
+    # compatible with their CSL spec, but ideally this would map all BibTeX fields
+    known_fields = BibTeX.fields
+
+    result = {}
+    for key, value in doc.items():
+        csl_key = known_fields.get(key)
+        if csl_key is None:
+            continue
+
+        csl_value: Any
+        if key in {"number", "volume"}:
+            with suppress(ValueError):
+                csl_value = int(value)
+        elif key == "pages":
+            # NOTE: this just tries to remove any double dashes from the pages
+            csl_value = "-".join([
+                p for page in value.split("-") if (p := page.strip())
+                ])
+        elif key == "author":
+            # FIXME: CSL supports the full 'first + von + last + jr' split naming
+            csl_value = [
+                Name(given=author["given"], family=author["family"])
+                for author in doc["author_list"]
+            ]
+        else:
+            # FIXME: citeproc seems to have some notion of MixedString that
+            # allows keeping some words capitalized. We don't have that..
+            csl_value = str(value)
+
+        result[csl_key] = csl_value
+
+    date = _parse_date(doc)
+    if date is not None:
+        result["issued"] = date
+
+    return result
+
+
+class PapisSource(BibliographySource):  # type: ignore[misc]
+    def __init__(self, doc: Document) -> None:
+        super().__init__()
+
+        csl_type = BibTeX.types.get(doc["type"], BibTeX.types["misc"])
+        csl_fields = to_csl(doc)
+        self.add(Reference(doc["ref"].lower(), csl_type, **csl_fields))
+
+
+def normalize_style_path(name: str) -> str:
+    name = os.path.basename(name)
+    if name.endswith(".csl"):
+        name = name[:-4]
+
+    from citeproc import STYLES_PATH
+
+    style_path = os.path.join(STYLES_PATH, f"{name}.csl")
+    if os.path.exists(style_path):
+        return style_path
+
+    style_path = os.path.join(get_styles_folder(), f"{name}.csl")
+    if os.path.exists(style_path):
+        return style_path
+
+    _download_style(name)
+    if os.path.exists(style_path):
+        return style_path
+
+    return ""
+
+
+def export_document(doc: Document,
+                    style_name: Optional[str] = None,
+                    formatter_name: Optional[str] = None) -> str:
+    if style_name is None:
+        style_name = papis.config.getstring("csl-style")
+
+    if formatter_name is None:
+        formatter_name = papis.config.getstring("csl-formatter")
+
+    style_name = os.path.normpath(os.path.expanduser(style_name))
+    if not os.path.isabs(style_name):
+        style_name = normalize_style_path(style_name)
+
+    if not os.path.exists(style_name):
+        logger.error("Cannot find style '%s'. You can download or create this "
+                     "style yourself and place it in '%s'.",
+                     os.path.basename(style_name), get_styles_folder())
+        return ""
+
+    from citeproc import CitationStylesStyle
+
+    source = PapisSource(doc)
+    style = CitationStylesStyle(style_name, validate=False)
+
+    from citeproc import CitationStylesBibliography, Citation, CitationItem, formatter
+
+    fmt = getattr(formatter, formatter_name, None)
+    if fmt is None:
+        logger.error("Formatter '%s' is not supported for CSL export. "
+                     "Check your 'csl-formatter' setting in the configuration file.",
+                     formatter_name)
+        return ""
+
+    bib = CitationStylesBibliography(style, source, fmt)
+    citation = Citation([CitationItem(doc["ref"])])
+    bib.register(citation)
+
+    # TODO: the citeproc example says we should strive to cite all the documents
+    # at once, since some of the formatting may depend on the previous citations
+    def warn(item: CitationItem) -> None:
+        logger.warning("Reference with key '%s' not found in the bibliography",
+                       item.key)
+
+    bib.cite(citation, callback=warn)
+
+    try:
+        for item in bib.bibliography():
+            return str(item).replace("..", ".")
+    except AttributeError as exc:
+        # NOTE: citeproc-py doesn't support all known styles, so the export can fail
+        logger.error("Failed to export citation '%s' to CSL style '%s'.",
+                     doc["ref"], os.path.basename(style_name), exc_info=exc)
+
+    return ""
+
+
+def exporter(documents: List[Document]) -> str:
+    formatter_name = papis.config.getstring("csl-formatter")
+    style_name = papis.config.getstring("csl-style")
+
+    return "\n\n".join(
+        export_document(doc, style_name=style_name, formatter_name=formatter_name)
+        for doc in documents
+    ).strip()

--- a/papis/defaults.py
+++ b/papis/defaults.py
@@ -91,6 +91,10 @@ settings: Dict[str, Any] = {
     "multiple-authors-separator": " and ",
     "multiple-authors-format": _f("{au[family]}, {au[given]}"),
 
+    # csl
+    "csl-style": "harvard1",
+    "csl-formatter": "plain",
+
     # add
     "ref-format": _f("{doc[title]:.15} {doc[author]:.6} {doc[year]}"),
     "add-folder-name": _f(""),

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -66,9 +66,10 @@ dependencies = [
     "arxiv>=1.0.0",
     "beautifulsoup4>=4.4.1",
     "bibtexparser>=0.6.2,<2",
+    "citeproc-py",
     "click>=7",
     "colorama>=0.2",
-    "dominate",
+    "dominate>=2.8",
     "filetype>=1.0.1",
     "habanero>=0.6",
     "isbnlib>=3.9.1",
@@ -202,6 +203,7 @@ bibtex = "papis.bibtex:exporter"
 json = "papis.json:exporter"
 typst = "papis.hayagriva:exporter"
 yaml = "papis.yaml:exporter"
+csl = "papis.csl:exporter"
 
 [project.entry-points."papis.format"]
 jinja2 = "papis.format:Jinja2Formatter"
@@ -299,6 +301,7 @@ warn_unused_ignores = false
 [[tool.mypy.overrides]]
 module = [
     "arxiv.*",
+    "citeproc.*",
     "bibtexparser.*",
     "colorama.*",
     "dominate.*",

--- a/tests/test_csl.py
+++ b/tests/test_csl.py
@@ -1,0 +1,38 @@
+from papis.testing import TemporaryConfiguration
+
+
+def test_csl_export(tmp_config: TemporaryConfiguration) -> None:
+    from papis.csl import export_document
+    from papis.document import from_data
+
+    doc = from_data({
+        "type": "article",
+        "author": "Albert Einstein",
+        "author_list": [{"given": "Albert", "family": "Einstein"}],
+        "title": "The Theory of Everything",
+        "journal": "Nature",
+        "year": 2350,
+        "ref": "MyDocument"})
+
+    result = export_document(doc, style_name="harvard1", formatter_name="rst")
+    assert result == "Einstein, A., 2350. The Theory of Everything. :emphasis:`Nature`."
+
+
+def test_csl_style_download(tmp_config: TemporaryConfiguration) -> None:
+    import papis.config
+    from papis.csl import exporter
+    from papis.document import from_data
+
+    doc = from_data({
+        "type": "article",
+        "author": "Albert Einstein",
+        "author_list": [{"given": "Albert", "family": "Einstein"}],
+        "title": "The Theory of Everything",
+        "journal": "Nature",
+        "year": 2350,
+        "ref": "MyDocument"})
+
+    papis.config.set("csl-style", "acm-siggraph")
+    result = exporter([doc])
+
+    assert result == "Einstein, A. 2350. The Theory of Everything. Nature."


### PR DESCRIPTION
This adds some basic support for exporting citations using the CSL library [citeproc-py](https://github.com/citeproc-py/citeproc-py). It seems like development has picked up a bit over there, so it can't hurt to add it.

It still seems to have a few bugs to iron out, but hopefully they'll get to that by the time we make a new release as well. In particular the popular APA and MLA styles don't seem to be working :(