### PR TITLE
Some general cleanup and refactoring for database backends

### DIFF
--- a/doc/source/developer_reference.rst
+++ b/doc/source/developer_reference.rst
@@ -39,6 +39,27 @@ Developer API reference
 .. automodule:: papis.config
     :members:
 
+``papis.database``
+------------------
+
+.. automodule:: papis.database
+   :members:
+
+.. automodule:: papis.database.base
+   :members:
+
+``papis.database.cache``
+^^^^^^^^^^^^^^^^^^^^^^^^
+
+.. automodule:: papis.database.cache
+   :members:
+
+``papis.database.whoosh``
+^^^^^^^^^^^^^^^^^^^^^^^^^
+
+.. automodule:: papis.database.whoosh
+   :members:
+
 ``papis.docmatcher``
 --------------------
 

--- a/papis/cli.py
+++ b/papis/cli.py
@@ -19,6 +19,7 @@ class FormattedStringParamType(click.ParamType):
                 value: Any,
                 param: Optional[click.Parameter],
                 ctx: Optional[click.Context]) -> Any:
+        """See :meth:`click.ParamType.convert`."""
         from papis.strings import FormattedString
 
         # NOTE: this is required to handle default values which have a formatter

--- a/papis/commands/add.py
+++ b/papis/commands/add.py
@@ -122,7 +122,6 @@ import papis.downloaders
 import papis.git
 import papis.format
 import papis.citations
-import papis.id
 import papis.logging
 import papis.commands.doctor
 
@@ -143,9 +142,11 @@ class FromFolderImporter(papis.importer.Importer):
 
     def fetch(self) -> None:
         self.logger.info("Importing from folder '%s'.", self.uri)
+        from papis.id import ID_KEY_NAME
 
         doc = papis.document.from_folder(self.uri)
-        del doc[papis.id.key_name()]
+        del doc[ID_KEY_NAME]
+
         self.ctx.data = papis.document.to_dict(doc)
         self.ctx.files = doc.get_files()
 

--- a/papis/database/__init__.py
+++ b/papis/database/__init__.py
@@ -9,22 +9,6 @@ logger = papis.logging.get_logger(__name__)
 DATABASES: Dict[Library, Database] = {}
 
 
-def get(library_name: Optional[str] = None) -> Database:
-    global DATABASES
-    import papis.config
-    if library_name is None:
-        library = papis.config.get_lib()
-    else:
-        library = papis.config.get_lib_from_name(library_name)
-    backend = papis.config.get("database-backend") or "papis"
-    try:
-        database = DATABASES[library]
-    except KeyError:
-        database = _instantiate_database(backend, library)
-        DATABASES[library] = database
-    return database
-
-
 def _instantiate_database(backend_name: str, library: Library) -> Database:
     if backend_name == "papis":
         import papis.database.cache
@@ -36,10 +20,43 @@ def _instantiate_database(backend_name: str, library: Library) -> Database:
         raise ValueError(f"Invalid database backend: '{backend_name}'")
 
 
+def get(library_name: Optional[str] = None) -> Database:
+    """Get the database for the library *library_name*.
+
+    If *library_name* is *None*, then the current database is retrieved from
+    :func:`papis.config.get_lib`. The given library name must exist in the
+    configuration file or it should be a path to a directory containing Papis
+    documents (see :func:`papis.config.get_lib_from_name`).
+
+    :return: the caching database for the given library. The same database is
+        returned on repeated calls to this function.
+    """
+    from papis.config import get_lib, get_lib_from_name
+
+    if library_name is None:
+        library = get_lib()
+    else:
+        library = get_lib_from_name(library_name)
+
+    backend = papis.config.get("database-backend") or "papis"
+    try:
+        database = DATABASES[library]
+    except KeyError:
+        database = _instantiate_database(backend, library)
+        DATABASES[library] = database
+
+    return database
+
+
 def get_all_query_string() -> str:
+    """Get the default query string for the current database."""
     return get().get_all_query_string()
 
 
 def clear_cached() -> None:
-    global DATABASES
-    DATABASES = {}
+    """Clear cached databases.
+
+    After this function is called, all subsequent calls to :func:`get` will
+    recreate the database for the given library.
+    """
+    DATABASES.clear()

--- a/papis/database/base.py
+++ b/papis/database/base.py
@@ -1,125 +1,144 @@
-"""
-Here the database abstraction for the libraries is defined.
-"""
-
 from abc import ABC, abstractmethod
-from typing import Optional, List, Dict
+from typing import Dict, List, Optional
+from warnings import warn
 
-import papis.utils
-import papis.config
-import papis.library
-import papis.document
-import papis.id
+from papis.document import Document
+from papis.library import Library
 
 
 class Database(ABC):
-    """Abstract class for the database backends
-    """
+    """Abstract base class for Papis caching database backends."""
 
-    def __init__(self, library: Optional[papis.library.Library] = None) -> None:
-        self.lib = library or papis.config.get_lib()
-        assert isinstance(self.lib, papis.library.Library)
+    def __init__(self, library: Optional[Library] = None) -> None:
+        if library is None:
+            from papis.config import get_lib
+            library = get_lib()
+
+        if not isinstance(library, Library):
+            raise TypeError(f"Provided library has unsupported type: {type(library)}")
+
+        self.lib = library
 
     @abstractmethod
     def initialize(self) -> None:
-        pass
+        """Initialize the caching database backend.
+
+        This can involve creating any necessary directories, opening files, etc.
+        This function should be called in the constructor of the database class,
+        as needed.
+        """
 
     @abstractmethod
     def get_backend_name(self) -> str:
