### PR TITLE
docs(readme): mention papis-ask instead of papis-qa

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -221,8 +221,8 @@ extend Papis' features or integrate it with other software.
 
    * - `papis-firefox <https://github.com/papis/papis-firefox>`__
      - `wavefrontshaping <https://github.com/wavefrontshaping>`__
-   * - `papis-qa <https://github.com/isaksamsten/papisqa>`__ (AI for Papis)
-     - `Isak Samsten <https://github.com/isaksamsten>`__
+   * - `papis-ask <https://github.com/jghauser/papis-ask>`__ (AI for Papis)
+     - `Julian Hauser <https://github.com/jghauser>`__
 
 Related software
 ----------------

--- a/doc/source/index.rst
+++ b/doc/source/index.rst
@@ -94,8 +94,8 @@ extend Papis' features or integrate it with other software.
    * - `papis-firefox <https://github.com/papis/papis-firefox>`__
      - `wavefrontshaping <https://github.com/wavefrontshaping>`__
 
-   * - `papis-qa <https://github.com/isaksamsten/papisqa>`__ (AI for Papis)
-     - `Isak Samsten <https://github.com/isaksamsten>`__
+   * - `papis-ask <https://github.com/jghauser/papis-ask>`__ (AI for Papis)
+     - `Julian Hauser <https://github.com/jghauser>`__
 
 .. toctree::
    :hidden:


### PR DESCRIPTION
My papis-ask plugin is now in a reasonably ok state. I can index my whole library without errors and querying seems to work very well. @isaksamsten says [he would be archiving his repo](https://github.com/isaksamsten/papisqa/issues/1), so I'm replacing his papis-qa with my papis-ask in the README.