### PR TITLE
Update flake

### DIFF
--- a/contrib/python-papis.scm
+++ b/contrib/python-papis.scm
@@ -242,7 +242,6 @@ an elegant DOM API.")
                       python-pylint
                       python-pytest
                       python-pytest-cov
-                      python-coveralls
                       python-lsp-server
                       python-sphinx-click
                       python-sphinx-rtd-theme

--- a/flake.lock
+++ b/flake.lock
@@ -5,72 +5,26 @@
         "systems": "systems"
       },
       "locked": {
-        "lastModified": 1705309234,
-        "narHash": "sha256-uNRRNRKmJyCRC/8y1RqBkqWBLM034y4qN7EprSdmgyA=",
+        "lastModified": 1731533236,
+        "narHash": "sha256-l0KFg5HjrsfsO/JpG+r7fRrqm12kzFHyUHqHCVpMMbI=",
         "owner": "numtide",
         "repo": "flake-utils",
-        "rev": "1ef2e671c3b0c19053962c07dbda38332dcebf26",
+        "rev": "11707dc2f618dd54ca8739b309ec4fc024de578b",
         "type": "github"
       },
       "original": {
         "owner": "numtide",
         "repo": "flake-utils",
-        "type": "github"
-      }
-    },
-    "mdbook-nixdoc": {
-      "inputs": {
-        "nix-github-actions": [
-          "pyproject-nix",
-          "nix-github-actions"
-        ],
-        "nixpkgs": [
-          "pyproject-nix",
-          "nixpkgs"
-        ]
-      },
-      "locked": {
-        "lastModified": 1708395692,
-        "narHash": "sha256-smf0VmxGbjJDZqKvxxG3ZVqubgbVwAWG26wPo+BT/A0=",
-        "owner": "adisbladis",
-        "repo": "mdbook-nixdoc",
-        "rev": "d6a71b114b9221c0b4f20d31b81766d072cc26be",
-        "type": "github"
-      },
-      "original": {
-        "owner": "adisbladis",
-        "repo": "mdbook-nixdoc",
-        "type": "github"
-      }
-    },
-    "nix-github-actions": {
-      "inputs": {
-        "nixpkgs": [
-          "pyproject-nix",
-          "nixpkgs"
-        ]
-      },
-      "locked": {
-        "lastModified": 1703863825,
-        "narHash": "sha256-rXwqjtwiGKJheXB43ybM8NwWB8rO2dSRrEqes0S7F5Y=",
-        "owner": "nix-community",
-        "repo": "nix-github-actions",
-        "rev": "5163432afc817cf8bd1f031418d1869e4c9d5547",
-        "type": "github"
-      },
-      "original": {
-        "owner": "nix-community",
-        "repo": "nix-github-actions",
         "type": "github"
       }
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1710451336,
-        "narHash": "sha256-pP86Pcfu3BrAvRO7R64x7hs+GaQrjFes+mEPowCfkxY=",
+        "lastModified": 1742069588,
+        "narHash": "sha256-C7jVfohcGzdZRF6DO+ybyG/sqpo1h6bZi9T56sxLy+k=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "d691274a972b3165335d261cc4671335f5c67de9",
+        "rev": "c80f6a7e10b39afcc1894e02ef785b1ad0b0d7e5",
         "type": "github"
       },
       "original": {
@@ -82,18 +36,16 @@
     },
     "pyproject-nix": {
       "inputs": {
-        "mdbook-nixdoc": "mdbook-nixdoc",
-        "nix-github-actions": "nix-github-actions",
         "nixpkgs": [
           "nixpkgs"
         ]
       },
       "locked": {
-        "lastModified": 1709886419,
-        "narHash": "sha256-qXZsmegy0W0hn9yxYQFin1jZB3ikmBWXyBDQx1AqEQ4=",
+        "lastModified": 1741648141,
+        "narHash": "sha256-jQEZCSCgm60NGmBg3JPu290DDhNVI1GVVEd0P8VCnME=",
         "owner": "nix-community",
         "repo": "pyproject.nix",
-        "rev": "2841577401c77106150b98bcb3a30510cb6c652a",
+        "rev": "7747e5a058245c7abe033a798f818f0572d8e155",
         "type": "github"
       },
       "original": {

--- a/flake.nix
+++ b/flake.nix
@@ -21,7 +21,6 @@
           arxiv = arxiv;
           flake8-quotes = flake8-quotes;
           flake8-pyproject = flake8-pyproject;
-          python-coveralls = python-coveralls;
           types-pygments = types-pygments;
           types-python-slugify = types-python-slugify;
           sphinx-click = sphinx-click;
@@ -91,25 +90,6 @@
           homepage = "https://github.com/john-hen/Flake8-pyproject";
           description = "Flake8 plug-in loading the configuration from pyproject.toml";
           license = licenses.mit;
-        };
-      };
-
-      python-coveralls = python.pkgs.buildPythonPackage rec {
-        pname = "python-coveralls";
-        version = "2.9.3";
-
-        src = python.pkgs.fetchPypi {
-          inherit pname version;
-          sha256 = "sha256-v694EefcVijoO2sWKWKk4khdv/GEsw5J84A3TtG87lU=";
-        };
-
-        doCheck = false;
-        checkInputs = [];
-
-        meta = with pkgs.lib; {
-          homepage = "http://github.com/z4r/python-coveralls";
-          description = "Python interface to coveralls.io API ";
-          license = licenses.asl20;
         };
       };
 