-        pass
+        """Get the name of the database backend.
 
-    def get_lib(self) -> str:
-        """Get library name
+        This name has to match the one used in the configuration file in the
+        :confval:`database-backend` setting.
         """
-        return self.lib.name
 
-    def get_dirs(self) -> List[str]:
-        """Get directories of the library
-        """
-        return self.lib.paths
-
+    @abstractmethod
     def get_cache_path(self) -> str:
-        """Get the path to the actual cache file or directory.
-        """
-        raise NotImplementedError("Cache path not defined for backend '{}'"
-                                  .format(self.get_backend_name()))
-
-    def match(
-            self,
-            document: papis.document.Document,
-            query_string: str) -> bool:
-        """
-        Whether or not document matches query_string.
-
-        :param document: Document to be matched
-        :param query_string: Query string
-        """
-        raise NotImplementedError(
-            f"Match not defined for backend '{self.get_backend_name()}'")
+        """Get the path to the database cache file (or directory)."""
 
     @abstractmethod
     def clear(self) -> None:
-        pass
+        """Clear the database by removing all files and directories.
+
+        After clearing the database, calling :meth:`initialize` may be necessary
+        to ensure that it is in the correct state.
+        """
 
     @abstractmethod
-    def add(self, document: papis.document.Document) -> None:
-        pass
+    def add(self, document: Document) -> None:
+        """Add a new document to the database."""
 
     @abstractmethod
-    def update(self, document: papis.document.Document) -> None:
-        pass
+    def update(self, document: Document) -> None:
+        """Update an existing document in the database.
+
+        The given *document* will overwrite all the common fields of the document
+        that already exists in the database, if any.
+        """
 
     @abstractmethod
-    def delete(self, document: papis.document.Document) -> None:
-        pass
+    def delete(self, document: Document) -> None:
+        """Remove a document from the database."""
 
     @abstractmethod
-    def query(self, query_string: str) -> List[papis.document.Document]:
-        pass
+    def query(self, query_string: str) -> List[Document]:
+        """Find a document in the database by the given *query_string*.
+
+        The query string can have a more complex syntax based on the database
+        backend.
+        """
 
     @abstractmethod
-    def query_dict(
-            self, query: Dict[str, str]) -> List[papis.document.Document]:
-        pass
+    def query_dict(self, query: Dict[str, str]) -> List[Document]:
+        """Find a document in the database that matches the keys in *query*."""
 
     @abstractmethod
-    def get_all_documents(self) -> List[papis.document.Document]:
-        pass
+    def get_all_documents(self) -> List[Document]:
+        """Get all documents in the database."""
 
     @abstractmethod
     def get_all_query_string(self) -> str:
-        pass
+        """Get the default query string that will match all documents."""
 
-    def find_by_id(self, identifier: str) -> Optional[papis.document.Document]:
-        results = self.query_dict({Database.get_id_key(): identifier})
+    def find_by_id(self, identifier: str) -> Optional[Document]:
+        """Find a document in the library by its Papis ID *identifier*."""
+        from papis.id import ID_KEY_NAME
+
+        results = self.query_dict({ID_KEY_NAME: identifier})
         if len(results) > 1:
-            raise ValueError("More than one document matches the unique id '{}'"
-                             .format(identifier))
+            raise ValueError(f"More than one document matches the ID '{identifier}'")
 
         return results[0] if results else None
 
+    def maybe_compute_id(self, doc: Document) -> None:
+        """Compute a Papis ID for the document *doc*.
+
+        If the document already has an ID, then the document is skipped and the
+        ID is not checked for duplicates. Otherwise a new unique ID is created
+        and the document :ref:`info-file` is updated accordingly.
+        """
+        from papis.id import ID_KEY_NAME, compute_an_id
+
+        if ID_KEY_NAME in doc:
+            return
+
+        # NOTE: `compute_an_id` adds a random seed to the ID, so this is quite
+        # unlikely to become an infinite loop
+        new_id = compute_an_id(doc)
+        while self.query_dict({ID_KEY_NAME: new_id}):
+            new_id = compute_an_id(doc)
+
+        # FIXME: Should this save the document?
+        doc[ID_KEY_NAME] = new_id
+        doc.save()
+
+    def get_lib(self) -> str:
+        warn(f"Calling '{type(self).__name__}.get_lib' directly is deprecated "
+             "and will be removed in the next version of Papis (after 0.15). Use "
+             "the 'self.lib.name' member directly.",
+             DeprecationWarning, stacklevel=2)
+
+        return self.lib.name
+
+    def get_dirs(self) -> List[str]:
+        warn(f"Calling '{type(self).__name__}.get_dirs' directly is deprecated "
+             "and will be removed in the next version of Papis (after 0.15). Use "
+             "the 'self.lib.paths' member directly.",
+             DeprecationWarning, stacklevel=2)
+
+        return self.lib.paths
+
     @staticmethod
     def get_id_key() -> str:
-        """
-        Get the unique key identifier name of the documents in the database
-        """
-        return papis.id.key_name()
+        from warnings import warn
 
-    def maybe_compute_id(self, doc: papis.document.Document) -> None:
-        """
-        Compute a Papis ID for the document doc.
+        warn("This function is deprecated and will be removed in the next "
+             "version of Papis (after 0.15). Use 'papis.id.ID_KEY_NAME' instead.",
+             DeprecationWarning, stacklevel=2)
 
-        If the document already has an ID, then the document is skipped (without
-        checking for duplicates). Otherwise try to create a new ID that is
-        unique in this database and update the document YAML accordingly.
-        """
-        key_name = papis.id.key_name()
-        if key_name in doc:
-            return
-        while True:
-            new_id = papis.id.compute_an_id(doc)
-            other_docs = self.query_dict({key_name: new_id})
-            if not other_docs:
-                break
-        doc[key_name] = new_id
-        doc.save()
+        from papis.id import ID_KEY_NAME
+        return ID_KEY_NAME

--- a/papis/database/base.py
+++ b/papis/database/base.py
@@ -128,7 +128,7 @@ class Database(ABC):
 
         If the document already has an ID, then the document is skipped and the
         ID is not checked for duplicates. Otherwise a new unique ID is created
-        and the document :ref:`info-file` is updated accordingly.
+        and the document :ref:`info.yaml <info-file>` is updated accordingly.
         """
         from papis.id import ID_KEY_NAME, compute_an_id
 

