### PR TITLE
doctor missing values

### DIFF
--- a/papis/commands/doctor.py
+++ b/papis/commands/doctor.py
@@ -39,6 +39,8 @@ implemented:
   :confval:`doctor-field-type-separator` setting.
 * ``keys-missing``: checks that the keys provided by
   :confval:`doctor-keys-missing-keys` exist in the document.
+* ``values-missing``: checks that fields in the document do not have empty values
+  (e.g. *None*, empty lists, empty strings, etc).
 * ``refs``: checks that the document has a valid reference (i.e. one that would
   be accepted by BibTeX and only contains valid characters).
 * ``string-cleaner``: checks that strings do contain various undesired characters

--- a/papis/doctor.py
+++ b/papis/doctor.py
@@ -193,6 +193,42 @@ def keys_missing_check(doc: Document) -> list[Error]:
             for k in keys if k not in doc]
 
 
+VALUES_MISSING_CHECK_NAME = "values-missing"
+
+
+def values_missing_check(doc: Document) -> list[Error]:
+    """
+    Checks whether any keys have missing values. This can values set to *None*,
+    empty lists or empty strings.
+
+    :returns: a :class: list or errors, one for each missing value.
+    """
+
+    def is_nonempty(arg: Any) -> bool:
+        if isinstance(arg, bool):
+            return True
+        else:
+            return bool(arg)
+
+    def make_fixer(key: str) -> FixFn:
+        def fix_missing_value() -> None:
+            if key not in doc:
+                return
+
+            del doc[key]
+            logger.info("[FIX] Removed key '%s' with empty value.", key)
+
+        return fix_missing_value
+
+    return [
+        make_error(doc, VALUES_MISSING_CHECK_NAME,
+                   msg=f"Key '{k}' has an empty value",
+                   fix_action=make_fixer(k),
+                   payload=k)
+        for k, v in doc.items() if not is_nonempty(v)
+    ]
+
+
 REFS_CHECK_NAME = "refs"
 REFS_BAD_SYMBOL_REGEX = re.compile(r"[ ,{}\[\]@#`']")
 
@@ -984,6 +1020,7 @@ def string_cleaner_check(doc: Document) -> list[Error]:
 
 register_check(FILES_CHECK_NAME, files_check)
 register_check(KEYS_MISSING_CHECK_NAME, keys_missing_check)
+register_check(VALUES_MISSING_CHECK_NAME, values_missing_check)
 register_check(DUPLICATED_KEYS_NAME, duplicated_keys_check)
 register_check(DUPLICATED_VALUES_NAME, duplicated_values_check)
 register_check(BIBTEX_TYPE_CHECK_NAME, bibtex_type_check)

--- a/tests/test_doctor.py
+++ b/tests/test_doctor.py
@@ -98,6 +98,60 @@ def test_keys_missing_check_authors(tmp_config: TemporaryConfiguration) -> None:
     assert doc["author"] == "Doe, John and Doe, Jane"
 
 
+def test_values_missing_check(tmp_config: TemporaryConfiguration) -> None:
+    from papis.doctor import values_missing_check
+
+    # check: no missing values
+    doc = papis.document.from_data({
+        "title": "DNA sequencing with chain-terminating inhibitors",
+        "author": "Sanger, F. and Nicklen, S. and Coulson, A. R.",
+        "year": 1977,
+        "bool_field": False,
+        "list": ["a", "b"],
+        "dict": {"a": 1},
+        })
+
+    errors = values_missing_check(doc)
+    assert not errors
+
+    # check: None value
+    doc["note"] = None
+    error, = values_missing_check(doc)
+    assert error.payload == "note"
+    assert "empty" in error.msg
+    assert error.fix_action is not None
+
+    error.fix_action()
+    assert "note" not in doc
+
+    # check: empty string
+    doc["journal"] = ""
+    error, = values_missing_check(doc)
+    assert error.payload == "journal"
+    assert error.fix_action is not None
+
+    error.fix_action()
+    assert "journal" not in doc
+
+    # check: empty list
+    doc["tags"] = []
+    error, = values_missing_check(doc)
+    assert error.payload == "tags"
+    assert error.fix_action is not None
+
+    error.fix_action()
+    assert "tags" not in doc
+
+    # check: empty dict
+    doc["extra"] = {}
+    error, = values_missing_check(doc)
+    assert error.payload == "extra"
+    assert error.fix_action is not None
+
+    error.fix_action()
+    assert "extra" not in doc
+
+
 def test_refs_check(tmp_config: TemporaryConfiguration) -> None:
     from papis.doctor import refs_check
 


### PR DESCRIPTION
Minor doctor enhancement intended to catch empty key values. I integrated it into the missing keys check and perhaps that is questionable placement, but it is conceptually simple and I've found it to work well for me the past 5 months.

It should address issues like #950. There, Alex suggested integrating this kind of check into the key-types doctor.