### PR TITLE
Doc: Cleanup pyproject deps

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -21,9 +21,71 @@
         pkgs = nixpkgs.legacyPackages.${system};
         python = pkgs.python3.override {
           packageOverrides = self: super: {
-            flake8-pyproject = flake8-pyproject;
-            types-pygments = types-pygments;
-            types-python-slugify = types-python-slugify;
+
+            flake8-pyproject = python.pkgs.buildPythonPackage {
+              pname = "flake8-pyproject";
+              version = "1.2.3";
+              pyproject = true;
+
+              src = pkgs.fetchFromGitHub {
+                owner = "john-hen";
+                repo = "Flake8-pyproject";
+                rev = "30b8444781d16edd54c11df08210a7c8fb79258d";
+                hash = "sha256-bPRIj7tYmm6I9eo1ZjiibmpVmGcHctZSuTvnKX+raPg=";
+              };
+
+              doCheck = false;
+              checkInputs = [ ];
+              propagatedBuildInputs = [
+                pypkgs.flit-core
+                pypkgs.flake8
+              ];
+
+              meta = with pkgs.lib; {
+                homepage = "https://github.com/john-hen/Flake8-pyproject";
+                description = "Flake8 plug-in loading the configuration from pyproject.toml";
+                license = licenses.mit;
+              };
+            };
+
+            types-pygments = final.buildPythonPackage rec {
+              pname = "types-Pygments";
+              version = "2.19.0.20250305";
+
+              src = final.fetchPypi {
+                inherit version;
+                pname = "types_pygments";
+                sha256 = "sha256-BExQ6A7NQSjACnJo8gNV4W9cVUZtPUnf2gm+kgr0C0s=";
+              };
+
+              doCheck = false;
+              checkInputs = [ ];
+
+              meta = with pkgs.lib; {
+                homepage = "https://github.com/python/typeshed";
+                description = "Typing stubs for Pygments";
+                license = licenses.asl20;
+              };
+            };
+
+            types-python-slugify = python.pkgs.buildPythonPackage rec {
+              pname = "types-python-slugify";
+              version = "8.0.2.20240310";
+
+              src = python.pkgs.fetchPypi {
+                inherit pname version;
+                sha256 = "sha256-UVe1CMf+1YdSDHDXf2KuoPr9xmIIk8LsiXLxOh+vVWA=";
+              };
+
+              doCheck = false;
+              checkInputs = [ ];
+
+              meta = with pkgs.lib; {
+                homepage = "https://github.com/python/typeshed";
+                description = "Typing stubs for python-slugify";
+                license = licenses.asl20;
+              };
+            };
           };
         };
         pypkgs = pkgs.python3Packages;
@@ -31,70 +93,6 @@
           projectRoot = ./.;
         };
 