--- a/papis/database/base.py
+++ b/papis/database/base.py
@@ -49,6 +49,10 @@ class Database(ABC):
         """
 
     @abstractmethod
+    def get_all_query_string(self) -> str:
+        """Get the default query string that will match all documents."""
+
+    @abstractmethod
     def add(self, document: Document) -> None:
         """Add a new document to the database."""
 
@@ -79,10 +83,6 @@ class Database(ABC):
     @abstractmethod
     def get_all_documents(self) -> List[Document]:
         """Get all documents in the database."""
-
-    @abstractmethod
-    def get_all_query_string(self) -> str:
-        """Get the default query string that will match all documents."""
 
     def find_by_id(self, identifier: str) -> Optional[Document]:
         """Find a document in the library by its Papis ID *identifier*."""

--- a/papis/database/cache.py
+++ b/papis/database/cache.py
@@ -141,10 +141,10 @@ class Database(papis.database.base.Database):
             import pickle
             with open(cache_path, "rb") as fd:
                 self.documents = pickle.load(fd)
-        elif self.get_dirs():
+        elif self.lib.paths:
             logger.info("Indexing library. This might take a while...")
             folders: List[str] = sum(
-                [papis.utils.get_folders(d) for d in self.get_dirs()],
+                [papis.utils.get_folders(d) for d in self.lib.paths],
                 [])
             self.documents = papis.utils.folders_to_documents(folders)
             logger.debug("Computing 'papis_id' for each document.")
@@ -190,13 +190,6 @@ class Database(papis.database.base.Database):
         index = result[0][0]
         docs.pop(index)
         self.save()
-
-    def match(self,
-              document: papis.document.Document,
-              query_string: str) -> bool:
-        from papis.docmatcher import get_regex_from_search
-        query = get_regex_from_search(query_string)
-        return bool(match_document(document, query))
 
     def clear(self) -> None:
         cache_path = self._get_cache_file_path()

--- a/papis/database/cache.py
+++ b/papis/database/cache.py
@@ -107,7 +107,9 @@ class Database(DatabaseBase):
         return "."
 
     def initialize(self) -> None:
-        pass
+        # NOTE: ensure that all the documents are loaded on initialize to match
+        # the behaviour of the whoosh backend
+        _ = self._get_documents()
 
     def clear(self) -> None:
         cache_path = self._get_cache_file_path()

--- a/papis/database/cache.py
+++ b/papis/database/cache.py
@@ -1,57 +1,23 @@
 import os
-import sys
 from typing import Dict, List, Match, Optional, Pattern, Tuple
 
-import papis.utils
-import papis.docmatcher
-import papis.document
 import papis.config
-import papis.format
-import papis.database.base
 import papis.logging
+from papis.database.base import Database as DatabaseBase, get_cache_file_path
+from papis.document import Document, describe
+from papis.exceptions import DocumentFolderNotFound
+from papis.library import Library
 from papis.strings import AnyString
 
 logger = papis.logging.get_logger(__name__)
 
 
-def get_cache_file_name(libpaths: str) -> str:
-    """Create a cache file name out of the path of a given directory.
+def filter_documents(documents: List[Document], search: str = "") -> List[Document]:
+    """Filter documents based on the *search* string.
 
-    :param libpaths: folder names to be used as a seed for the cache name.
-    :returns: a name for the cache file specific to *libpaths*.
-
-    >>> get_cache_file_name('path/to/my/lib')
-    'a8c689820a94babec20c5d6269c7d488-lib'
-    >>> get_cache_file_name('papers')
-    'a566b2bebc62611dff4cdaceac1a7bbd-papers'
-    """
-    import hashlib
-    return "{}-{}".format(
-        hashlib.md5(libpaths.encode()).hexdigest(),
-        os.path.basename(libpaths))
-
-
-def get_cache_file_path(libpaths: str) -> str:
-    """Get the full path to the cache file.
-
-    :param libpaths: a cache file specific for the given library paths.
-    """
-    cache_name = get_cache_file_name(libpaths)
-    folder = os.path.join(papis.utils.get_cache_home(), "database")
-    if not os.path.exists(folder):
-        os.makedirs(folder)
-
-    return os.path.join(folder, cache_name)
-
-
-def filter_documents(
-        documents: List[papis.document.Document],
-        search: str = "") -> List[papis.document.Document]:
-    """Filter documents. It can be done in a multi core way.
-
-    :param documents: List of Papis documents.
-    :param search: Valid Papis search string.
-    :returns: List of filtered documents
+    :param search: a search string that will be parsed by
+        :class:`~papis.docmatcher.DocMatcher`.
+    :returns: a list of filtered documents.
 
     >>> document = papis.document.from_data({'author': 'einstein'})
     >>> len(filter_documents([document], search="einstein")) == 1
@@ -62,38 +28,44 @@ def filter_documents(
     False
 
     """
-    papis.docmatcher.DocMatcher.set_search(search)
-    papis.docmatcher.DocMatcher.set_matcher(match_document)
-    papis.docmatcher.DocMatcher.parse()
+    from papis.docmatcher import DocMatcher
+
+    DocMatcher.set_search(search)
+    DocMatcher.set_matcher(match_document)
+    DocMatcher.parse()
 
     logger.debug("Filtering %d docs (search '%s').", len(documents), search)
 
+    import sys
     import time
-    begin_t = time.time()
+
+    t_start = time.time()
+
     # FIXME: find a better solution for this that works for both OSes
     if sys.platform == "win32":
         filtered_docs = [
-            d for d in [papis.docmatcher.DocMatcher.return_if_match(d)
-                        for d in documents] if d is not None]
+            d for d in (DocMatcher.return_if_match(d) for d in documents)
+            if d is not None]
     else:
-        result = papis.utils.parmap(papis.docmatcher.DocMatcher.return_if_match,
-                                    documents)
+        from papis.utils import parmap
+
+        result = parmap(DocMatcher.return_if_match, documents)
         filtered_docs = [d for d in result if d is not None]
 
