### PR TITLE
Add more handling for jats tags

### DIFF
--- a/papis/commands/doctor.py
+++ b/papis/commands/doctor.py
@@ -848,7 +848,7 @@ def html_tags_check(doc: papis.document.Document) -> List[Error]:
                     tag.replace_with(f" {tag.text.strip()} ")
 
             for tag in soup.find_all("jats:title"):
-                if tag.text.strip() == "Abstract":
+                if tag.text.strip().lower() in {"abstract", "summary", "synopsis"}:
                     tag.extract()
                 else:
                     # NOTE: these will get cleaned up in `make_fixer`


### PR DESCRIPTION
This also cleans up abstracts that start with `Synopsis:` or `Summary:`. For an example: http://dx.doi.org/10.1002/fld.3923.