### PR TITLE
Make citeproc-py optional for the CSL exporter

### DIFF
--- a/PACKAGING.md
+++ b/PACKAGING.md
@@ -25,6 +25,8 @@ Some optional dependencies are required for various Papis plugins
   formatter.
 * `Whoosh` is required for the `whoosh` cache database, alternative to the default
   `papis` database based on `pickle`.
+* `citeproc-py` is required for the `csl` exporter, which allows exporting through
+  the popular CSL (Citation Style Language) to styles like APA or MLA.
 * `chardet` is used by `beautifulsoup4` when parsing webpages to improve character
   detection. This is recommended when making heavy use of Papis downloaders and
   importers.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -66,7 +66,6 @@ dependencies = [
     "arxiv>=1.0.0",
     "beautifulsoup4>=4.4.1",
     "bibtexparser>=0.6.2,<2",
-    "citeproc-py",
     "click>=7",
     "colorama>=0.2",
     "dominate>=2.8",
@@ -132,6 +131,7 @@ optional = [
     "Jinja2>=3.0.0",
     "Whoosh>=2.7.4",
     "chardet>=3.0.2",
+    "citeproc-py>=0.6",
     "markdownify>=0.11.6",
 ]
 # Custom Sphinx directives for papis docs

--- a/tests/test_csl.py
+++ b/tests/test_csl.py
@@ -1,7 +1,11 @@
+import pytest
+
 from papis.testing import TemporaryConfiguration
 
 
 def test_csl_export(tmp_config: TemporaryConfiguration) -> None:
+    pytest.importorskip("citeproc")
+
     from papis.csl import export_document
     from papis.document import from_data
 
@@ -19,6 +23,8 @@ def test_csl_export(tmp_config: TemporaryConfiguration) -> None:
 
 
 def test_csl_style_download(tmp_config: TemporaryConfiguration) -> None:
+    pytest.importorskip("citeproc")
+
     import papis.config
     from papis.csl import exporter
     from papis.document import from_data


### PR DESCRIPTION
This makes `citeproc-py` an optional dependency, since it causes some packaging issues.

cc @hseg 