-    _delta = 1000 * (time.time() - begin_t)
-    logger.debug("Finished filtering in %.2fms (%d docs).", _delta, len(filtered_docs))
+    t_delta = 1000 * (time.time() - t_start)
+    logger.debug("Finished querying in %.2fms (%d docs).", t_delta, len(filtered_docs))
 
     return filtered_docs
 
 
 def match_document(
-        document: papis.document.Document,
+        document: Document,
         search: Pattern[str],
         match_format: Optional[AnyString] = None,
         doc_key: Optional[str] = None) -> Optional[Match[str]]:
     """Match a document's keys to a given search pattern.
 
-    See ``papis.docmatcher.MatcherCallable``.
+    See :class:`~papis.docmatcher.MatcherCallable`.
 
     >>> from papis.docmatcher import get_regex_from_search as regex
     >>> document = papis.document.from_data({'author': 'einstein'})
@@ -107,122 +79,145 @@ def match_document(
     if doc_key is not None:
         match_string = str(document[doc_key])
     else:
+        from papis.format import format
+
         match_format = match_format or papis.config.getformattedstring("match-format")
-        match_string = papis.format.format(match_format, document)
+        match_string = format(match_format, document)
 
     return search.match(match_string)
 
 
-class Database(papis.database.base.Database):
+class Database(DatabaseBase):
+    """A caching database backend for Papis based on :mod:`pickle`."""
 
-    def __init__(self, library: Optional[papis.library.Library] = None) -> None:
+    def __init__(self, library: Optional[Library] = None) -> None:
         super().__init__(library)
 
-        self.documents: Optional[List[papis.document.Document]] = None
+        self.use_cache = papis.config.getboolean("use-cache")
+        self.documents: Optional[List[Document]] = None
         self.initialize()
-
-    def get_cache_path(self) -> str:
-        return self._get_cache_file_path()
 
     def get_backend_name(self) -> str:
         return "papis"
 
+    def get_cache_path(self) -> str:
+        return self._get_cache_file_path()
+
+    def get_all_query_string(self) -> str:
+        return "."
+
     def initialize(self) -> None:
         pass
 
-    def get_documents(self) -> List[papis.document.Document]:
+    def clear(self) -> None:
+        cache_path = self._get_cache_file_path()
+        if os.path.exists(cache_path):
+            logger.info("Clearing cache at '%s'.", cache_path)
+            os.remove(cache_path)
+
+        if self.documents:
+            self.documents.clear()
+            self.documents = None
+
+    def add(self, document: Document) -> None:
+        if not self.use_cache:
+            return
+
+        folder = document.get_main_folder()
+        if folder is None:
+            raise ValueError("Cannot add a document without a main folder to database")
+
+        if not os.path.exists(folder):
+            raise ValueError(f"Document folder '{folder}' does not exist")
+
+        logger.debug("Adding document: '%s'.", describe(document))
+        docs = self._get_documents()
+
+        self.maybe_compute_id(document)
+        docs.append(document)
+
+        self._save_documents()
+
+    def update(self, document: Document) -> None:
+        if not self.use_cache:
+            return
+
+        logger.debug("Updating document: '%s'.", describe(document))
+
+        docs = self._get_documents()
+        result = self._locate_document(document)
+        if not result:
+            raise DocumentFolderNotFound(describe(document))
+
+        index, _ = result[0]
+        docs[index] = document
+        self._save_documents()
+
+    def delete(self, document: Document) -> None:
+        if not self.use_cache:
+            return
+
+        logger.debug("Deleting document: '%s'.", describe(document))
+
+        docs = self._get_documents()
+        result = self._locate_document(document)
+        if not result:
+            raise DocumentFolderNotFound(describe(document))
+
+        index, _ = result[0]
+        docs.pop(index)
+        self._save_documents()
+
+    def query(self, query_string: str) -> List[Document]:
+        logger.debug("Querying database for '%s'.", query_string)
+
+        docs = self._get_documents()
+        if query_string == self.get_all_query_string():
+            return docs
+
+        return filter_documents(docs, query_string)
+
+    def query_dict(self, query: Dict[str, str]) -> List[Document]:
+        query_string = " ".join(f'{key}:"{val}" ' for key, val in query.items())
+        return self.query(query_string)
+
+    def get_all_documents(self) -> List[Document]:
+        return self._get_documents()
+
+    def _get_documents(self) -> List[Document]:
         if self.documents is not None:
             return self.documents
-        use_cache = papis.config.getboolean("use-cache")
+
         cache_path = self._get_cache_file_path()
-        if use_cache and os.path.exists(cache_path):
+        if self.use_cache and os.path.exists(cache_path):
             logger.debug("Getting documents from cache at '%s'.", cache_path)
 
             import pickle
             with open(cache_path, "rb") as fd:
                 self.documents = pickle.load(fd)
         elif self.lib.paths:
+            from papis.utils import get_folders, folders_to_documents
+
             logger.info("Indexing library. This might take a while...")
-            folders: List[str] = sum(
-                [papis.utils.get_folders(d) for d in self.lib.paths],
-                [])
-            self.documents = papis.utils.folders_to_documents(folders)
-            logger.debug("Computing 'papis_id' for each document.")
+            folders: List[str] = sum((get_folders(d) for d in self.lib.paths), [])
+            self.documents = folders_to_documents(folders)
+
+            from papis.id import ID_KEY_NAME
+            logger.debug("Computing '%s' for each document.", ID_KEY_NAME)
+
             for doc in self.documents:
                 self.maybe_compute_id(doc)
-            if use_cache:
-                self.save()
+
+            if self.use_cache:
+                self._save_documents()
         else:
             self.documents = []
 
         logger.debug("Loaded %d documents.", len(self.documents))
         return self.documents
 
-    def add(self, document: papis.document.Document) -> None:
-        logger.debug("Adding document: '%s'.", papis.document.describe(document))
-        docs = self.get_documents()
-        self.maybe_compute_id(document)
-        docs.append(document)
-        assert docs[-1].get_main_folder() == document.get_main_folder()
-        _folder = document.get_main_folder()
-        assert _folder is not None
-        assert os.path.exists(_folder)
-        self.save()
-
-    def update(self, document: papis.document.Document) -> None:
-        if not papis.config.getboolean("use-cache"):
-            return
-        logger.debug("Updating document: '%s'.", papis.document.describe(document))
-
-        docs = self.get_documents()
-        result = self._locate_document(document)
-        index = result[0][0]
-        docs[index] = document
-        self.save()
-
-    def delete(self, document: papis.document.Document) -> None:
-        if not papis.config.getboolean("use-cache"):
-            return
-        logger.debug("Deleting document: '%s'.", papis.document.describe(document))
-
-        docs = self.get_documents()
-        result = self._locate_document(document)
-        index = result[0][0]
-        docs.pop(index)
-        self.save()
-
-    def clear(self) -> None:
-        cache_path = self._get_cache_file_path()
-        logger.warning("Clearing cache at '%s'.", cache_path)
-
-        if os.path.exists(cache_path):
-            os.remove(cache_path)
-
-    def query_dict(self,
-                   dictionary: Dict[str, str]) -> List[papis.document.Document]:
-        query_string = " ".join(
-            [f'{key}:"{val}" ' for key, val in dictionary.items()])
-        return self.query(query_string)
-
-    def query(self, query_string: str) -> List[papis.document.Document]:
-        logger.debug("Querying database for '%s'.", query_string)
-
-        docs = self.get_documents()
-        # This makes it faster, if it's the all query string, return everything
-        # without filtering
-        if query_string == self.get_all_query_string():
-            return docs
-        else:
-            return filter_documents(docs, query_string)
-
-    def get_all_query_string(self) -> str:
-        return "."
-
-    def get_all_documents(self) -> List[papis.document.Document]:
-        return self.get_documents()
-
-    def save(self) -> None:
-        docs = self.get_documents()
+    def _save_documents(self) -> None:
+        docs = self._get_documents()
         logger.debug("Saving %d documents.", len(docs))
 
         import pickle
@@ -233,25 +228,27 @@ class Database(papis.database.base.Database):
     def _get_cache_file_path(self) -> str:
         return get_cache_file_path(self.lib.path_format())
 
-    def _locate_document(
-            self,
-            document: papis.document.Document
-            ) -> List[Tuple[int, papis.document.Document]]:
-        assert isinstance(document, papis.document.Document)
+    def _locate_document(self, document: Document) -> List[Tuple[int, Document]]:
+        from papis.id import ID_KEY_NAME
 
-        result = list(filter(
-            lambda d: d[1]["papis_id"] == document["papis_id"],
-            enumerate(self.get_documents())))
-
+        # FIXME: Why are we iterating twice over the documents here?
+        # first try to match by ID
+        result = [
+            (i, doc) for i, doc in enumerate(self._get_documents())
+            if doc[ID_KEY_NAME] == document[ID_KEY_NAME]
+        ]
         if result:
             return result
 
-        result = list(filter(
-            lambda d: d[1].get_main_folder() == document.get_main_folder(),
-            enumerate(self.get_documents())))
-        if not result:
-            raise ValueError(
-                "The document passed could not be found in the library: '{}'"
-                .format(papis.document.describe(document)))
+        # if no documents match, try matching by main folder
+        result = [
+            (i, doc) for i, doc in enumerate(self._get_documents())
+            if doc.get_main_folder() == document.get_main_folder()
+        ]
+        if result:
+            return result
 
-        return result
+        # otherwise, we error
+        raise ValueError(
+            f"Document could not be found in the library '{self.lib.name}': "
+            f"'{describe(document)}'")

--- a/papis/database/whoosh.py
+++ b/papis/database/whoosh.py
@@ -1,56 +1,48 @@
-"""This is the whoosh interface to Papis. For future Papis developers
-here are some considerations.
+"""This is the whoosh interface to Papis.
 
-Whoosh works with 3 main objects, the Index, the Writer and the Schema.
+For future Papis developers here are some considerations.
+
+Whoosh works with 3 main objects, the ``Index``, the ``Writer`` and the ``Schema``.
 The indices are stored in a subfolder of :func:`~papis.utils.get_cache_home`.
-The name of the indices folders is similar to the cache files of the papis
+The name of the indices folders is similar to the cache files of the ``papis``
 cache database.
 
-Once the index is created in the mentioned folder, a Schema is initialized,
+Once the Index is created in the mentioned folder, a Schema is initialized,
 which is a declaration of the data prototype of the database, or the
-definition of the table in sql parlance. This is controlled by the
-Papis configuration through the `whoosh-schema-prototype`. For instance
+definition of the table in SQL parlance. This is controlled by the
+Papis configuration through the :confval:`whoosh-schema-prototype`. For instance
 if the database is supposed to only contain the key fields
-``author``, ``title``, ``year`` and ``tags``, then the
-``whoosh-schema-prototype`` STRING should look like the following:
+``[author, title, year, tags]``, then the :confval:`whoosh-schema-prototype``
+string should look like the following:
 
-::
+.. code:: python
 
-        {
-            "author": TEXT(stored=True),
-            "title": TEXT(stored=True),
-            "year": TEXT(stored=True),
-            "tags": TEXT(stored=True),
-        }
+    {
+        "author": TEXT(stored=True),
+        "title": TEXT(stored=True),
+        "year": TEXT(stored=True),
+        "tags": TEXT(stored=True),
+    }
 
 where all the fields are explained in the whoosh
 `documentation <https://whoosh.readthedocs.io/en/latest/schema.html>`__.
 
-After this Schema is created, the folders of the library are recursed over
-and the documents are added to the database where only these
-properties are stored. This means, if ``publisher`` is not in the above list,
-you will not be able to parse the publisher through a search.
-
-.. note::
-
-    This is a point where maybe a great deal of discussion and optimization
-    should be made.
-
-
-
+After this Schema is created, the folders of the library are traversed
+and the documents are added to the database. When adding documents, only the
+keys in the schema are stored. This means, if ``publisher`` is not in the schema,
+you will not be able to search for the publisher through a query.
 """
