### PR TITLE
doctor unexpected keys

### DIFF
--- a/papis/commands/doctor.py
+++ b/papis/commands/doctor.py
@@ -129,6 +129,7 @@ import click
 
 import papis
 import papis.cli
+import papis.tui.utils
 import papis.config
 import papis.strings
 import papis.database
@@ -494,7 +495,7 @@ def bibtex_type_check(doc: papis.document.Document) -> List[Error]:
         return [Error(name=BIBTEX_TYPE_CHECK_NAME,
                       path=folder,
                       msg=f"Document does not define type as one of:\n{
-                      '\n'.join(sorted(bibtex_types))
+                      papis.tui.utils.string_grid(sorted(bibtex_types))
                       }",
                       suggestion_cmd=f"papis edit --doc-folder {folder}",
                       fix_action=None,
@@ -662,8 +663,8 @@ def biblatex_expected_keys_check(doc: papis.document.Document) -> List[Error]:
 
     return [Error(name=BIBLATEX_EXPECTED_KEYS_CHECK_NAME,
                   path=folder,
-                  msg=f"Document contains key {key} not one of:\n{
-                  '\n'.join(bibtex_keys)
+                  msg=f"Document contains key '{key}' not a bibtex key:\n{
+                  papis.tui.utils.string_grid(sorted(bibtex_keys))
                   }",
                   suggestion_cmd=f"papis edit --doc-folder {folder}",
                   fix_action=None,

--- a/papis/commands/doctor.py
+++ b/papis/commands/doctor.py
@@ -493,7 +493,9 @@ def bibtex_type_check(doc: papis.document.Document) -> List[Error]:
     if bib_type is None:
         return [Error(name=BIBTEX_TYPE_CHECK_NAME,
                       path=folder,
-                      msg="Document does not define a type",
+                      msg=f"Document does not define type as one of:\n{
+                      '\n'.join(sorted(bibtex_types))
+                      }",
                       suggestion_cmd=f"papis edit --doc-folder {folder}",
                       fix_action=None,
                       payload="type",
@@ -502,7 +504,9 @@ def bibtex_type_check(doc: papis.document.Document) -> List[Error]:
     if bib_type not in bibtex_types:
         return [Error(name=BIBTEX_TYPE_CHECK_NAME,
                       path=folder,
-                      msg=f"Document type '{bib_type}' is not a valid BibTeX type",
+                      msg=f"Document type '{bib_type}' is not a valid BibTeX type:\n{
+                      papis.tui.utils.string_grid(sorted(bibtex_types))
+                      }",
                       suggestion_cmd=f"papis edit --doc-folder {folder}",
                       fix_action=make_fixer(bib_type),
                       payload=bib_type,

--- a/papis/commands/doctor.py
+++ b/papis/commands/doctor.py
@@ -649,8 +649,8 @@ def biblatex_expected_keys_check(doc: papis.document.Document) -> List[Error]:
     """
     Check that all keys in info.yaml are expected by biblatex processors.
 
-    Note, in most circumstances using arbitrary keys is completely inconsequential.
-    This simply offers a check for users keep strict control over metadata.
+    In most circumstances, using arbitrary keys is completely inconsequential.
+    This check simply helps users keep strict control over metadata.
 
     :returns: an error per document key that is not a known key
     """

--- a/papis/commands/doctor.py
+++ b/papis/commands/doctor.py
@@ -641,7 +641,7 @@ def biblatex_required_keys_check(doc: papis.document.Document) -> List[Error]:
 BIBLATEX_EXPECTED_KEYS_IGNORED = {
     "papis_id", "author_list", "citations", "doc_url",
     "files", "ref", "time-added", "type"
-}
+} | frozenset(papis.config.getlist("bibtex-ignore-keys"))
 BIBLATEX_EXPECTED_KEYS_CHECK_NAME = "biblatex-expected-keys"
 
 

--- a/papis/commands/doctor.py
+++ b/papis/commands/doctor.py
@@ -639,8 +639,8 @@ def biblatex_required_keys_check(doc: papis.document.Document) -> List[Error]:
 
 
 BIBLATEX_EXPECTED_KEYS_IGNORED = {
-    "papis_id", "author_list", "citations", "doc_url",
-    "files", "ref", "time-added", "type"
+    "papis_id", "author_list", "editor_list", "citations", "doc_url",
+    "files", "ref", "time-added", "type", "tags"
 } | frozenset(papis.config.getlist("bibtex-ignore-keys"))
 BIBLATEX_EXPECTED_KEYS_CHECK_NAME = "biblatex-expected-keys"
 

--- a/papis/tui/utils.py
+++ b/papis/tui/utils.py
@@ -1,5 +1,6 @@
 import re
 from typing import Optional, List, Callable, Any, Iterable
+from collections.abc import Sequence
 
 import click
 
@@ -183,6 +184,17 @@ def progress_bar(iterable: Iterable[T]) -> Iterable[T]:
     with ProgressBar(style=style, formatters=fmt) as pb:
         for item in pb(iterable):
             yield item
+
+
+def string_grid(strings: Sequence[str]) -> str:
+    from shutil import get_terminal_size
+    from itertools import zip_longest
+    width, _ = get_terminal_size()
+    maxchars = len(max(strings, key=len)) + 4
+    maxwords = width // maxchars
+    lines = zip_longest(*[strings[i::maxwords] for i in range(maxwords)], fillvalue="")
+    lines_fixed_width = ["".join([f"{word:>{maxchars}}" for word in line]) for line in lines]
+    return '\n'.join(lines_fixed_width)
 
 
 def get_range(range_str: str) -> List[int]:


### PR DESCRIPTION
I wanted a compliment to the required keys check that would help me eliminate pointless metadata from my entries destined for bibtex export.

With this check comes some improvements to the doctor's diagnoses. Namely clearer and more actionable descriptions facilitated by a no dependency TUI list printing function.

As part of the implementation the fixer function edits the user's config file so that may be objectionable.