--- a/flake.nix
+++ b/flake.nix
@@ -18,56 +18,14 @@
       pkgs = nixpkgs.legacyPackages.${system};
       python = pkgs.python3.override {
         packageOverrides = self: super: {
-          arxiv = arxiv;
-          flake8-quotes = flake8-quotes;
           flake8-pyproject = flake8-pyproject;
           types-pygments = types-pygments;
           types-python-slugify = types-python-slugify;
-          sphinx-click = sphinx-click;
         };
       };
       pypkgs = pkgs.python3Packages;
       project = pyproject-nix.lib.project.loadPyproject {
         projectRoot = ./.;
-      };
-
-      arxiv = python.pkgs.buildPythonPackage rec {
-        pname = "arxiv";
-        version = "2.1.0";
-
-        src = python.pkgs.fetchPypi {
-          inherit pname version;
-          sha256 = "sha256-60sdWrnf1mAnw0S7MkwgviHVb+FfbOIW7VsgnfdH3qg=";
-        };
-
-        doCheck = false;
-        checkInputs = [];
-        propagatedBuildInputs = [pypkgs.feedparser];
-
-        meta = with pkgs.lib; {
-          homepage = "https://github.com/lukasschwab/arxiv.py";
-          description = "Python wrapper for the arXiv API";
-          license = licenses.mit;
-        };
-      };
-
-      flake8-quotes = python.pkgs.buildPythonPackage rec {
-        pname = "flake8-quotes";
-        version = "3.4.0";
-
-        src = python.pkgs.fetchPypi {
-          inherit pname version;
-          sha256 = "sha256-qthJL7cQotPqvmjF+GoUKN5lDISEEn4UxD0FBLowJ2w=";
-        };
-
-        doCheck = false;
-        checkInputs = [];
-
-        meta = with pkgs.lib; {
-          homepage = "http://github.com/zheller/flake8-quotes";
-          description = "Flake8 lint for quotes.";
-          license = licenses.mit;
-        };
       };
 
       flake8-pyproject = python.pkgs.buildPythonPackage {
@@ -95,11 +53,12 @@
 
       types-pygments = python.pkgs.buildPythonPackage rec {
         pname = "types-Pygments";
-        version = "2.17.0.20240310";
+        version = "2.19.0.20250305";
 
         src = python.pkgs.fetchPypi {
-          inherit pname version;
-          sha256 = "sha256-sdl+kFzjY0PHKDsDGRgq5tT5ZxiPNh9FUCoYrkPgPh8=";
+          inherit version;
+          pname = "types_pygments";
+          sha256 = "sha256-BExQ6A7NQSjACnJo8gNV4W9cVUZtPUnf2gm+kgr0C0s=";
         };
 
         doCheck = false;
@@ -128,26 +87,6 @@
           homepage = "https://github.com/python/typeshed";
           description = "Typing stubs for python-slugify";
           license = licenses.asl20;
-        };
-      };
-
-      sphinx-click = python.pkgs.buildPythonPackage rec {
-        pname = "sphinx-click";
-        version = "5.1.0";
-
-        src = python.pkgs.fetchPypi {
-          inherit pname version;
-          sha256 = "sha256-aBLC22LT+ucaSt2+WooKFsl+tJHzzWP+NLTtfgcjbzM=";
-        };
-
-        doCheck = false;
-        checkInputs = [];
-        propagatedBuildInputs = [pypkgs.pbr];
-
-        meta = with pkgs.lib; {
-          homepage = "https://github.com/click-contrib/sphinx-click";
-          description = "Sphinx extension that automatically documents click applications";
-          license = licenses.mit;
         };
       };
     in {

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -98,7 +98,6 @@ develop = [
     "pylint",
     "pytest",
     "pytest-cov",
-    "python-coveralls",
     "types-beautifulsoup4",
     "types-Pygments",
     "types-docutils",


### PR DESCRIPTION
This updates the flake. We no longer build dependencies that are now in nixpkgs and I've updated those dependencies we still need to build ourselves. It also removes `python-coveralls` from wherever I found it mentioned, since we don't seem to be using anymore (see #981).