+
 import os
-from typing import List, Dict, Optional, Any, KeysView, TYPE_CHECKING
+from typing import List, Dict, Optional, KeysView, TYPE_CHECKING
 
 import papis.config
-import papis.strings
-import papis.document
 import papis.logging
-import papis.database.base
-import papis.database.cache
-from papis.id import ID_KEY_NAME
-from papis.utils import get_cache_home, get_folders, folders_to_documents
+from papis.database.base import Database as DatabaseBase, get_cache_file_name
+from papis.document import Document, describe, from_folder
 from papis.exceptions import DocumentFolderNotFound
+from papis.id import ID_KEY_NAME
+from papis.library import Library
 
 if TYPE_CHECKING:
     from whoosh.index import Index
@@ -60,250 +52,204 @@ if TYPE_CHECKING:
 logger = papis.logging.get_logger(__name__)
 
 
-class Database(papis.database.base.Database):
-
-    def __init__(self, library: Optional[papis.library.Library] = None) -> None:
+class Database(DatabaseBase):
+    def __init__(self, library: Optional[Library] = None) -> None:
         super().__init__(library)
+
+        from papis.utils import get_cache_home
 
         self.cache_dir = os.path.join(get_cache_home(), "database", "whoosh")
         self.index_dir = os.path.expanduser(
-            os.path.join(
-                self.cache_dir,
-                papis.database.cache.get_cache_file_name(
-                    self.lib.path_format()
-                )))
+            os.path.join(self.cache_dir, get_cache_file_name(self.lib.path_format()))
+            )
 
         self.initialize()
-
-    def get_cache_path(self) -> str:
-        return self.index_dir
 
     def get_backend_name(self) -> str:
         return "whoosh"
 
-    def clear(self) -> None:
-        import shutil
-        if self.index_exists():
-            logger.warning("Clearing the database at '%s'...", self.get_cache_path())
-            shutil.rmtree(self.index_dir)
-
-    def add(self, document: papis.document.Document) -> None:
-        schema_keys = self.get_schema_init_fields().keys()
-
-        logger.debug("Adding document: '%s'.", papis.document.describe(document))
-        writer = self.get_writer()
-        self.add_document_with_writer(document, writer, schema_keys)
-
-        logger.debug("Committing document: '%s'.", papis.document.describe(document))
-        writer.commit()
-
-    def update(self, document: papis.document.Document) -> None:
-        """As it says in the docs, just delete the document and add it again
-        """
-        self.delete(document)
-        self.add(document)
-
-    def delete(self, document: papis.document.Document) -> None:
-        writer = self.get_writer()
-
-        logger.debug("Deleting document: '%s'.", papis.document.describe(document))
-        writer.delete_by_term(ID_KEY_NAME, self.get_id_value(document))
-
-        logger.debug("Committing document: '%s'.", papis.document.describe(document))
-        writer.commit()
-
-    def query_dict(self,
-                   dictionary: Dict[str, str]) -> List[papis.document.Document]:
-        query_string = " AND ".join(
-            [f'{key}:"{val}" ' for key, val in dictionary.items()])
-        return self.query(query_string)
-
-    def query(self, query_string: str) -> List[papis.document.Document]:
-        logger.debug("Querying database for '%s'.", query_string)
-
-        import whoosh.qparser
-        index = self.get_index()
-        qp = whoosh.qparser.MultifieldParser(["title", "author", "tags"],
-                                             schema=self.get_schema())
-        qp.add_plugin(whoosh.qparser.FuzzyTermPlugin())
-        query = qp.parse(query_string)
-        with index.searcher() as searcher:
-            results = searcher.search(query, limit=None)
-            logger.debug("Found %d results: %s", len(results), results)
-            documents = [
-                papis.document.from_folder(r.get("papis-folder"))
-                for r in results]
-        return documents
+    def get_cache_path(self) -> str:
+        return self.index_dir
 
     def get_all_query_string(self) -> str:
         return "*"
 