-        flake8-pyproject = python.pkgs.buildPythonPackage {
-          pname = "flake8-pyproject";
-          version = "1.2.3";
-          pyproject = true;
-
-          src = pkgs.fetchFromGitHub {
-            owner = "john-hen";
-            repo = "Flake8-pyproject";
-            rev = "30b8444781d16edd54c11df08210a7c8fb79258d";
-            hash = "sha256-bPRIj7tYmm6I9eo1ZjiibmpVmGcHctZSuTvnKX+raPg=";
-          };
-
-          doCheck = false;
-          checkInputs = [ ];
-          propagatedBuildInputs = [
-            pypkgs.flit-core
-            pypkgs.flake8
-          ];
-
-          meta = with pkgs.lib; {
-            homepage = "https://github.com/john-hen/Flake8-pyproject";
-            description = "Flake8 plug-in loading the configuration from pyproject.toml";
-            license = licenses.mit;
-          };
-        };
-
-        types-pygments = python.pkgs.buildPythonPackage rec {
-          pname = "types-Pygments";
-          version = "2.19.0.20250305";
-
-          src = python.pkgs.fetchPypi {
-            inherit version;
-            pname = "types_pygments";
-            sha256 = "sha256-BExQ6A7NQSjACnJo8gNV4W9cVUZtPUnf2gm+kgr0C0s=";
-          };
-
-          doCheck = false;
-          checkInputs = [ ];
-
-          meta = with pkgs.lib; {
-            homepage = "https://github.com/python/typeshed";
-            description = "Typing stubs for Pygments";
-            license = licenses.asl20;
-          };
-        };
-
-        types-python-slugify = python.pkgs.buildPythonPackage rec {
-          pname = "types-python-slugify";
-          version = "8.0.2.20240310";
-
-          src = python.pkgs.fetchPypi {
-            inherit pname version;
-            sha256 = "sha256-UVe1CMf+1YdSDHDXf2KuoPr9xmIIk8LsiXLxOh+vVWA=";
-          };
-
-          doCheck = false;
-          checkInputs = [ ];
-
-          meta = with pkgs.lib; {
-            homepage = "https://github.com/python/typeshed";
-            description = "Typing stubs for python-slugify";
-            license = licenses.asl20;
-          };
-        };
       in
       {
         packages = {

--- a/flake.nix
+++ b/flake.nix
@@ -20,9 +20,9 @@
       let
         pkgs = nixpkgs.legacyPackages.${system};
         python = pkgs.python3.override {
-          packageOverrides = self: super: {
+          packageOverrides = final: prev: {
 
-            flake8-pyproject = python.pkgs.buildPythonPackage {
+            flake8-pyproject = final.buildPythonPackage {
               pname = "flake8-pyproject";
               version = "1.2.3";
               pyproject = true;
@@ -37,8 +37,8 @@
               doCheck = false;
               checkInputs = [ ];
               propagatedBuildInputs = [
-                pypkgs.flit-core
-                pypkgs.flake8
+                final.flit-core
+                final.flake8
               ];
 
               meta = with pkgs.lib; {
@@ -68,11 +68,11 @@
               };
             };
 
-            types-python-slugify = python.pkgs.buildPythonPackage rec {
+            types-python-slugify = final.buildPythonPackage rec {
               pname = "types-python-slugify";
               version = "8.0.2.20240310";
 
-              src = python.pkgs.fetchPypi {
+              src = final.fetchPypi {
                 inherit pname version;
                 sha256 = "sha256-UVe1CMf+1YdSDHDXf2KuoPr9xmIIk8LsiXLxOh+vVWA=";
               };
@@ -88,7 +88,7 @@
             };
           };
         };
-        pypkgs = pkgs.python3Packages;
+
         project = pyproject-nix.lib.project.loadPyproject {
           projectRoot = ./.;
         };

--- a/flake.nix
+++ b/flake.nix
@@ -115,7 +115,10 @@
           # Returns a function that can be passed to `python.withPackages`
           arg = project.renderers.withPackages {
             inherit python;
-            extras = ["develop" "docs" "lsp" "optional"];
+            # extras = ["develop" "docs" "lsp" "optional"];
+            # Until https://github.com/pyproject-nix/pyproject.nix/issues/278 is
+            # resolved, we must explicitly enumerate the components of develop
+            extras = ["lint" "typing" "test" "docs" "lsp" "optional"];
           };
 
           # Returns a wrapped environment (virtualenv like) with all our packages

--- a/flake.nix
+++ b/flake.nix
@@ -86,6 +86,24 @@
                 license = licenses.asl20;
               };
             };
+
+            papis =
+              let
+                # Returns an attribute set that can be passed to `buildPythonPackage`.
+                attrs = project.renderers.buildPythonPackage {
+                  inherit python;
+                  extras = [ "optional" ];
+                };
+              in
+              # Pass attributes to buildPythonPackage.
+              # Here is a good spot to add on any missing or custom attributes.
+              final.buildPythonPackage (
+                attrs
+                // {
+                  # Because we're following main, use the git rev as version
+                  version = if (self ? rev) then self.shortRev else self.dirtyShortRev;
+                }
+              );
           };
         };
 
@@ -96,24 +114,8 @@
       in
       {
         packages = {
-          papis =
-            let
-              # Returns an attribute set that can be passed to `buildPythonPackage`.
-              attrs = project.renderers.buildPythonPackage {
-                inherit python;
-                extras = [ "optional" ];
-              };
-            in
-            # Pass attributes to buildPythonPackage.
-            # Here is a good spot to add on any missing or custom attributes.
-            python.pkgs.buildPythonPackage (
-              attrs
-              // {
-                # Because we're following main, use the git rev as version
-                version = if (self ? rev) then self.shortRev else self.dirtyShortRev;
-              }
-            );
           default = self.packages.${system}.papis;
+          inherit (python.pkgs) papis;
         };
         devShells = {
           default =

--- a/flake.nix
+++ b/flake.nix
@@ -8,194 +8,210 @@
     pyproject-nix.inputs.nixpkgs.follows = "nixpkgs";
   };
 
-  outputs = {
-    self,
-    nixpkgs,
-    flake-utils,
-    pyproject-nix,
-  }:
-    flake-utils.lib.eachDefaultSystem (system: let
-      pkgs = nixpkgs.legacyPackages.${system};
-      python = pkgs.python3.override {
-        packageOverrides = self: super: {
-          flake8-pyproject = flake8-pyproject;
-          types-pygments = types-pygments;
-          types-python-slugify = types-python-slugify;
-        };
-      };
-      pypkgs = pkgs.python3Packages;
-      project = pyproject-nix.lib.project.loadPyproject {
-        projectRoot = ./.;
-      };
-
-      flake8-pyproject = python.pkgs.buildPythonPackage {
-        pname = "flake8-pyproject";
-        version = "1.2.3";
-        pyproject = true;
-
-        src = pkgs.fetchFromGitHub {
-          owner = "john-hen";
-          repo = "Flake8-pyproject";
-          rev = "30b8444781d16edd54c11df08210a7c8fb79258d";
-          hash = "sha256-bPRIj7tYmm6I9eo1ZjiibmpVmGcHctZSuTvnKX+raPg=";
-        };
-
-        doCheck = false;
-        checkInputs = [];
-        propagatedBuildInputs = [pypkgs.flit-core pypkgs.flake8];
-
-        meta = with pkgs.lib; {
-          homepage = "https://github.com/john-hen/Flake8-pyproject";
-          description = "Flake8 plug-in loading the configuration from pyproject.toml";
-          license = licenses.mit;
-        };
-      };
-
-      types-pygments = python.pkgs.buildPythonPackage rec {
-        pname = "types-Pygments";
-        version = "2.19.0.20250305";
-
-        src = python.pkgs.fetchPypi {
-          inherit version;
-          pname = "types_pygments";
-          sha256 = "sha256-BExQ6A7NQSjACnJo8gNV4W9cVUZtPUnf2gm+kgr0C0s=";
-        };
-
-        doCheck = false;
-        checkInputs = [];
-
-        meta = with pkgs.lib; {
-          homepage = "https://github.com/python/typeshed";
-          description = "Typing stubs for Pygments";
-          license = licenses.asl20;
-        };
-      };
-
-      types-python-slugify = python.pkgs.buildPythonPackage rec {
-        pname = "types-python-slugify";
-        version = "8.0.2.20240310";
-
-        src = python.pkgs.fetchPypi {
-          inherit pname version;
-          sha256 = "sha256-UVe1CMf+1YdSDHDXf2KuoPr9xmIIk8LsiXLxOh+vVWA=";
-        };
-
-        doCheck = false;
-        checkInputs = [];
-
-        meta = with pkgs.lib; {
-          homepage = "https://github.com/python/typeshed";
-          description = "Typing stubs for python-slugify";
-          license = licenses.asl20;
-        };
-      };
-    in {
-      packages = {
-        papis = let
-          # Returns an attribute set that can be passed to `buildPythonPackage`.
-          attrs = project.renderers.buildPythonPackage {
-            inherit python;
-            extras = ["optional"];
+  outputs =
+    {
+      self,
+      nixpkgs,
+      flake-utils,
+      pyproject-nix,
+    }:
+    flake-utils.lib.eachDefaultSystem (
+      system:
+      let
+        pkgs = nixpkgs.legacyPackages.${system};
+        python = pkgs.python3.override {
+          packageOverrides = self: super: {
+            flake8-pyproject = flake8-pyproject;
+            types-pygments = types-pygments;
+            types-python-slugify = types-python-slugify;
           };
-        in
-          # Pass attributes to buildPythonPackage.
-          # Here is a good spot to add on any missing or custom attributes.
-          python.pkgs.buildPythonPackage (attrs
-            // {
-              # Because we're following main, use the git rev as version
-              version =
-                if (self ? rev)
-                then self.shortRev
-                else self.dirtyShortRev;
-            });
-        default = self.packages.${system}.papis;
-      };
-      devShells = {
-        default = let
-          # Returns a function that can be passed to `python.withPackages`
-          arg = project.renderers.withPackages {
-            inherit python;
-            # extras = ["develop" "docs" "lsp" "optional"];
-            # Until https://github.com/pyproject-nix/pyproject.nix/issues/278 is
-            # resolved, we must explicitly enumerate the components of develop
-            extras = ["lint" "typing" "test" "docs" "lsp" "optional"];
+        };
+        pypkgs = pkgs.python3Packages;
+        project = pyproject-nix.lib.project.loadPyproject {
+          projectRoot = ./.;
+        };
+
+        flake8-pyproject = python.pkgs.buildPythonPackage {
+          pname = "flake8-pyproject";
+          version = "1.2.3";
+          pyproject = true;
+
+          src = pkgs.fetchFromGitHub {
+            owner = "john-hen";
+            repo = "Flake8-pyproject";
+            rev = "30b8444781d16edd54c11df08210a7c8fb79258d";
+            hash = "sha256-bPRIj7tYmm6I9eo1ZjiibmpVmGcHctZSuTvnKX+raPg=";
           };
 
-          # Returns a wrapped environment (virtualenv like) with all our packages
-          pythonEnv = python.withPackages arg;
+          doCheck = false;
+          checkInputs = [ ];
+          propagatedBuildInputs = [
+            pypkgs.flit-core
+            pypkgs.flake8
+          ];
 
-          # used in below scripts to check if docker or podman is available
-          check-container-cmd =
-            # bash
-            ''
-              if command -v podman &> /dev/null
-              then
-                  container_cmd="podman"
-              elif command -v docker &> /dev/null
-              then
-                  container_cmd="docker"
-              else
-                  echo "Neither Podman or Docker could be found. Aborting..."
-                  exit 1
-              fi
-            '';
+          meta = with pkgs.lib; {
+            homepage = "https://github.com/john-hen/Flake8-pyproject";
+            description = "Flake8 plug-in loading the configuration from pyproject.toml";
+            license = licenses.mit;
+          };
+        };
 
-          # convenience command to build a Papis container with docker/podman
-          papis-build-container = pkgs.writeShellApplication {
-            name = "papis-build-container";
-            text =
-              check-container-cmd
-              +
-              # bash
-              ''
-                "$container_cmd" build -t papisdev .
+        types-pygments = python.pkgs.buildPythonPackage rec {
+          pname = "types-Pygments";
+          version = "2.19.0.20250305";
+
+          src = python.pkgs.fetchPypi {
+            inherit version;
+            pname = "types_pygments";
+            sha256 = "sha256-BExQ6A7NQSjACnJo8gNV4W9cVUZtPUnf2gm+kgr0C0s=";
+          };
+
+          doCheck = false;
+          checkInputs = [ ];
+
+          meta = with pkgs.lib; {
+            homepage = "https://github.com/python/typeshed";
+            description = "Typing stubs for Pygments";
+            license = licenses.asl20;
+          };
+        };
+
+        types-python-slugify = python.pkgs.buildPythonPackage rec {
+          pname = "types-python-slugify";
+          version = "8.0.2.20240310";
+
+          src = python.pkgs.fetchPypi {
+            inherit pname version;
+            sha256 = "sha256-UVe1CMf+1YdSDHDXf2KuoPr9xmIIk8LsiXLxOh+vVWA=";
+          };
+
+          doCheck = false;
+          checkInputs = [ ];
+
+          meta = with pkgs.lib; {
+            homepage = "https://github.com/python/typeshed";
+            description = "Typing stubs for python-slugify";
+            license = licenses.asl20;
+          };
+        };
+      in
+      {
+        packages = {
+          papis =
+            let
+              # Returns an attribute set that can be passed to `buildPythonPackage`.
+              attrs = project.renderers.buildPythonPackage {
+                inherit python;
+                extras = [ "optional" ];
+              };
+            in
+            # Pass attributes to buildPythonPackage.
+            # Here is a good spot to add on any missing or custom attributes.
+            python.pkgs.buildPythonPackage (
+              attrs
+              // {
+                # Because we're following main, use the git rev as version
+                version = if (self ? rev) then self.shortRev else self.dirtyShortRev;
+              }
+            );
+          default = self.packages.${system}.papis;
+        };
+        devShells = {
+          default =
+            let
+              # Returns a function that can be passed to `python.withPackages`
+              arg = project.renderers.withPackages {
+                inherit python;
+                # extras = ["develop" "docs" "lsp" "optional"];
+                # Until https://github.com/pyproject-nix/pyproject.nix/issues/278 is
+                # resolved, we must explicitly enumerate the components of develop
+                extras = [
+                  "lint"
+                  "typing"
+                  "test"
+                  "docs"
+                  "lsp"
+                  "optional"
+                ];
+              };
+
+              # Returns a wrapped environment (virtualenv like) with all our packages
+              pythonEnv = python.withPackages arg;
+
+              # used in below scripts to check if docker or podman is available
+              check-container-cmd =
+                # bash
+                ''
+                  if command -v podman &> /dev/null
+                  then
+                      container_cmd="podman"
+                  elif command -v docker &> /dev/null
+                  then
+                      container_cmd="docker"
+                  else
+                      echo "Neither Podman or Docker could be found. Aborting..."
+                      exit 1
+                  fi
+                '';
+
+              # convenience command to build a Papis container with docker/podman
+              papis-build-container = pkgs.writeShellApplication {
+                name = "papis-build-container";
+                text =
+                  check-container-cmd
+                  +
+                    # bash
+                    ''
+                      "$container_cmd" build -t papisdev .
+                    '';
+              };
+
+              # convenience command to run containerised tests
+              papis-run-container-tests = pkgs.writeShellApplication {
+                name = "papis-run-container-tests";
+                text =
+                  check-container-cmd
+                  +
+                    # bash
+                    ''
+                      "$container_cmd" run -v "$(pwd)":/papis --rm -it papisdev
+                    '';
+              };
+
+              # convenience command to enter a container with a populated test library
+              papis-run-container-interactive = pkgs.writeShellApplication {
+                name = "papis-run-container-interactive";
+                text =
+                  check-container-cmd
+                  +
+                    # bash
+                    ''
+                      populateLibPy=$(cat << END
+                      import papis.testing
+                      papis.testing.populate_library('/root/Documents/papers')
+                      END
+                      )
+                      entryCmd="python -c \"$populateLibPy\"; bash"
+
+                      "$container_cmd" run -v "$(pwd)":/papis --rm -it papisdev bash -c "$entryCmd"
+                    '';
+              };
+            in
+            # Create a devShell like normal.
+            pkgs.mkShell {
+              packages = [
+                self.packages.${system}.papis
+                pythonEnv
+                papis-build-container
+                papis-run-container-tests
+                papis-run-container-interactive
+              ];
+              shellHook = ''
+                export PYTHONPATH="$(pwd):$PYTHONPATH"
               '';
-          };
-
-          # convenience command to run containerised tests
-          papis-run-container-tests = pkgs.writeShellApplication {
-            name = "papis-run-container-tests";
-            text =
-              check-container-cmd
-              +
-              # bash
-              ''
-                "$container_cmd" run -v "$(pwd)":/papis --rm -it papisdev
-              '';
-          };
-
-          # convenience command to enter a container with a populated test library
-          papis-run-container-interactive = pkgs.writeShellApplication {
-            name = "papis-run-container-interactive";
-            text =
-              check-container-cmd
-              +
-              # bash
-              ''
-                populateLibPy=$(cat << END
-                import papis.testing
-                papis.testing.populate_library('/root/Documents/papers')
-                END
-                )
-                entryCmd="python -c \"$populateLibPy\"; bash"
-
-                "$container_cmd" run -v "$(pwd)":/papis --rm -it papisdev bash -c "$entryCmd"
-              '';
-          };
-        in
-          # Create a devShell like normal.
-          pkgs.mkShell {
-            packages = [
-              self.packages.${system}.papis
-              pythonEnv
-              papis-build-container
-              papis-run-container-tests
-              papis-run-container-interactive
-            ];
-            shellHook = ''
-              export PYTHONPATH="$(pwd):$PYTHONPATH"
-            '';
-          };
-      };
-    });
+            };
+        };
+      }
+    );
 }

