### PR TITLE
Structure configuration state

### DIFF
--- a/doc/source/default-settings.rst
+++ b/doc/source/default-settings.rst
@@ -451,7 +451,6 @@ Add options
     If this setting is ``None`` the template ``{doc[papis_id]}`` is used.
 
 .. papis-config:: add-file-name
-    :type: str
 
     Set the default file name for newly added documents, similarly to
     :confval:`add-folder-name`. If it is not set, the names of the

--- a/papis/config.py
+++ b/papis/config.py
@@ -27,6 +27,220 @@ OVERRIDE_VARS: Dict[str, Optional[str]] = {
 GENERAL_SETTINGS_NAME = "settings"
 
 
+schema = {
+    # general settings
+    "local-config-file": {'type': 'path', 'default': ".papis.config"},
+    "dir-umask": {'type': 'number', 'default': 0o755},
+    "use-git": {'type': 'boolean', 'default': False},
+    "user-agent": {'type': 'string', 'default': "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_9_3)"},
+    "scripts-short-help-regex": {'type': 'regex', 'default': ".*papis-short-help: *(.*)"},
+    "info-name": {'type': 'path', 'default': "info.yaml"},
+    "doc-url-key-name": {'type': '', 'default': "doc_url"},
+    "default-library": "papers",
+    "format-doc-name": "doc",
+    "match-format": _f(
+            "{doc[tags]}{doc.subfolder}{doc[title]}{doc[author]}{doc[year]}"),
+    "header-format": _f(
+            "<ansired>{doc.html_escape[title]}</ansired>\n"
+            " <ansigreen>{doc.html_escape[author]}</ansigreen>\n"
+            "  <ansiblue>({doc.html_escape[year]})</ansiblue> "
+            "[<ansiyellow>{doc.html_escape[tags]}</ansiyellow>]"
+            ),
+    "header-format-file": None,
+    "info-allow-unicode": True,
+    "unique-document-keys": ["doi", "isbn", "isbn10", "eprint", "url", "doc_url"],
+    "document-description-format": _f("{doc[title]} - {doc[author]}"),
+    "sort-field": None,
+    "sort-reverse": False,
+    "formatter": "python",
+    "doc-paths-lowercase": True,
+    "doc-paths-extra-chars": "",
+    "doc-paths-word-separator": "-",
+    "ref-word-separator": "_",
+    "library-header-format": _f(
+            "<ansired>{library[name]}</ansired>"
+            " <ansiblue>{library[paths]}</ansiblue>"
+            ),
+
+    # tools
+    "opentool": get_default_opener(),
+    "browser": os.environ.get("BROWSER") or get_default_opener(),
+    "picktool": "papis",
+    "editor": (
+            os.environ.get("EDITOR")
+            or os.environ.get("VISUAL")
+            or get_default_opener()),
+    "file-browser": get_default_opener(),
+
+    # bibtex
+    "bibtex-journal-key": "journal",
+    "extra-bibtex-keys": [],
+    "bibtex-ignore-keys": [],
+    "extra-bibtex-types": [],
+    "bibtex-unicode": False,
+    "bibtex-export-file": False,
+    "multiple-authors-separator": " and ",
+    "multiple-authors-format": _f("{au[family]}, {au[given]}"),
+
+    # csl
+    "csl-style": "harvard1",
+    "csl-formatter": "plain",
+
+    # add
+    "ref-format": _f("{doc[title]:.15} {doc[author]:.6} {doc[year]}"),
+    "add-folder-name": _f(""),
+    "add-file-name": _f(""),
+    "add-subfolder": "",
+    "add-confirm": False,
+    "add-edit": False,
+    "add-open": False,
+    "add-download-files": True,
+    "add-fetch-citations": False,
+    "auto-doctor": False,
+    "time-stamp": True,
+
+    # browse
+    "browse-key": "auto",
+    "browse-query-format": _f("{doc[title]} {doc[author]}"),
+    "search-engine": "https://duckduckgo.com",
+
+    # edit
+    "notes-name": "notes.tex",
+    "notes-template": "",
+
+    # doctor
+    "doctor-default-checks": ["files", "biblatex-required-keys", "bibtex-type", "refs"],
+    "doctor-default-checks-extend": [],
+    "doctor-keys-missing-keys": ["title", "author", "author_list", "ref"],
+    "doctor-keys-missing-keys-extend": [],
+    "doctor-duplicated-keys-keys": ["ref"],
+    "doctor-duplicated-keys-keys-extend": [],
+    "doctor-duplicated-values-keys": ["files", "author_list"],
+    "doctor-duplicated-values-keys-extend": [],
+    "doctor-html-codes-keys": ["title", "author", "abstract", "journal"],
+    "doctor-html-codes-keys-extend": [],
+    "doctor-html-tags-keys": ["title", "author", "abstract", "journal"],
+    "doctor-html-tags-keys-extend": [],
+    "doctor-key-type-keys": ["year:int",
+                             "month:int",
+                             "files:list",
+                             "notes:str",
+                             "author_list:list",
+                             "doi:str",
+                             "ref:str",
+                             "isbn:str",
+                             "author:str",
+                             "journal:str",
+                             "note:str",
+                             "tags:list",
+                             "type:str",
+                             "publisher:str",
+                             "title:str",
+                             "shorttitle:str"],
+    "doctor-key-type-keys-extend": [],
+    "doctor-key-type-separator": None,
+
+    # open
+    "open-mark": False,
+    "mark-key-name": "marks",
+    "mark-format-name": "mark",
+    "mark-header-format": _f("{mark[name]} - {mark[value]}"),
+    "mark-match-format": _f("{mark[name]} - {mark[value]}"),
+    "mark-opener-format": get_default_opener(),
+
+    # serve
+    "serve-empty-query-get-all-documents": False,
+    "serve-default-tag-sorting": "numeric",
+    "serve-timeline-max": 500,
+    "serve-enable-timeline": False,
+    # serve-frameworks
+    "serve-user-css": [],
+    "serve-user-js": [],
+    "serve-font-awesome-css": [("https://cdnjs.cloudflare.com/ajax/"
+                                "libs/font-awesome/6.2.1/css/all.min.css"),
+                               ("https://cdnjs.cloudflare.com/ajax/"
+                                "libs/font-awesome/6.2.1/css/brands.min.css"),
+                               ("https://cdnjs.cloudflare.com/ajax/"
+                                "libs/font-awesome/6.2.1/css/solid.min.css"),
+                               ],
+    "serve-bootstrap-css": ("https://cdn.jsdelivr.net/npm/"
+                            "bootstrap@5.1.1/dist/css/bootstrap.min.css"),
+    "serve-bootstrap-js": ("https://cdn.jsdelivr.net/npm/"
+                           "bootstrap@5.1.1/dist/js/bootstrap.bundle.min.js"),
+    "serve-jquery-js": "https://code.jquery.com/jquery-3.6.0.min.js",
+    "serve-jquery.dataTables-css": ("https://cdn.datatables.net/"
+                                    "v/bs5/dt-1.13.1/kt-2.8.0/"
+                                    "sc-2.0.7/sb-1.4.0/datatables.min.css"),
+    "serve-jquery.dataTables-js": ("https://cdn.datatables.net/"
+                                   "v/bs5/dt-1.13.1/kt-2.8.0/"
+                                   "sc-2.0.7/sb-1.4.0/datatables.min.js"),
+    "serve-katex-css": ("https://cdn.jsdelivr.net/npm/"
+                        "katex@0.16.4/dist/katex.min.css"),
+    "serve-katex-js": ("https://cdn.jsdelivr.net/npm/"
+                       "katex@0.16.4/dist/katex.min.js"),
+    "serve-katex-auto-render-js":
+        ("https://cdn.jsdelivr.net/npm/"
+         "katex@0.16.4/dist/contrib/auto-render.min.js"),
+    "serve-ace-urls": [("https://cdnjs.cloudflare.com/ajax/libs/ace/"
+                        "1.14.0/ace.min.js"),
+                       ("https://cdnjs.cloudflare.com/ajax/libs/ace/"
+                        "1.14.0/mode-yaml.min.js"),
+                       ("https://cdnjs.cloudflare.com/ajax/libs/ace/"
+                        "1.14.0/mode-bibtex.min.js"),
+                       ("https://cdnjs.cloudflare.com/ajax/libs/ace/"
+                        "1.14.0/mode-markdown.min.js"),
+                       ("https://cdnjs.cloudflare.com/ajax/libs/ace/"
+                        "1.14.0/mode-latex.min.js"),
+                       ("https://cdnjs.cloudflare.com/ajax/libs/ace/"
+                        "1.14.0/ext-textarea.min.js"),
+                       ("https://cdnjs.cloudflare.com/ajax/libs/ace/"
+                        "1.14.0/ext-settings_menu.min.js"),
+                       ("https://cdnjs.cloudflare.com/ajax/libs/ace/"
+                        "1.14.0/ext-keybinding_menu.min.js"),
+                       ("https://cdnjs.cloudflare.com/ajax/libs/ace/"
+                        "1.14.0/keybinding-vim.min.js"),
+                       ("https://cdnjs.cloudflare.com/ajax/libs/ace/"
+                        "1.14.0/keybinding-emacs.min.js"),
+                       ],
+    "serve-timeline-js": ("https://cdn.knightlab.com/libs/timeline3/"
+                          "latest/js/timeline.js"),
+    "serve-timeline-css": ("https://cdn.knightlab.com/libs/timeline3/"
+                           "latest/css/timeline.css"),
+
+    # citations
+    "citations-file-name": "citations.yaml",
+    "cited-by-file-name": "cited-by.yaml",
+
+    # downloaders
+    "downloader-proxy": None,
+    "isbn-service": "openl",
+
+    # database
+    "default-query-string": ".",
+    "database-backend": "papis",
+    "use-cache": True,
+    "cache-dir": None,
+    "whoosh-schema-fields": ["doi"],
+    "whoosh-schema-prototype":
+        "{\n"
+    '"author": TEXT(stored=True),\n'
+    '"title": TEXT(stored=True),\n'
+    '"year": TEXT(stored=True),\n'
+    '"tags": TEXT(stored=True),\n'
+    "}",
+
+    # fzf options
+    "fzf-binary": "fzf",
+    "fzf-extra-flags": ["--ansi", "--multi", "-i"],
+    "fzf-extra-bindings": ["ctrl-s:jump"],
+    "fzf-header-format": _f(
+            "{c.Fore.MAGENTA}{doc[title]:<70.70}{c.Style.RESET_ALL}"
+            " :: "
+            "{c.Fore.CYAN}{doc[author]:<20.20}{c.Style.RESET_ALL}"
+            "{c.Fore.YELLOW}«{doc[year]:4}»{c.Style.RESET_ALL}:{doc[tags]}"),
+}
+
+
 def get_general_settings_name() -> str:
     """Get the section name of the general settings.
 

--- a/papis/sphinx_ext.py
+++ b/papis/sphinx_ext.py
@@ -109,6 +109,8 @@ class PapisConfig(Directive):
         # NOTE: try to get some type information for display purposes
         if "type" in self.options:
             default_type = self.options["type"].strip()
+            if default is None:
+                default_type = f"`~typing.Optional` [:class:`{default_type}`]"
             if not default_type.startswith(":"):
                 default_type = f":class:`~{default_type}`"
         elif default is not None:

--- a/tests/commands/test_config.py
+++ b/tests/commands/test_config.py
@@ -9,9 +9,12 @@ from papis.testing import TemporaryConfiguration
 def test_config_single_option(tmp_config: TemporaryConfiguration) -> None:
     from papis.commands.config import run
 
-    assert run(["editor"]) == {"editor": papis.config.get("editor")}
-    assert run(["settings.editor"]) == {"editor": papis.config.get("editor")}
-    assert run(["papers.dir"]) == {"dir": papis.config.get("dir", section="papers")}
+    assert run(["editor"]) == {
+        "editor": papis.config.getstring("editor")}
+    assert run(["settings.editor"]) == {
+        "editor": papis.config.getstring("editor")}
+    assert run(["papers.dir"]) == {
+        "dir": papis.config.getstring("dir", section="papers")}
 
 
 @pytest.mark.config_setup(overwrite=True, settings={})


### PR DESCRIPTION
Note: This PR is currently a WIP which I won't be touching until 2025-05-08 at the earliest, I'm parking it here for self-accountability and to provide a place to discuss it.

Following on https://github.com/papis/papis/pull/1006#issuecomment-2833433395, this PR makes the configuration state explicit, clarifying its fields and their types.

The idea is to have a `...Config` type for each registered plugin, as well as
for the papis core config, so that the global configuration state becomes a
`Dict[str,Dict[Optional[str],Config]]`.

The intent is that `config[lib][plugin][key] == (set_lib(lib); general_get(key, plugin))`, with the defaulting and cross-section search done at the time `config` is created, with plugins registering a function `ConfigParser -> ...Config` to be used to populate their own config objects. The `None` plugin references the core papis configuration.

If everything goes well, this should enable us to generate `doc/source/default-settings.rst` from the `...Config` types and eventually deprecate the use of `general_get` and friends outside the config-parsing code.