-    def get_all_documents(self) -> List[papis.document.Document]:
+    def initialize(self) -> None:
+        if self._index_exists():
+            index = self._get_index()
+
+            user_fields = self._get_schema_init_fields()
+            db_fields = index.schema
+
+            # NOTE: the database should be rebuilt if new fields have been added
+            # or if the field types have been changed in any way by the user
+            rebuild_db = (
+                set(user_fields) != set(db_fields.names())
+                or any(user_fields[name] != db_fields[name] for name in user_fields)
+            )
+            if not rebuild_db:
+                logger.debug("Initialized index found for library.")
+                return
+
+            logger.debug("Rebuilding database because fields do not match.")
+            self.clear()
+        else:
+            logger.info("Indexing library. This might take a while...")
+
+        self._create_index()
+        self._index_documents()
+
+    def clear(self) -> None:
+        import shutil
+        if self._index_exists():
+            logger.warning("Clearing the database at '%s'...", self.get_cache_path())
+            shutil.rmtree(self.index_dir)
+
+    def add(self, document: Document) -> None:
+        logger.debug("Adding document: '%s'.", describe(document))
+        schema_keys = self._get_schema_init_fields().keys()
+        index = self._get_index()
+        writer = index.writer()
+
+        self._add_document_with_writer(document, writer, schema_keys)
+        writer.commit()
+
+    def update(self, document: Document) -> None:
+        self.delete(document)
+        self.add(document)
+
+    def delete(self, document: Document) -> None:
+        logger.debug("Deleting document: '%s'.", describe(document))
+        index = self._get_index()
+        writer = index.writer()
+
+        writer.delete_by_term(ID_KEY_NAME, document[ID_KEY_NAME])
+        writer.commit()
+
+    def query(self, query_string: str) -> List[Document]:
+        logger.debug("Querying database for '%s'.", query_string)
+
+        import time
+        from whoosh.qparser import MultifieldParser, FuzzyTermPlugin
+
+        index = self._get_index()
+        qp = MultifieldParser(["title", "author", "tags"], schema=index.schema)
+        qp.add_plugin(FuzzyTermPlugin())
+
+        t_start = time.time()
+        query = qp.parse(query_string)
+        with index.searcher() as searcher:
+            results = searcher.search(query, limit=None)
+            documents = [from_folder(r.get("papis-folder")) for r in results]
+
+        t_delta = 1000 * (time.time() - t_start)
+        logger.debug("Finished querying in %.2fms (%d docs).", t_delta, len(documents))
+
+        return documents
+
+    def query_dict(self, query: Dict[str, str]) -> List[Document]:
+        query_string = " AND ".join(f'{key}:"{val}" ' for key, val in query.items())
+        return self.query(query_string)
+
+    def get_all_documents(self) -> List[Document]:
         return self.query(self.get_all_query_string())
 
-    def get_id_value(self, document: papis.document.Document) -> str:
-        """Get the value that is stored in the unique key identifier
-        of the documents in the database.
+    def _create_index(self) -> None:
+        """Create a new index.
 
-        :param document: Papis document
-        :returns: The papis-id
-        """
-        return str(document[ID_KEY_NAME])
-
-    def _get_doc_folder(self, document: papis.document.Document) -> str:
-        _folder = document.get_main_folder()
-        if _folder is None:
-            raise DocumentFolderNotFound(papis.document.describe(document))
-        else:
-            return _folder
-
-    def create_index(self) -> None:
-        """Create a brand new index, notice that if an index already
-        exists it will delete it and create a new one.
+        If an index already exists, this will delete it and create a new one.
         """
         logger.debug("Creating index.")
         if not os.path.exists(self.index_dir):
             logger.debug("Creating index directory '%s'.", self.index_dir)
             os.makedirs(self.index_dir)
 
-        import whoosh.index
-        whoosh.index.create_in(self.index_dir, self.create_schema())
+        from whoosh.index import create_in
+        create_in(self.index_dir, self._create_schema())
 
-    def index_exists(self) -> Any:
+    def _index_exists(self) -> bool:
         """Check if index already exists in :attr:`index_dir`."""
-        import whoosh.index
-        return whoosh.index.exists_in(self.index_dir)
+        from whoosh.index import exists_in
+        return bool(exists_in(self.index_dir))
 
-    def add_document_with_writer(self,
-                                 document: papis.document.Document,
-                                 writer: "IndexWriter",
-                                 schema_keys: KeysView[str]) -> None:
-        """Helper function that takes a writer and a dictionary
-        containing the keys of the schema and adds the document to the writer.
-        Notice that this function does only two things, creating a suitable
-        dictionary to be added to the database and adding it to the writer.
-        It DOES NOT commit the change to the writer, this has to be done
-        separately.
+    def _add_document_with_writer(self,
+                                  document: Document,
+                                  writer: "IndexWriter",
+                                  schema_keys: KeysView[str]) -> None:
+        """Helper function that adds a document document (without committing).
 
-        :param document: Papis document
-        :param writer: Whoosh writer
-        :param schema_keys: Dictionary containing the defining keys of the
-            database Schema
+        This function does only two things: creates a suitable dictionary to be
+        added to the database and adds it to the writer. It does not commit the
+        change to the writer, so that has to be done separately.
         """
-        # !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
-        # maybe_compute_id overwrites the info file, so put it before
-        # anything else, else you'll get `papis-folder` on your info.yaml
-        # !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
+        # NOTE: `maybe_compute_id` overwrites the info file, so put it before
+        # anything else, otherwise get `papis-folder` in your info.yaml
         self.maybe_compute_id(document)
-        document["papis-folder"] = self._get_doc_folder(document)
+
+        folder = document.get_main_folder()
+        if not folder:
+            raise DocumentFolderNotFound(describe(document))
+
+        document["papis-folder"] = folder
         doc_d = {k: str(document[k]) or "" for k in schema_keys}
         writer.add_document(**doc_d)
 