--- a/flake.nix
+++ b/flake.nix
@@ -123,13 +123,8 @@
               # Returns a function that can be passed to `python.withPackages`
               arg = project.renderers.withPackages {
                 inherit python;
-                # extras = ["develop" "docs" "lsp" "optional"];
-                # Until https://github.com/pyproject-nix/pyproject.nix/issues/278 is
-                # resolved, we must explicitly enumerate the components of develop
                 extras = [
-                  "lint"
-                  "typing"
-                  "test"
+                  "develop"
                   "docs"
                   "lsp"
                   "optional"

--- a/flake.nix
+++ b/flake.nix
@@ -95,6 +95,16 @@
                   extras = [ "optional" ];
                 };
               in
+              assert
+                project.validators.validateVersionConstraints {
+                  inherit python;
+                  extras = [
+                    "develop"
+                    "docs"
+                    "lsp"
+                    "optional"
+                  ];
+                } == { };
               # Pass attributes to buildPythonPackage.
               # Here is a good spot to add on any missing or custom attributes.
               final.buildPythonPackage (

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -89,22 +89,32 @@ Documentation = "https://papis.readthedocs.io"
 Repository = "https://github.com/papis/papis"
 
 [project.optional-dependencies]
-develop = [
+# Dev environment -- install if you're working on papis
+develop = ["papis[lint,typing,test]"]
+# Style enforcement
+lint = [
     "flake8",
     "flake8-bugbear",
     "flake8-quotes",
     "Flake8-pyproject",
-    "mypy>=0.7",
     "pep8-naming",
     "pylint",
+]
+# Test suite
+test = [
     "pytest",
     "pytest-cov",
+]
+# Type-checking
+typing = [
+    "mypy>=0.7",
     "types-beautifulsoup4",
     "types-Pygments",
     "types-docutils",
     "types-PyYAML",
     "types-requests",
 ]
+# To generate documentation
 docs = [
     "pytest",
     "sphinx>=4",
@@ -112,15 +122,19 @@ docs = [
     "sphinx_design",
     "sphinx_rtd_theme>=1",
 ]
+# Python LSP support
+# (provided for convenience setting up a devenv, not a workflow dependency)
 lsp = [
     "python-lsp-server",
 ]
+# Libraries that papis knows how to interact with if installed
 optional = [
     "Jinja2>=3.0.0",
     "Whoosh>=2.7.4",
     "chardet>=3.0.2",
     "markdownify>=0.11.6",
 ]
+# Needed when installing on windows
 windows = [
     "pyinstaller"
 ]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -102,7 +102,6 @@ develop = [
     "types-beautifulsoup4",
     "types-Pygments",
     "types-docutils",
-    "types-python-slugify",
     "types-PyYAML",
     "types-requests",
 ]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -134,6 +134,16 @@ optional = [
     "chardet>=3.0.2",
     "markdownify>=0.11.6",
 ]
+# Custom Sphinx directives for papis docs
+"papis.sphinx_ext" = [
+    "docutils",
+    "sphinx",
+    "sphinx_click",
+]
+# Pytest fixtures and helpers for testing Papis and plugins
+"papis.testing" = [
+    "pytest"
+]
 # Needed when installing on windows
 windows = [
     "pyinstaller"


### PR DESCRIPTION
- **clean: Remove stale deps**
  Testing reveals types-slugify is no longer needed


- **doc: Document optional features**
  For this purpose, also split develop into style and test to make the components easier to document. The develop feature is left in place for ease of setup, other dev dependency components can be added to it as needed.


- **doc: Document deps for plugins using papis modules**
  This way, packagers have a single source of truth to consult.

Closes: #984
