### PR TITLE
Doc: Move LSP advertisement from pyproject.toml to docs

### DIFF
--- a/HACKING.md
+++ b/HACKING.md
@@ -43,6 +43,10 @@ The docs can be generated with
 make doc
 ```
 
+It is generally advisable to have `python-lsp-server` installed, as it enables
+your text editor to perform semantic operations on the codebase (eg Go to
+Definition, Replace All, refactorings, etc)
+
 ### Containers
 
 To quickly get things up and running, you can also use Docker with the included

--- a/flake.nix
+++ b/flake.nix
@@ -101,7 +101,6 @@
                   extras = [
                     "develop"
                     "docs"
-                    "lsp"
                     "optional"
                   ];
                 } == { };
@@ -136,13 +135,18 @@
                 extras = [
                   "develop"
                   "docs"
-                  "lsp"
                   "optional"
                 ];
               };
 
               # Returns a wrapped environment (virtualenv like) with all our packages
               pythonEnv = python.withPackages arg;
+
+              # Tools useful to have in the dev environment but not strictly
+              # necessary to our workflow
+              extra-dev-tools = python.withPackages (ps: [
+                ps.python-lsp-server
+              ]);
 
               # used in below scripts to check if docker or podman is available
               check-container-cmd =
@@ -208,6 +212,7 @@
               packages = [
                 self.packages.${system}.papis
                 pythonEnv
+                extra-dev-tools
                 papis-build-container
                 papis-run-container-tests
                 papis-run-container-interactive

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -122,11 +122,6 @@ docs = [
     "sphinx_design",
     "sphinx_rtd_theme>=1",
 ]
-# Python LSP support
-# (provided for convenience setting up a devenv, not a workflow dependency)
-lsp = [
-    "python-lsp-server",
-]
 # Libraries that papis knows how to interact with if installed
 optional = [
     "Jinja2>=3.0.0",


### PR DESCRIPTION
As promised in https://github.com/papis/papis/pull/985#issuecomment-2759768177, here's an attempt to reduce the presence of `python-lsp-server` to merely an advertisement and a convenience feature in `flake.nix` (dropped from that PR since polishing this up was questionably-useful scope creep).

To recap the motivation for this: It isn't a dependency for the project, but merely a useful-to-have tool we recommend developers install. (This is unlike linters and test suites that allow us to maintain project standards -- in contrast, an LSP server is one way to configure a text editor for better Python support). In view of this, it doesn't make sense to advertise this as a component of the project (as is the implication by putting it in `pyproject.toml`).

Hopefully I've guessed the nix syntax correctly this time. Otherwise, I'll set this as a draft and withdraw from it -- I have little free time this month and do not want to commit to polishing this to a releasable state.