-    def do_indexing(self) -> None:
-        """This function initializes the database. Basically it goes through
-        all folders from the library (that contain an `info.yaml` file)
-        and adds the documents to the database index. This function is
-        expensive and will be called only if no index is present, so
-        at the time of building a brand new index.
+    def _index_documents(self) -> None:
+        """Initializes the database with an index of all the documents.
+
+        This function basically it goes through all folders from the library
+        (that contain an `info.yaml` file) and adds the documents to the database
+        index. It is quite expensive and will only be called if no index is present
+        or a rebuild is necessary.
         """
+        from papis.utils import get_folders, folders_to_documents
+
         logger.debug("Indexing the library, this might take a while...")
         folders: List[str] = sum([get_folders(d) for d in self.lib.paths], [])
         documents = folders_to_documents(folders)
-        schema_keys = self.get_schema_init_fields().keys()
-        writer = self.get_writer()
+
+        schema_keys = self._get_schema_init_fields().keys()
+        index = self._get_index()
+        writer = index.writer()
+
         for doc in documents:
-            self.add_document_with_writer(doc, writer, schema_keys)
+            self._add_document_with_writer(doc, writer, schema_keys)
         writer.commit()
 
-    def initialize(self) -> None:
-        """Function to be called every time a database object is created.
-        It checks if an index exists, if not, it creates one and
-        indexes the library.
-
-        If the schema fields have been changed, it updates the database.
-        """
-        if self.index_exists():
-            user_fields = self.get_schema_init_fields()
-            db_fields = self.get_schema()
-
-            user_field_names = sorted(user_fields)
-            db_field_names = sorted(db_fields.names())
-
-            # If the user fields and the fields in the DB
-            # aren't the same, then we have to rebuild the
-            # database.
-            if user_field_names != db_field_names:
-                logger.debug("Rebuilding database because field names do not match.")
-                self.rebuild()
-            else:
-                # Otherwise, verify that the fields are
-                # all the same and rebuild if any have
-                # changed at all.
-                rebuilt_db = False
-                for field in user_field_names:
-                    if user_fields[field] != db_fields[field]:
-                        logger.debug(
-                            "Rebuilding database because field types do not match.")
-
-                        self.rebuild()
-                        rebuilt_db = True
-                        break
-
-                if not rebuilt_db:
-                    logger.debug("Initialized index found for library.")
-                    return
-        else:
-            logger.info("Indexing library. This might take a while...")
-
-        self.create_index()
-        self.do_indexing()
-
-    def rebuild(self) -> None:
-        self.clear()
-        self.create_index()
-        self.do_indexing()
-
-    def get_index(self) -> "Index":
+    def _get_index(self) -> "Index":
         """Gets the index for the current library
         """
-        import whoosh.index
-        return whoosh.index.open_dir(self.index_dir)
+        from whoosh.index import open_dir
+        return open_dir(self.index_dir)
 
-    def get_writer(self) -> "IndexWriter":
-        """Gets the writer for the current library
-        """
-        return self.get_index().writer()
-
-    def get_schema(self) -> "Schema":
-        """Gets current schema
-        """
-        return self.get_index().schema
-
-    def create_schema(self) -> "Schema":
-        """Creates and returns whoosh schema to be applied to the library
-        """
-        logger.debug("Creating schema.")
-        fields = self.get_schema_init_fields()
-
+    def _create_schema(self) -> "Schema":
+        """Creates and returns whoosh schema to be applied to the library"""
         from whoosh.fields import Schema
+        logger.debug("Creating schema.")
+
+        fields = self._get_schema_init_fields()
         return Schema(**fields)
 
-    def get_schema_init_fields(self) -> Dict[str, "FieldType"]:
-        """Returns the arguments to be passed to the whoosh schema
-        object instantiation found in the method `get_schema`.
+    def _get_schema_init_fields(self) -> Dict[str, "FieldType"]:
         """
+        :returns: the keyword arguments to be passed to the whoosh schema object
+            (see :meth:`_create_schema`).
+        """
+        # NOTE: these are imported here so that `eval` sees them
         from whoosh.fields import TEXT, ID, KEYWORD, STORED  # noqa: F401
 
-        # This part is non-negotiable
+        # TODO: this is a security risk, find a way to fix it
+        user_prototype = eval(papis.config.getstring("whoosh-schema-prototype"))
+
+        # add default fields that should always be in the database
         fields = {
             ID_KEY_NAME: ID(stored=True, unique=True),
             "papis-folder": TEXT(stored=True)
         }
-
-        # TODO: this is a security risk, find a way to fix it
-        user_prototype = eval(papis.config.getstring("whoosh-schema-prototype"))
+        # add user provided fields
         fields.update(user_prototype)
 
+        # add simpler text fields
         fields_list = papis.config.getlist("whoosh-schema-fields")
         for field in fields_list:
             fields.update({field: TEXT(stored=True)})

--- a/papis/database/whoosh.py
+++ b/papis/database/whoosh.py
@@ -12,7 +12,7 @@ which is a declaration of the data prototype of the database, or the
 definition of the table in SQL parlance. This is controlled by the
 Papis configuration through the :confval:`whoosh-schema-prototype`. For instance
 if the database is supposed to only contain the key fields
