### PR TITLE
test: Add testpaths

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -267,6 +267,7 @@ addopts = [
     "--cov=papis",
 ]
 doctest_optionflags = ["NORMALIZE_WHITESPACE", "ELLIPSIS"]
+testpaths = [ "papis", "tests" ]
 norecursedirs = [".git", "doc", "build", "dist"]
 python_files = "*.py"
 markers = [


### PR DESCRIPTION
While investigating something else, finally found how to get rid of this minor irritant. This enables invoking pytest with a simple `python -m pytest`, instead of requiring enumerating the test directories as `python -m pytest papis tests`, which trips me up from time to time.
