### PR TITLE
Bump minimum Python version to 3.10

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -29,7 +29,7 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest, macos-latest, windows-latest]
-        python-version: ['3.8', '3.9', '3.10', '3.11', '3.12', '3.13']
+        python-version: ['3.10', '3.11', '3.12', '3.13']
       fail-fast: false
 
     steps:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## Dependency Changes
 
+- Minimum required Python version bumped to 3.10.
 - The [citeproc-py](https://github.com/citeproc-py/citeproc-py) library is now
   required for CSL exporter support.
 - All linting has been migrated from `flake8` to `ruff`. This is only relevant

--- a/HACKING.md
+++ b/HACKING.md
@@ -4,7 +4,7 @@ Guidelines for Code Modification
 Coding Style
 ------------
 
-* Use syntax compatible with Python `3.8+`.
+* Use syntax compatible with Python `3.10+`.
 * Use docstrings with [Sphinx](https://www.sphinx-doc.org/en/master/) in mind.
 * Follow the [PEP8 style guide](https://www.python.org/dev/peps/pep-0008/).
 * Try and run tests locally before submitting a new PR.

--- a/examples/scripts/papis-abbrev.py
+++ b/examples/scripts/papis-abbrev.py
@@ -43,7 +43,6 @@ Command Options
 
 import json
 import os
-from typing import Dict, Optional
 
 import papis.api
 import papis.document
@@ -95,7 +94,7 @@ ABBREV_IGNORE_ACRONYMS = frozenset([
 ]) | frozenset(papis.config.getlist("ignore-acronyms", section="abbrev"))
 
 
-def ltwa_abbreviate(full_journal_name: str, d: Optional[Dict[str, str]] = None) -> str:
+def ltwa_abbreviate(full_journal_name: str, d: dict[str, str] | None = None) -> str:
     """
     Abbreviates a journal name using International Standard Serial
     Number (ISSN) guidelines.

--- a/examples/scripts/papis-check.py
+++ b/examples/scripts/papis-check.py
@@ -34,7 +34,8 @@ Command Options
 """
 
 import os
-from typing import Any, Dict, List, Sequence
+from collections.abc import Sequence
+from typing import Any
 
 import click
 
@@ -80,7 +81,7 @@ def check_files(document: papis.document.Document) -> bool:
 
 def run(keys: Sequence[str],
         documents: Sequence[papis.document.Document],
-        ) -> Sequence[Dict[str, Any]]:
+        ) -> Sequence[dict[str, Any]]:
     result = []
     for document in documents:
         for key in keys:
@@ -104,7 +105,7 @@ def run(keys: Sequence[str],
     multiple=True,
     default=lambda: papis.config.getlist("keys", section="check")
 )
-def cli(query: str, keys: List[str]) -> None:
+def cli(query: str, keys: list[str]) -> None:
     """Check document from a given library"""
     documents = papis.database.get().query(query)
     troubled_docs = run(keys, documents)

--- a/examples/scripts/papis-tags.py
+++ b/examples/scripts/papis-tags.py
@@ -23,7 +23,6 @@ a document. However, for this script the following formats are supported:
 """
 
 import re
-from typing import Set
 
 import click
 
@@ -58,7 +57,7 @@ def main(query: str, confirm: bool) -> None:
     )
 
     # Create an empty tag list
-    tag_list: Set[str] = set()
+    tag_list: set[str] = set()
     for doc in documents:
         tags = doc.get("tags")
         if tags is None:

--- a/papis/api.py
+++ b/papis/api.py
@@ -5,7 +5,8 @@ create Papis scripts.
 .. class:: T
 """
 
-from typing import Any, Callable, Dict, List, Optional, Sequence, TypeVar, Union
+from collections.abc import Callable, Sequence
+from typing import Any, TypeVar
 
 import papis.config
 import papis.document
@@ -47,7 +48,7 @@ def set_lib_from_name(library: str) -> None:
     papis.config.set_lib_from_name(library)
 
 
-def get_libraries() -> List[str]:
+def get_libraries() -> list[str]:
     """
     Get all the libraries declared in the configuration files.
 
@@ -78,8 +79,8 @@ def pick_doc(
 
 def pick(items: Sequence[T],
          default_index: int = 0,
-         header_filter: Optional[Callable[[T], str]] = None,
-         match_filter: Optional[Callable[[T], str]] = None) -> Sequence[T]:
+         header_filter: Callable[[T], str] | None = None,
+         match_filter: Callable[[T], str] | None = None) -> Sequence[T]:
     """
     Pick a subset of items from the given *items*.
 
@@ -138,7 +139,7 @@ def edit_file(file_path: str, wait: bool = True) -> None:
 
 
 def get_all_documents_in_lib(
-        library: Optional[str] = None) -> List[papis.document.Document]:
+        library: str | None = None) -> list[papis.document.Document]:
     """
     Get *all* documents in the given library.
 
@@ -158,7 +159,7 @@ def get_all_documents_in_lib(
 
 def get_documents_in_dir(
         directory: str,
-        search: str = "") -> List[papis.document.Document]:
+        search: str = "") -> list[papis.document.Document]:
     """
     Get documents contained in the given *directory*.
 
@@ -176,8 +177,8 @@ def get_documents_in_dir(
 
 
 def get_documents_in_lib(
-        library: Optional[str] = None,
-        search: Union[Dict[str, Any], str] = "") -> List[papis.document.Document]:
+        library: str | None = None,
+        search: dict[str, Any] | str = "") -> list[papis.document.Document]:
     """
     Get documents contained in the given *library*.
 
@@ -196,7 +197,7 @@ def get_documents_in_lib(
         raise TypeError(f"Unknown search parameter: '{search}'")
 
 
-def clear_lib_cache(lib: Optional[str] = None) -> None:
+def clear_lib_cache(lib: str | None = None) -> None:
     """
     Clear the cache associated with a library.
 
@@ -210,7 +211,7 @@ def clear_lib_cache(lib: Optional[str] = None) -> None:
     papis.database.get(lib).clear()
 
 
-def doi_to_data(doi: str) -> Dict[str, Any]:
+def doi_to_data(doi: str) -> dict[str, Any]:
     """
     Get metadata for the given *doi* by querying
     `Crossref <https://www.crossref.org/>`__.

--- a/papis/bibtex.py
+++ b/papis/bibtex.py
@@ -7,7 +7,8 @@ the `manual`_).
 """
 import os
 import string
-from typing import Any, Dict, Iterator, List, Optional
+from collections.abc import Iterator
+from typing import Any
 
 import click
 
@@ -226,7 +227,7 @@ bibtex_type_required_keys_aliases = {
 #: A mapping of arbitrary types to BibLaTeX types in :data:`bibtex_types`. This
 #: mapping can be used when translating from other software, e.g. Zotero has
 #: custom fields in its `schema <https://github.com/zotero/zotero-schema>`__.
-bibtex_type_converter: Dict[str, str] = {
+bibtex_type_converter: dict[str, str] = {
     # Zotero
     "annotation": "misc",
     "attachment": "misc",
@@ -269,7 +270,7 @@ bibtex_type_converter: Dict[str, str] = {
 
 #: A mapping of arbitrary fields to BibLaTeX fields in :data:`bibtex_keys`. This
 #: mapping can be used when translating from other software.
-bibtex_key_converter: Dict[str, str] = {
+bibtex_key_converter: dict[str, str] = {
     "abstractNote": "abstract",
     "university": "school",
     "conferenceName": "eventtitle",
@@ -295,7 +296,7 @@ ref_allowed_characters = r"([^a-zA-Z0-9._]+|(?<!\\)[._])"
 bibtex_verbatim_fields = frozenset({"doi", "eprint", "file", "pdf", "url", "urlraw"})
 
 
-def exporter(documents: List[papis.document.Document]) -> str:
+def exporter(documents: list[papis.document.Document]) -> str:
     """Convert documents into a list of BibLaTeX entries"""
     return "\n\n".join(to_bibtex_multiple(documents))
 
@@ -312,7 +313,7 @@ class Importer(papis.importer.Importer):
         super().__init__(name="bibtex", **kwargs)
 
     @classmethod
-    def match(cls, uri: str) -> Optional[papis.importer.Importer]:
+    def match(cls, uri: str) -> papis.importer.Importer | None:
         if (not os.path.exists(uri) or os.path.isdir(uri)
                 or papis.filetype.get_document_extension(uri) == "pdf"):
             return None
@@ -374,7 +375,7 @@ def explorer(ctx: click.core.Context, bibfile: str) -> None:
     logger.info("Found %d documents.", len(docs))
 
 
-def bibtexparser_entry_to_papis(entry: Dict[str, Any]) -> Dict[str, Any]:
+def bibtexparser_entry_to_papis(entry: dict[str, Any]) -> dict[str, Any]:
     """Convert the keys of a BibTeX entry parsed by :mod:`bibtexparser` to a
     papis-compatible format.
 
@@ -406,7 +407,7 @@ def bibtexparser_entry_to_papis(entry: Dict[str, Any]) -> Dict[str, Any]:
     return result
 
 
-def bibtex_to_dict(bibtex: str) -> List[papis.document.DocumentLike]:
+def bibtex_to_dict(bibtex: str) -> list[papis.document.DocumentLike]:
     """Convert a BibTeX file (or string) to a list of Papis-compatible dictionaries.
 
     This will convert an entry like:
@@ -471,7 +472,7 @@ def ref_cleanup(ref: str) -> str:
     return str(ref).strip()
 
 
-def create_reference(doc: Dict[str, Any], force: bool = False) -> str:
+def create_reference(doc: dict[str, Any], force: bool = False) -> str:
     """Try to create a reference for the document *doc*.
 
     If the document *doc* does not have a ``"ref"`` key, this function attempts
@@ -515,7 +516,7 @@ def create_reference(doc: Dict[str, Any], force: bool = False) -> str:
 
 
 def author_list_to_author(doc: papis.document.Document,
-                          author_list: List[Dict[str, Any]]) -> str:
+                          author_list: list[dict[str, Any]]) -> str:
     if not author_list:
         return ""
 
@@ -543,7 +544,7 @@ def author_list_to_author(doc: papis.document.Document,
     return " and ".join(result)
 
 
-def to_bibtex_multiple(documents: List[papis.document.Document]) -> Iterator[str]:
+def to_bibtex_multiple(documents: list[papis.document.Document]) -> Iterator[str]:
     for doc in documents:
         bib = to_bibtex(doc)
         if not bib:

--- a/papis/citations.py
+++ b/papis/citations.py
@@ -1,5 +1,6 @@
 import os
-from typing import Any, Dict, List, Optional, Sequence, Tuple
+from collections.abc import Sequence
+from typing import Any, TypeAlias
 
 import papis.config
 import papis.crossref
@@ -12,9 +13,9 @@ import papis.yaml
 logger = papis.logging.get_logger(__name__)
 
 #: A citation for an existing document.
-Citation = Dict[str, Any]
+Citation: TypeAlias = dict[str, Any]
 #: A list of citations for an existing document.
-Citations = List[Citation]
+Citations: TypeAlias = list[Citation]
 
 
 def _delete_citations_key(citations: Citations) -> None:
@@ -125,7 +126,7 @@ def update_citations_from_database(citations: Citations) -> Citations:
 
     :param citations: a list of existing citations to update.
     """
-    new_citations: List[Dict[str, Any]] = []
+    new_citations: list[dict[str, Any]] = []
     dois = [str(c.get("doi")).lower() for c in citations
             if "doi" in c]
 
@@ -164,7 +165,7 @@ def fetch_and_save_citations(doc: papis.document.Document) -> None:
         save_citations(doc, citations)
 
 
-def get_citations_file(doc: papis.document.Document) -> Optional[str]:
+def get_citations_file(doc: papis.document.Document) -> str | None:
     """Get the document's citation file path (see
     :confval:`citations-file-name`).
 
@@ -208,7 +209,7 @@ def get_citations(doc: papis.document.Document) -> Citations:
 # =============================================================================
 
 
-def get_cited_by_file(doc: papis.document.Document) -> Optional[str]:
+def get_cited_by_file(doc: papis.document.Document) -> str | None:
     """Get the documents cited-by file (see :confval:`cited-by-file-name`).
 
     :returns: an absolute path to the cited-by file for *doc*.
@@ -242,7 +243,7 @@ def save_cited_by(doc: papis.document.Document, citations: Citations) -> None:
     papis.yaml.list_to_path(citations, file_path, allow_unicode=allow_unicode)
 
 
-def _cites_me_p(doi_doc: Tuple[str, papis.document.Document]) -> Optional[Citation]:
+def _cites_me_p(doi_doc: tuple[str, papis.document.Document]) -> Citation | None:
     doi, doc = doi_doc
     if not has_citations(doc):
         return None
@@ -266,7 +267,7 @@ def fetch_cited_by_from_database(cit: Citation) -> Citations:
     if not doi:
         return []
 
-    result: List[Citation] = []
+    result: list[Citation] = []
     db = papis.database.get()
     documents = db.get_all_documents()
 

--- a/papis/cli.py
+++ b/papis/cli.py
@@ -1,4 +1,5 @@
-from typing import Any, Callable, List, Optional, Tuple, Union
+from collections.abc import Callable
+from typing import Any
 
 import click
 from click.shell_completion import CompletionItem
@@ -17,8 +18,8 @@ class FormatPatternParamType(click.ParamType):
 
     def convert(self,  # noqa: PLR6301
                 value: Any,
-                param: Optional[click.Parameter],
-                ctx: Optional[click.Context]) -> Any:
+                param: click.Parameter | None,
+                ctx: click.Context | None) -> Any:
         """See :meth:`click.ParamType.convert`."""
         from papis.strings import FormatPattern
 
@@ -39,7 +40,7 @@ class LibraryParamType(click.ParamType):
     def shell_complete(self,  # noqa: PLR6301
                        ctx: click.Context,
                        param: click.Parameter,
-                       incomplete: str) -> List[CompletionItem]:
+                       incomplete: str) -> list[CompletionItem]:
 
         # Named libraries from Papis config
         completions = [
@@ -142,8 +143,8 @@ def git_option(**attrs: Any) -> DecoratorCallable:
 
 def handle_doc_folder_or_query(
         query: str,
-        doc_folder: Optional[Union[str, Tuple[str, ...]]],
-        ) -> List[papis.document.Document]:
+        doc_folder: str | tuple[str, ...] | None,
+        ) -> list[papis.document.Document]:
     """Query database for documents.
 
     This handles the :func:`query_option` and :func:`doc_folder_option`
@@ -164,9 +165,9 @@ def handle_doc_folder_or_query(
 
 def handle_doc_folder_query_sort(
         query: str,
-        doc_folder: Optional[Union[str, Tuple[str, ...]]],
-        sort_field: Optional[str],
-        sort_reverse: bool) -> List[papis.document.Document]:
+        doc_folder: str | tuple[str, ...] | None,
+        sort_field: str | None,
+        sort_reverse: bool) -> list[papis.document.Document]:
     """Query database for documents.
 
     Similar to :func:`handle_doc_folder_or_query`, but also handles the
@@ -187,10 +188,10 @@ def handle_doc_folder_query_sort(
 
 def handle_doc_folder_query_all_sort(
         query: str,
-        doc_folder: Optional[Union[str, Tuple[str, ...]]],
-        sort_field: Optional[str],
+        doc_folder: str | tuple[str, ...] | None,
+        sort_field: str | None,
         sort_reverse: bool,
-        _all: bool) -> List[papis.document.Document]:
+        _all: bool) -> list[papis.document.Document]:
     """Query database for documents.
 
     Similar to :func:`handle_doc_folder_query_sort`, but also handles the

--- a/papis/commands/__init__.py
+++ b/papis/commands/__init__.py
@@ -1,6 +1,6 @@
 import os
 import re
-from typing import Dict, NamedTuple, Optional
+from typing import NamedTuple
 
 import click.core
 
@@ -51,7 +51,7 @@ class AliasedGroup(click.core.Group):
 
     def get_command(self,
                     ctx: click.core.Context,
-                    cmd_name: str) -> Optional[click.core.Command]:
+                    cmd_name: str) -> click.core.Command | None:
         """
         :returns: given a context and a command name, this returns a
             :class:`click.Command` object if it exists or returns *None*.
@@ -81,12 +81,12 @@ class Script(NamedTuple):
     #: The name of the command.
     command_name: str
     #: The path to the script if it is a separate executable.
-    path: Optional[str]
+    path: str | None
     #: A :class:`click.Command` if the script is registered as an entry point.
-    plugin: Optional[click.Command]
+    plugin: click.Command | None
 
 
-def get_external_scripts() -> Dict[str, Script]:
+def get_external_scripts() -> dict[str, Script]:
     """Get a mapping of all external scripts that should be registered with Papis.
 
     An external script is an executable that can be found in the
@@ -98,7 +98,7 @@ def get_external_scripts() -> Dict[str, Script]:
     import glob
     paths = [papis.config.get_scripts_folder(), *os.environ.get("PATH", "").split(":")]
 
-    scripts: Dict[str, Script] = {}
+    scripts: dict[str, Script] = {}
     for path in paths:
         for script in glob.iglob(os.path.join(path, "papis-*")):
             m = EXTERNAL_COMMAND_REGEX.match(script)
@@ -117,7 +117,7 @@ def get_external_scripts() -> Dict[str, Script]:
     return scripts
 
 
-def get_scripts() -> Dict[str, Script]:
+def get_scripts() -> dict[str, Script]:
     """Get a mapping of commands that should be registered with Papis.
 
     This finds all the commands that are registered as entry points in the
@@ -143,7 +143,7 @@ def get_scripts() -> Dict[str, Script]:
     return scripts
 
 
-def get_all_scripts() -> Dict[str, Script]:
+def get_all_scripts() -> dict[str, Script]:
     """Get a mapping of all commands that should be registered with Papis.
 
     This includes the results from :func:`get_external_scripts` and

--- a/papis/commands/add.py
+++ b/papis/commands/add.py
@@ -103,7 +103,7 @@ Command-line interface
 """
 
 import os
-from typing import Any, Dict, List, Optional, Tuple
+from typing import Any
 from warnings import warn
 
 import click
@@ -137,7 +137,7 @@ class FromFolderImporter(papis.importer.Importer):
         super().__init__(name="folder", **kwargs)
 
     @classmethod
-    def match(cls, uri: str) -> Optional[papis.importer.Importer]:
+    def match(cls, uri: str) -> papis.importer.Importer | None:
         return FromFolderImporter(uri=uri) if os.path.isdir(uri) else None
 
     def fetch(self) -> None:
@@ -161,7 +161,7 @@ class FromLibImporter(papis.importer.Importer):
         super().__init__(name="lib", **kwargs)
 
     @classmethod
-    def match(cls, uri: str) -> Optional[papis.importer.Importer]:
+    def match(cls, uri: str) -> papis.importer.Importer | None:
         try:
             papis.config.get_lib_from_name(uri)
         except Exception:
@@ -183,7 +183,7 @@ def get_file_name(
         doc: papis.document.Document,
         original_filepath: str,
         suffix: str = "",
-        file_name_format: Optional[papis.strings.AnyString] = None,
+        file_name_format: papis.strings.AnyString | None = None,
         base_name_limit: int = 150) -> str:
     warn("'get_file_name' is deprecated and will be removed in the next "
          "version. Use 'papis.paths.get_document_file_name' instead.",
@@ -194,7 +194,7 @@ def get_file_name(
                                   base_name_limit=base_name_limit)
 
 
-def get_hash_folder(data: Dict[str, Any], document_paths: List[str]) -> str:
+def get_hash_folder(data: dict[str, Any], document_paths: list[str]) -> str:
     warn("'get_hash_folder' is deprecated and will be removed in the next "
          "version. Use 'papis.paths.get_document_hash_folder' instead.",
          DeprecationWarning, stacklevel=2)
@@ -212,12 +212,12 @@ def ensure_new_folder(path: str) -> str:
     return _make_unique_folder(path)
 
 
-def run(paths: List[str],
-        data: Optional[Dict[str, Any]] = None,
-        folder_name: Optional[papis.strings.AnyString] = None,
-        file_name: Optional[papis.strings.AnyString] = None,
-        subfolder: Optional[str] = None,
-        base_path: Optional[str] = None,
+def run(paths: list[str],
+        data: dict[str, Any] | None = None,
+        folder_name: papis.strings.AnyString | None = None,
+        file_name: papis.strings.AnyString | None = None,
+        subfolder: str | None = None,
+        base_path: str | None = None,
         batch: bool = False,
         confirm: bool = False,
         open_file: bool = False,
@@ -225,7 +225,7 @@ def run(paths: List[str],
         git: bool = False,
         link: bool = False,
         move: bool = False,
-        citations: Optional[papis.citations.Citations] = None,
+        citations: papis.citations.Citations | None = None,
         auto_doctor: bool = False) -> None:
     """
     :param paths: Paths to the documents to be added.
@@ -482,13 +482,13 @@ def run(paths: List[str],
     "--fetch-citations/--no-fetch-citations",
     help="Fetch citations from a DOI (Digital Object Identifier).",
     default=lambda: papis.config.getboolean("add-fetch-citations"))
-def cli(files: List[str],
-        set_list: List[Tuple[str, str]],
+def cli(files: list[str],
+        set_list: list[tuple[str, str]],
         subfolder: str,
         pick_subfolder: bool,
         folder_name: papis.strings.AnyString,
-        file_name: Optional[papis.strings.AnyString],
-        from_importer: List[Tuple[str, str]],
+        file_name: papis.strings.AnyString | None,
+        from_importer: list[tuple[str, str]],
         batch: bool,
         confirm: bool,
         open_file: bool,

--- a/papis/commands/add.py
+++ b/papis/commands/add.py
@@ -292,7 +292,8 @@ def run(paths: List[str],
     import shutil
 
     document_file_list = []
-    for in_file_path, out_file_name in zip(in_document_paths, renamed_file_list):
+    for in_file_path, out_file_name in (
+            zip(in_document_paths, renamed_file_list, strict=True)):
         out_file_path = os.path.join(temp_dir, out_file_name)
         if os.path.exists(out_file_path):
             logger.warning("File '%s' already exists. Skipping...", out_file_path)

--- a/papis/commands/addto.py
+++ b/papis/commands/addto.py
@@ -73,7 +73,7 @@ def run(document: papis.document.Document,
     # a temporary directory. We keep track of a boolean per file that
     # tells us whether to link
     new_filepaths: List[Tuple[str, bool]] = []
-    for orig_filepath, filepath in zip(filepaths, local_files):
+    for orig_filepath, filepath in zip(filepaths, local_files, strict=True):
         # skip remote files that haven't been properly downloaded
         if not filepath:
             continue
@@ -97,8 +97,8 @@ def run(document: papis.document.Document,
     )
     assert len(new_filepaths) == len(new_filenames)
 
-    for (in_file_path, link_file), out_file_name in zip(new_filepaths, new_filenames):
-
+    for (in_file_path, link_file), out_file_name in (
+            zip(new_filepaths, new_filenames, strict=True)):
         out_file_path = os.path.join(doc_folder, out_file_name)
         if os.path.exists(out_file_path):
             logger.warning("File '%s' already exists. Skipping...", out_file_path)

--- a/papis/commands/addto.py
+++ b/papis/commands/addto.py
@@ -29,7 +29,6 @@ Command-line interface
 """
 
 import os
-from typing import List, Optional, Tuple
 
 import click
 
@@ -49,8 +48,8 @@ logger = papis.logging.get_logger(__name__)
 
 
 def run(document: papis.document.Document,
-        filepaths: List[str],
-        file_name: Optional[str] = None,
+        filepaths: list[str],
+        file_name: str | None = None,
         link: bool = False,
         git: bool = False) -> None:
     doc_folder = document.get_main_folder()
@@ -72,7 +71,7 @@ def run(document: papis.document.Document,
     # we only symlink a file it isn't a downloaded file that is stored in
     # a temporary directory. We keep track of a boolean per file that
     # tells us whether to link
-    new_filepaths: List[Tuple[str, bool]] = []
+    new_filepaths: list[tuple[str, bool]] = []
     for orig_filepath, filepath in zip(filepaths, local_files, strict=True):
         # skip remote files that haven't been properly downloaded
         if not filepath:
@@ -147,11 +146,11 @@ def run(document: papis.document.Document,
 def cli(query: str,
         git: bool,
         link: bool,
-        files: List[str],
-        urls: List[str],
-        file_name: Optional[str],
-        sort_field: Optional[str],
-        doc_folder: Tuple[str, ...],
+        files: list[str],
+        urls: list[str],
+        file_name: str | None,
+        sort_field: str | None,
+        doc_folder: tuple[str, ...],
         sort_reverse: bool) -> None:
     """Add files to an existing document."""
     documents = papis.cli.handle_doc_folder_query_sort(

--- a/papis/commands/bibtex.py
+++ b/papis/commands/bibtex.py
@@ -123,7 +123,6 @@ Command-line interface
 
 import os
 import re
-from typing import List, Optional, Tuple
 
 import click
 
@@ -187,7 +186,7 @@ if BIBTEX_EXPLORER:
 def cli_add(ctx: click.Context,
             query: str,
             _all: bool,
-            refs_file: Optional[str]) -> None:
+            refs_file: str | None) -> None:
     """Add documents from the library to the BibTeX file."""
     from papis.api import get_documents_in_lib, pick_doc
 
@@ -236,7 +235,7 @@ def cli_add(ctx: click.Context,
               multiple=True)
 @click.pass_context
 def cli_update(ctx: click.Context, _all: bool,
-               fromdb: bool, todb: bool, keys: List[str]) -> None:
+               fromdb: bool, todb: bool, keys: list[str]) -> None:
     """Update documents from and to the library."""
     if fromdb and todb:
         logger.error("Cannot pass both '--from' and '--to'.")
@@ -346,7 +345,7 @@ def cli_open(ctx: click.Context) -> None:
 @papis.cli.all_option()
 @click.pass_context
 def cli_edit(ctx: click.Context,
-             set_tuples: List[Tuple[str, str]],
+             set_tuples: list[tuple[str, str]],
              _all: bool) -> None:
     """
     Edit documents by adding keys or opening an editor.
@@ -405,7 +404,7 @@ def cli_edit(ctx: click.Context,
 @click.help_option("-h", "--help")
 @click.option("-k", "--key", default=None, help="doi, url, ...")
 @click.pass_context
-def cli_browse(ctx: click.Context, key: Optional[str]) -> None:
+def cli_browse(ctx: click.Context, key: str | None) -> None:
     """Browse a document in the document list."""
     from papis.api import pick_doc
 
@@ -435,7 +434,7 @@ def cli_rm(ctx: click.Context) -> None:
 @click.help_option("-h", "--help")
 @click.option("-o", "--out", help="Output ref to a file.", default=None)
 @click.pass_context
-def cli_ref(ctx: click.Context, out: Optional[str]) -> None:
+def cli_ref(ctx: click.Context, out: str | None) -> None:
     """Print the reference for a document."""
     from papis.api import pick_doc
 
@@ -488,7 +487,7 @@ def cli_save(ctx: click.Context, bibfile: str, force: bool) -> None:
               required=True)
 @papis.cli.bool_flag("-r", "--reverse", help="Reverse the sort order.")
 @click.pass_context
-def cli_sort(ctx: click.Context, key: Optional[str], reverse: bool) -> None:
+def cli_sort(ctx: click.Context, key: str | None, reverse: bool) -> None:
     """Sort the documents in the BibTeX file."""
     docs = ctx.obj["documents"]
     ctx.obj["documents"] = sorted(docs,
@@ -507,7 +506,7 @@ def cli_sort(ctx: click.Context, key: Optional[str], reverse: bool) -> None:
               default=None,
               type=str)
 @click.pass_context
-def cli_unique(ctx: click.Context, key: str, o: Optional[str]) -> None:
+def cli_unique(ctx: click.Context, key: str, o: str | None) -> None:
     """Remove duplicate BibTeX entries."""
     docs = ctx.obj["documents"]
     unique_docs = []
@@ -555,7 +554,7 @@ def cli_unique(ctx: click.Context, key: str, o: Optional[str]) -> None:
               default=("doi", "url", "year", "title", "author"),
               type=str)
 @click.pass_context
-def cli_doctor(ctx: click.Context, key: List[str]) -> None:
+def cli_doctor(ctx: click.Context, key: list[str]) -> None:
     """
     Check BibTeX file for correctness.
 
@@ -584,7 +583,7 @@ def cli_doctor(ctx: click.Context, key: List[str]) -> None:
               help="Text file to check for references.",
               multiple=True, required=True, type=str)
 @click.pass_context
-def cli_filter_cited(ctx: click.Context, _files: List[str]) -> None:
+def cli_filter_cited(ctx: click.Context, _files: list[str]) -> None:
     """
     Filter cited documents from the BibTeX file.
 
@@ -614,7 +613,7 @@ def cli_filter_cited(ctx: click.Context, _files: List[str]) -> None:
               help="Text file to check for references.",
               multiple=True, required=True, type=str)
 @click.pass_context
-def cli_iscited(ctx: click.Context, _files: List[str]) -> None:
+def cli_iscited(ctx: click.Context, _files: list[str]) -> None:
     """
     Check which documents are not cited.
 
@@ -646,7 +645,7 @@ def cli_iscited(ctx: click.Context, _files: List[str]) -> None:
 @click.option("-o", "--out", help="Out folder to export.", default=None)
 @papis.cli.all_option()
 @click.pass_context
-def cli_import(ctx: click.Context, out: Optional[str], _all: bool) -> None:
+def cli_import(ctx: click.Context, out: str | None, _all: bool) -> None:
     """
     Import documents from a BibTeX file to the current library.
 

--- a/papis/commands/browse.py
+++ b/papis/commands/browse.py
@@ -61,8 +61,6 @@ Command-line interface
     :prog: papis browse
 """
 
-from typing import Optional, Tuple
-
 import click
 
 import papis
@@ -79,7 +77,7 @@ logger = papis.logging.get_logger(__name__)
 
 
 def run(document: papis.document.Document,
-        browse: bool = True) -> Optional[str]:
+        browse: bool = True) -> str | None:
     """Open the document's URL in the selected :confval:`browser`.
 
     :arg browse: if *True*, the URL is opened after it is found, instead of just
@@ -147,8 +145,8 @@ def cli(query: str,
         key: str,
         _all: bool,
         _print: bool,
-        doc_folder: Tuple[str, ...],
-        sort_field: Optional[str],
+        doc_folder: tuple[str, ...],
+        sort_field: str | None,
         sort_reverse: bool) -> None:
     """Open a document URL in a browser."""
     documents = papis.cli.handle_doc_folder_query_all_sort(query,

--- a/papis/commands/cache.py
+++ b/papis/commands/cache.py
@@ -49,7 +49,6 @@ Command-line interface
     :nested: full
 """
 import os
-from typing import Optional, Tuple
 
 import click
 
@@ -79,9 +78,9 @@ def cli() -> None:
 @papis.cli.all_option()
 @papis.cli.sort_option()
 def update(query: str,
-           doc_folder: Tuple[str, ...],
+           doc_folder: tuple[str, ...],
            _all: bool,
-           sort_field: Optional[str],
+           sort_field: str | None,
            sort_reverse: bool) -> None:
     """
     Reload info.yaml files from disk and update the cache.
@@ -128,7 +127,7 @@ def reset() -> None:
 @cli.command("add")
 @click.help_option("--help", "-h")
 @papis.cli.doc_folder_option()
-def add(doc_folder: Tuple[str, ...]) -> None:
+def add(doc_folder: tuple[str, ...]) -> None:
     """
     Add a document to the cache.
 
@@ -156,9 +155,9 @@ def add(doc_folder: Tuple[str, ...]) -> None:
 @papis.cli.all_option()
 @papis.cli.sort_option()
 def rm(query: str,
-       doc_folder: Tuple[str, ...],
+       doc_folder: tuple[str, ...],
        _all: bool,
-       sort_field: Optional[str],
+       sort_field: str | None,
        sort_reverse: bool) -> None:
     """
     Delete documents from the cache.
@@ -190,9 +189,9 @@ def pwd() -> None:
 @papis.cli.all_option()
 @papis.cli.sort_option()
 def update_newer(query: str,
-                 doc_folder: Tuple[str, ...],
+                 doc_folder: tuple[str, ...],
                  _all: bool,
-                 sort_field: Optional[str],
+                 sort_field: str | None,
                  sort_reverse: bool) -> None:
     """
     Update documents newer than the cache modification time.

--- a/papis/commands/citations.py
+++ b/papis/commands/citations.py
@@ -45,8 +45,6 @@ Command-line interface
     :prog: papis citations
 """
 
-from typing import Optional, Tuple
-
 import click
 
 import papis.cli
@@ -78,8 +76,8 @@ logger = papis.logging.get_logger(__name__)
 @papis.cli.all_option()
 @papis.cli.doc_folder_option()
 def cli(query: str,
-        doc_folder: Tuple[str, ...],
-        sort_field: Optional[str],
+        doc_folder: tuple[str, ...],
+        sort_field: str | None,
         sort_reverse: bool,
         _all: bool,
         force: bool,

--- a/papis/commands/config.py
+++ b/papis/commands/config.py
@@ -70,7 +70,7 @@ Command-line interface
     :prog: papis config
 """
 
-from typing import Any, Dict, List, Optional, Tuple
+from typing import Any
 
 import click
 import colorama
@@ -91,8 +91,8 @@ def format_option(key: str, value: Any) -> str:
 
 
 def parse_option(
-        option: str, default_section: Optional[str]
-        ) -> Tuple[Optional[str], str]:
+        option: str, default_section: str | None
+        ) -> tuple[str | None, str]:
     """
     :returns: a ``(section, key)`` tuple parsed from *option*.
     """
@@ -118,8 +118,8 @@ def parse_option(
 
 
 def _get_option_safe(
-        option: str, default_section: Optional[str], default: bool = False,
-        ) -> Tuple[Optional[str], Optional[str]]:
+        option: str, default_section: str | None, default: bool = False,
+        ) -> tuple[str | None, str | None]:
     key = option
     value = None
 
@@ -153,10 +153,10 @@ def _get_option_safe(
 
 
 def run(
-        options: List[str],
-        section: Optional[str] = None,
+        options: list[str],
+        section: str | None = None,
         default: bool = False,
-        ) -> Dict[str, Any]:
+        ) -> dict[str, Any]:
     """
     :param options: a list of strings, each in a format ``[<section>].<key>``
         (i.e. where the section is optional).
@@ -165,7 +165,7 @@ def run(
         the values from the configuration file.
     """
     config = papis.config.get_configuration()
-    result: Dict[str, Any] = {}
+    result: dict[str, Any] = {}
 
     if len(options) == 0:
         # NOTE: no options given -> just get all the settings
@@ -228,8 +228,8 @@ def run(
 @papis.cli.bool_flag(
     "--json", "print_json",
     help="Print settings in a JSON format.")
-def cli(options: List[str],
-        section: Optional[str],
+def cli(options: list[str],
+        section: str | None,
         default: bool,
         print_json: bool) -> None:
     """Print configuration values."""

--- a/papis/commands/default.py
+++ b/papis/commands/default.py
@@ -29,7 +29,8 @@ Command-line interface
 """
 
 import os
-from typing import TYPE_CHECKING, Callable, List, Optional, Tuple
+from collections.abc import Callable
+from typing import TYPE_CHECKING
 
 import click
 import click.core
@@ -53,7 +54,7 @@ class ScriptLoaderGroup(click.Group):
     scripts = papis.commands.get_all_scripts()
     script_names = sorted(scripts)
 
-    def list_commands(self, ctx: click.core.Context) -> List[str]:
+    def list_commands(self, ctx: click.core.Context) -> list[str]:
         """List all matched commands in the command folder and in path
 
         >>> group = ScriptLoaderGroup()
@@ -66,7 +67,7 @@ class ScriptLoaderGroup(click.Group):
     def get_command(
             self,
             ctx: click.core.Context,
-            name: str) -> Optional[click.core.Command]:
+            name: str) -> click.core.Command | None:
         """Get the command to be run
 
         >>> group = ScriptLoaderGroup()
@@ -181,13 +182,13 @@ def run(ctx: click.Context,
         verbose: bool,
         profile: str,
         config: str,
-        lib: Optional[str],
+        lib: str | None,
         log: str,
-        logfile: Optional[str],
+        logfile: str | None,
         pick_lib: bool,
-        set_list: List[Tuple[str, str]],
+        set_list: list[tuple[str, str]],
         color: str,
-        np: Optional[int]) -> None:
+        np: int | None) -> None:
 
     if np:
         os.environ["PAPIS_NP"] = str(np)

--- a/papis/commands/edit.py
+++ b/papis/commands/edit.py
@@ -9,7 +9,6 @@ Command-line interface
 .. click:: papis.commands.edit:cli
     :prog: papis edit
 """
-from typing import Optional, Tuple
 
 import click
 
@@ -97,12 +96,12 @@ def edit_notes(document: papis.document.Document,
     help="Editor to be used.",
     default=None)
 def cli(query: str,
-        doc_folder: Tuple[str, ...],
+        doc_folder: tuple[str, ...],
         git: bool,
         notes: bool,
         _all: bool,
-        editor: Optional[str],
-        sort_field: Optional[str],
+        editor: str | None,
+        sort_field: str | None,
         sort_reverse: bool) -> None:
     """Edit document information from a given library."""
     documents = papis.cli.handle_doc_folder_query_all_sort(query,

--- a/papis/commands/exec.py
+++ b/papis/commands/exec.py
@@ -34,7 +34,6 @@ Command-line interface
 """
 
 import sys
-from typing import List
 
 import click
 
@@ -48,7 +47,7 @@ def run(_file: str) -> None:
 @click.help_option("--help", "-h")
 @click.argument("python_file", type=click.Path(exists=True))
 @click.argument("args", nargs=-1)
-def cli(python_file: str, args: List[str]) -> None:
+def cli(python_file: str, args: list[str]) -> None:
     """Execute a python file in the environment of papis' executable"""
     sys.argv = [python_file, *args]
     run(python_file)

--- a/papis/commands/explore.py
+++ b/papis/commands/explore.py
@@ -91,7 +91,7 @@ Command-line interface
 """
 
 import shlex
-from typing import TYPE_CHECKING, List, Optional, Tuple
+from typing import TYPE_CHECKING
 
 import click
 
@@ -107,7 +107,7 @@ logger = papis.logging.get_logger(__name__)
 EXPLORER_EXTENSION_NAME = "papis.explorer"
 
 
-def get_available_explorers() -> List[click.Command]:
+def get_available_explorers() -> list[click.Command]:
     """
     Gets all exporters registered.
     """
@@ -122,7 +122,7 @@ def get_explorer_mgr() -> "ExtensionManager":
     return get_extension_manager(EXPLORER_EXTENSION_NAME)
 
 
-def get_explorer_by_name(name: str) -> Optional[click.Command]:
+def get_explorer_by_name(name: str) -> click.Command | None:
     try:
         mgr = get_explorer_mgr()
         plugin: click.Command = mgr[name].plugin
@@ -139,8 +139,8 @@ def get_explorer_by_name(name: str) -> Optional[click.Command]:
 @click.option("--library", "-l", default=None, help="Papis library to look in.")
 def lib(ctx: click.Context,
         query: str,
-        doc_folder: Tuple[str, ...],
-        library: Optional[str]) -> None:
+        doc_folder: tuple[str, ...],
+        library: str | None) -> None:
     """
     Query for documents in your library.
 
@@ -174,7 +174,7 @@ def lib(ctx: click.Context,
               type=int,
               default=None,
               help="Automatically pick the n-th document.")
-def pick(ctx: click.Context, number: Optional[int]) -> None:
+def pick(ctx: click.Context, number: int | None) -> None:
     """
     Pick a document from the retrieved documents.
 
@@ -209,7 +209,7 @@ def pick(ctx: click.Context, number: Optional[int]) -> None:
 @papis.cli.all_option()
 def citations(ctx: click.Context,
               query: str,
-              doc_folder: Tuple[str, ...],
+              doc_folder: tuple[str, ...],
               cited_by: bool,
               _all: bool) -> None:
     """

--- a/papis/commands/export.py
+++ b/papis/commands/export.py
@@ -57,7 +57,6 @@ Command-line interface
 """
 
 import os
-from typing import List, Optional, Tuple
 
 import click
 
@@ -79,11 +78,11 @@ logger = papis.logging.get_logger(__name__)
 EXPORTER_EXTENSION_NAME = "papis.exporter"
 
 
-def available_formats() -> List[str]:
+def available_formats() -> list[str]:
     return papis.plugin.get_available_entrypoints(EXPORTER_EXTENSION_NAME)
 
 
-def run(documents: List[papis.document.Document], to_format: str) -> str:
+def run(documents: list[papis.document.Document], to_format: str) -> str:
     """
     Exports several documents into something else.
 
@@ -131,8 +130,8 @@ def run(documents: List[papis.document.Document], to_format: str) -> str:
     "--batch",
     help="Do not prompt when overwriting a file.")
 def cli(query: str,
-        doc_folder: Tuple[str, ...],
-        sort_field: Optional[str],
+        doc_folder: tuple[str, ...],
+        sort_field: str | None,
         sort_reverse: bool,
         folder: str,
         out: str,

--- a/papis/commands/external.py
+++ b/papis/commands/external.py
@@ -4,7 +4,7 @@ This module define the entry point for external scripts to be called by papis.
 
 import os
 import re
-from typing import Any, Dict, List, Optional
+from typing import Any
 
 import click
 
@@ -28,7 +28,7 @@ def get_command_help(path: str) -> str:
     return "No help message available"
 
 
-def get_exported_variables(ctx: Optional[Dict[str, Any]] = None) -> Dict[str, str]:
+def get_exported_variables(ctx: dict[str, Any] | None = None) -> dict[str, str]:
     """
     Export environment variables so that external script can access to
     the information
@@ -62,7 +62,7 @@ def get_exported_variables(ctx: Optional[Dict[str, Any]] = None) -> Dict[str, st
     )
 @click.argument("flags", nargs=-1)
 @click.pass_context
-def external_cli(ctx: click.core.Context, flags: List[str]) -> None:
+def external_cli(ctx: click.core.Context, flags: list[str]) -> None:
     """Actual papis command to call the external command"""
     script: papis.commands.Script = ctx.obj
     path = script.path

--- a/papis/commands/init.py
+++ b/papis/commands/init.py
@@ -32,7 +32,7 @@ Command-line interface
 """
 
 import os
-from typing import NamedTuple, Optional
+from typing import NamedTuple
 
 import click
 
@@ -101,7 +101,7 @@ def _is_git_repository(path: str) -> bool:
     metavar="<LIBRARY DIRECTORY>",
     nargs=1,
 )
-def cli(dir_path: Optional[str]) -> None:
+def cli(dir_path: str | None) -> None:
     """Initialize a Papis library."""
 
     from papis.tui.utils import confirm, prompt

--- a/papis/commands/list.py
+++ b/papis/commands/list.py
@@ -51,7 +51,7 @@ Command-line interface
 
 import os
 import re
-from typing import List, Optional, Sequence, Tuple
+from collections.abc import Sequence
 
 import click
 
@@ -74,7 +74,7 @@ def list_plugins(show_paths: bool = False,
                  show_downloaders: bool = False,
                  show_pickers: bool = False,
                  show_doctor: bool = False,
-                 verbose: bool = False) -> List[str]:
+                 verbose: bool = False) -> list[str]:
     import colorama as c
 
     from papis.plugin import get_extension_manager
@@ -83,7 +83,7 @@ def list_plugins(show_paths: bool = False,
         return (f"{c.Style.BRIGHT}{name}{c.Style.RESET_ALL}"
                 f" {c.Fore.YELLOW}{ids}{c.Style.RESET_ALL}")
 
-    def _stringify(namespace: str) -> List[str]:
+    def _stringify(namespace: str) -> list[str]:
         results = []
         for p in get_extension_manager(namespace):
             results.append(_format(p.name, f"{p.module_name}.{p.attr}"))
@@ -155,8 +155,8 @@ def list_documents(documents: Sequence[papis.document.Document],
                    show_info: bool = False,
                    show_notes: bool = False,
                    show_format: papis.strings.AnyString = "",
-                   template: Optional[str] = None
-                   ) -> List[str]:
+                   template: str | None = None
+                   ) -> list[str]:
     """List document properties.
 
     :arg template: a path to a file containing a format pattern that can be
@@ -270,11 +270,11 @@ def cli(query: str,
         show_downloaders: bool,
         show_pickers: bool,
         show_doctor: bool,
-        template: Optional[str],
+        template: str | None,
         quiet: bool,
         _all: bool,
-        doc_folder: Tuple[str, ...],
-        sort_field: Optional[str],
+        doc_folder: tuple[str, ...],
+        sort_field: str | None,
         sort_reverse: bool) -> None:
     """List document metadata."""
 

--- a/papis/commands/merge.py
+++ b/papis/commands/merge.py
@@ -58,7 +58,7 @@ Command-line interface
 """
 
 import os
-from typing import Any, Dict, List, Optional
+from typing import Any
 
 import click
 
@@ -81,8 +81,8 @@ logger = papis.logging.get_logger(__name__)
 
 def run(keep: papis.document.Document,
         erase: papis.document.Document,
-        data: Dict[str, Any],
-        files: List[str],
+        data: dict[str, Any],
+        files: list[str],
         keep_both: bool,
         git: bool = False) -> None:
 
@@ -124,8 +124,8 @@ def run(keep: papis.document.Document,
               default=None)
 @papis.cli.git_option(help="Merge in git.")
 def cli(query: str,
-        sort_field: Optional[str],
-        out: Optional[str],
+        sort_field: str | None,
+        out: str | None,
         second: bool,
         git: bool,
         keep_both: bool,
@@ -168,7 +168,7 @@ def cli(query: str,
                                                    data_b,
                                                    papis.document.describe(b))
 
-    files: List[str] = []
+    files: list[str] = []
     for doc in documents:
         indices = papis.tui.utils.select_range(
             doc.get_files(),

--- a/papis/commands/mv.py
+++ b/papis/commands/mv.py
@@ -9,7 +9,6 @@ Command-line interface
 """
 
 import os
-from typing import Optional, Tuple
 
 import click
 
@@ -61,8 +60,8 @@ def run(document: papis.document.Document,
 @papis.cli.doc_folder_option()
 def cli(query: str,
         git: bool,
-        sort_field: Optional[str],
-        doc_folder: Tuple[str, ...],
+        sort_field: str | None,
+        doc_folder: tuple[str, ...],
         sort_reverse: bool) -> None:
     """Move a document into some other path."""
     # Leave this imports here for performance

--- a/papis/commands/open.py
+++ b/papis/commands/open.py
@@ -69,7 +69,6 @@ Command-line interface
 """
 
 import os
-from typing import Optional, Tuple
 
 import click
 
@@ -90,7 +89,7 @@ logger = papis.logging.get_logger(__name__)
 
 
 def run(document: papis.document.Document,
-        opener: Optional[str] = None,
+        opener: str | None = None,
         folder: bool = False,
         mark: bool = False) -> None:
     if opener is not None:
@@ -170,8 +169,8 @@ def run(document: papis.document.Document,
     "-m", "--mark/--no-mark",
     help="Open mark.",
     default=lambda: papis.config.getboolean("open-mark"))
-def cli(query: str, doc_folder: Tuple[str, ...], tool: str, folder: bool,
-        sort_field: Optional[str], sort_reverse: bool, _all: bool,
+def cli(query: str, doc_folder: tuple[str, ...], tool: str, folder: bool,
+        sort_field: str | None, sort_reverse: bool, _all: bool,
         mark: bool) -> None:
     """Open document from a given library."""
     if tool:

--- a/papis/commands/rename.py
+++ b/papis/commands/rename.py
@@ -53,8 +53,6 @@ Command-line interface
     :prog: papis rename
 """
 
-from typing import Optional, Tuple
-
 import click
 
 import papis.cli
@@ -125,8 +123,8 @@ def cli(query: str,
         _all: bool,
         batch: bool,
         git: bool,
-        sort_field: Optional[str],
-        doc_folder: Tuple[str, ...],
+        sort_field: str | None,
+        doc_folder: tuple[str, ...],
         sort_reverse: bool) -> None:
     """Rename document folders."""
     if not folder_name:

--- a/papis/commands/rm.py
+++ b/papis/commands/rm.py
@@ -13,7 +13,6 @@ Command-line interface
 """
 
 import os
-from typing import Optional, Tuple
 
 import click
 
@@ -31,8 +30,8 @@ logger = papis.logging.get_logger(__name__)
 
 
 def run(document: papis.document.Document,
-        filepath: Optional[str] = None,
-        notespath: Optional[str] = None,
+        filepath: str | None = None,
+        notespath: str | None = None,
         git: bool = False) -> None:
     """Main method to the rm command
     """
@@ -97,8 +96,8 @@ def cli(query: str,
         _notes: bool,
         force: bool,
         _all: bool,
-        doc_folder: Tuple[str, ...],
-        sort_field: Optional[str],
+        doc_folder: tuple[str, ...],
+        sort_field: str | None,
         sort_reverse: bool) -> None:
     """
     Remove a document, a file, or a notes-file.

--- a/papis/commands/run.py
+++ b/papis/commands/run.py
@@ -51,8 +51,6 @@ Command-line interface
     :prog: papis run
 """
 
-from typing import List, Optional, Tuple
-
 import click
 
 import papis.cli
@@ -66,7 +64,7 @@ import papis.utils
 logger = papis.logging.get_logger(__name__)
 
 
-def run(folder: str, command: Optional[List[str]] = None) -> None:
+def run(folder: str, command: list[str] | None = None) -> None:
     if command is None:
         return
 
@@ -91,12 +89,12 @@ def run(folder: str, command: Optional[List[str]] = None) -> None:
     metavar="<PREFIX>",
     help="Prefix shell commands by a prefix command.")
 @click.argument("run_command", metavar="<COMMANDS>", nargs=-1)
-def cli(run_command: List[str],
+def cli(run_command: list[str],
         pick: str,
         sort_field: str,
         sort_reverse: bool,
-        prefix: Optional[str],
-        doc_folder: Tuple[str, ...],
+        prefix: str | None,
+        doc_folder: tuple[str, ...],
         _all: bool) -> None:
     """Run an arbitrary shell command in the library or command folder."""
 

--- a/papis/commands/tag.py
+++ b/papis/commands/tag.py
@@ -57,7 +57,7 @@ Command-line interface
 
 """
 
-from typing import Any, Dict, List, Optional, Tuple
+from typing import Any
 
 import click
 
@@ -110,13 +110,13 @@ logger = papis.logging.get_logger(__name__)
 def cli(
     git: bool,
     drop: bool,
-    to_add: List[str],
-    to_remove: List[str],
-    to_rename: List[Tuple[str, str]],
-    sort_field: Optional[str],
+    to_add: list[str],
+    to_remove: list[str],
+    to_rename: list[tuple[str, str]],
+    sort_field: str | None,
     sort_reverse: bool,
     query: str,
-    doc_folder: Tuple[str, ...],
+    doc_folder: tuple[str, ...],
     _all: bool,
 ) -> None:
     """
@@ -134,10 +134,10 @@ def cli(
 
     from papis.commands.update import run, run_append, run_drop, run_remove, run_rename
 
-    key_types: Dict[str, type] = {"tags": list}
+    key_types: dict[str, type] = {"tags": list}
 
     success = True
-    processed_documents: List[Any] = []
+    processed_documents: list[Any] = []
     for document in documents:
         tags = document.get("tags", [])
         if not isinstance(tags, list):

--- a/papis/commands/update.py
+++ b/papis/commands/update.py
@@ -128,7 +128,8 @@ Command-line interface
 """
 
 import ast
-from typing import Any, Dict, List, Optional, Sequence, Tuple
+from collections.abc import Sequence
+from typing import Any
 
 import click
 
@@ -165,8 +166,8 @@ def try_parsing_str(key: str, value: str) -> str:
 
 def run_set(
     document: papis.document.DocumentLike,
-    to_set: Sequence[Tuple[str, AnyString]],
-    key_types: Dict[str, type],
+    to_set: Sequence[tuple[str, AnyString]],
+    key_types: dict[str, type],
 ) -> None:
     """
     Processes a list of ``to_set`` tuples and applies the resulting changes to the
@@ -209,8 +210,8 @@ def run_set(
 
 def run_append(
     document: papis.document.DocumentLike,
-    to_append: Sequence[Tuple[str, AnyString]],
-    key_types: Dict[str, type],
+    to_append: Sequence[tuple[str, AnyString]],
+    key_types: dict[str, type],
     batch: bool,
 ) -> bool:
     """
@@ -270,7 +271,7 @@ def run_append(
 
 def run_remove(
     document: papis.document.DocumentLike,
-    to_remove: Sequence[Tuple[str, AnyString]],
+    to_remove: Sequence[tuple[str, AnyString]],
     batch: bool
 ) -> bool:
     """
@@ -332,7 +333,7 @@ def run_drop(document: papis.document.DocumentLike, to_remove: Sequence[str]) ->
 
 def run_rename(
     document: papis.document.DocumentLike,
-    to_rename: Sequence[Tuple[str, AnyString, AnyString]],
+    to_rename: Sequence[tuple[str, AnyString, AnyString]],
     batch: bool,
 ) -> bool:
     """
@@ -353,7 +354,7 @@ def run_rename(
 
 def run(
     document: papis.document.Document,
-    data: Optional[Dict[str, Any]] = None,
+    data: dict[str, Any] | None = None,
     git: bool = False,
     auto_doctor: bool = False,
 ) -> None:
@@ -472,19 +473,19 @@ def run(
 def cli(
     query: str,
     git: bool,
-    doc_folder: Tuple[str, ...],
-    from_importer: List[Tuple[str, str]],
+    doc_folder: tuple[str, ...],
+    from_importer: list[tuple[str, str]],
     batch: bool,
     auto: bool,
     auto_doctor: bool,
     _all: bool,
-    sort_field: Optional[str],
+    sort_field: str | None,
     sort_reverse: bool,
-    to_set: List[Tuple[str, str]],
-    to_drop: List[str],
-    to_append: List[Tuple[str, str]],
-    to_remove: List[Tuple[str, str]],
-    to_rename: List[Tuple[str, str, str]],
+    to_set: list[tuple[str, str]],
+    to_drop: list[str],
+    to_append: list[tuple[str, str]],
+    to_remove: list[tuple[str, str]],
+    to_rename: list[tuple[str, str, str]],
 ) -> None:
     """Update document metadata."""
     success = True

--- a/papis/config.py
+++ b/papis/config.py
@@ -1,6 +1,7 @@
 import configparser
 import os
-from typing import Any, Callable, Dict, List, Optional
+from collections.abc import Callable
+from typing import Any
 
 import click
 import platformdirs
@@ -12,13 +13,13 @@ from papis.strings import FormatPattern
 
 logger = papis.logging.get_logger(__name__)
 
-PapisConfigType = Dict[str, Dict[str, Any]]
+PapisConfigType = dict[str, dict[str, Any]]
 
 CURRENT_LIBRARY = None
-CURRENT_CONFIGURATION: Optional["Configuration"] = None
+CURRENT_CONFIGURATION: "Configuration | None" = None
 
-DEFAULT_SETTINGS: Optional[PapisConfigType] = None
-OVERRIDE_VARS: Dict[str, Optional[str]] = {
+DEFAULT_SETTINGS: PapisConfigType | None = None
+OVERRIDE_VARS: dict[str, str | None] = {
     "folder": None,
     "file": None,
     "scripts": None
@@ -300,7 +301,7 @@ def get_scripts_folder() -> str:
     return os.path.join(get_config_folder(), "scripts")
 
 
-def set(key: str, value: Any, section: Optional[str] = None) -> None:
+def set(key: str, value: Any, section: str | None = None) -> None:
     """Set a key in the configuration.
 
     :param key: the name of the key to set.
@@ -326,8 +327,8 @@ def set(key: str, value: Any, section: Optional[str] = None) -> None:
 
 
 def general_get(key: str,
-                section: Optional[str] = None,
-                data_type: Optional[type] = None) -> Optional[Any]:
+                section: str | None = None,
+                data_type: type | None = None) -> Any | None:
     """Get the value for a given *key* in *section*.
 
     This function is a bit more general than the get from :class:`Configuration`
@@ -421,12 +422,12 @@ def general_get(key: str,
     return value
 
 
-def get(key: str, section: Optional[str] = None) -> Optional[Any]:
+def get(key: str, section: str | None = None) -> Any | None:
     """Retrieve a general value (can be *None*) from the configuration file."""
     return general_get(key, section=section)
 
 
-def getint(key: str, section: Optional[str] = None) -> Optional[int]:
+def getint(key: str, section: str | None = None) -> int | None:
     """Retrieve an integer value from the configuration file.
 
         >>> set("something", 42)
@@ -440,7 +441,7 @@ def getint(key: str, section: Optional[str] = None) -> Optional[int]:
         raise ValueError(f"Key '{key}' should be an integer: '{value}'") from exc
 
 
-def getfloat(key: str, section: Optional[str] = None) -> Optional[float]:
+def getfloat(key: str, section: str | None = None) -> float | None:
     """Retrieve an floating point value from the configuration file.
 
         >>> set("something", 0.42)
@@ -454,7 +455,7 @@ def getfloat(key: str, section: Optional[str] = None) -> Optional[float]:
         raise ValueError(f"Key '{key}' should be a float: '{value}'") from exc
 
 
-def getboolean(key: str, section: Optional[str] = None) -> Optional[bool]:
+def getboolean(key: str, section: str | None = None) -> bool | None:
     """Retrieve a boolean value from the configuration file.
 
         >>> set("add-open", True)
@@ -468,7 +469,7 @@ def getboolean(key: str, section: Optional[str] = None) -> Optional[bool]:
         raise ValueError(f"Key '{key}' should be a boolean: '{value}'") from exc
 
 
-def getstring(key: str, section: Optional[str] = None) -> str:
+def getstring(key: str, section: str | None = None) -> str:
     """Retrieve a string value from the configuration file.
 
         >>> set("add-open", "hello world")
@@ -482,7 +483,7 @@ def getstring(key: str, section: Optional[str] = None) -> str:
     return str(result)
 
 
-def getformatpattern(key: str, section: Optional[str] = None) -> FormatPattern:
+def getformatpattern(key: str, section: str | None = None) -> FormatPattern:
     """Retrieve a format pattern from the configuration file.
 
     Format patterns use the :class:`~papis.strings.FormatPattern` class to
@@ -517,7 +518,7 @@ def getformatpattern(key: str, section: Optional[str] = None) -> FormatPattern:
     from papis.format import get_available_formatters, get_default_formatter
 
     formatter = get_default_formatter()
-    result: Optional[str] = None
+    result: str | None = None
 
     for f in get_available_formatters():
         try:
@@ -538,7 +539,7 @@ def getformatpattern(key: str, section: Optional[str] = None) -> FormatPattern:
         raise ValueError(f"Key '{key}' should be a string: '{result}'")
 
 
-def getlist(key: str, section: Optional[str] = None) -> List[str]:
+def getlist(key: str, section: str | None = None) -> list[str]:
     """Retrieve a list value from the configuration file.
 
     This function uses :func:`eval` to execute a the string present in the
@@ -589,7 +590,7 @@ def get_configuration() -> Configuration:
     return CURRENT_CONFIGURATION
 
 
-def merge_configuration_from_path(path: Optional[str],
+def merge_configuration_from_path(path: str | None,
                                   configuration: Configuration) -> None:
     """Merge information of a configuration file found in *path* into *configuration*.
 
@@ -677,7 +678,7 @@ def get_lib_from_name(libname: str) -> papis.library.Library:
     return lib
 
 
-def get_lib_dirs() -> List[str]:
+def get_lib_dirs() -> list[str]:
     """Get the directories of the current library."""
     return get_lib().paths
 
@@ -716,12 +717,12 @@ def get_lib() -> papis.library.Library:
     return CURRENT_LIBRARY
 
 
-def get_libs() -> List[str]:
+def get_libs() -> list[str]:
     """Get all the library names from the configuration file."""
     return get_libs_from_config(get_configuration())
 
 
-def get_libs_from_config(config: Configuration) -> List[str]:
+def get_libs_from_config(config: Configuration) -> list[str]:
     """Get all library names from the given *configuration*.
 
     In the configuration file, any sections that contain a ``"dir"`` or a

--- a/papis/crossref.py
+++ b/papis/crossref.py
@@ -1,6 +1,6 @@
 import os
 import re
-from typing import Any, Dict, List, Optional, Tuple, Union
+from typing import Any
 
 import click
 import doi
@@ -163,8 +163,7 @@ key_conversion = [
 ]  # List[papis.document.KeyConversionPair]
 
 
-def _crossref_date_parts(entry: Dict[str, Any],
-                         i: int = 0) -> Optional[int]:
+def _crossref_date_parts(entry: dict[str, Any], i: int = 0) -> int | None:
     date_parts = entry.get("date-parts")
     if date_parts is None:
         return date_parts
@@ -179,7 +178,7 @@ def _crossref_date_parts(entry: Dict[str, Any],
     return int(parts[i])
 
 
-def _crossref_link(entry: List[Dict[str, str]]) -> Optional[str]:
+def _crossref_link(entry: list[dict[str, str]]) -> str | None:
     if len(entry) == 1:
         return entry[0]["URL"]
 
@@ -192,7 +191,7 @@ def _crossref_link(entry: List[Dict[str, str]]) -> Optional[str]:
     return links[0] if links else None
 
 
-def crossref_data_to_papis_data(data: Dict[str, Any]) -> Dict[str, Any]:
+def crossref_data_to_papis_data(data: dict[str, Any]) -> dict[str, Any]:
     new_data = papis.document.keyconversion_to_data(key_conversion, data)
 
     # ensure that author_list and author are consistent
@@ -221,7 +220,7 @@ def crossref_data_to_papis_data(data: Dict[str, Any]) -> Dict[str, Any]:
     return new_data
 
 
-def _get_crossref_works(**kwargs: Any) -> Union[Dict[str, Any], List[Dict[str, Any]]]:
+def _get_crossref_works(**kwargs: Any) -> dict[str, Any] | list[dict[str, Any]]:
     import habanero
 
     from papis import PAPIS_USER_AGENT
@@ -240,11 +239,11 @@ def get_data(
         query: str = "",
         author: str = "",
         title: str = "",
-        dois: Optional[List[str]] = None,
+        dois: list[str] | None = None,
         max_results: int = 0,
-        filters: Optional[Dict[str, Any]] = None,
+        filters: dict[str, Any] | None = None,
         sort: str = "score",
-        order: str = "desc") -> List[Dict[str, Any]]:
+        order: str = "desc") -> list[dict[str, Any]]:
     assert sort in _sort_values, "Sort value not valid"
     assert order in _order_values, "Sort value not valid"
 
@@ -297,7 +296,7 @@ def get_data(
     return [crossref_data_to_papis_data(d) for d in docs]
 
 
-def doi_to_data(doi_string: str) -> Dict[str, Any]:
+def doi_to_data(doi_string: str) -> dict[str, Any]:
     """Search through Crossref and get the document metadata.
 
     :param doi_string: DOI or an url that contains a DOI.
@@ -337,7 +336,7 @@ def explorer(
         author: str,
         title: str,
         _ma: int,
-        _filters: List[Tuple[str, str]],
+        _filters: list[tuple[str, str]],
         sort: str,
         order: str) -> None:
     """
@@ -376,10 +375,10 @@ class DoiFromPdfImporter(papis.importer.Importer):
     def __init__(self, uri: str) -> None:
         """The uri should be a filepath"""
         super().__init__(name="pdf2doi", uri=uri)
-        self._doi: Optional[str] = None
+        self._doi: str | None = None
 
     @classmethod
-    def match(cls, uri: str) -> Optional[papis.importer.Importer]:
+    def match(cls, uri: str) -> papis.importer.Importer | None:
         """The uri should be a filepath"""
         filepath = uri
         if (
@@ -393,7 +392,7 @@ class DoiFromPdfImporter(papis.importer.Importer):
         return importer if importer.doi else None
 
     @property
-    def doi(self) -> Optional[str]:
+    def doi(self) -> str | None:
         if self._doi is None:
             self._doi = doi.pdf_to_doi(self.uri, maxlines=2000)
             self._doi = "" if self._doi is None else self._doi
@@ -423,7 +422,7 @@ class Importer(papis.importer.Importer):
         super().__init__(name="doi", uri=uri)
 
     @classmethod
-    def match(cls, uri: str) -> Optional[papis.importer.Importer]:
+    def match(cls, uri: str) -> papis.importer.Importer | None:
         try:
             doi.validate_doi(uri)
         except ValueError:
@@ -432,8 +431,7 @@ class Importer(papis.importer.Importer):
             return Importer(uri=uri)
 
     @classmethod
-    def match_data(
-            cls, data: Dict[str, Any]) -> Optional[papis.importer.Importer]:
+    def match_data(cls, data: dict[str, Any]) -> papis.importer.Importer | None:
         if "doi" in data:
             return Importer(uri=data["doi"])
 
@@ -471,13 +469,12 @@ class FromCrossrefImporter(papis.importer.Importer):
         super().__init__(uri=uri, name="crossref")
 
     @classmethod
-    def match(cls, uri: str) -> Optional[papis.importer.Importer]:
+    def match(cls, uri: str) -> papis.importer.Importer | None:
         # There is no way to check if it matches
         return None
 
     @classmethod
-    def match_data(
-            cls, data: Dict[str, Any]) -> Optional[papis.importer.Importer]:
+    def match_data(cls, data: dict[str, Any]) -> papis.importer.Importer | None:
         if "title" in data:
             return FromCrossrefImporter(uri=data["title"])
 
@@ -507,15 +504,15 @@ class Downloader(papis.downloaders.Downloader):
 
     def __init__(self, uri: str) -> None:
         super().__init__(uri=uri, name="doi")
-        self._doi: Optional[str] = None
+        self._doi: str | None = None
 
     @classmethod
-    def match(cls, uri: str) -> Optional[papis.downloaders.Downloader]:
+    def match(cls, uri: str) -> papis.downloaders.Downloader | None:
         down = Downloader(uri)
         return down if down.doi else None
 
     @property
-    def doi(self) -> Optional[str]:
+    def doi(self) -> str | None:
         if self._doi is None:
             self._doi = doi.find_doi_in_text(self.uri)
             self._doi = "" if self._doi is None else self._doi

--- a/papis/csl.py
+++ b/papis/csl.py
@@ -1,6 +1,6 @@
 import os
 from contextlib import suppress
-from typing import TYPE_CHECKING, Any, List, Optional
+from typing import TYPE_CHECKING, Any
 
 import papis.config
 import papis.logging
@@ -51,7 +51,7 @@ def _download_style(name: str) -> None:
     logger.info("Style '%s' downloaded to '%s'.", name, style_path)
 
 
-def _parse_date(doc: Document) -> Optional["Date"]:
+def _parse_date(doc: Document) -> "Date | None":
     """Extract a date from a document."""
 
     if "year" not in doc:
@@ -159,8 +159,8 @@ def normalize_style_path(name: str) -> str:
 
 
 def export_document(doc: Document,
-                    style_name: Optional[str] = None,
-                    formatter_name: Optional[str] = None) -> str:
+                    style_name: str | None = None,
+                    formatter_name: str | None = None) -> str:
     if style_name is None:
         style_name = papis.config.getstring("csl-style")
 
@@ -221,7 +221,7 @@ def export_document(doc: Document,
     return ""
 
 
-def exporter(documents: List[Document]) -> str:
+def exporter(documents: list[Document]) -> str:
     try:
         import citeproc  # noqa: F401
     except ImportError:

--- a/papis/database/__init__.py
+++ b/papis/database/__init__.py
@@ -1,5 +1,3 @@
-from typing import Dict, Optional
-
 import papis.logging
 from papis.library import Library
 
@@ -7,7 +5,7 @@ from .base import Database
 
 logger = papis.logging.get_logger(__name__)
 
-DATABASES: Dict[Library, Database] = {}
+DATABASES: dict[Library, Database] = {}
 
 
 def _instantiate_database(backend_name: str, library: Library) -> Database:
@@ -21,7 +19,7 @@ def _instantiate_database(backend_name: str, library: Library) -> Database:
         raise ValueError(f"Invalid database backend: '{backend_name}'")
 
 
-def get(library_name: Optional[str] = None) -> Database:
+def get(library_name: str | None = None) -> Database:
     """Get the database for the library *library_name*.
 
     If *library_name* is *None*, then the current database is retrieved from

--- a/papis/database/base.py
+++ b/papis/database/base.py
@@ -1,6 +1,5 @@
 import os
 from abc import ABC, abstractmethod
-from typing import Dict, List, Optional
 from warnings import warn
 
 from papis.document import Document
@@ -42,7 +41,7 @@ def get_cache_file_path(libpaths: str) -> str:
 class Database(ABC):
     """Abstract base class for Papis caching database backends."""
 
-    def __init__(self, library: Optional[Library] = None) -> None:
+    def __init__(self, library: Library | None = None) -> None:
         if library is None:
             from papis.config import get_lib
             library = get_lib()
@@ -98,7 +97,7 @@ class Database(ABC):
         """Remove a document from the database."""
 
     @abstractmethod
-    def query(self, query_string: str) -> List[Document]:
+    def query(self, query_string: str) -> list[Document]:
         """Find a document in the database by the given *query_string*.
 
         The query string can have a more complex syntax based on the database
@@ -106,14 +105,14 @@ class Database(ABC):
         """
 
     @abstractmethod
-    def query_dict(self, query: Dict[str, str]) -> List[Document]:
+    def query_dict(self, query: dict[str, str]) -> list[Document]:
         """Find a document in the database that matches the keys in *query*."""
 
     @abstractmethod
-    def get_all_documents(self) -> List[Document]:
+    def get_all_documents(self) -> list[Document]:
         """Get all documents in the database."""
 
-    def find_by_id(self, identifier: str) -> Optional[Document]:
+    def find_by_id(self, identifier: str) -> Document | None:
         """Find a document in the library by its Papis ID *identifier*."""
         from papis.id import ID_KEY_NAME
 
@@ -153,7 +152,7 @@ class Database(ABC):
 
         return self.lib.name
 
-    def get_dirs(self) -> List[str]:
+    def get_dirs(self) -> list[str]:
         warn(f"Calling '{type(self).__name__}.get_dirs' directly is deprecated "
              "and will be removed in the next version of Papis (after 0.15). Use "
              "the 'self.lib.paths' member directly.",

--- a/papis/database/cache.py
+++ b/papis/database/cache.py
@@ -1,5 +1,5 @@
 import os
-from typing import Dict, List, Match, Optional, Pattern, Tuple
+import re
 
 import papis.config
 import papis.logging
@@ -12,7 +12,7 @@ from papis.strings import AnyString
 logger = papis.logging.get_logger(__name__)
 
 
-def filter_documents(documents: List[Document], search: str = "") -> List[Document]:
+def filter_documents(documents: list[Document], search: str = "") -> list[Document]:
     """Filter documents based on the *search* string.
 
     :param search: a search string that will be parsed by
@@ -60,9 +60,9 @@ def filter_documents(documents: List[Document], search: str = "") -> List[Docume
 
 def match_document(
         document: Document,
-        search: Pattern[str],
-        match_format: Optional[AnyString] = None,
-        doc_key: Optional[str] = None) -> Optional[Match[str]]:
+        search: re.Pattern[str],
+        match_format: AnyString | None = None,
+        doc_key: str | None = None) -> re.Match[str] | None:
     """Match a document's keys to a given search pattern.
 
     See :class:`~papis.docmatcher.MatcherCallable`.
@@ -90,11 +90,11 @@ def match_document(
 class Database(DatabaseBase):
     """A caching database backend for Papis based on :mod:`pickle`."""
 
-    def __init__(self, library: Optional[Library] = None) -> None:
+    def __init__(self, library: Library | None = None) -> None:
         super().__init__(library)
 
         self.use_cache = papis.config.getboolean("use-cache")
-        self.documents: Optional[List[Document]] = None
+        self.documents: list[Document] | None = None
         self.initialize()
 
     def get_backend_name(self) -> str:  # noqa: PLR6301
@@ -170,7 +170,7 @@ class Database(DatabaseBase):
         docs.pop(index)
         self._save_documents()
 
-    def query(self, query_string: str) -> List[Document]:
+    def query(self, query_string: str) -> list[Document]:
         logger.debug("Querying database for '%s'.", query_string)
 
         docs = self._get_documents()
@@ -179,14 +179,14 @@ class Database(DatabaseBase):
 
         return filter_documents(docs, query_string)
 
-    def query_dict(self, query: Dict[str, str]) -> List[Document]:
+    def query_dict(self, query: dict[str, str]) -> list[Document]:
         query_string = " ".join(f'{key}:"{val}" ' for key, val in query.items())
         return self.query(query_string)
 
-    def get_all_documents(self) -> List[Document]:
+    def get_all_documents(self) -> list[Document]:
         return self._get_documents()
 
-    def _get_documents(self) -> List[Document]:
+    def _get_documents(self) -> list[Document]:
         if self.documents is not None:
             return self.documents
 
@@ -230,7 +230,7 @@ class Database(DatabaseBase):
     def _get_cache_file_path(self) -> str:
         return get_cache_file_path(self.lib.path_format())
 
-    def _locate_document(self, document: Document) -> List[Tuple[int, Document]]:
+    def _locate_document(self, document: Document) -> list[tuple[int, Document]]:
         from papis.id import ID_KEY_NAME
 
         # FIXME: Why are we iterating twice over the documents here?

--- a/papis/database/whoosh.py
+++ b/papis/database/whoosh.py
@@ -34,7 +34,8 @@ the schema you will not be able to search for the publisher through a query.
 """
 
 import os
-from typing import TYPE_CHECKING, Dict, KeysView, List, Optional
+from collections.abc import KeysView
+from typing import TYPE_CHECKING
 
 import papis.config
 import papis.logging
@@ -56,7 +57,7 @@ WHOOSH_FOLDER_FIELD = "papis-folder"
 
 
 class Database(DatabaseBase):
-    def __init__(self, library: Optional[Library] = None) -> None:
+    def __init__(self, library: Library | None = None) -> None:
         super().__init__(library)
 
         from papis.utils import get_cache_home
@@ -129,7 +130,7 @@ class Database(DatabaseBase):
         writer.delete_by_term(ID_KEY_NAME, document[ID_KEY_NAME])
         writer.commit()
 
-    def query(self, query_string: str) -> List[Document]:
+    def query(self, query_string: str) -> list[Document]:
         logger.debug("Querying database for '%s'.", query_string)
 
         import time
@@ -151,11 +152,11 @@ class Database(DatabaseBase):
 
         return documents
 
-    def query_dict(self, query: Dict[str, str]) -> List[Document]:
+    def query_dict(self, query: dict[str, str]) -> list[Document]:
         query_string = " AND ".join(f'{key}:"{val}" ' for key, val in query.items())
         return self.query(query_string)
 
-    def get_all_documents(self) -> List[Document]:
+    def get_all_documents(self) -> list[Document]:
         return self.query(self.get_all_query_string())
 
     def _create_index(self) -> None:
@@ -236,7 +237,7 @@ class Database(DatabaseBase):
         fields = self._get_schema_init_fields()
         return Schema(**fields)
 
-    def _get_schema_init_fields(self) -> Dict[str, "FieldType"]:  # noqa: PLR6301
+    def _get_schema_init_fields(self) -> dict[str, "FieldType"]:  # noqa: PLR6301
         """
         :returns: the keyword arguments to be passed to the Whoosh schema object
             (see :meth:`_create_schema`).

--- a/papis/dblp.py
+++ b/papis/dblp.py
@@ -1,5 +1,5 @@
 import re
-from typing import Any, Dict, List, Optional
+from typing import Any
 
 import click
 
@@ -54,7 +54,7 @@ DBLP_KEY_CONVERSION = [
 ]
 
 
-def _dblp_journal(name: str) -> Optional[str]:
+def _dblp_journal(name: str) -> str | None:
     import json
     result = json.loads(search(query=f"{name}$", api="venue"))
 
@@ -66,7 +66,7 @@ def _dblp_journal(name: str) -> Optional[str]:
     return str(journal) if journal else None
 
 
-def _dblp_authors(entries: Dict[str, Any]) -> List[Dict[str, Any]]:
+def _dblp_authors(entries: dict[str, Any]) -> list[dict[str, Any]]:
     return [papis.document.split_author_name(author["text"])
             for author in entries["author"]]
 
@@ -126,7 +126,7 @@ def search(
     return response.content.decode()
 
 
-def get_data(query: str = "", max_results: int = 30) -> List[Dict[str, Any]]:
+def get_data(query: str = "", max_results: int = 30) -> list[dict[str, Any]]:
     import json
     response = json.loads(
         search(query=query, output_format="json", max_results=max_results)
@@ -201,7 +201,7 @@ class Importer(papis.importer.Importer):
         super().__init__(name="dblp", uri=uri)
 
     @classmethod
-    def match(cls, uri: str) -> Optional[papis.importer.Importer]:
+    def match(cls, uri: str) -> papis.importer.Importer | None:
         if re.match(r".*dblp\.org.*\.html", uri):
             return Importer(uri)
         elif is_valid_dblp_key(uri):

--- a/papis/defaults.py
+++ b/papis/defaults.py
@@ -1,6 +1,6 @@
 import os
 import sys
-from typing import Any, Dict
+from typing import Any
 
 from papis.strings import FormatPattern
 
@@ -28,7 +28,7 @@ def get_default_opener() -> str:
 
 NOT_SET = object()
 
-settings: Dict[str, Any] = {
+settings: dict[str, Any] = {
     # unused or deprecated
     "add-interactive": False,
     "mvtool": "mv",

--- a/papis/downloaders/acl.py
+++ b/papis/downloaders/acl.py
@@ -1,5 +1,5 @@
 import re
-from typing import Any, Dict, Optional
+from typing import Any
 
 import papis.document
 import papis.downloaders.base
@@ -17,10 +17,10 @@ class Downloader(papis.downloaders.Downloader):
         )
 
     @classmethod
-    def match(cls, url: str) -> Optional[papis.downloaders.Downloader]:
+    def match(cls, url: str) -> papis.downloaders.Downloader | None:
         return Downloader(url) if re.match(r".*aclanthology\.org.*", url) else None
 
-    def fetch_acl_data(self) -> Dict[str, str]:
+    def fetch_acl_data(self) -> dict[str, str]:
         soup = self._get_soup()
 
         elem: Any = soup.find("div", "row acl-paper-details")
@@ -37,7 +37,7 @@ class Downloader(papis.downloaders.Downloader):
 
         return data
 
-    def get_data(self) -> Dict[str, Any]:
+    def get_data(self) -> dict[str, Any]:
         soup = self._get_soup()
         data = papis.downloaders.base.parse_meta_headers(soup)
 
@@ -52,7 +52,7 @@ class Downloader(papis.downloaders.Downloader):
 
         return data
 
-    def get_bibtex_url(self) -> Optional[str]:
+    def get_bibtex_url(self) -> str | None:
         if self.ctx.data.get("acl_anthology_id") is not None:
             acl_anthology_id = self.ctx.data.get("acl_anthology_id")
             url = f"https://aclanthology.org/{acl_anthology_id}.bib"
@@ -61,7 +61,7 @@ class Downloader(papis.downloaders.Downloader):
 
         return None
 
-    def get_document_url(self) -> Optional[str]:
+    def get_document_url(self) -> str | None:
         if "pdf_url" in self.ctx.data:
             url = str(self.ctx.data["pdf_url"])
             self.logger.debug("Using document URL: '%s'.", url)

--- a/papis/downloaders/acm.py
+++ b/papis/downloaders/acm.py
@@ -1,5 +1,4 @@
 import re
-from typing import Optional
 
 import papis.downloaders.base
 
@@ -15,13 +14,13 @@ class Downloader(papis.downloaders.Downloader):
             )
 
     @classmethod
-    def match(cls, url: str) -> Optional[papis.downloaders.Downloader]:
+    def match(cls, url: str) -> papis.downloaders.Downloader | None:
         if re.match(r".*acm.org.*", url):
             return Downloader(url)
         else:
             return None
 
-    def get_doi(self) -> Optional[str]:
+    def get_doi(self) -> str | None:
         url = self.uri
         self.logger.debug("Parsing DOI from '%s'.", url)
         mdoi = re.match(r".*/doi/(.*/[^?&%^$]*).*", url)
@@ -31,7 +30,7 @@ class Downloader(papis.downloaders.Downloader):
 
         return None
 
-    def get_document_url(self) -> Optional[str]:
+    def get_document_url(self) -> str | None:
         durl = f"https://dl.acm.org/doi/pdf/{self.get_doi()}"
         self.logger.debug("Using document URL: '%s'.", durl)
         return durl

--- a/papis/downloaders/acs.py
+++ b/papis/downloaders/acs.py
@@ -1,5 +1,5 @@
 import re
-from typing import Any, ClassVar, Dict, Optional
+from typing import Any, ClassVar
 
 import papis.document
 import papis.downloaders
@@ -26,23 +26,23 @@ class Downloader(papis.downloaders.Downloader):
             )
 
     @classmethod
-    def match(cls, url: str) -> Optional[papis.downloaders.Downloader]:
+    def match(cls, url: str) -> papis.downloaders.Downloader | None:
         return Downloader(url) if re.match(r".*acs.org.*", url) else None
 
-    def get_data(self) -> Dict[str, Any]:
+    def get_data(self) -> dict[str, Any]:
         soup = self._get_soup()
         data = papis.downloaders.base.parse_meta_headers(soup)
 
         return data
 
-    def get_document_url(self) -> Optional[str]:
+    def get_document_url(self) -> str | None:
         doi = self.ctx.data.get("doi")
         if doi is not None:
             return self.DOCUMENT_URL.format(doi=doi)
 
         return None
 
-    def get_bibtex_url(self) -> Optional[str]:
+    def get_bibtex_url(self) -> str | None:
         doi = self.ctx.data.get("doi")
         if doi is not None:
             url = self.BIBTEX_URL.format(doi=doi)

--- a/papis/downloaders/annualreviews.py
+++ b/papis/downloaders/annualreviews.py
@@ -1,5 +1,5 @@
 import re
-from typing import Any, ClassVar, Dict, Optional
+from typing import Any, ClassVar
 
 import papis.downloaders.base
 
@@ -22,13 +22,13 @@ class Downloader(papis.downloaders.Downloader):
             )
 
     @classmethod
-    def match(cls, url: str) -> Optional[papis.downloaders.Downloader]:
+    def match(cls, url: str) -> papis.downloaders.Downloader | None:
         if re.match(r".*annualreviews.org.*", url):
             return Downloader(url)
         else:
             return None
 
-    def get_document_url(self) -> Optional[str]:
+    def get_document_url(self) -> str | None:
         if "doi" in self.ctx.data:
             url = self.DOCUMENT_URL.format(doi=self.ctx.data["doi"])
             self.logger.debug("Using document URL: '%s'.", url)
@@ -37,7 +37,7 @@ class Downloader(papis.downloaders.Downloader):
         else:
             return None
 
-    def get_bibtex_url(self) -> Optional[str]:
+    def get_bibtex_url(self) -> str | None:
         if "doi" in self.ctx.data:
             url = self.BIBTEX_URL.format(doi=self.ctx.data["doi"])
             self.logger.debug("Using BibTeX URL: '%s'.", url)
@@ -46,7 +46,7 @@ class Downloader(papis.downloaders.Downloader):
         else:
             return None
 
-    def get_data(self) -> Dict[str, Any]:
+    def get_data(self) -> dict[str, Any]:
         data = {}
         soup = self._get_soup()
         data.update(papis.downloaders.base.parse_meta_headers(soup))

--- a/papis/downloaders/aps.py
+++ b/papis/downloaders/aps.py
@@ -1,5 +1,4 @@
 import re
-from typing import Optional
 
 import papis.downloaders.fallback
 
@@ -15,17 +14,17 @@ class Downloader(papis.downloaders.fallback.Downloader):
             )
 
     @classmethod
-    def match(cls, url: str) -> Optional[papis.downloaders.fallback.Downloader]:
+    def match(cls, url: str) -> papis.downloaders.fallback.Downloader | None:
         return Downloader(url) if re.match(r".*aps.org.*", url) else None
 
-    def get_bibtex_url(self) -> Optional[str]:
+    def get_bibtex_url(self) -> str | None:
         url = "{}?type=bibtex&download=true".format(
             self.uri.replace("/abstract", "/export"))
         self.logger.debug("Using BibTeX URL '%s'.", url)
 
         return url
 
-    def get_document_url(self) -> Optional[str]:
+    def get_document_url(self) -> str | None:
         url = self.uri.replace("/abstract", "/pdf")
         self.logger.debug("Using document URL: '%s'.", url)
 

--- a/papis/downloaders/base.py
+++ b/papis/downloaders/base.py
@@ -1,15 +1,6 @@
 import re
-from typing import (
-    TYPE_CHECKING,
-    Any,
-    Dict,
-    Iterator,
-    List,
-    Pattern,
-    Tuple,
-    TypedDict,
-    Union,
-)
+from collections.abc import Iterator
+from typing import TYPE_CHECKING, Any, TypedDict
 
 import papis.config
 import papis.document
@@ -23,10 +14,10 @@ if TYPE_CHECKING:
 class MetaEquivalence(TypedDict):
     tag: str
     key: str
-    attrs: Dict[str, Union[str, Pattern[str]]]
+    attrs: dict[str, str | re.Pattern[str]]
 
 
-meta_equivalences: List[MetaEquivalence] = [
+meta_equivalences: list[MetaEquivalence] = [
     # google
     {"tag": "meta", "key": "abstract", "attrs": {"name": "description"}},
     {"tag": "meta", "key": "doi", "attrs": {"name": "doi"}},
@@ -106,8 +97,8 @@ meta_equivalences: List[MetaEquivalence] = [
 ]
 
 
-def parse_meta_headers(soup: "bs4.BeautifulSoup") -> Dict[str, Any]:
-    data: Dict[str, Any] = {}
+def parse_meta_headers(soup: "bs4.BeautifulSoup") -> dict[str, Any]:
+    data: dict[str, Any] = {}
     for equiv in meta_equivalences:
         elements = soup.find_all(equiv["tag"], attrs=equiv["attrs"])
         if elements:
@@ -139,7 +130,7 @@ def parse_meta_headers(soup: "bs4.BeautifulSoup") -> Dict[str, Any]:
     return data
 
 
-def parse_meta_authors(soup: "bs4.BeautifulSoup") -> List[Dict[str, Any]]:
+def parse_meta_authors(soup: "bs4.BeautifulSoup") -> list[dict[str, Any]]:
     # find author tags
     authors = soup.find_all(name="meta", attrs={"name": "citation_author"})
     if not authors:
@@ -155,12 +146,12 @@ def parse_meta_authors(soup: "bs4.BeautifulSoup") -> List[Dict[str, Any]]:
         attrs={"name": "citation_author_institution"})
 
     if affs and len(authors) == len(affs):
-        authors_and_affs: Iterator[Tuple[Any, Any]] = zip(authors, affs, strict=True)
+        authors_and_affs: Iterator[tuple[Any, Any]] = zip(authors, affs, strict=True)
     else:
         authors_and_affs = ((a, None) for a in authors)
 
     # convert to papis author format
-    author_list: List[Dict[str, Any]] = []
+    author_list: list[dict[str, Any]] = []
     for author, aff in authors_and_affs:
         fullname = papis.document.split_author_name(author.get("content"))
         affiliation = [{"name": aff.get("content")}] if aff else []

--- a/papis/downloaders/base.py
+++ b/papis/downloaders/base.py
@@ -155,7 +155,7 @@ def parse_meta_authors(soup: "bs4.BeautifulSoup") -> List[Dict[str, Any]]:
         attrs={"name": "citation_author_institution"})
 
     if affs and len(authors) == len(affs):
-        authors_and_affs: Iterator[Tuple[Any, Any]] = zip(authors, affs)
+        authors_and_affs: Iterator[Tuple[Any, Any]] = zip(authors, affs, strict=True)
     else:
         authors_and_affs = ((a, None) for a in authors)
 

--- a/papis/downloaders/citeseerx.py
+++ b/papis/downloaders/citeseerx.py
@@ -1,6 +1,6 @@
 import os
 import re
-from typing import Any, ClassVar, Dict, Optional
+from typing import Any, ClassVar
 
 import papis.document
 import papis.downloaders
@@ -43,7 +43,7 @@ class Downloader(papis.downloaders.Downloader):
 
     @classmethod
     def match(cls,
-              url: str) -> Optional[papis.downloaders.Downloader]:
+              url: str) -> papis.downloaders.Downloader | None:
         return (Downloader(url)
                 if re.match(r".*citeseerx\.ist\.psu\.edu.*", url)  # spell: disable
                 else None)
@@ -60,7 +60,7 @@ class Downloader(papis.downloaders.Downloader):
 
         return response.content
 
-    def get_data(self) -> Dict[str, Any]:
+    def get_data(self) -> dict[str, Any]:
         import json
         data = json.loads(self._get_raw_data().decode())
 
@@ -70,5 +70,5 @@ class Downloader(papis.downloaders.Downloader):
         else:
             return {}
 
-    def get_document_url(self) -> Optional[str]:
+    def get_document_url(self) -> str | None:
         return self.DOCUMENT_URL.format(pid=self.pid)

--- a/papis/downloaders/fallback.py
+++ b/papis/downloaders/fallback.py
@@ -1,4 +1,4 @@
-from typing import Any, Dict, List, Optional, Union
+from typing import Any
 
 import papis.downloaders.base
 
@@ -7,7 +7,7 @@ class Downloader(papis.downloaders.Downloader):
     """Retrieve documents from websites using Dublin Core or Google Scholar metadata"""
 
     def __init__(self, uri: str, name: str = "fallback",
-                 expected_document_extension: Optional[Union[str, List[str]]] = None,
+                 expected_document_extension: str | list[str] | None = None,
                  priority: int = -1,
                  ) -> None:
         super().__init__(
@@ -17,10 +17,10 @@ class Downloader(papis.downloaders.Downloader):
             )
 
     @classmethod
-    def match(cls, url: str) -> Optional[papis.downloaders.Downloader]:
+    def match(cls, url: str) -> papis.downloaders.Downloader | None:
         return Downloader(url)
 
-    def get_data(self) -> Dict[str, Any]:
+    def get_data(self) -> dict[str, Any]:
         soup = self._get_soup()
         data = papis.downloaders.base.parse_meta_headers(soup)
 
@@ -29,7 +29,7 @@ class Downloader(papis.downloaders.Downloader):
 
         return data
 
-    def get_doi(self) -> Optional[str]:
+    def get_doi(self) -> str | None:
         if self.ctx.data:
             doi = self.ctx.data.get("doi")
             if doi:
@@ -39,7 +39,7 @@ class Downloader(papis.downloaders.Downloader):
         soup = self._get_soup()
         return find_doi_in_text(str(soup))
 
-    def get_document_url(self) -> Optional[str]:
+    def get_document_url(self) -> str | None:
         url = self.ctx.data.get("pdf_url")
         if url is not None:
             self.logger.debug("Using document URL: '%s'.", url)

--- a/papis/downloaders/frontiersin.py
+++ b/papis/downloaders/frontiersin.py
@@ -1,5 +1,4 @@
 import re
-from typing import Optional
 
 import papis.downloaders.base
 
@@ -15,13 +14,13 @@ class Downloader(papis.downloaders.Downloader):
             )
 
     @classmethod
-    def match(cls, url: str) -> Optional[papis.downloaders.Downloader]:
+    def match(cls, url: str) -> papis.downloaders.Downloader | None:
         if re.match(r".*frontiersin.org.*", url):
             return Downloader(url)
         else:
             return None
 
-    def get_doi(self) -> Optional[str]:
+    def get_doi(self) -> str | None:
         url = self.uri
         self.logger.debug("Parsing DOI from '%s'.", url)
         mdoi = re.match(r".*/articles/([^/]+/[^/?&%^$]+).*", url)
@@ -30,12 +29,12 @@ class Downloader(papis.downloaders.Downloader):
             return doi
         return None
 
-    def get_document_url(self) -> Optional[str]:
+    def get_document_url(self) -> str | None:
         durl = f"https://www.frontiersin.org/articles/{self.get_doi()}/pdf"
         self.logger.debug("Using document URL: '%s'.", durl)
         return durl
 
-    def get_bibtex_url(self) -> Optional[str]:
+    def get_bibtex_url(self) -> str | None:
         url = f"https://www.frontiersin.org/articles/{self.get_doi()}/bibTex"
         self.logger.debug("Using BibTeX URL: '%s'.", url)
         return url

--- a/papis/downloaders/get.py
+++ b/papis/downloaders/get.py
@@ -1,5 +1,4 @@
 import re
-from typing import Optional
 
 import papis.downloaders.base
 
@@ -11,7 +10,7 @@ class Downloader(papis.downloaders.Downloader):
         super().__init__(url, name="get", priority=0)
 
     @classmethod
-    def match(cls, url: str) -> Optional[papis.downloaders.Downloader]:
+    def match(cls, url: str) -> papis.downloaders.Downloader | None:
         """
         >>> Downloader.match('https://wha2341!@#!@$%!@#file.pdf') is None  # spell: disable
         False
@@ -33,5 +32,5 @@ class Downloader(papis.downloaders.Downloader):
         else:
             return None
 
-    def get_document_url(self) -> Optional[str]:
+    def get_document_url(self) -> str | None:
         return self.uri

--- a/papis/downloaders/hal.py
+++ b/papis/downloaders/hal.py
@@ -1,5 +1,5 @@
 import re
-from typing import Any, ClassVar, Dict, Optional, Tuple
+from typing import Any, ClassVar
 
 import papis.downloaders.fallback
 
@@ -13,11 +13,11 @@ class Downloader(papis.downloaders.fallback.Downloader):
     # TODO: a list of other domains seems to be available at
     # https://hal.science/browse/portal
 
-    SUPPORTED_HAL_SCIENCE_SUBDOMAINS: ClassVar[Tuple[str, ...]] = (
+    SUPPORTED_HAL_SCIENCE_SUBDOMAINS: ClassVar[tuple[str, ...]] = (
         "hal", r"shs\.hal", r"theses\.hal", r"media\.hal",  # spell: disable
         )
 
-    SUPPORTED_ARCHIVES_OUVERTES_SUBDOMAINS: ClassVar[Tuple[str, ...]] = (
+    SUPPORTED_ARCHIVES_OUVERTES_SUBDOMAINS: ClassVar[tuple[str, ...]] = (
         "hal", "halshs", "tel", "medihal",
         # other domains
         "hal-anr", "hal-bnf", "hal-cea", "hal-centralesupelec", "hal-cnam",
@@ -33,7 +33,7 @@ class Downloader(papis.downloaders.fallback.Downloader):
 
     @classmethod
     def match(
-            cls, url: str) -> Optional[papis.downloaders.fallback.Downloader]:
+            cls, url: str) -> papis.downloaders.fallback.Downloader | None:
         subdomains = "|".join(cls.SUPPORTED_ARCHIVES_OUVERTES_SUBDOMAINS)
         if re.match(fr".*({subdomains})\.archives-ouvertes\.fr.*", url):
             return Downloader(url)
@@ -44,7 +44,7 @@ class Downloader(papis.downloaders.fallback.Downloader):
 
         return None
 
-    def get_data(self) -> Dict[str, Any]:
+    def get_data(self) -> dict[str, Any]:
         data = super().get_data()
 
         keywords = data.get("keywords")
@@ -58,7 +58,7 @@ class Downloader(papis.downloaders.fallback.Downloader):
 
         return data
 
-    def get_bibtex_url(self) -> Optional[str]:
+    def get_bibtex_url(self) -> str | None:
         if "pdf_url" in self.ctx.data:
             url = self.uri.replace("document", "bibtex")
             self.logger.debug("Using BibTeX URL: '%s'.", url)

--- a/papis/downloaders/ieee.py
+++ b/papis/downloaders/ieee.py
@@ -1,5 +1,4 @@
 import re
-from typing import Dict, Optional, Tuple
 
 import papis.downloaders.base
 import papis.utils
@@ -12,7 +11,7 @@ class Downloader(papis.downloaders.Downloader):
         super().__init__(url, name="ieee", expected_document_extension="pdf")
 
     @classmethod
-    def match(cls, url: str) -> Optional[papis.downloaders.Downloader]:
+    def match(cls, url: str) -> papis.downloaders.Downloader | None:
         m = re.match(r"^ieee:(.*)", url, re.IGNORECASE)
         if m:
             url = f"https://ieeexplore.ieee.org/document/{m.group(1)}"
@@ -27,7 +26,7 @@ class Downloader(papis.downloaders.Downloader):
         url = self.uri
         return re.sub(r"^.*ieeexplore\.ieee\.org/document/(.*)\/", r"\1", url)
 
-    def _get_bibtex_url(self) -> Tuple[str, Dict[str, str]]:
+    def _get_bibtex_url(self) -> tuple[str, dict[str, str]]:
         identifier = self.get_identifier()
         bibtex_url = \
             "https://ieeexplore.ieee.org/xpl/downloadCitations?reload=true"
@@ -50,7 +49,7 @@ class Downloader(papis.downloaders.Downloader):
 
         self.bibtex_data = response.content.decode().replace("<br>", "")
 
-    def get_document_url(self) -> Optional[str]:
+    def get_document_url(self) -> str | None:
         identifier = self.get_identifier()
         pdf_url = "{}{}{}".format(
             "https://ieeexplore.ieee.org/",

--- a/papis/downloaders/iopscience.py
+++ b/papis/downloaders/iopscience.py
@@ -1,5 +1,5 @@
 import re
-from typing import ClassVar, Optional
+from typing import ClassVar
 
 import papis.downloaders.base
 
@@ -25,19 +25,19 @@ class Downloader(papis.downloaders.Downloader):
             )
 
     @classmethod
-    def match(cls, url: str) -> Optional[papis.downloaders.Downloader]:
+    def match(cls, url: str) -> papis.downloaders.Downloader | None:
         url = url.replace("/pdf", "")
         if re.match(r".*iopscience\.iop\.org.*", url):
             return Downloader(url)
         else:
             return None
 
-    def get_doi(self) -> Optional[str]:
+    def get_doi(self) -> str | None:
         # NOTE: this is not very robust, but we do not have access to any data
         offset = len("https://iopscience.iop.org/article/")
         return self.uri[offset:]
 
-    def get_document_url(self) -> Optional[str]:
+    def get_document_url(self) -> str | None:
         url = self.ctx.data.get("pdf_url")
         if url is not None:
             return str(url)
@@ -51,7 +51,7 @@ class Downloader(papis.downloaders.Downloader):
 
         return url
 
-    def get_bibtex_url(self) -> Optional[str]:
+    def get_bibtex_url(self) -> str | None:
         doi = self.get_doi()
         if doi is None:
             return None

--- a/papis/downloaders/projecteuclid.py
+++ b/papis/downloaders/projecteuclid.py
@@ -1,5 +1,4 @@
 import re
-from typing import Optional
 
 import papis.downloaders.fallback
 
@@ -17,13 +16,13 @@ class Downloader(papis.downloaders.fallback.Downloader):
             )
 
     @classmethod
-    def match(cls, url: str) -> Optional["Downloader"]:
+    def match(cls, url: str) -> "Downloader | None":
         if re.match(r".*projecteuclid\.org.*", url):
             return Downloader(url)
         else:
             return None
 
-    def get_bibtex_url(self) -> Optional[str]:
+    def get_bibtex_url(self) -> str | None:
         try:
             # NOTE: this was determined heuristically by looking at the IDs
             # generated for a couple of papers and may change in the future

--- a/papis/downloaders/sciencedirect.py
+++ b/papis/downloaders/sciencedirect.py
@@ -1,5 +1,5 @@
 import re
-from typing import Any, Dict, List, Optional
+from typing import Any
 
 import papis.document
 import papis.downloaders
@@ -9,7 +9,7 @@ import papis.downloaders.base
 KNOWN_TEXT = {"inf", "__text__", "simple-para"}
 
 
-def _parse_author_list(data: Dict[str, Any]) -> List[Dict[str, Any]]:
+def _parse_author_list(data: dict[str, Any]) -> list[dict[str, Any]]:
     # NOTE: this seems to be a data structure of the form
     #   entry {
     #       "#name": <key-name>,
@@ -24,7 +24,7 @@ def _parse_author_list(data: Dict[str, Any]) -> List[Dict[str, Any]]:
     if "#name" not in data or "$$" not in data:
         return [{}]
 
-    def _parse_author(author: Dict[str, Any]) -> Dict[str, Any]:
+    def _parse_author(author: dict[str, Any]) -> dict[str, Any]:
         # NOTE: this seems fairly fragile, so hopefully it won't break too badly
         if "$$" not in author:
             return {}
@@ -43,7 +43,7 @@ def _parse_author_list(data: Dict[str, Any]) -> List[Dict[str, Any]]:
     return [_parse_author(a) for a in data["$$"] if a["#name"] == "author"]
 
 
-def _parse_full_abstract(data: List[Dict[str, Any]]) -> str:
+def _parse_full_abstract(data: list[dict[str, Any]]) -> str:
     # NOTE: `data` contains `abstract-sec` sections with `__text__` entries that
     # we retrieve and concatenate to get the full abstract text
 
@@ -95,15 +95,15 @@ class Downloader(papis.downloaders.Downloader):
             )
 
     @classmethod
-    def match(cls, url: str) -> Optional[papis.downloaders.Downloader]:
+    def match(cls, url: str) -> papis.downloaders.Downloader | None:
         if re.match(r".*\.sciencedirect\.com.*", url):
             return Downloader(url)
         else:
             return None
 
-    def get_data(self) -> Dict[str, Any]:
+    def get_data(self) -> dict[str, Any]:
         soup = self._get_soup()
-        data: Dict[str, Any] = {}
+        data: dict[str, Any] = {}
 
         # get authors
         scripts = soup.find_all(name="script", attrs={"data-iso-key": "_0"})

--- a/papis/downloaders/scitationaip.py
+++ b/papis/downloaders/scitationaip.py
@@ -1,5 +1,4 @@
 import re
-from typing import Optional
 
 import papis.downloaders.base
 
@@ -14,14 +13,14 @@ class Downloader(papis.downloaders.Downloader):
             )
 
     @classmethod
-    def match(cls, url: str) -> Optional[papis.downloaders.Downloader]:
+    def match(cls, url: str) -> papis.downloaders.Downloader | None:
         # https://aip.scitation.org/doi/10.1063/1.4873138
         if re.match(r".*(aip|aapt)\.scitation\.org.*", url):
             return Downloader(url)
         else:
             return None
 
-    def get_doi(self) -> Optional[str]:
+    def get_doi(self) -> str | None:
         mdoi = re.match(r".*/doi/(.*/[^?&%^$]*).*", self.uri)
         if mdoi:
             doi = mdoi.group(1).replace("abs/", "").replace("full/", "")
@@ -29,14 +28,14 @@ class Downloader(papis.downloaders.Downloader):
         else:
             return None
 
-    def get_document_url(self) -> Optional[str]:
+    def get_document_url(self) -> str | None:
         # https://aip.scitation.org/doi/pdf/10.1063/1.4873138
         durl = f"https://aip.scitation.org/doi/pdf/{self.get_doi()}"
         self.logger.debug("Using document URL: '%s'.", durl)
 
         return durl
 
-    def get_bibtex_url(self) -> Optional[str]:
+    def get_bibtex_url(self) -> str | None:
         url = ("https://aip.scitation.org/action/downloadCitation"
                f"?format=bibtex&cookieSet=1&doi={self.get_doi()}")
         self.logger.debug("Using BibTeX URL: '%s'.", url)

--- a/papis/downloaders/springer.py
+++ b/papis/downloaders/springer.py
@@ -1,5 +1,5 @@
 import re
-from typing import Any, ClassVar, Dict, Optional
+from typing import Any, ClassVar
 
 import papis.document
 import papis.downloaders.base
@@ -25,10 +25,10 @@ class Downloader(papis.downloaders.Downloader):
             )
 
     @classmethod
-    def match(cls, url: str) -> Optional[papis.downloaders.Downloader]:
+    def match(cls, url: str) -> papis.downloaders.Downloader | None:
         return Downloader(url) if re.match(r".*link\.springer.com.*", url) else None
 
-    def get_data(self) -> Dict[str, Any]:
+    def get_data(self) -> dict[str, Any]:
         soup = self._get_soup()
         data = papis.downloaders.base.parse_meta_headers(soup)
 
@@ -38,7 +38,7 @@ class Downloader(papis.downloaders.Downloader):
 
         return data
 
-    def get_bibtex_url(self) -> Optional[str]:
+    def get_bibtex_url(self) -> str | None:
         if "doi" in self.ctx.data:
             url = self.BIBTEX_URL.format(doi=self.ctx.data["doi"])
             self.logger.debug("Using BibTeX URL: '%s'.", url)
@@ -46,7 +46,7 @@ class Downloader(papis.downloaders.Downloader):
         else:
             return None
 
-    def get_document_url(self) -> Optional[str]:
+    def get_document_url(self) -> str | None:
         if "doi" in self.ctx.data:
             url = self.DOCUMENT_URL.format(doi=self.ctx.data["doi"])
             self.logger.debug("Using document URL: '%s'.", url)

--- a/papis/downloaders/tandfonline.py
+++ b/papis/downloaders/tandfonline.py
@@ -1,5 +1,5 @@
 import re
-from typing import Any, ClassVar, Dict, Optional
+from typing import Any, ClassVar
 
 import papis.document
 import papis.downloaders.base
@@ -19,7 +19,7 @@ article_key_conversion = [
 ]
 
 
-def _parse_year(date: str) -> Optional[int]:
+def _parse_year(date: str) -> int | None:
     from datetime import datetime
     try:
         return datetime.strptime(date, "%d %b %Y").year
@@ -27,7 +27,7 @@ def _parse_year(date: str) -> Optional[int]:
         return None
 
 
-def _parse_month(date: str) -> Optional[int]:
+def _parse_month(date: str) -> int | None:
     from datetime import datetime
     try:
         return datetime.strptime(date, "%d %b %Y").month
@@ -57,11 +57,11 @@ class Downloader(papis.downloaders.Downloader):
             )
 
     @classmethod
-    def match(cls, url: str) -> Optional[papis.downloaders.Downloader]:
+    def match(cls, url: str) -> papis.downloaders.Downloader | None:
         return (Downloader(url)
                 if re.match(r".*tandfonline.com.*", url) else None)
 
-    def get_data(self) -> Dict[str, Any]:
+    def get_data(self) -> dict[str, Any]:
         soup = self._get_soup()
         data = papis.downloaders.base.parse_meta_headers(soup)
 
@@ -73,7 +73,7 @@ class Downloader(papis.downloaders.Downloader):
 
         return data
 
-    def get_bibtex_url(self) -> Optional[str]:
+    def get_bibtex_url(self) -> str | None:
         doi = self.ctx.data.get("doi")
         if doi is None:
             return None
@@ -82,7 +82,7 @@ class Downloader(papis.downloaders.Downloader):
         self.logger.debug("Using BibTeX URL: '%s'.", url)
         return url
 
-    def get_document_url(self) -> Optional[str]:
+    def get_document_url(self) -> str | None:
         doi = self.ctx.data.get("doi")
         if doi is None:
             return None

--- a/papis/downloaders/thesesfr.py
+++ b/papis/downloaders/thesesfr.py
@@ -1,5 +1,4 @@
 import re
-from typing import Optional
 
 import papis.downloaders.base
 
@@ -14,7 +13,7 @@ class Downloader(papis.downloaders.Downloader):
         super().__init__(url, name="thesesfr", expected_document_extension="pdf")
 
     @classmethod
-    def match(cls, url: str) -> Optional[papis.downloaders.Downloader]:
+    def match(cls, url: str) -> papis.downloaders.Downloader | None:
         # ID format ("nnt" in french). Not specified in the docs, but it's
         # the pattern that all the published theses until now follow.
         # https://documentation.abes.fr/aidetheses/thesesfr/index.html
@@ -24,18 +23,18 @@ class Downloader(papis.downloaders.Downloader):
         else:
             return None
 
-    def get_identifier(self) -> Optional[str]:
+    def get_identifier(self) -> str | None:
         if match := re.search(r"(\d{4}[A-Z]{3,5}\d{3,5})", self.uri):
             return match.group(1)
         else:
             return None
 
-    def get_document_url(self) -> Optional[str]:
+    def get_document_url(self) -> str | None:
         baseurl = "https://theses.fr/api/v1/document"
         identifier = self.get_identifier()
         return f"{baseurl}/{identifier}"
 
-    def get_bibtex_url(self) -> Optional[str]:
+    def get_bibtex_url(self) -> str | None:
         url = f"https://www.theses.fr/{self.get_identifier()}.bib"
         self.logger.debug("Using BibTeX URL: '%s'.", url)
         return url

--- a/papis/downloaders/usenix.py
+++ b/papis/downloaders/usenix.py
@@ -1,5 +1,4 @@
 import re
-from typing import Optional
 from urllib.parse import urlparse
 
 import papis.downloaders.base
@@ -14,16 +13,16 @@ class Downloader(papis.downloaders.Downloader):
             "usenix",
             expected_document_extension="pdf",
         )
-        self._raw_data: Optional[str] = None
+        self._raw_data: str | None = None
 
     @classmethod
-    def match(cls, url: str) -> Optional[papis.downloaders.Downloader]:
+    def match(cls, url: str) -> papis.downloaders.Downloader | None:
         if re.match(r".*usenix.org/.*", url):
             return cls(url)
         else:
             return None
 
-    def get_identifier(self) -> Optional[str]:
+    def get_identifier(self) -> str | None:
         """
         >>> d = Downloader("https://www.usenix.org/conference/usenixsecurity22/presentation/bulekov")
         >>> d.get_identifier()
@@ -47,7 +46,7 @@ class Downloader(papis.downloaders.Downloader):
             if not self._raw_data:
                 self.logger.warning("Failed to fetch data from '%s'.", self.uri)
 
-    def get_document_url(self) -> Optional[str]:
+    def get_document_url(self) -> str | None:
         import bs4
 
         # make sure self._raw_data is available
@@ -85,7 +84,7 @@ class Downloader(papis.downloaders.Downloader):
 
         return pdf_url.strip()
 
-    def get_bibtex_url(self) -> Optional[str]:
+    def get_bibtex_url(self) -> str | None:
         o = urlparse(self.uri)
         import bs4
 

--- a/papis/downloaders/worldscientific.py
+++ b/papis/downloaders/worldscientific.py
@@ -1,5 +1,4 @@
 import re
-from typing import Optional
 
 import papis.downloaders.base
 
@@ -15,13 +14,13 @@ class Downloader(papis.downloaders.Downloader):
             )
 
     @classmethod
-    def match(cls, url: str) -> Optional[papis.downloaders.Downloader]:
+    def match(cls, url: str) -> papis.downloaders.Downloader | None:
         if re.match(r".*worldscientific.com.*", url):
             return Downloader(url)
         else:
             return None
 
-    def get_doi(self) -> Optional[str]:
+    def get_doi(self) -> str | None:
         url = self.uri
         self.logger.debug("Parsing DOI from '%s'.", url)
         mdoi = re.match(r".*/doi/(.*/[^?&%^$]*).*", url)
@@ -36,12 +35,12 @@ class Downloader(papis.downloaders.Downloader):
 
         return None
 
-    def get_document_url(self) -> Optional[str]:
+    def get_document_url(self) -> str | None:
         durl = f"https://www.worldscientific.com/doi/pdf/{self.get_doi()}"
         self.logger.debug("Using document URL: '%s'.", durl)
         return durl
 
-    def get_bibtex_url(self) -> Optional[str]:
+    def get_bibtex_url(self) -> str | None:
         url = (
             "https://www.worldscientific.com/action/downloadCitation"
             f"?format=bibtex&cookieSet=1&doi={self.get_doi()}")

--- a/papis/filetype.py
+++ b/papis/filetype.py
@@ -1,6 +1,5 @@
 import os
 import re
-from typing import Optional
 
 import filetype
 
@@ -36,7 +35,7 @@ if filetype.get_type(DjVu.MIME) is None:
     filetype.add_type(DjVu())
 
 
-def guess_content_extension(content: bytes) -> Optional[str]:
+def guess_content_extension(content: bytes) -> str | None:
     """Guess the extension from (potential) file contents.
 
     This method attempts to look at known file signatures to determine the file
@@ -50,7 +49,7 @@ def guess_content_extension(content: bytes) -> Optional[str]:
     return str(kind.extension) if kind is not None else None
 
 
-def guess_document_extension(document_path: str) -> Optional[str]:
+def guess_document_extension(document_path: str) -> str | None:
     """Guess the extension of a given file at *document_path*.
 
     :param document_path: path to an existing file.

--- a/papis/format.py
+++ b/papis/format.py
@@ -1,5 +1,5 @@
 import string
-from typing import Any, ClassVar, Dict, List, Optional
+from typing import Any, ClassVar
 
 import papis.config
 import papis.document
@@ -9,7 +9,7 @@ import papis.strings
 
 logger = papis.logging.get_logger(__name__)
 
-FORMATTER: Dict[str, "Formatter"] = {}
+FORMATTER: dict[str, "Formatter"] = {}
 
 #: The entry point name for formatter plugins.
 FORMATTER_EXTENSION_NAME = "papis.format"
@@ -44,8 +44,8 @@ class Formatter:
                fmt: str,
                doc: papis.document.DocumentLike,
                doc_key: str = "",
-               additional: Optional[Dict[str, Any]] = None,
-               default: Optional[str] = None) -> str:
+               additional: dict[str, Any] | None = None,
+               default: str | None = None) -> str:
         """
         :param fmt: a format pattern understood by the formatter.
         :param doc: an object convertible to a document.
@@ -91,7 +91,7 @@ class _PythonStringFormatter(string.Formatter):
 
         return super().format_field(value, format_spec)
 
-    def convert_field(self, value: Any, conversion: Optional[str]) -> Any:
+    def convert_field(self, value: Any, conversion: str | None) -> Any:
         if conversion == "l":
             return str(value).lower()
         if conversion == "u":
@@ -155,8 +155,8 @@ class PythonFormatter(Formatter):
                fmt: str,
                doc: papis.document.DocumentLike,
                doc_key: str = "",
-               additional: Optional[Dict[str, Any]] = None,
-               default: Optional[str] = None) -> str:
+               additional: dict[str, Any] | None = None,
+               default: str | None = None) -> str:
         if additional is None:
             additional = {}
 
@@ -252,8 +252,8 @@ class Jinja2Formatter(Formatter):
                fmt: str,
                doc: papis.document.DocumentLike,
                doc_key: str = "",
-               additional: Optional[Dict[str, Any]] = None,
-               default: Optional[str] = None) -> str:
+               additional: dict[str, Any] | None = None,
+               default: str | None = None) -> str:
         if additional is None:
             additional = {}
 
@@ -275,7 +275,7 @@ class Jinja2Formatter(Formatter):
                 raise FormatFailedError(fmt) from exc
 
 
-def get_available_formatters() -> List[str]:
+def get_available_formatters() -> list[str]:
     """Get a list of all the available formatter plugins."""
     return papis.plugin.get_available_entrypoints(FORMATTER_EXTENSION_NAME)
 
@@ -297,7 +297,7 @@ def get_default_formatter() -> str:
     return name
 
 
-def get_formatter(name: Optional[str] = None) -> Formatter:
+def get_formatter(name: str | None = None) -> Formatter:
     """Initialize and return a formatter plugin.
 
     Note that the formatter is cached and all subsequent calls to this function
@@ -328,8 +328,8 @@ def get_formatter(name: Optional[str] = None) -> Formatter:
 def format(fmt: papis.strings.AnyString,
            doc: papis.document.DocumentLike,
            doc_key: str = "",
-           additional: Optional[Dict[str, Any]] = None,
-           default: Optional[str] = None) -> str:
+           additional: dict[str, Any] | None = None,
+           default: str | None = None) -> str:
     """Format a string using the selected formatter.
 
     This is the user-facing function that should be called when formatting a
@@ -346,7 +346,7 @@ def format(fmt: papis.strings.AnyString,
                             default=default)
 
 
-_DEPRECATIONS: Dict[str, Any] = {
+_DEPRECATIONS: dict[str, Any] = {
     "InvalidFormaterError": InvalidFormatterError,
     "Formater": Formatter,
     "PythonFormater": PythonFormatter,

--- a/papis/git.py
+++ b/papis/git.py
@@ -1,6 +1,8 @@
-"""This module serves as an lightweight interface for git related functions.
 """
-from typing import Sequence
+This module serves as an lightweight interface for ``git`` related functions.
+"""
+
+from collections.abc import Sequence
 
 import papis.logging
 import papis.utils

--- a/papis/hayagriva.py
+++ b/papis/hayagriva.py
@@ -1,4 +1,4 @@
-from typing import Any, Dict, List, Optional
+from typing import Any
 
 import papis.document
 import papis.logging
@@ -149,18 +149,18 @@ PAPIS_TO_HAYAGRIVA_KEY_CONVERSION_MAP = [
 ]
 
 
-def to_hayagriva_authors(authors: List[Dict[str, Any]]) -> List[Dict[str, Any]]:
+def to_hayagriva_authors(authors: list[dict[str, Any]]) -> list[dict[str, Any]]:
     return [{"given-name": a["given"], "name": a["family"]} for a in authors]
 
 
-def to_hayagriva(doc: papis.document.Document) -> Dict[str, Any]:
+def to_hayagriva(doc: papis.document.Document) -> dict[str, Any]:
     from contextlib import suppress
 
     bibtype = doc["type"]
     htype = BIBTEX_TO_HAYAGRIVA_TYPE_MAP.get(bibtype, bibtype)
 
     parent_known_keys = HAYAGRIVA_TYPE_PARENT_KEYS.get(htype, frozenset())
-    ptype: Optional[str] = None
+    ptype: str | None = None
 
     if htype == "article":
         if "proceedings" in bibtype:
@@ -177,8 +177,8 @@ def to_hayagriva(doc: papis.document.Document) -> Dict[str, Any]:
         ptype = HAYAGRIVA_PARENT_TYPES.get(htype)
 
     # NOTE: the type is case insensitive, but typst seems to capitalize them
-    data: Dict[str, Any] = {"type": htype.capitalize()}
-    parent: Dict[str, Any] = {"type": ptype.capitalize()} if ptype else {}
+    data: dict[str, Any] = {"type": htype.capitalize()}
+    parent: dict[str, Any] = {"type": ptype.capitalize()} if ptype else {}
 
     for foreign_key, conversions in PAPIS_TO_HAYAGRIVA_KEY_CONVERSION_MAP:
         if foreign_key not in doc:
@@ -213,7 +213,7 @@ def to_hayagriva(doc: papis.document.Document) -> Dict[str, Any]:
     return data
 
 
-def exporter(documents: List[papis.document.Document]) -> str:
+def exporter(documents: list[papis.document.Document]) -> str:
     """Convert document to the Hayagriva format used by Typst"""
     import yaml
 

--- a/papis/hooks.py
+++ b/papis/hooks.py
@@ -1,4 +1,5 @@
-from typing import TYPE_CHECKING, Any, Callable, Dict, List
+from collections.abc import Callable
+from typing import TYPE_CHECKING, Any
 
 import papis.logging
 import papis.plugin
@@ -13,7 +14,7 @@ HOOKS_EXTENSION_FORMAT = "papis.hook.{name}"
 
 #: A dictionary of hooks added with :func:`add`. These can be added in ``config.py``
 #: or from other places that do not use the entrypoint framework.
-CUSTOM_LOCAL_HOOKS: Dict[str, List[Callable[..., None]]] = {}
+CUSTOM_LOCAL_HOOKS: dict[str, list[Callable[..., None]]] = {}
 
 
 def get(name: str) -> "ExtensionManager":

--- a/papis/id.py
+++ b/papis/id.py
@@ -1,6 +1,5 @@
 import hashlib
 import random
-from typing import Optional
 from warnings import warn
 
 import papis.logging
@@ -14,7 +13,7 @@ logger = papis.logging.get_logger(__name__)
 ID_KEY_NAME: str = "papis_id"
 
 
-def compute_an_id(doc: Document, separator: Optional[str] = None) -> str:
+def compute_an_id(doc: Document, separator: str | None = None) -> str:
     """Make an ID for the input document *doc*.
 
     This is a non-deterministic function if *separator* is *None* (a random value

--- a/papis/importer.py
+++ b/papis/importer.py
@@ -1,4 +1,5 @@
-from typing import TYPE_CHECKING, Any, Callable, Dict, List, Optional, Type, TypeVar
+from collections.abc import Callable
+from typing import TYPE_CHECKING, Any, TypeVar
 
 import papis
 import papis.logging
@@ -44,8 +45,8 @@ class Context:
     """
 
     def __init__(self) -> None:
-        self.data: Dict[str, Any] = {}
-        self.files: List[str] = []
+        self.data: dict[str, Any] = {}
+        self.files: list[str] = []
 
     def __bool__(self) -> bool:
         return bool(self.files) or bool(self.data)
@@ -72,7 +73,7 @@ class Importer:
     def __init__(self,
                  uri: str = "",
                  name: str = "",
-                 ctx: Optional[Context] = None) -> None:
+                 ctx: Context | None = None) -> None:
         """
         :param uri: uri
         :param name: Name of the importer
@@ -89,7 +90,7 @@ class Importer:
         self.logger = papis.logging.get_logger(f"papis.importer.{self.name}")
 
     @classmethod
-    def match(cls, uri: str) -> Optional["Importer"]:
+    def match(cls, uri: str) -> "Importer | None":
         """Check if the importer can process the given URI.
 
         For example, an importer that supports links from the arXiv can check
@@ -112,7 +113,7 @@ class Importer:
             )
 
     @classmethod
-    def match_data(cls, data: Dict[str, Any]) -> Optional["Importer"]:
+    def match_data(cls, data: dict[str, Any]) -> "Importer | None":
         """Check if the importer can process the given metadata.
 
         This method can be used to search for valid URIs inside the *data* that
@@ -176,17 +177,17 @@ def get_import_mgr() -> "stevedore.extension.ExtensionManager":
     return papis.plugin.get_extension_manager(IMPORTER_EXTENSION_NAME)
 
 
-def available_importers() -> List[str]:
+def available_importers() -> list[str]:
     """Get a list of available importer names."""
     return papis.plugin.get_available_entrypoints(IMPORTER_EXTENSION_NAME)
 
 
-def get_importers() -> List[Type[Importer]]:
+def get_importers() -> list[type[Importer]]:
     """Get a list of available importer classes."""
     return [e.plugin for e in get_import_mgr()]
 
 
-def get_importer_by_name(name: str) -> Type[Importer]:
+def get_importer_by_name(name: str) -> type[Importer]:
     """Get an importer class by *name*."""
-    imp: Type[Importer] = get_import_mgr()[name].plugin
+    imp: type[Importer] = get_import_mgr()[name].plugin
     return imp

--- a/papis/isbn.py
+++ b/papis/isbn.py
@@ -1,5 +1,5 @@
 # See https://github.com/xlcnd/isbnlib for details
-from typing import Any, Dict, List, Optional
+from typing import Any
 
 import click
 from isbnlib.registry import services as isbn_services
@@ -15,7 +15,7 @@ ISBN_SERVICE_NAMES = list(isbn_services)
 
 
 def get_data(query: str = "",
-             service: Optional[str] = None) -> List[Dict[str, Any]]:
+             service: str | None = None) -> list[dict[str, Any]]:
     logger.debug("Trying to retrieve ISBN from query: '%s'.", query)
 
     if service is None:
@@ -36,7 +36,7 @@ def get_data(query: str = "",
         return []
 
 
-def data_to_papis(data: Dict[str, Any]) -> Dict[str, Any]:
+def data_to_papis(data: dict[str, Any]) -> dict[str, Any]:
     """
     Convert data from isbnlib into Papis formatted data.
 
@@ -108,7 +108,7 @@ class Importer(papis.importer.Importer):
         super().__init__(name="isbn", uri=uri)
 
     @classmethod
-    def match(cls, uri: str) -> Optional[papis.importer.Importer]:
+    def match(cls, uri: str) -> papis.importer.Importer | None:
         import isbnlib
         if isbnlib.notisbn(uri):
             return None

--- a/papis/json.py
+++ b/papis/json.py
@@ -1,5 +1,3 @@
-from typing import List
-
 import click
 
 import papis.document
@@ -8,7 +6,7 @@ import papis.logging
 logger = papis.logging.get_logger(__name__)
 
 
-def exporter(documents: List[papis.document.Document]) -> str:
+def exporter(documents: list[papis.document.Document]) -> str:
     """Convert document to the JSON format"""
     import json
     return json.dumps([papis.document.to_dict(doc) for doc in documents],

--- a/papis/library.py
+++ b/papis/library.py
@@ -1,18 +1,19 @@
 import glob
 import os
-from itertools import chain
-from typing import List, Sequence
+from collections.abc import Sequence
 
 
 class Library:
     """A class containing library information."""
 
     def __init__(self, name: str, paths: Sequence[str]) -> None:
+        from itertools import chain
+
         #: The name of the library, as it appears in the configuration file if
         #: defined there.
         self.name: str = name
         #: A list of paths with documents that form the library.
-        self.paths: List[str] = list(
+        self.paths: list[str] = list(
             chain.from_iterable(glob.glob(os.path.expanduser(p)) for p in paths)
             )
 

--- a/papis/logging.py
+++ b/papis/logging.py
@@ -1,7 +1,7 @@
 import logging
 import os
 import sys
-from typing import Any, Optional, Tuple, Union
+from typing import Any
 
 import click
 import colorama as c
@@ -31,7 +31,7 @@ class ColoramaFormatter(logging.Formatter):
         #: used with ``logger.info(..., exc_info=ext)``.
         self.full_tb: bool = full_tb
 
-    def formatException(self, exc_info: Tuple[Any, ...]) -> str:    # noqa: N802
+    def formatException(self, exc_info: tuple[Any, ...]) -> str:    # noqa: N802
         """Format and return the specified exception information as a string.
 
         If :attr:`full_tb` is *True*, then the full traceback is shown. Otherwise,
@@ -95,10 +95,10 @@ def _disable_color(color: str = "auto") -> bool:
         )
 
 
-def setup(level: Optional[Union[int, str]] = None,
-          color: Optional[str] = None,
-          logfile: Optional[str] = None,
-          verbose: Optional[bool] = None) -> None:
+def setup(level: int | str | None = None,
+          color: str | None = None,
+          logfile: str | None = None,
+          verbose: bool | None = None) -> None:
     """Set up formatting and handlers for the root level Papis logger.
 
     :param level: default logging level (see :mod:`logging`). By default, this
@@ -170,10 +170,10 @@ def setup(level: Optional[Union[int, str]] = None,
     logger.addHandler(handler)
 
 
-def reset(level: Optional[Union[int, str]] = None,
-          color: Optional[str] = None,
-          logfile: Optional[str] = None,
-          verbose: Optional[bool] = None) -> None:
+def reset(level: int | str | None = None,
+          color: str | None = None,
+          logfile: str | None = None,
+          verbose: bool | None = None) -> None:
     """Reset the root level Papis logger.
 
     This function removes all the custom handlers and resets the logger
@@ -189,7 +189,7 @@ def reset(level: Optional[Union[int, str]] = None,
     setup(level, color=color, logfile=logfile, verbose=verbose)
 
 
-def get_logger(name: Optional[str] = None) -> logging.Logger:
+def get_logger(name: str | None = None) -> logging.Logger:
     """Get a logger instance for the given name under the ``papis`` namespace.
 
     :arg name: the provisional name of the logger instance.

--- a/papis/paths.py
+++ b/papis/paths.py
@@ -1,7 +1,8 @@
 import os
 import pathlib
 import sys
-from typing import Iterable, Iterator, List, Literal, Optional, Union
+from collections.abc import Iterable, Iterator
+from typing import Literal
 from warnings import warn
 
 import papis.config
@@ -12,7 +13,7 @@ from papis.strings import AnyString, FormatPattern
 logger = papis.logging.get_logger(__name__)
 
 #: A union type for allowable paths.
-PathLike = Union[pathlib.Path, str]
+PathLike = pathlib.Path | str
 
 # NOTE: private error codes for Windows
 WIN_ERROR_PRIVILEGE_NOT_HELD = 1314
@@ -21,7 +22,7 @@ WIN_ERROR_PRIVILEGE_NOT_HELD = 1314
 _SLUGIFY_HYPHEN_PLACEHOLDER = "slugifyhyphenplaceholder"
 
 
-def unique_suffixes(chars: Optional[str] = None, skip: int = 0) -> Iterator[str]:
+def unique_suffixes(chars: str | None = None, skip: int = 0) -> Iterator[str]:
     """Creates an infinite list of suffixes based on *chars*.
 
     This creates a generator object capable of iterating over lists to
@@ -56,9 +57,9 @@ def unique_suffixes(chars: Optional[str] = None, skip: int = 0) -> Iterator[str]
 
 
 def normalize_path(path: str, *,
-                   lowercase: Optional[bool] = None,
-                   extra_chars: Optional[str] = None,
-                   separator: Optional[str] = None) -> str:
+                   lowercase: bool | None = None,
+                   extra_chars: str | None = None,
+                   separator: str | None = None) -> str:
     """Clean a path to only contain visible ASCII characters.
 
     This function will create ASCII strings that can be safely used as file names
@@ -120,14 +121,7 @@ def is_relative_to(path: PathLike, other: PathLike) -> bool:
 
     :returns: *True* if *path* is relative to the *other* path.
     """
-    if sys.version_info >= (3, 9):
-        return pathlib.Path(path).is_relative_to(other)
-
-    # NOTE: this should give the same result as above for older versions
-    try:
-        return not os.path.relpath(path, start=other).startswith("..")
-    except ValueError:
-        return False
+    return pathlib.Path(path).is_relative_to(other)
 
 
 def symlink(src: PathLike, dst: PathLike) -> None:
@@ -156,7 +150,7 @@ def get_document_file_name(
         doc: DocumentLike,
         orig_path: PathLike,
         suffix: str = "", *,
-        file_name_format: Optional[Union[AnyString, Literal[False]]] = None,
+        file_name_format: AnyString | Literal[False] | None = None,
         base_name_limit: int = 150) -> str:
     """Generate a file name based on *orig_path* for the document *doc*.
 
@@ -218,9 +212,9 @@ def get_document_file_name(
 
 def get_document_hash_folder(
         doc: DocumentLike,
-        paths: Optional[Iterable[str]] = None, *,
+        paths: Iterable[str] | None = None, *,
         file_read_limit: int = 2000,
-        seed: Optional[str] = None) -> str:
+        seed: str | None = None) -> str:
     warn("'get_document_hash_folder' is deprecated and will be removed. "
          "Use 'papis.paths.get_document_folder' instead.",
          DeprecationWarning, stacklevel=2)
@@ -232,7 +226,7 @@ def get_document_hash_folder(
 def get_document_folder(
         doc: DocumentLike,
         dirname: PathLike, *,
-        folder_name_format: Optional[AnyString] = None) -> str:
+        folder_name_format: AnyString | None = None) -> str:
     """Generate a folder name for the document at *dirname*.
 
     This function uses :confval:`add-folder-name` to generate a folder name for
@@ -270,7 +264,7 @@ def get_document_folder(
         # could contain a backslash and ruin the hierarchy -- instead we clean it
         # and remove any such characters from messing up the folder name
 
-        components: List[str] = []
+        components: list[str] = []
         while tmp_path != dirname and is_relative_to(tmp_path, dirname):
             tmp_component = os.path.basename(tmp_path)
 
@@ -339,7 +333,7 @@ def _make_unique_file(filename: PathLike) -> str:
 def get_document_unique_folder(
         doc: DocumentLike,
         dirname: PathLike, *,
-        folder_name_format: Optional[AnyString] = None) -> str:
+        folder_name_format: AnyString | None = None) -> str:
     """A wrapper around :func:`get_document_folder` that ensures that the
     folder is unique by adding suffixes.
 
@@ -357,7 +351,7 @@ def is_remote_file(uri: str) -> bool:
     return uri.startswith("http://") or uri.startswith("https://")
 
 
-def download_remote_files(in_document_paths: Iterable[str]) -> List[Optional[str]]:
+def download_remote_files(in_document_paths: Iterable[str]) -> list[str | None]:
     """
     Download all remote filepaths that are provided in the document list.
 
@@ -369,7 +363,7 @@ def download_remote_files(in_document_paths: Iterable[str]) -> List[Optional[str
 
     from papis.downloaders import download_document
 
-    new_files: List[Optional[str]] = []
+    new_files: list[str | None] = []
     for in_file_path in in_document_paths:
         if is_remote_file(in_file_path):
             local_in_file_path = download_document(in_file_path)
@@ -383,9 +377,9 @@ def download_remote_files(in_document_paths: Iterable[str]) -> List[Optional[str
 def rename_document_files(
         doc: DocumentLike,
         in_document_paths: Iterable[str], *,
-        allow_remote: Optional[bool] = None,
-        file_name_format: Optional[Union[AnyString, Literal[False]]] = None,
-        ) -> List[str]:
+        allow_remote: bool | None = None,
+        file_name_format: AnyString | Literal[False] | None = None,
+        ) -> list[str]:
     """Rename *in_document_paths* according to *file_name_format* and ensure
     uniqueness.
 

--- a/papis/pick.py
+++ b/papis/pick.py
@@ -1,6 +1,7 @@
 import os
 from abc import ABC, abstractmethod
-from typing import Any, Callable, Generic, List, Optional, Sequence, Type, TypeVar
+from collections.abc import Callable, Sequence
+from typing import Any, Generic, TypeVar
 
 import papis.config
 import papis.document
@@ -29,7 +30,7 @@ class Picker(ABC, Generic[T]):
             header_filter: Callable[[T], str],
             match_filter: Callable[[T], str],
             default_index: int = 0
-            ) -> List[T]:
+            ) -> list[T]:
         """
         :arg items: a sequence of items from which to pick a subset.
         :arg header_filter: (optional) a callable that takes an item from *items*
@@ -44,13 +45,13 @@ class Picker(ABC, Generic[T]):
         """
 
 
-def get_picker(name: str) -> Type[Picker[Any]]:
+def get_picker(name: str) -> type[Picker[Any]]:
     """Get a picker by its plugin name.
 
     :arg name: the name of an entrypoint to load a :class:`Picker` plugin from.
     :returns: a :class:`Picker` subclass implemented in the plugin.
     """
-    picker: Type[Picker[Any]] = (
+    picker: type[Picker[Any]] = (
         papis.plugin.get_extension_manager(PICKER_EXTENSION_NAME)[name].plugin
     )
 
@@ -60,7 +61,7 @@ def get_picker(name: str) -> Type[Picker[Any]]:
 def pick(items: Sequence[T],
          header_filter: Callable[[T], str] = str,
          match_filter: Callable[[T], str] = str,
-         default_index: int = 0) -> List[T]:
+         default_index: int = 0) -> list[T]:
     """Load a :class:`Picker` plugin and select a subset of *items*.
 
     The arguments to this function match those of :meth:`Picker.__call__`. The
@@ -72,7 +73,7 @@ def pick(items: Sequence[T],
 
     name = papis.config.getstring("picktool")
     try:
-        picker: Type[Picker[T]] = get_picker(name)
+        picker: type[Picker[T]] = get_picker(name)
     except KeyError:
         entrypoints = papis.plugin.get_available_entrypoints(PICKER_EXTENSION_NAME)
         logger.error(
@@ -88,7 +89,7 @@ def pick(items: Sequence[T],
 
 def pick_doc(
         documents: Sequence[papis.document.Document]
-        ) -> List[papis.document.Document]:
+        ) -> list[papis.document.Document]:
     """Pick from a sequence of *documents* using :func:`pick`.
 
     This function uses the :confval:`header-format-file` setting
@@ -119,7 +120,7 @@ def pick_doc(
                 match_filter=match_filter)
 
 
-def pick_subfolder_from_lib(lib: str) -> List[str]:
+def pick_subfolder_from_lib(lib: str) -> list[str]:
     """Pick subfolders from all existing subfolders in *lib*.
 
     Note that this includes document folders in *lib* as well nested library
@@ -141,7 +142,7 @@ def pick_subfolder_from_lib(lib: str) -> List[str]:
     return pick(folders)
 
 
-def pick_library(libs: Optional[List[str]] = None) -> List[str]:
+def pick_library(libs: list[str] | None = None) -> list[str]:
     """Pick a library from the current configuration.
 
     :arg libs: a list of libraries to pick from.

--- a/papis/plugin.py
+++ b/papis/plugin.py
@@ -1,4 +1,4 @@
-from typing import Any, Dict, List
+from typing import Any
 
 from stevedore import ExtensionManager
 
@@ -6,7 +6,7 @@ import papis.logging
 
 logger = papis.logging.get_logger(__name__)
 
-MANAGERS: Dict[str, ExtensionManager] = {}
+MANAGERS: dict[str, ExtensionManager] = {}
 
 
 def stevedore_error_handler(manager: ExtensionManager,
@@ -36,7 +36,7 @@ def get_extension_manager(namespace: str) -> ExtensionManager:
     return manager
 
 
-def get_available_entrypoints(namespace: str) -> List[str]:
+def get_available_entrypoints(namespace: str) -> list[str]:
     """
     :returns: a list of all available entry points in the given *namespace*
         sorted alphabetically.
@@ -45,7 +45,7 @@ def get_available_entrypoints(namespace: str) -> List[str]:
     return sorted(str(e) for e in manager.entry_points_names())
 
 
-def get_available_plugins(namespace: str) -> List[Any]:
+def get_available_plugins(namespace: str) -> list[Any]:
     """
     :returns: a list of all available plugins in the given *namespace*.
     """

--- a/papis/pubmed.py
+++ b/papis/pubmed.py
@@ -1,4 +1,4 @@
-from typing import Any, Dict, Optional
+from typing import Any
 
 import papis
 import papis.document
@@ -58,7 +58,7 @@ key_conversion = [
 ]
 
 
-def pubmed_data_to_papis_data(data: Dict[str, Any]) -> Dict[str, Any]:
+def pubmed_data_to_papis_data(data: dict[str, Any]) -> dict[str, Any]:
     new_data = papis.document.keyconversion_to_data(key_conversion, data)
     new_data["author"] = papis.document.author_list_to_author(new_data)
 
@@ -76,7 +76,7 @@ def is_valid_pmid(pmid: str) -> bool:
     return response.ok
 
 
-def get_data(query: str = "") -> Dict[str, Any]:
+def get_data(query: str = "") -> dict[str, Any]:
     # NOTE: being nice and using the project version as a user agent
     # as requested in https://api.ncbi.nlm.nih.gov/lit/ctxp
     with papis.utils.get_session() as session:
@@ -97,7 +97,7 @@ class Importer(papis.importer.Importer):
         super().__init__(name="pubmed", uri=uri)
 
     @classmethod
-    def match(cls, uri: str) -> Optional[papis.importer.Importer]:
+    def match(cls, uri: str) -> papis.importer.Importer | None:
         if is_valid_pmid(uri):
             return Importer(uri)
 

--- a/papis/sphinx_ext.py
+++ b/papis/sphinx_ext.py
@@ -19,7 +19,8 @@ Sphinx configuration.
 
 import os
 import sys
-from typing import Any, Callable, ClassVar, Dict, List, Optional
+from collections.abc import Callable
+from typing import Any, ClassVar
 
 import docutils
 from docutils.parsers.rst import Directive
@@ -87,7 +88,7 @@ class PapisConfig(Directive):
     #: Number of required arguments to the directive.
     required_arguments: ClassVar[int] = 1
     #: A description of the arguments, mapping names to validator functions.
-    option_spec: ClassVar[Dict[str, Callable[[str], Any]]] = {
+    option_spec: ClassVar[dict[str, Callable[[str], Any]]] = {
         "default": str, "section": str, "type": str
         }
     add_index: int = True
@@ -144,7 +145,7 @@ class PapisConfig(Directive):
 
 def make_link_resolve(
         github_project_url: str,
-        revision: str) -> Callable[[str, Dict[str, Any]], Optional[str]]:
+        revision: str) -> Callable[[str, dict[str, Any]], str | None]:
     """Create a function that can be used with ``sphinx.ext.linkcode``.
 
     This can be used in the ``conf.py`` file as:
@@ -157,7 +158,7 @@ def make_link_resolve(
     :param revision: the revision to which to point to, e.g. ``main``.
     """
 
-    def linkcode_resolve(domain: str, info: Dict[str, Any]) -> Optional[str]:
+    def linkcode_resolve(domain: str, info: dict[str, Any]) -> str | None:
         url = None
         if domain != "py" or not info["module"]:
             return url
@@ -205,7 +206,7 @@ def remove_module_docstring(app: application.Sphinx,
                             name: str,
                             obj: object,
                             options: Any,
-                            lines: List[str]) -> None:
+                            lines: list[str]) -> None:
     # NOTE: this is used to remove the module documentation for commands so that
     # we can show the module members in the `Developer API Reference` section
     # without the tutorial / examples parts.
@@ -213,7 +214,7 @@ def remove_module_docstring(app: application.Sphinx,
         del lines[:]
 
 
-def setup(app: application.Sphinx) -> Dict[str, Any]:
+def setup(app: application.Sphinx) -> dict[str, Any]:
     from sphinx.util.docfields import Field
 
     app.setup_extension("sphinx_click.ext")

--- a/papis/strings.py
+++ b/papis/strings.py
@@ -1,4 +1,4 @@
-from typing import Any, NamedTuple, Optional, Tuple, Union
+from typing import Any, NamedTuple, TypeAlias
 
 
 class FormatPattern(NamedTuple):
@@ -22,7 +22,7 @@ class FormatPattern(NamedTuple):
     #: The formatter that should be used on the string :attr:`pattern`. If none
     #: is provided, the default formatter is used, as defined by
     #: :confval:`formatter`.
-    formatter: Optional[str]
+    formatter: str | None
     #: Pattern that should be evaluated by the *formatter*.
     pattern: str
 
@@ -53,13 +53,13 @@ class FormatPattern(NamedTuple):
         return hash(self.pattern)
 
 
-AnyString = Union[str, FormatPattern]
+AnyString: TypeAlias = str | FormatPattern
 
 
 def process_format_pattern_pair(
     key: str,
     pattern: AnyString
-) -> Tuple[str, FormatPattern]:
+) -> tuple[str, FormatPattern]:
     """
     :param key: a document key in the format ``key[.formatter]``.
     :param pattern: an unformatted pattern.

--- a/papis/testing.py
+++ b/papis/testing.py
@@ -1,8 +1,9 @@
 import os
 import random
 import tempfile
+from collections.abc import Iterator, Sequence
 from types import TracebackType
-from typing import Any, ClassVar, Dict, Iterator, Optional, Sequence, Type
+from typing import Any, ClassVar
 
 import click
 import click.testing
@@ -16,10 +17,10 @@ if PAPIS_UPDATE_RESOURCES not in {"none", "remote", "local", "both"}:
     raise ValueError("unsupported value of 'PAPIS_UPDATE_RESOURCES'")
 
 
-def create_random_file(filetype: Optional[str] = None,
-                       prefix: Optional[str] = None,
-                       suffix: Optional[str] = None,
-                       dir: Optional[str] = None) -> str:
+def create_random_file(filetype: str | None = None,
+                       prefix: str | None = None,
+                       suffix: str | None = None,
+                       dir: str | None = None) -> str:
     """Create a random file with the correct magic signature.
 
     This function creates random empty files that can be used for testing. It
@@ -200,10 +201,10 @@ class TemporaryConfiguration:
 
     def __init__(self,
                  prefix: str = "papis-test-",
-                 settings: Optional[Dict[str, Any]] = None,
+                 settings: dict[str, Any] | None = None,
                  overwrite: bool = False) -> None:
         #: A set of settings to be added to the configuration on creation
-        self.settings: Optional[Dict[str, Any]] = settings
+        self.settings: dict[str, Any] | None = settings
         #: If *True*, any configuration settings are overwritten by *settings*.
         self.overwrite: bool = overwrite
 
@@ -220,8 +221,8 @@ class TemporaryConfiguration:
         #: Prefix for the temporary directory created for the test.
         self.prefix = prefix
 
-        self._tmpdir: Optional[tempfile.TemporaryDirectory[str]] = None
-        self._monkeypatch: Optional[pytest.MonkeyPatch] = None
+        self._tmpdir: tempfile.TemporaryDirectory[str] | None = None
+        self._monkeypatch: pytest.MonkeyPatch | None = None
 
     @property
     def tmpdir(self) -> str:
@@ -230,9 +231,9 @@ class TemporaryConfiguration:
         return self._tmpdir.name
 
     def create_random_file(self,
-                           filetype: Optional[str] = None,
-                           prefix: Optional[str] = None,
-                           suffix: Optional[str] = None) -> str:
+                           filetype: str | None = None,
+                           prefix: str | None = None,
+                           suffix: str | None = None) -> str:
         """Create a random file in the :attr:`tmpdir` using `create_random_file`."""
         return create_random_file(
             filetype, suffix=suffix, prefix=prefix,
@@ -320,9 +321,9 @@ class TemporaryConfiguration:
         return self
 
     def __exit__(self,
-                 exc_type: Optional[Type[BaseException]],
-                 exc_val: Optional[BaseException],
-                 exc_tb: Optional[TracebackType]) -> None:
+                 exc_type: type[BaseException] | None,
+                 exc_val: BaseException | None,
+                 exc_tb: TracebackType | None) -> None:
         # cleanup
         if self._monkeypatch:
             self._monkeypatch.undo()
@@ -346,7 +347,7 @@ class TemporaryLibrary(TemporaryConfiguration):
     """
 
     def __init__(self,
-                 settings: Optional[Dict[str, Any]] = None,
+                 settings: dict[str, Any] | None = None,
                  use_git: bool = False,
                  populate: bool = True) -> None:
         super().__init__(settings=settings)
@@ -457,9 +458,9 @@ class ResourceCache:
     def get_remote_resource(
             self, filename: str, url: str,
             force: bool = False,
-            params: Optional[Dict[str, str]] = None,
-            headers: Optional[Dict[str, str]] = None,
-            cookies: Optional[Dict[str, str]] = None,
+            params: dict[str, str] | None = None,
+            headers: dict[str, str] | None = None,
+            cookies: dict[str, str] | None = None,
             ) -> bytes:
         """Retrieve a remote resource from the resource cache.
 

--- a/papis/tui/__init__.py
+++ b/papis/tui/__init__.py
@@ -1,6 +1,6 @@
-from typing import Any, Dict
+from typing import Any, TypeAlias
 
-PapisConfigType = Dict[str, Dict[str, Any]]
+PapisConfigType: TypeAlias = dict[str, dict[str, Any]]
 
 
 def get_default_settings() -> PapisConfigType:

--- a/papis/tui/app.py
+++ b/papis/tui/app.py
@@ -1,17 +1,7 @@
 import threading
+from collections.abc import Callable, Sequence
 from functools import partial
-from typing import (
-    Any,
-    Callable,
-    Dict,
-    Generic,
-    List,
-    Optional,
-    Sequence,
-    Tuple,
-    TypedDict,
-    Union,
-)
+from typing import Any, Generic, TypedDict
 
 from prompt_toolkit.application import Application
 from prompt_toolkit.enums import EditingMode
@@ -43,10 +33,10 @@ class KeyInfo(TypedDict):
     help: str
 
 
-_KEYS_INFO: Optional[Dict[str, KeyInfo]] = None
+_KEYS_INFO: dict[str, KeyInfo] | None = None
 
 
-def get_keys_info() -> Dict[str, KeyInfo]:
+def get_keys_info() -> dict[str, KeyInfo]:
     global _KEYS_INFO
     if _KEYS_INFO is None:
         _KEYS_INFO = {
@@ -210,24 +200,24 @@ def create_keybindings(app: "Picker[Any]") -> KeyBindings:
     return kb
 
 
-def get_commands(app: "Picker[Any]") -> Tuple[List[Command], KeyBindings]:
+def get_commands(app: "Picker[Any]") -> tuple[list[Command], KeyBindings]:
     kb = KeyBindings()
     keys_info = get_keys_info()
 
     @kb.add("c-q")
     @kb.add("c-c")
-    def exit(event: Union[Command, KeyPressEvent]) -> None:
+    def exit(event: Command | KeyPressEvent) -> None:
         app.deselect()
         app.exit()
 
     @kb.add("enter",                                    # type: ignore[misc]
             filter=has_focus(app.options_list.search_buffer))
-    def select(event: Union[Command, KeyPressEvent]) -> None:
+    def select(event: Command | KeyPressEvent) -> None:
         app.exit()
 
     @kb.add(keys_info["open_document_key"]["key"],      # type: ignore[misc]
             filter=has_focus(app.options_list.search_buffer))
-    def open(event: Union[Command, KeyPressEvent]) -> None:
+    def open(event: Command | KeyPressEvent) -> None:
         from papis.commands.open import run
 
         docs = app.get_selection()
@@ -244,7 +234,7 @@ def get_commands(app: "Picker[Any]") -> Tuple[List[Command], KeyBindings]:
 
     @kb.add(keys_info["browse_document_key"]["key"],      # type: ignore[misc]
             filter=has_focus(app.options_list.search_buffer))
-    def browse(event: Union[Command, KeyPressEvent]) -> None:
+    def browse(event: Command | KeyPressEvent) -> None:
         from papis.commands.browse import run
         docs = app.get_selection()
         for doc in docs:
@@ -252,7 +242,7 @@ def get_commands(app: "Picker[Any]") -> Tuple[List[Command], KeyBindings]:
 
     @kb.add(keys_info["edit_document_key"]["key"],      # type: ignore[misc]
             filter=has_focus(app.options_list.search_buffer))
-    def edit(event: Union[Command, KeyPressEvent]) -> None:
+    def edit(event: Command | KeyPressEvent) -> None:
         from papis.commands.edit import run
         docs = app.get_selection()
         for doc in docs:
@@ -269,25 +259,25 @@ def get_commands(app: "Picker[Any]") -> Tuple[List[Command], KeyBindings]:
 
     @kb.add(keys_info["show_help_key"]["key"],          # type: ignore[misc]
             filter=~has_focus(app.help_window))
-    def help(event: Union[Command, KeyPressEvent]) -> None:
+    def help(event: Command | KeyPressEvent) -> None:
         app.layout.focus(app.help_window.window)
         app.message_toolbar.text = "Press q to quit"
 
     @kb.add(keys_info["show_info_key"]["key"],          # type: ignore[misc]
             filter=~has_focus(app.info_window))
-    def info(event: Union[Command, KeyPressEvent]) -> None:
+    def info(event: Command | KeyPressEvent) -> None:
         app.update_info_window()
         app.layout.focus(app.info_window.window)
 
     @kb.add("c-g", "g")
     @kb.add(keys_info["go_top_key"]["key"])
-    def go_top(event: Union[Command, KeyPressEvent]) -> None:
+    def go_top(event: Command | KeyPressEvent) -> None:
         app.options_list.go_top()
         app.refresh()
 
     @kb.add("c-g", "G")
     @kb.add(keys_info["go_bottom_key"]["key"])
-    def go_end(event: Union[Command, KeyPressEvent]) -> None:
+    def go_end(event: Command | KeyPressEvent) -> None:
         app.options_list.go_bottom()
         app.refresh()
 

--- a/papis/tui/picker.py
+++ b/papis/tui/picker.py
@@ -1,5 +1,6 @@
 import sys
-from typing import Callable, List, Sequence, TypeVar
+from collections.abc import Callable, Sequence
+from typing import TypeVar
 
 import papis.logging
 import papis.pick
@@ -16,7 +17,7 @@ class Picker(papis.pick.Picker[T]):
             header_filter: Callable[[T], str] = str,
             match_filter: Callable[[T], str] = str,
             default_index: int = 0
-            ) -> List[T]:
+            ) -> list[T]:
 
         if len(options) == 0:
             return []
@@ -24,7 +25,7 @@ class Picker(papis.pick.Picker[T]):
         if len(options) == 1:
             return [options[0]]
 
-        def run() -> List[T]:
+        def run() -> list[T]:
             picker = tui.Picker(
                 options,
                 default_index,

--- a/papis/tui/utils.py
+++ b/papis/tui/utils.py
@@ -1,5 +1,6 @@
 import re
-from typing import Any, Callable, Iterable, List, Optional
+from collections.abc import Callable, Iterable
+from typing import Any
 
 import click
 
@@ -54,7 +55,7 @@ PAPIS_PYGMENTS_DEFAULT_STYLE = {
 
 def confirm(prompt_string: str,
             yes: bool = True,
-            bottom_toolbar: Optional[str] = None) -> bool:
+            bottom_toolbar: str | None = None) -> bool:
     """Confirm with user input
 
     :param prompt_string: Question or text that the user gets.
@@ -121,9 +122,9 @@ def yes_no_dialog(title: str, text: str) -> Any:
 def prompt(
         prompt_string: str,
         default: str = "",
-        bottom_toolbar: Optional[str] = None,
+        bottom_toolbar: str | None = None,
         multiline: bool = False,
-        validator_function: Optional[Callable[[str], bool]] = None,
+        validator_function: Callable[[str], bool] | None = None,
         dirty_message: str = "") -> str:
     """Prompt user for input
 
@@ -183,7 +184,7 @@ def progress_bar(iterable: Iterable[T]) -> Iterable[T]:
         yield from pb(iterable)
 
 
-def get_range(range_str: str) -> List[int]:
+def get_range(range_str: str) -> list[int]:
     from itertools import chain
 
     range_regex = re.compile(r"(\d+)-?(\d+)?")
@@ -195,10 +196,10 @@ def get_range(range_str: str) -> List[int]:
         return []
 
 
-def select_range(options: List[Any],
+def select_range(options: list[Any],
                  message: str,
                  accept_none: bool = False,
-                 bottom_toolbar: Optional[str] = None) -> List[int]:
+                 bottom_toolbar: str | None = None) -> list[int]:
     for i, o in enumerate(options):
         click.echo(f"{i}. {o}")
 

--- a/papis/tui/widgets/command_line_prompt.py
+++ b/papis/tui/widgets/command_line_prompt.py
@@ -1,4 +1,5 @@
-from typing import Any, Callable, List, Optional
+from collections.abc import Callable
+from typing import Any
 
 from prompt_toolkit.application import Application
 from prompt_toolkit.application.current import get_app
@@ -33,7 +34,7 @@ class Command:
             self,
             name: str,
             run: Callable[["Command"], Any],
-            aliases: Optional[List[str]] = None) -> None:
+            aliases: list[str] | None = None) -> None:
         if aliases is None:
             aliases = []
 
@@ -46,7 +47,7 @@ class Command:
         return get_app()
 
     @property
-    def names(self) -> List[str]:
+    def names(self) -> list[str]:
         return [self.name, *self.aliases]
 
 
@@ -55,14 +56,14 @@ class CommandLinePrompt(ConditionalContainer):
     A vim-like command line prompt widget.
     It's supposed to be instantiated only once.
     """
-    def __init__(self, commands: Optional[List[Command]] = None) -> None:
+    def __init__(self, commands: list[Command] | None = None) -> None:
         if commands is None:
             commands = []
 
         from itertools import chain
 
         self.commands = commands
-        names: List[str] = list(chain.from_iterable(c.names for c in commands))
+        names: list[str] = list(chain.from_iterable(c.names for c in commands))
         wc = WordCompleter(names)
         self.buf = Buffer(
             completer=wc, complete_while_typing=True

--- a/papis/tui/widgets/diff.py
+++ b/papis/tui/widgets/diff.py
@@ -1,4 +1,5 @@
-from typing import Any, Callable, Dict, List, NamedTuple, Optional, Union
+from collections.abc import Callable
+from typing import Any, NamedTuple
 
 from prompt_toolkit import Application, print_formatted_text
 from prompt_toolkit.formatted_text import FormattedText
@@ -14,9 +15,9 @@ class Action(NamedTuple):
     action: Callable[[KeyPressEvent], None]
 
 
-def prompt(text: Union[str, FormattedText],
+def prompt(text: str | FormattedText,
            title: str = "",
-           actions: Optional[List[Action]] = None,
+           actions: list[Action] | None = None,
            **kwargs: Any
            ) -> None:
     """A simple and extensible prompt helper routine
@@ -80,7 +81,7 @@ def diffshow(texta: str,
              title: str = "",
              namea: str = "a",
              nameb: str = "b",
-             actions: Optional[List[Action]] = None
+             actions: list[Action] | None = None
              ) -> None:
     """Show the difference of texta and textb with a prompt.
 
@@ -128,11 +129,11 @@ def diffshow(texta: str,
            actions=actions)
 
 
-def diffdict(dicta: Dict[str, Any],
-             dictb: Dict[str, Any],
+def diffdict(dicta: dict[str, Any],
+             dictb: dict[str, Any],
              namea: str = "a",
              nameb: str = "b"
-             ) -> Dict[str, Any]:
+             ) -> dict[str, Any]:
     """
     Compute the difference of two dictionaries.
 

--- a/papis/tui/widgets/list.py
+++ b/papis/tui/widgets/list.py
@@ -1,18 +1,8 @@
 import functools
 import os
 import re
-from typing import (
-    Any,
-    Callable,
-    Generic,
-    List,
-    Optional,
-    Pattern,
-    Sequence,
-    Tuple,
-    TypeVar,
-    Union,
-)
+from collections.abc import Callable, Sequence
+from typing import Any, Generic, TypeVar
 
 from prompt_toolkit.buffer import Buffer
 from prompt_toolkit.data_structures import Point
@@ -35,8 +25,8 @@ Option = TypeVar("Option")
 
 
 def match_against_regex(
-        regex: Pattern[str],
-        pair: Tuple[int, str]) -> Optional[int]:
+        regex: re.Pattern[str],
+        pair: tuple[int, str]) -> int | None:
     """Return index if line matches regex
 
         pair[0] is the index of the element
@@ -55,9 +45,9 @@ class OptionsList(ConditionalContainer, Generic[Option]):
             default_index: int = 0,
             header_filter: Callable[[Option], str] = str,
             match_filter: Callable[[Option], str] = str,
-            custom_filter: Optional[Union[Filter, Callable[[str], bool]]] = None,
-            search_buffer: Optional[Buffer] = None,
-            cpu_count: Optional[int] = None) -> None:
+            custom_filter: Filter | Callable[[str], bool] | None = None,
+            search_buffer: Buffer | None = None,
+            cpu_count: int | None = None) -> None:
         if search_buffer is None:
             search_buffer = Buffer(multiline=False)
 
@@ -70,18 +60,18 @@ class OptionsList(ConditionalContainer, Generic[Option]):
 
         self.header_filter = header_filter
         self.match_filter = match_filter
-        self.current_index: Optional[int] = default_index
+        self.current_index: int | None = default_index
         self.entries_left_offset = 0
         self.cpu_count = cpu_count
 
-        self.options_headers_linecount: List[int] = []
-        self._indices_to_lines: List[int] = []
+        self.options_headers_linecount: list[int] = []
+        self._indices_to_lines: list[int] = []
 
-        self.options_headers: List[FormattedText] = []
-        self.options_matchers: List[str] = []
-        self.indices: List[int] = []
-        self._options: List[Option] = []
-        self.marks: List[int] = []
+        self.options_headers: list[FormattedText] = []
+        self.options_matchers: list[str] = []
+        self.indices: list[int] = []
+        self._options: list[Option] = []
+        self.marks: list[int] = []
         self.max_entry_height = 1
 
         # options are processed here also through the setter
@@ -134,7 +124,7 @@ class OptionsList(ConditionalContainer, Generic[Option]):
                 < self.options_headers_linecount[self.current_index]):
             return [("class:options_list.selected_margin", "|")]
         else:
-            marked_lines: List[int] = []
+            marked_lines: list[int] = []
             for index in self.marks:
                 start_line = self.index_to_line(index)
                 end_line = start_line + self.options_headers_linecount[index]
@@ -155,7 +145,7 @@ class OptionsList(ConditionalContainer, Generic[Option]):
         if self.current_index is not None:
             self.marks.append(self.current_index)
 
-    def get_options(self) -> List[Option]:
+    def get_options(self) -> list[Option]:
         """Get the original options
         """
         return self._options
@@ -213,7 +203,7 @@ class OptionsList(ConditionalContainer, Generic[Option]):
         return str(self.search_buffer.text)
 
     @property
-    def search_regex(self) -> Pattern[str]:
+    def search_regex(self) -> re.Pattern[str]:
         """Get and form the regular expression out of the query text"""
         cleaned_search = (
             self.query_text
@@ -262,7 +252,7 @@ class OptionsList(ConditionalContainer, Generic[Option]):
             else:
                 self.current_index = self.indices[0]
 
-    def get_selection(self) -> List[Option]:
+    def get_selection(self) -> list[Option]:
         """Get the selected item, if there is Any"""
         if len(self.marks):
             return [self.get_options()[m] for m in self.marks]
@@ -286,7 +276,7 @@ class OptionsList(ConditionalContainer, Generic[Option]):
         except Exception:
             self.cursor = Point(0, 0)
 
-    def get_tokens(self) -> List[Tuple[str, str]]:
+    def get_tokens(self) -> list[tuple[str, str]]:
         """Creates the body of the list, which is just a list of tuples,
         where the tuples follow the FormattedText structure.
         """
@@ -295,7 +285,7 @@ class OptionsList(ConditionalContainer, Generic[Option]):
 
         self.update_cursor()
         begin_t = time.time()
-        internal_text: List[Tuple[str, str]] = functools.reduce(
+        internal_text: list[tuple[str, str]] = functools.reduce(
             operator.add,
             [self.options_headers[i] for i in self.indices],
             [])

--- a/papis/utils.py
+++ b/papis/utils.py
@@ -1,20 +1,8 @@
 import os
 import re
 import sys
-from typing import (
-    TYPE_CHECKING,
-    Any,
-    Callable,
-    Dict,
-    Iterable,
-    Iterator,
-    List,
-    Optional,
-    Sequence,
-    Tuple,
-    TypeVar,
-    Union,
-)
+from collections.abc import Callable, Iterable, Iterator, Sequence
+from typing import TYPE_CHECKING, Any, TypeVar
 from warnings import warn
 
 try:
@@ -78,7 +66,7 @@ def has_multiprocessing() -> bool:
 
 def parmap(f: Callable[[A], B],
            xs: Iterable[A],
-           np: Optional[int] = None) -> List[B]:
+           np: int | None = None) -> list[B]:
     """Apply the function *f* to all elements of *xs*.
 
     When available, this function uses the :mod:`multiprocessing` module to
@@ -112,8 +100,8 @@ def parmap(f: Callable[[A], B],
 
 def run(cmd: Sequence[str],
         wait: bool = True,
-        env: Optional[Dict[str, Any]] = None,
-        cwd: Optional[str] = None) -> None:
+        env: dict[str, Any] | None = None,
+        cwd: str | None = None) -> None:
     """Run a given command with :mod:`subprocess`.
 
     This is a simple wrapper around :class:`subprocess.Popen` with custom
@@ -151,7 +139,7 @@ def run(cmd: Sequence[str],
     else:
         # NOTE: detach process so that the terminal can be closed without also
         # closing the 'opentool' itself with the open document
-        platform_kwargs: Dict[str, Any] = {}
+        platform_kwargs: dict[str, Any] = {}
         if sys.platform == "win32":
             platform_kwargs["creationflags"] = (
                 subprocess.DETACHED_PROCESS
@@ -175,7 +163,7 @@ def run(cmd: Sequence[str],
 
 def general_open(file_name: str,
                  key: str,
-                 default_opener: Optional[str] = None,
+                 default_opener: str | None = None,
                  wait: bool = True) -> None:
     """Open a file with a configured open tool (executable).
 
@@ -221,7 +209,7 @@ def open_file(file_path: str, wait: bool = True) -> None:
     general_open(file_name=file_path, key="opentool", wait=wait)
 
 
-def get_folders(folder: str) -> List[str]:
+def get_folders(folder: str) -> list[str]:
     """Get all folders with ``papis`` documents inside of *folder*.
 
     This is the main indexing routine. It looks inside *folder* and crawls
@@ -245,7 +233,7 @@ def get_folders(folder: str) -> List[str]:
     return folders
 
 
-def create_identifier(input_list: Optional[str] = None, skip: int = 0) -> Iterator[str]:
+def create_identifier(input_list: str | None = None, skip: int = 0) -> Iterator[str]:
     warn("'create_identifier' is deprecated and will be removed in the next "
          "version. Use 'papis.paths.unique_suffixes' instead.",
          DeprecationWarning, stacklevel=2)
@@ -267,9 +255,9 @@ def clean_document_name(doc_path: str, is_path: bool = True) -> str:
 
 
 def locate_document_in_lib(document: papis.document.Document,
-                           library: Optional[str] = None,
+                           library: str | None = None,
                            *,
-                           unique_document_keys: Optional[List[str]] = None,
+                           unique_document_keys: list[str] | None = None,
                            ) -> papis.document.Document:
     """Locate a document in a library.
 
@@ -303,7 +291,7 @@ def locate_document_in_lib(document: papis.document.Document,
 def locate_document(
         document: papis.document.Document,
         documents: Iterable[papis.document.Document]
-        ) -> Optional[papis.document.Document]:
+        ) -> papis.document.Document | None:
     """Locate a *document* in a list of *documents*.
 
     This function uses the :confval:`unique-document-keys`
@@ -330,7 +318,7 @@ def locate_document(
     return None
 
 
-def folders_to_documents(folders: Iterable[str]) -> List[papis.document.Document]:
+def folders_to_documents(folders: Iterable[str]) -> list[papis.document.Document]:
     """Load a list of documents from their respective *folders*.
 
     :param folders: a list of folder paths to load from.
@@ -346,8 +334,8 @@ def folders_to_documents(folders: Iterable[str]) -> List[papis.document.Document
 
 
 def update_doc_from_data_interactively(
-        document: Union[papis.document.Document, Dict[str, Any]],
-        data: Dict[str, Any],
+        document: papis.document.Document | dict[str, Any],
+        data: dict[str, Any],
         data_name: str) -> None:
     """Shows a TUI to update the *document* interactively with fields from *data*.
 
@@ -394,9 +382,9 @@ def get_cache_home() -> str:
 
 def get_matching_importer_or_downloader(
         uri: str,
-        download_files: Optional[bool] = None,
-        only_data: Optional[bool] = None
-        ) -> List[papis.importer.Importer]:
+        download_files: bool | None = None,
+        only_data: bool | None = None
+        ) -> list[papis.importer.Importer]:
     """Gets all the importers and downloaders that match *uri*.
 
     This function tries to match the URI using :meth:`~papis.importer.Importer.match`
@@ -462,10 +450,10 @@ def get_matching_importer_or_downloader(
 
 
 def get_matching_importer_by_name(
-        name_and_uris: Iterable[Tuple[str, str]],
-        download_files: Optional[bool] = None,
-        only_data: Optional[bool] = None,
-        ) -> List[papis.importer.Importer]:
+        name_and_uris: Iterable[tuple[str, str]],
+        download_files: bool | None = None,
+        only_data: bool | None = None,
+        ) -> list[papis.importer.Importer]:
     """Get importers that match the given URIs.
 
     This function tries to match the URI using :meth:`~papis.importer.Importer.match`
@@ -522,8 +510,8 @@ def get_matching_importer_by_name(
 def collect_importer_data(
         importers: Iterable[papis.importer.Importer],
         batch: bool = True,
-        use_files: Optional[bool] = None,
-        only_data: Optional[bool] = None,
+        use_files: bool | None = None,
+        only_data: bool | None = None,
         ) -> papis.importer.Context:
     """Collect all data from the given *importers*.
 

--- a/papis/web/citations.py
+++ b/papis/web/citations.py
@@ -1,5 +1,6 @@
 import urllib.parse
-from typing import Any, Callable, Dict
+from collections.abc import Callable
+from typing import Any
 
 import dominate.tags as t
 
@@ -14,7 +15,7 @@ def render(doc: papis.document.Document,
            libname: str,
            libfolder: str,
            timeline_id: str,
-           fetch_path: Callable[[str, Dict[str, Any]], str],
+           fetch_path: Callable[[str, dict[str, Any]], str],
            checker: Callable[[papis.document.Document], bool],
            getter: Callable[[papis.document.Document],
                             papis.citations.Citations],

--- a/papis/web/document.py
+++ b/papis/web/document.py
@@ -1,6 +1,5 @@
 import os
 import urllib.parse
-from typing import List
 
 import dominate.tags as t
 
@@ -48,7 +47,7 @@ def links(doc: papis.document.Document, small: bool = True) -> None:
                                             safe="")))
 
 
-def _doc_files_icons(files: List[str],
+def _doc_files_icons(files: list[str],
                      libname: str,
                      libfolder: str) -> t.html_tag:
     with t.div() as result:

--- a/papis/web/docview.py
+++ b/papis/web/docview.py
@@ -1,4 +1,5 @@
-from typing import Any, Callable, List
+from collections.abc import Callable
+from typing import Any
 
 import dominate.tags as t
 import dominate.util as tu
@@ -60,7 +61,7 @@ def html(libname: str, doc: papis.document.Document) -> t.html_tag:
                 with t.ul(cls="nav nav-tabs"):
 
                     def _tab_element(content: Callable[..., t.html_tag],
-                                     args: List[Any],
+                                     args: list[Any],
                                      href: str,
                                      active: bool = False) -> t.html_tag:
                         with t.li(cls="active nav-item") as result:

--- a/papis/web/html.py
+++ b/papis/web/html.py
@@ -1,4 +1,5 @@
-from typing import Any, Callable
+from collections.abc import Callable
+from typing import Any
 
 import dominate.tags as t
 

--- a/papis/web/paths.py
+++ b/papis/web/paths.py
@@ -1,15 +1,15 @@
-from typing import Any, Dict, Optional
+from typing import Any
 
 import papis.id
 
 
-def _ref(doc: Dict[str, Any]) -> Optional[str]:
+def _ref(doc: dict[str, Any]) -> str | None:
     if papis.id.has_id(doc):
         return papis.id.get(doc)
     return None
 
 
-def format_if_has_id(doc: Dict[str, Any],
+def format_if_has_id(doc: dict[str, Any],
                      fmt: str,
                      *args: Any,
                      **kwargs: Any) -> str:
@@ -29,7 +29,7 @@ def query_path(libname: str) -> str:
     return f"/library/{libname}/query"
 
 
-def fetch_citations_server_path(libname: str, doc: Dict[str, Any]) -> str:
+def fetch_citations_server_path(libname: str, doc: dict[str, Any]) -> str:
     """
     Path for fetching citations for papers.
     """
@@ -40,7 +40,7 @@ def fetch_citations_server_path(libname: str, doc: Dict[str, Any]) -> str:
                             libname=libname)
 
 
-def fetch_cited_by_server_path(libname: str, doc: Dict[str, Any]) -> str:
+def fetch_cited_by_server_path(libname: str, doc: dict[str, Any]) -> str:
     """
     Path for fetching cited-by type citations for papers
     """
@@ -51,7 +51,7 @@ def fetch_cited_by_server_path(libname: str, doc: Dict[str, Any]) -> str:
                             libname=libname)
 
 
-def update_notes(libname: str, doc: Dict[str, Any]) -> str:
+def update_notes(libname: str, doc: dict[str, Any]) -> str:
     """
     Path for updating the notes of the paper.
     """
@@ -61,7 +61,7 @@ def update_notes(libname: str, doc: Dict[str, Any]) -> str:
                             libname=libname)
 
 
-def update_info(libname: str, doc: Dict[str, Any]) -> str:
+def update_info(libname: str, doc: dict[str, Any]) -> str:
     """
     Path for updating the ``info.yaml`` file itself.
     """
@@ -71,7 +71,7 @@ def update_info(libname: str, doc: Dict[str, Any]) -> str:
                             libname=libname)
 
 
-def doc_server_path(libname: str, doc: Dict[str, Any]) -> str:
+def doc_server_path(libname: str, doc: dict[str, Any]) -> str:
     """
     The server path for a document (it might change in the future).
     """

--- a/papis/web/search.py
+++ b/papis/web/search.py
@@ -1,5 +1,3 @@
-from typing import List
-
 import dominate.tags as t
 import dominate.util as tu
 
@@ -25,7 +23,7 @@ def _clear_cache(libname: str) -> None:
 
 def _jquery_table(libname: str,
                   libfolder: str,
-                  documents: List[papis.document.Document]) -> t.html_tag:
+                  documents: list[papis.document.Document]) -> t.html_tag:
     script = """
     $(document).ready(function(){
         $('#pub_table').DataTable({
@@ -57,7 +55,7 @@ def html(pretitle: str,
          libname: str,
          libfolder: str,
          query: str,
-         documents: List[papis.document.Document]) -> t.html_tag:
+         documents: list[papis.document.Document]) -> t.html_tag:
     """
     Page for querying the Papis database and present the results.
     """

--- a/papis/web/static.py
+++ b/papis/web/static.py
@@ -1,10 +1,9 @@
 import os
-from typing import List
 
 import papis.config
 
 
-def static_paths() -> List[str]:
+def static_paths() -> list[str]:
     """
     This is the static directories where the Papis web-application
     can access files.

--- a/papis/web/tags.py
+++ b/papis/web/tags.py
@@ -1,5 +1,4 @@
 import re
-from typing import Dict, List, Union
 
 import dominate.tags as t
 
@@ -7,13 +6,13 @@ import papis.web.header
 import papis.web.html as wh
 import papis.web.navbar
 
-Tags = Union[str, List[str]]
+Tags = str | list[str]
 TAGS_SPLIT_RX = re.compile(r"\s*[,\s]\s*")
 PAPIS_TAGS_CLASS = "papis-tags"
 PAPIS_TAG_CLASS = "papis-tag"
 
 
-def ensure_tags_list(tags: Tags) -> List[str]:
+def ensure_tags_list(tags: Tags) -> list[str]:
     """
     Ensure getting a list of tags to render them.
     """
@@ -35,7 +34,7 @@ def tags_list_div(tags: Tags, libname: str) -> None:
             _tag(tag=tag, libname=libname)
 
 
-def html(pretitle: str, libname: str, tags: Dict[str, int],
+def html(pretitle: str, libname: str, tags: dict[str, int],
          sort_by: str) -> t.html_tag:
     with papis.web.header.main_html_document(pretitle) as result:
         with result.body:

--- a/papis/web/timeline.py
+++ b/papis/web/timeline.py
@@ -2,7 +2,8 @@
 This file creates a timeline of documents with year and possibly month
 information.
 """
-from typing import Any, Dict, Sequence
+from collections.abc import Sequence
+from typing import Any
 
 import dominate.tags as t
 import dominate.util as tu
@@ -11,7 +12,7 @@ import papis.document
 import papis.web.paths as wp
 
 
-def widget(documents: Sequence[Dict[str, Any]],
+def widget(documents: Sequence[dict[str, Any]],
            libname: str,
            _id: str) -> None:
     """
@@ -19,7 +20,7 @@ def widget(documents: Sequence[Dict[str, Any]],
     """
     t.div(id=_id, style="width: 100%; height: 300px;")
 
-    def _make_text(_d: Dict[str, Any]) -> str:
+    def _make_text(_d: dict[str, Any]) -> str:
         text = papis.document.describe(_d)
         href = wp.doc_server_path(libname, _d)
         if href:

--- a/papis/yaml.py
+++ b/papis/yaml.py
@@ -1,5 +1,6 @@
 import os
-from typing import Any, Dict, List, Optional, Sequence
+from collections.abc import Sequence
+from typing import Any
 
 import click
 import yaml
@@ -24,8 +25,8 @@ logger = papis.logging.get_logger(__name__)
 
 
 def data_to_yaml(yaml_path: str,
-                 data: Dict[str, Any], *,
-                 allow_unicode: Optional[bool] = True) -> None:
+                 data: dict[str, Any], *,
+                 allow_unicode: bool | None = True) -> None:
     """Save *data* to *yaml_path* in the YAML format.
 
     :param yaml_path: path to a file.
@@ -39,9 +40,9 @@ def data_to_yaml(yaml_path: str,
                   default_flow_style=False)
 
 
-def list_to_path(data: Sequence[Dict[str, Any]],
+def list_to_path(data: Sequence[dict[str, Any]],
                  filepath: str, *,
-                 allow_unicode: Optional[bool] = True) -> None:
+                 allow_unicode: bool | None = True) -> None:
     r"""Save a list of :class:`dict`\ s to a YAML file.
 
     :param data: a sequence of dictionaries to save as YAML documents.
@@ -56,7 +57,7 @@ def list_to_path(data: Sequence[Dict[str, Any]],
 
 
 def yaml_to_data(yaml_path: str,
-                 raise_exception: bool = False) -> Dict[str, Any]:
+                 raise_exception: bool = False) -> dict[str, Any]:
     """Read a YAML document from *yaml_path*.
 
     :param yaml_path: path to a file.
@@ -81,7 +82,7 @@ def yaml_to_data(yaml_path: str,
 
 
 def yaml_to_list(yaml_path: str,
-                 raise_exception: bool = False) -> List[Dict[str, Any]]:
+                 raise_exception: bool = False) -> list[dict[str, Any]]:
     """Read a list of YAML documents.
 
     This is analogous to :func:`yaml_to_data`, but uses ``yaml.load_all`` to
@@ -106,7 +107,7 @@ def yaml_to_list(yaml_path: str,
         return []
 
 
-def exporter(documents: List[papis.document.Document]) -> str:
+def exporter(documents: list[papis.document.Document]) -> str:
     """Convert document to the YAML format."""
     string = yaml.dump_all(
         [papis.document.to_dict(document) for document in documents],
@@ -146,7 +147,7 @@ class Importer(papis.importer.Importer):
         super().__init__(name="yaml", uri=uri)
 
     @classmethod
-    def match(cls, uri: str) -> Optional[papis.importer.Importer]:
+    def match(cls, uri: str) -> papis.importer.Importer | None:
         """Check if the *uri* points to an existing YAML file."""
         importer = Importer(uri=uri)
         if os.path.exists(uri) and not os.path.isdir(uri):

--- a/papis/zenodo.py
+++ b/papis/zenodo.py
@@ -1,6 +1,6 @@
 import datetime
 import json
-from typing import Any, Dict, List, Optional
+from typing import Any
 
 import papis
 import papis.document
@@ -14,7 +14,7 @@ ZENODO_URL = "https://www.zenodo.org/api/records/{record_id}"
 logger = papis.logging.get_logger(__name__)
 
 
-def get_author_info(authors: List[Dict[str, str]]) -> List[Dict[str, str]]:
+def get_author_info(authors: list[dict[str, str]]) -> list[dict[str, str]]:
     """Formats each of the authors as a dictionary with given name,
     family name, and affiliation if available.
 
@@ -127,7 +127,7 @@ key_conversion = [
 ]
 
 
-def zenodo_data_to_papis_data(data: Dict[str, Any]) -> Dict[str, Any]:
+def zenodo_data_to_papis_data(data: dict[str, Any]) -> dict[str, Any]:
     """Converts the dictionary from Zenodo to the conventional papis format.
 
     :param data: the raw dictionary from Zenodo
@@ -166,7 +166,7 @@ def _get_zenodo_response(record_id: str) -> str:
     return response.content.decode()
 
 
-def get_data(record_id: str) -> Dict[str, Any]:
+def get_data(record_id: str) -> dict[str, Any]:
     """Fetches a record from the Zenodo API and processes it with a helper function
 
     :param record_id: a Zenodo record id
@@ -190,7 +190,7 @@ def get_data(record_id: str) -> Dict[str, Any]:
 class Context(papis.importer.Context):
     def __init__(self) -> None:
         super().__init__()
-        self.file_info: Dict[str, Any] = {}
+        self.file_info: dict[str, Any] = {}
 
 
 class Importer(papis.importer.Importer):
@@ -202,14 +202,14 @@ class Importer(papis.importer.Importer):
         super().__init__(name="zenodo", uri=uri, ctx=Context())
 
     @classmethod
-    def match(cls, uri: str) -> Optional[papis.importer.Importer]:
+    def match(cls, uri: str) -> papis.importer.Importer | None:
         if is_valid_record_id(uri):
             return Importer(uri)
 
         return None
 
     @classmethod
-    def match_data(cls, data: Dict[str, Any]) -> Optional["Importer"]:
+    def match_data(cls, data: dict[str, Any]) -> "Importer | None":
         return None
 
     def fetch_data(self) -> None:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -33,10 +33,10 @@ keywords = [
     "tui",
     "zotero",
 ]
-license = { text = "GPL-3.0" }
+license = { text = "GPL-3.0-or-later" }
 maintainers = [{ name = "Alejandro Gallo", email = "aamsgallo@gmail.com" }]
 authors = [{ name = "Alejandro Gallo", email = "aamsgallo@gmail.com" }]
-requires-python = ">=3.8"
+requires-python = ">=3.10"
 classifiers = [
     "Development Status :: 4 - Beta",
     "Environment :: Console",
@@ -53,8 +53,6 @@ classifiers = [
     "Operating System :: POSIX",
     "Operating System :: Unix",
     "Programming Language :: Python :: 3 :: Only",
-    "Programming Language :: Python :: 3.8",
-    "Programming Language :: Python :: 3.9",
     "Programming Language :: Python :: 3.10",
     "Programming Language :: Python :: 3.11",
     "Programming Language :: Python :: 3.12",
@@ -320,12 +318,13 @@ multiline-quotes = "double"
 combine-as-imports = true
 
 [tool.mypy]
+python_version = "3.10"
 strict = true
-show_column_numbers = true
-hide_error_codes = false
 pretty = true
 files = [ "papis", "tests", "examples", "tools" ]
 warn_unused_ignores = false
+show_column_numbers = true
+hide_error_codes = false
 
 [[tool.mypy.overrides]]
 module = [

--- a/tests/commands/test_add.py
+++ b/tests/commands/test_add.py
@@ -1,7 +1,6 @@
 import os
 import shutil
 import sys
-from typing import List
 
 import pytest
 
@@ -92,7 +91,7 @@ def test_add_auto_doctor_run(tmp_library: TemporaryLibrary) -> None:
         "year": "2009",
         "ref": "#{2FJT2E3A}"
     }
-    paths: List[str] = []
+    paths: list[str] = []
 
     import papis.config
 

--- a/tests/commands/test_addto.py
+++ b/tests/commands/test_addto.py
@@ -1,6 +1,6 @@
 import logging
 import os
-from typing import Any, Dict, Optional
+from typing import Any
 
 import pytest
 
@@ -82,10 +82,10 @@ def test_addto_cli(tmp_library: TemporaryLibrary, nfiles: int = 5) -> None:
 
 def _mock_download_document(
         url: str,
-        expected_document_extension: Optional[str] = None,
-        _cookies: Optional[Dict[str, Any]] = None,
-        filename: Optional[str] = None,
-        ) -> Optional[str]:
+        expected_document_extension: str | None = None,
+        _cookies: dict[str, Any] | None = None,
+        filename: str | None = None,
+        ) -> str | None:
     # certain markers in the url signal the failure case
     if "fail" in url or "nonexist" in url:
         return None

--- a/tests/commands/test_addto.py
+++ b/tests/commands/test_addto.py
@@ -75,8 +75,9 @@ def test_addto_cli(tmp_library: TemporaryLibrary, nfiles: int = 5) -> None:
         infile, _ = os.path.splitext(os.path.basename(infile))
         return outfile.startswith(normalize_path(infile))
 
-    assert all(eq(outfile, infile) for outfile, infile in zip(files, inputfiles)), (
-        list(zip(files, inputfiles)))
+    assert (
+        all(eq(a, b) for a, b in zip(files, inputfiles, strict=True))), (
+        list(zip(files, inputfiles, strict=True)))
 
 
 def _mock_download_document(

--- a/tests/commands/test_export.py
+++ b/tests/commands/test_export.py
@@ -20,7 +20,7 @@ def test_export_run(tmp_library: TemporaryLibrary) -> None:
 
     # FIXME: not all fields are there and some don't match due to bibtex
     # pre- or post-processing
-    assert all(d["title"] == doc["title"] for d, doc in zip(data, docs))
+    assert all(d["title"] == doc["title"] for d, doc in zip(data, docs, strict=True))
 
     # json
     exported_json = run(docs, to_format="json")

--- a/tests/commands/test_update.py
+++ b/tests/commands/test_update.py
@@ -1,5 +1,5 @@
 import os
-from typing import Any, Dict
+from typing import Any
 
 import pytest
 
@@ -19,7 +19,7 @@ def _get_resource_file(filename: str) -> str:
 
 
 def update_doc_from_data_interactively(
-    document: Document, data: Dict[str, Any], data_name: str
+    document: Document, data: dict[str, Any], data_name: str
 ) -> None:
     document.update(data)
 

--- a/tests/downloaders/test_utils.py
+++ b/tests/downloaders/test_utils.py
@@ -1,5 +1,4 @@
 import os
-from typing import Optional
 
 import pytest
 
@@ -42,7 +41,7 @@ def test_get_downloader(tmp_config: TemporaryConfiguration) -> None:
 def test_download_document(tmp_config: TemporaryConfiguration,
                            url: str,
                            expected_file_name: str,
-                           ext: Optional[str]) -> None:
+                           ext: str | None) -> None:
     from papis.downloaders import download_document
 
     local_file_name = download_document(url, expected_document_extension=ext)

--- a/tests/test_crossref.py
+++ b/tests/test_crossref.py
@@ -1,6 +1,6 @@
 import json
 import os
-from typing import Any, Dict
+from typing import Any
 
 import pytest
 
@@ -12,7 +12,7 @@ RESOURCEDIR = os.path.join(
 )
 
 
-def _get_test_json(filename: str) -> Dict[str, Any]:
+def _get_test_json(filename: str) -> dict[str, Any]:
     with open(filename, encoding="utf-8") as fd:
         result = json.load(fd)
 

--- a/tests/test_docmatcher.py
+++ b/tests/test_docmatcher.py
@@ -1,16 +1,15 @@
 import os
+import re
 from functools import partial
-from typing import TYPE_CHECKING, Any, List, Optional, Pattern, Tuple
+from typing import Any
 
 import yaml
 
+from papis.document import Document
 from papis.testing import TemporaryConfiguration
 
-if TYPE_CHECKING:
-    from papis.document import Document
 
-
-def get_docs() -> List["Document"]:
+def get_docs() -> list["Document"]:
     from papis.document import from_data
 
     yamlfile = os.path.join(os.path.dirname(__file__), "data", "licl.yaml")
@@ -19,11 +18,11 @@ def get_docs() -> List["Document"]:
 
 
 def docmatcher_matcher(
-        res: Tuple[bool, int],
+        res: tuple[bool, int],
         document: "Document",
-        search: Pattern[str],
-        match_format: Optional[str] = None,
-        doc_key: Optional[str] = None,
+        search: re.Pattern[str],
+        match_format: str | None = None,
+        doc_key: str | None = None,
         ) -> Any:
     return res[0]
 

--- a/tests/test_isbn.py
+++ b/tests/test_isbn.py
@@ -1,12 +1,13 @@
 import os
-from typing import Any, Callable, Optional
+from collections.abc import Callable
+from typing import Any
 
 import pytest
 
 from papis.testing import TemporaryConfiguration
 
 
-def load_json(filename: str, data_getter: Optional[Callable[[], Any]] = None) -> Any:
+def load_json(filename: str, data_getter: Callable[[], Any] | None = None) -> Any:
     import json
     path = os.path.join(
         os.path.dirname(__file__), "resources", "isbn", filename)

--- a/tests/test_paths.py
+++ b/tests/test_paths.py
@@ -14,10 +14,11 @@ def test_unique_suffixes() -> None:
         "N", "O", "P", "Q", "R", "S", "T", "U", "V", "W", "X", "Y", "Z",
         "AA", "AB", "AC", "AD"
     ]
-    for value, output in zip(expected, unique_suffixes(string.ascii_uppercase)):
+    for value, output in zip(expected, unique_suffixes(string.ascii_uppercase),
+                             strict=False):
         assert output == value
 
-    for value, output in zip(expected[3:], unique_suffixes(skip=3)):
+    for value, output in zip(expected[3:], unique_suffixes(skip=3), strict=False):
         assert output == value.lower()
 
 

--- a/tools/extract-changelog.py
+++ b/tools/extract-changelog.py
@@ -1,8 +1,7 @@
 import pathlib
-from typing import Optional
 
 
-def main(filename: pathlib.Path, *, outfile: Optional[pathlib.Path] = None) -> int:
+def main(filename: pathlib.Path, *, outfile: pathlib.Path | None = None) -> int:
     if not filename.exists():
         print(f"ERROR: Filename does not exist: '{filename}'")
         return 1

--- a/tools/test-all-py-versions-in-docker.sh
+++ b/tools/test-all-py-versions-in-docker.sh
@@ -7,7 +7,7 @@ fi
 
 set -ex
 
-for pyversion in 3.8 3.9 3.10 3.11 3.12 3.13; do
+for pyversion in 3.10 3.11 3.12 3.13; do
     "$CTRT" build \
         --build-arg "PYTHON_VERSION=$pyversion" \
         -t "papisdev:$pyversion" \

--- a/tools/windows/populate_wxs_artifacts.py
+++ b/tools/windows/populate_wxs_artifacts.py
@@ -4,7 +4,6 @@ dist/papis/_internal into the XML manifest that is used to create the MSI."""
 import hashlib
 import os
 import uuid
-from typing import Optional
 
 
 def get_id(*path_components: str) -> str:
@@ -32,7 +31,7 @@ def get_id(*path_components: str) -> str:
 
 def render_template(template: str,
                     outfile: str, *,
-                    version: Optional[str] = None) -> None:
+                    version: str | None = None) -> None:
     from xml.etree import ElementTree
 
     if version is None:


### PR DESCRIPTION
This just bumps the minimum python version to 3.10 and ~does not do any code modification / upgrades to use some newer features~ fixes all the `ruff` issues.

Fixes #978.