-``[author, title, year, tags]``, then the :confval:`whoosh-schema-prototype``
+``[author, title, year, tags]``, then the :confval:`whoosh-schema-prototype`
 string should look like the following:
 
 .. code:: python
@@ -29,8 +29,8 @@ where all the fields are explained in the whoosh
 
 After this Schema is created, the folders of the library are traversed
 and the documents are added to the database. When adding documents, only the
-keys in the schema are stored. This means, if ``publisher`` is not in the schema,
-you will not be able to search for the publisher through a query.
+keys in the schema are stored. This means that, e.g., if ``publisher`` is not in
+the schema you will not be able to search for the publisher through a query.
 """
 
 import os

--- a/papis/defaults.py
+++ b/papis/defaults.py
@@ -83,9 +83,9 @@ settings: Dict[str, Any] = {
 
     # bibtex
     "bibtex-journal-key": "journal",
-    "extra-bibtex-keys": "[]",
-    "bibtex-ignore-keys": "[]",
-    "extra-bibtex-types": "[]",
+    "extra-bibtex-keys": [],
+    "bibtex-ignore-keys": [],
+    "extra-bibtex-types": [],
     "bibtex-unicode": False,
     "bibtex-export-file": False,
     "multiple-authors-separator": " and ",
@@ -229,7 +229,7 @@ settings: Dict[str, Any] = {
     "database-backend": "papis",
     "use-cache": True,
     "cache-dir": None,
-    "whoosh-schema-fields": "['doi']",
+    "whoosh-schema-fields": ["doi"],
     "whoosh-schema-prototype":
     "{\n"
     '"author": TEXT(stored=True),\n'

--- a/papis/format.py
+++ b/papis/format.py
@@ -229,6 +229,15 @@ class Jinja2Formatter(Formatter):
 
     @classmethod
     def get_environment(cls, *, force: bool = False) -> Any:
+        """Construct and cache the ``jinja2`` environment used by the formatter.
+
+        The environment is created on the first call to :meth:`format` and cached
+        for future use. If it should be recreated after that, this function can
+        be called with *force* set to *True*.
+
+        :arg force: if *True*, the environment will be recreated.
+        """
+
         if cls.env is None or force:
             from jinja2 import Environment
 

--- a/papis/testing.py
+++ b/papis/testing.py
@@ -152,7 +152,7 @@ def populate_library(libdir: str) -> None:
 
     :arg libdir: an existing empty library directory.
     """
-    import papis.id
+    from papis.id import ID_KEY_NAME, compute_an_id
     from papis.document import Document
 
     for i, data in enumerate(PAPIS_TEST_DOCUMENTS):
@@ -171,7 +171,7 @@ def populate_library(libdir: str) -> None:
 
         # create document
         doc = Document(folder_path, doc_data)
-        doc[papis.id.key_name()] = papis.id.compute_an_id(doc)
+        doc[ID_KEY_NAME] = compute_an_id(doc)
         doc.save()
 
 

--- a/tests/commands/test_cache.py
+++ b/tests/commands/test_cache.py
@@ -9,9 +9,6 @@ from papis.testing import TemporaryLibrary, PapisRunner
 
 def test_clear(tmp_library: TemporaryLibrary) -> None:
     db = papis.database.get()
-
-    assert not os.path.exists(db.get_cache_path())
-    db.get_all_documents()
     assert os.path.exists(db.get_cache_path())
 
     cli_runner = PapisRunner()
@@ -61,16 +58,16 @@ def test_rm_add_update(tmp_library: TemporaryLibrary) -> None:
     ###################################################
     # NOTE: modifying `doc` directly may modify the version in the database, so
     # this modifies the info file behind its back completely to check the update
-    doc_dict = {**dict(doc), "cache": "test-update"}
+    doc_dict = {**dict(doc), "tags": "test-update"}
     papis.yaml.data_to_yaml(doc.get_info_file(), doc_dict, allow_unicode=True)
 
-    query_results = db.query_dict({"cache": "test-update"})
+    query_results = db.query_dict({"tags": "test-update"})
     assert len(query_results) == 0
 
     result = cli_runner.invoke(cli, ["update", "--doc-folder", folder])
     assert result.exit_code == 0
 
-    query_results = db.query_dict({"cache": "test-update"})
+    query_results = db.query_dict({"tags": "test-update"})
     assert len(query_results) == 1
 
     # update-newer
@@ -79,14 +76,14 @@ def test_rm_add_update(tmp_library: TemporaryLibrary) -> None:
     # meaningfully changed and the OS had time to update it
     time.sleep(1)
 
-    doc_dict = {**dict(doc), "cache": "test-update-newer"}
+    doc_dict = {**dict(doc), "tags": "test-update-newer"}
     papis.yaml.data_to_yaml(doc.get_info_file(), doc_dict, allow_unicode=True)
 
-    query_results = db.query_dict({"cache": "test-update-newer"})
+    query_results = db.query_dict({"tags": "test-update-newer"})
     assert len(query_results) == 0
 
     result = cli_runner.invoke(cli, ["update-newer", "--all"])
     assert result.exit_code == 0
 
-    query_results = db.query_dict({"cache": "test-update-newer"})
+    query_results = db.query_dict({"tags": "test-update-newer"})
     assert len(query_results) == 1

--- a/tests/commands/test_rm.py
+++ b/tests/commands/test_rm.py
@@ -40,6 +40,7 @@ def test_rm_files_run(tmp_library: TemporaryLibrary) -> None:
     assert not os.path.exists(filename)
 
     db.clear()
+    db.initialize()
     db.documents = None
 
     doc, = db.query_dict({"title": title})

--- a/tests/database/test_database.py
+++ b/tests/database/test_database.py
@@ -18,10 +18,11 @@ PAPIS_DB_SETTINGS = [{"settings": {"database-backend": b}} for b in PAPIS_DB_BAC
 @pytest.mark.parametrize("tmp_library", PAPIS_DB_SETTINGS, indirect=True)
 def test_database_paths(tmp_library: TemporaryLibrary) -> None:
     db = papis.database.get()
+
     assert db is not None
     assert db.get_backend_name() == papis.config.get("database-backend")
-    assert db.get_lib() == papis.config.get_lib_name()
-    assert db.get_dirs() == papis.config.get_lib_dirs()
+    assert db.lib.name == papis.config.get_lib_name()
+    assert db.lib.paths == papis.config.get_lib_dirs()
     assert db.get_all_query_string() == papis.database.get_all_query_string()
 
     docs = db.get_all_documents()

--- a/tests/database/test_papis.py
+++ b/tests/database/test_papis.py
@@ -31,7 +31,7 @@ def test_database_reload(tmp_library: TemporaryLibrary) -> None:
     assert isinstance(db, papis.database.Database)
 
     ndocs = len(db.get_all_documents())
-    db.save()
+    db._save_documents()
     db.documents = None
 
     ndocs_reload = len(db.get_all_documents())
@@ -51,7 +51,7 @@ def test_database_missing(tmp_library: TemporaryLibrary) -> None:
 
     with pytest.raises(
             Exception,
-            match="document passed could not be found"):
+            match="Document could not be found"):
         db._locate_document(doc)
 
 
@@ -71,7 +71,7 @@ def test_cache_path(tmp_library: TemporaryLibrary) -> None:
     import papis.database
 
     db = papis.database.get()
-    _ = db.get_documents()
+    _ = db.get_all_documents()
 
     assert os.path.exists(db.get_cache_path())
     assert not os.path.isdir(db.get_cache_path())


### PR DESCRIPTION
I wanted to implement a backend based on sqlite and managed to amass a bunch of random cleanup stuff while looking through it. There's quite a few changes, but most of them are just moving things around.

Added some deprecations for the next next release (i.e. 0.16):
* Deprecated `papis.id.key_name()` in favour of a constant `papis.id.ID_KEY_NAME`.
* Deprecated `papis.id.has_id()` in favour of just using `ID_KEY_NAME in doc`.
* Deprecated `Database.get_lib`, `Database.get_dirs` and `Database.get_id_key` in favour of just accessing the members directly.
* Removed `Database.match` since it didn't seem to be used anywhere and was only implemented by the `papis` backend.

Some other changes:
* Made a bunch of methods "private" with a little underscore. I don't think these were ever meant to be used outside of the `Database` classes.
* Rearranged all the methods in `papis.database.cache` and `whoosh` to match the ones in `base`. I was mostly confused trying to match which abstractmethods were implemented where.
* Updated and added docs for all the methods. They were also added to the `Developer API reference` in the docs in case anyone wants to look through them in there.

I've ran the entire test suite locally with the `papis` backend and the `whoosh` backend and it all seems to work (after some fixes to the unittests).