### PR TITLE
docs: fix grammar, small mistakes and inconsistencies

### DIFF
--- a/doc/source/bibtex.rst
+++ b/doc/source/bibtex.rst
@@ -11,19 +11,19 @@ in :ref:`bibtex-options`.
 Unicode output
 --------------
 
-If you are using TeX engines like XeTeX or LuaTeX, then you can use unicode
-characters for your BibTeX files as well. This means there is no need to write
-``\`{a}`` instead of ``à`` in words such as ``apareixerà``. To control the
-output of unicode characters in Papis, use the
-:confval:`bibtex-unicode` setting.
+Depending on the TeX engine used, you may be able to use unicode characters in
+your BibTeX files, such as with XeTeX or LuaTeX. In that case there is no need
+to write ``\`{a}`` instead of ``à`` in words such as ``apareixerà``. To control
+the output of unicode characters in Papis, use the :confval:`bibtex-unicode`
+setting.
 
 Override keys
 -------------
 
-There might be some issues with this approach though. If you are
-exporting the information from your ``info.yaml`` to a BibTeX file, characters
-like ``&`` or ``$`` have a special meaning in TeX and would need to be escaped.
-When ``bibtex-unicode = False``, these characters would be exported as ``\&``
+There might be some issues with the above approach though. If you are exporting
+the information from your ``info.yaml`` to a BibTeX file, characters like ``&``
+or ``$`` have a special meaning in TeX and would need to be escaped. With the
+default ``bibtex-unicode = False``, these characters would be exported as ``\&``
 and ``\$``, respectively. If it is just a couple of documents that are causing
 this problem, you can just override the problematic field like so
 
@@ -44,5 +44,5 @@ Ignore keys
 -----------
 
 If you do not want to export certain keys to the BibTeX file,
-like the ``abstract``, you might use the :confval:`bibtex-ignore-keys`
+like the ``abstract``, you can use the :confval:`bibtex-ignore-keys`
 setting to omit them in the exporting process.

--- a/doc/source/bibtex.rst
+++ b/doc/source/bibtex.rst
@@ -22,10 +22,10 @@ Override keys
 
 There might be some issues with the above approach though. If you are exporting
 the information from your ``info.yaml`` to a BibTeX file, characters like ``&``
-or ``$`` have a special meaning in TeX and would need to be escaped. With the
-default ``bibtex-unicode = False``, these characters would be exported as ``\&``
-and ``\$``, respectively. If it is just a couple of documents that are causing
-this problem, you can just override the problematic field like so:
+or ``$`` have a special meaning in TeX and need to be escaped. With the default
+``bibtex-unicode = False``, these characters are exported as ``\&`` and ``\$``,
+respectively. If it is just a couple of documents that are causing this problem,
+you can instead override the problematic field like so:
 
 .. code:: yaml
 

--- a/doc/source/bibtex.rst
+++ b/doc/source/bibtex.rst
@@ -11,13 +11,13 @@ in :ref:`bibtex-options`.
 Unicode output
 --------------
 
-The setting :confval:`bibtex-unicode` can be used to allow unicode characters in
-documents.
+The :confval:`bibtex-unicode` setting can be used to allow Unicode characters in
+exported BibTeX files.
 
-Even though this setting is set to False by default, many TeX setups support the
-use of unicode characters in BibTeX files. Enabling unicode avoids having to
+Even though this setting is set to ``False`` by default, many TeX setups support
+the use of Unicode characters in BibTeX files. Enabling Unicode avoids having to
 write ``\`{a}`` instead of just ``à`` to display words such as ``apareixerà``.
-If your setup supports unicode in BibTeX files, you can safely set
+If your setup supports Unicode in BibTeX files, you can safely set
 :confval:`bibtex-unicode` to ``True``.
 
 Override keys

--- a/doc/source/bibtex.rst
+++ b/doc/source/bibtex.rst
@@ -11,11 +11,14 @@ in :ref:`bibtex-options`.
 Unicode output
 --------------
 
-Depending on the TeX engine used, you may be able to use unicode characters in
-your BibTeX files, such as with XeTeX or LuaTeX. In that case there is no need
-to write ``\`{a}`` instead of ``à`` in words such as ``apareixerà``. To control
-the output of unicode characters in Papis, use the :confval:`bibtex-unicode`
-setting.
+The setting :confval:`bibtex-unicode` can be used to allow unicode characters in
+documents.
+
+Even though this setting is set to False by default, many TeX setups support the
+use of unicode characters in BibTeX files. Enabling unicode avoids having to
+write ``\`{a}`` instead of just ``à`` to display words such as ``apareixerà``.
+If your setup supports unicode in BibTeX files, you can safely set
+:confval:`bibtex-unicode` to ``True``.
 
 Override keys
 -------------

--- a/doc/source/bibtex.rst
+++ b/doc/source/bibtex.rst
@@ -25,7 +25,7 @@ the information from your ``info.yaml`` to a BibTeX file, characters like ``&``
 or ``$`` have a special meaning in TeX and would need to be escaped. With the
 default ``bibtex-unicode = False``, these characters would be exported as ``\&``
 and ``\$``, respectively. If it is just a couple of documents that are causing
-this problem, you can just override the problematic field like so
+this problem, you can just override the problematic field like so:
 
 .. code:: yaml
 

--- a/doc/source/citations.rst
+++ b/doc/source/citations.rst
@@ -1,9 +1,9 @@
 Citations of documents: ``citations.yaml`` and ``cited-by.yaml`` files
 ----------------------------------------------------------------------
 
-Papis has support for downloading and exploring citations that are referenced by
-a document (citing references) and also that reference the document (cited-by
-references).
+Papis supports downloading and exploring citations. You can explore the
+citations referenced by a document (citing references) and those that reference
+the document (cited-by references).
 
 If your document has a ``doi`` associated and you use the updater from
 this ``doi``, or you added information from the ``doi`` when you added the

--- a/doc/source/citations.rst
+++ b/doc/source/citations.rst
@@ -1,8 +1,8 @@
 Citations of documents: ``citations.yaml`` and ``cited-by.yaml`` files
 ----------------------------------------------------------------------
 
-Papis has support for downloading and exploring citations that documents reference,
-and also cited-by type references.
+Papis has support for downloading and exploring citations that documents
+reference, and also cited-by type references.
 
 If your document has a ``doi`` associated and you use the updater from
 this ``doi``, or you added information from the ``doi`` when you added the
@@ -23,9 +23,9 @@ your document. This is done by scanning your Papis library for
 documents that cite said document. You can also generate this
 file from the web application or from the ``papis citations`` command.
 
-The citation files try to include always first information already
-existing in the library. This is, before doing any online query,
-Papis tries to find the relevant information in your library.
+The citation files try to include information already existing in the library
+first, i.e. before doing any online query, Papis tries to find the relevant
+information in your library.
 
 Notice that Papis copies most of the metadata to the ``citations.yaml``
 and ``cited-by.yaml`` files. Even though this might seem quite heavy on

--- a/doc/source/citations.rst
+++ b/doc/source/citations.rst
@@ -1,8 +1,9 @@
 Citations of documents: ``citations.yaml`` and ``cited-by.yaml`` files
 ----------------------------------------------------------------------
 
-Papis has support for downloading and exploring citations that documents
-reference, and also cited-by type references.
+Papis has support for downloading and exploring citations that are referenced by
+a document (citing references) and also that reference the document (cited-by
+references).
 
 If your document has a ``doi`` associated and you use the updater from
 this ``doi``, or you added information from the ``doi`` when you added the
@@ -23,12 +24,13 @@ your document. This is done by scanning your Papis library for
 documents that cite said document. You can also generate this
 file from the web application or from the ``papis citations`` command.
 
-The citation files try to include information already existing in the library
-first, i.e. before doing any online query, Papis tries to find the relevant
-information in your library.
+The citation commands first try to find information that already exists in the
+library. That is to say, before doing any online query, it tries to find the
+relevant information in your library (e.g. Crossref supports ``citations`` that
+can be cross-referenced).
 
 Notice that Papis copies most of the metadata to the ``citations.yaml``
 and ``cited-by.yaml`` files. Even though this might seem quite heavy on
-disk space, as a rule of thumb all the ``citation.yaml`` files of a
+disk space, as a rule of thumb all the ``citations.yaml`` files of a
 library with 2k papers containing physics papers will amount to only
 around 30MB.

--- a/doc/source/citations.rst
+++ b/doc/source/citations.rst
@@ -24,10 +24,10 @@ your document. This is done by scanning your Papis library for
 documents that cite said document. You can also generate this
 file from the web application or from the ``papis citations`` command.
 
-The citation commands first try to find information that already exists in the
+The *citations* command first tries to find information that already exists in the
 library. That is to say, before doing any online query, it tries to find the
-relevant information in your library (e.g. Crossref supports ``citations`` that
-can be cross-referenced).
+relevant information in your library (e.g. the Crossref importer supports
+``citations`` that can be cross-referenced).
 
 Notice that Papis copies most of the metadata to the ``citations.yaml``
 and ``cited-by.yaml`` files. Even though this might seem quite heavy on

--- a/doc/source/commands/addto.rst
+++ b/doc/source/commands/addto.rst
@@ -1,4 +1,5 @@
 Addto
 -----
+
 .. automodule:: papis.commands.addto
 

--- a/doc/source/commands/bibtex.rst
+++ b/doc/source/commands/bibtex.rst
@@ -2,5 +2,6 @@
 
 Bibtex
 ------
+
 .. automodule:: papis.commands.bibtex
 

--- a/doc/source/commands/browse.rst
+++ b/doc/source/commands/browse.rst
@@ -1,4 +1,5 @@
 Browse
 ------
+
 .. automodule:: papis.commands.browse
 

--- a/doc/source/commands/cache.rst
+++ b/doc/source/commands/cache.rst
@@ -2,3 +2,4 @@ Cache
 -----
 
 .. automodule:: papis.commands.cache
+ 

--- a/doc/source/commands/citations.rst
+++ b/doc/source/commands/citations.rst
@@ -2,3 +2,4 @@ Citations
 ---------
 
 .. automodule:: papis.commands.citations
+

--- a/doc/source/commands/config.rst
+++ b/doc/source/commands/config.rst
@@ -2,5 +2,6 @@
 
 Config
 ------
+
 .. automodule:: papis.commands.config
 

--- a/doc/source/commands/default.rst
+++ b/doc/source/commands/default.rst
@@ -2,3 +2,4 @@ Papis
 -----
 
 .. automodule:: papis.commands.default
+

--- a/doc/source/commands/doctor.rst
+++ b/doc/source/commands/doctor.rst
@@ -3,3 +3,4 @@ Doctor
 
 .. automodule:: papis.commands.doctor
     :no-index:
+

--- a/doc/source/commands/edit.rst
+++ b/doc/source/commands/edit.rst
@@ -1,4 +1,5 @@
 Edit
 ----
+
 .. automodule:: papis.commands.edit
 

--- a/doc/source/commands/explore.rst
+++ b/doc/source/commands/explore.rst
@@ -1,4 +1,5 @@
 Explore
 -------
+
 .. automodule:: papis.commands.explore
 

--- a/doc/source/commands/export.rst
+++ b/doc/source/commands/export.rst
@@ -1,4 +1,5 @@
 Export
 ------
+
 .. automodule:: papis.commands.export
 

--- a/doc/source/commands/git.rst
+++ b/doc/source/commands/git.rst
@@ -1,4 +1,5 @@
 Git
 ---
+
 .. automodule:: papis.commands.git
 

--- a/doc/source/commands/init.rst
+++ b/doc/source/commands/init.rst
@@ -2,3 +2,4 @@ Init
 ----
 
 .. automodule:: papis.commands.init
+

--- a/doc/source/commands/list.rst
+++ b/doc/source/commands/list.rst
@@ -1,4 +1,5 @@
 List
 ----
+
 .. automodule:: papis.commands.list
 

--- a/doc/source/commands/merge.rst
+++ b/doc/source/commands/merge.rst
@@ -2,3 +2,4 @@ Merge
 -----
 
 .. automodule:: papis.commands.merge
+

--- a/doc/source/commands/mv.rst
+++ b/doc/source/commands/mv.rst
@@ -1,4 +1,5 @@
 Mv
 --
+
 .. automodule:: papis.commands.mv
 

--- a/doc/source/commands/open.rst
+++ b/doc/source/commands/open.rst
@@ -1,4 +1,5 @@
 Open
 ----
+
 .. automodule:: papis.commands.open
 

--- a/doc/source/commands/rename.rst
+++ b/doc/source/commands/rename.rst
@@ -1,4 +1,5 @@
 Rename
 ------
+
 .. automodule:: papis.commands.rename
 

--- a/doc/source/commands/rm.rst
+++ b/doc/source/commands/rm.rst
@@ -1,4 +1,5 @@
 Rm
 --
+
 .. automodule:: papis.commands.rm
 

--- a/doc/source/commands/run.rst
+++ b/doc/source/commands/run.rst
@@ -1,4 +1,5 @@
 Run
 ---
+
 .. automodule:: papis.commands.run
 

--- a/doc/source/commands/tag.rst
+++ b/doc/source/commands/tag.rst
@@ -1,4 +1,5 @@
 Tag
 ---
+
 .. automodule:: papis.commands.tag
 

--- a/doc/source/commands/update.rst
+++ b/doc/source/commands/update.rst
@@ -1,4 +1,5 @@
 Update
 ------
+
 .. automodule:: papis.commands.update
 

--- a/doc/source/conf.py
+++ b/doc/source/conf.py
@@ -117,6 +117,9 @@ exclude_patterns = [
 # The name of the Pygments (syntax highlighting) style to use.
 pygments_style = "sphinx"
 
+# By default, treat code blocks as plain text (no syntax highlighting)
+highlight_language = "text"
+
 # A list of ignored prefixes for module index sorting.
 # modindex_common_prefix = []
 

--- a/doc/source/configuration.rst
+++ b/doc/source/configuration.rst
@@ -33,7 +33,7 @@ However, an important aspect of the configuration system is that you can overrid
 settings on a per library basis. This means that you can set options with different
 values for each of your libraries, depending on the use case you had in mind.
 For example, let's suppose you want to open your documents from ``papers``
-using the PDF reader ``okular`` however in ``books`` you want to open
+using the PDF reader ``okular``, however in ``books`` you want to open
 the documents in ``firefox`` (for some reason). Then, you would add the following
 lines to your configuration
 
@@ -53,7 +53,7 @@ lines to your configuration
     dir = ~/Documents/books
     opentool = firefox
 
-Here we also added the ``opentool`` setting the global section ``[settings]``.
+Here we also added the ``opentool`` setting in the global section ``[settings]``.
 With this configuration file, the two shown libraries will open documents with
 their respective tool, while any other library will default to ``evince``. There
 are many configuration options and you can check their values using the

--- a/doc/source/configuration.rst
+++ b/doc/source/configuration.rst
@@ -31,11 +31,12 @@ system, like so:
 The ``[settings]`` section is used to set global configuration options.
 However, an important aspect of the configuration system is that you can override
 settings on a per library basis. This means that you can set options with different
-values for each of your libraries, depending on the use case you had in mind.
-For example, let's suppose you want to open your documents from ``papers``
-using the PDF reader ``okular``, however in ``books`` you want to open
-the documents in ``firefox`` (for some reason). Then, you would add the following
-lines to your configuration:
+values for each of your libraries.
+
+For example, let's suppose you want to open your documents from ``papers`` using
+the PDF reader ``okular``. In ``books``, however, you want to open the documents
+in ``firefox``. In this case, you would add the following lines to your
+configuration:
 
 .. code:: ini
 

--- a/doc/source/configuration.rst
+++ b/doc/source/configuration.rst
@@ -13,7 +13,7 @@ called ``papers`` and another called ``books``. In general, these libraries
 work and can be configured independently from each other.
 
 In the simplest case, you would simply need to declare their location in your
-system, like so
+system, like so:
 
 .. code:: ini
 
@@ -35,7 +35,7 @@ values for each of your libraries, depending on the use case you had in mind.
 For example, let's suppose you want to open your documents from ``papers``
 using the PDF reader ``okular``, however in ``books`` you want to open
 the documents in ``firefox`` (for some reason). Then, you would add the following
-lines to your configuration
+lines to your configuration:
 
 .. code:: ini
 
@@ -57,7 +57,7 @@ Here we also added the ``opentool`` setting in the global section ``[settings]``
 With this configuration file, the two shown libraries will open documents with
 their respective tool, while any other library will default to ``evince``. There
 are many configuration options and you can check their values using the
-:ref:`papis config <command-config>` command, e.g.
+:ref:`papis config <command-config>` command, e.g.:
 
 .. code:: sh
 
@@ -70,7 +70,7 @@ are many configuration options and you can check their values using the
 
 A more complete example of a configuration file is the following
 (see :ref:`General Settings <general-settings>` for a comprehensive list of
-all the options and more extensive descriptions)
+all the options and more extensive descriptions):
 
 .. warning::
 
@@ -160,7 +160,7 @@ all the options and more extensive descriptions)
    Papis uses the standard :class:`~configparser.ConfigParser` to read and write
    configuration options. It also allows interpolation of values
    (using :class:`~configparser.BasicInterpolation`) so that previous values
-   can be referred back to. For example, one can do
+   can be referred back to. For example, one can do:
 
    .. code:: ini
 

--- a/doc/source/database_structure.rst
+++ b/doc/source/database_structure.rst
@@ -34,7 +34,7 @@ Papis database
 
 The fact that there is no database means that Papis should crawl through
 the library folder and see which folders have an ``info.yaml`` file, which
-is for slow computers (and harddrives) quite bad.
+is quite bad for slow computers (and hard drives).
 
 Papis implements a very rudimentary caching system. A cache is created for
 every library. Inside the cache the whole information already converted
@@ -74,22 +74,18 @@ In order to clear and rebuild the cache (i.e., reset it), you can simply run
 Query language
 ^^^^^^^^^^^^^^
 
-Since version `0.3` there is a query language in place for the searching
-of documents.
-The queries can contain any field of the info file, e.g.,
-``author:einstein publisher : review`` will match documents that have
-a matching ``author`` with ``einstein`` AND have a ``publisher``
-matching ``review``.
-The AND part here is important, since
-only the ``AND`` filter is implemented in this simple query
-language. At the moment it is not possible to do an ``OR``.
-If you need this, you should consider using the
-`Whoosh database`_.
+Since version ``v0.3`` there is a query language in place for the searching of
+documents. The queries can contain any field of the info file, e.g.,
+``author:einstein publisher : review`` will match documents that have ``author``
+match with ``einstein`` AND ``publisher`` match with ``review``. The AND part
+here is important, since only the ``AND`` filter is implemented in this simple
+query language. At the moment it is not possible to do an ``OR``. If you need
+this, you should consider using the `Whoosh database`_.
 
 For illustration, here are some examples:
 
   - Open documents where the author key matches 'albert' (ignoring case) and
-    year matches '19' (i.e., 1990, 2019, 1920):
+    year matches '05' (i.e. could be '1905' or '2005'):
 
     .. code::
 
@@ -130,19 +126,18 @@ and set it to ``False``, e.g.
 Whoosh database
 ---------------
 
-Papis has also the possibility to use the blazing fast and pure python
-`Whoosh library <https://whoosh.readthedocs.io/en/latest>`__.
-Its performance is orders of magnitude better than the crude cache based
-database.
+Papis can alternatively use the blazing fast and pure Python `Whoosh library
+<https://whoosh.readthedocs.io/en/latest>`__. Its performance is orders of
+magnitude better than the crude cache based database.
 
-Of course, the performance comes at a cost. To achieve more performance
+Of course, the performance comes at a cost. To achieve more performance,
 a database backend should create an index with information about the documents.
 Parsing a user query means going to the index and matching the query to
 what is found in the index. This means that the index can not in general
 have all the information that the info file of the documents includes.
 
 In other words, the whoosh index will store only certain fields from the
-document's info files. The good news is that we can tell Papis exactly
+documents' info files. The good news is that we can tell Papis exactly
 which fields we want to index. These flags are
 
 - :confval:`whoosh-schema-fields`
@@ -168,10 +163,10 @@ will not return anything, since the publisher field is not being stored.
 Query language
 ^^^^^^^^^^^^^^
 
-The whoosh database uses the whoosh query language which is much more
+The Whoosh database uses the Whoosh query language which is much more
 advanced than the query language in the `Papis database`_.
 
-The whoosh query language supports both ``AND`` and ``OR``, for instance
+The Whoosh query language supports both ``AND`` and ``OR``, for instance
 
 ::
 
@@ -180,5 +175,5 @@ The whoosh query language supports both ``AND`` and ``OR``, for instance
 will give papers of einstein in the year 1905 together with all papers
 where einstein appears in the title.
 
-You can read more about the whoosh query language
+You can read more about the Whoosh query language
 `here <https://whoosh.readthedocs.io/en/latest/querylang.html>`__.

--- a/doc/source/database_structure.rst
+++ b/doc/source/database_structure.rst
@@ -32,13 +32,13 @@ You can select a database by using the flag :confval:`database-backend`.
 Papis database
 --------------
 
-Without a database, Papis would need to crawl through the library folder and see
-which folders have an ``info.yaml`` file, which is slow on older computers (and
-hard drives).
+Without a database, Papis would need to crawl through the library folders and see
+which subfolders have an ``info.yaml`` file. Repeatedly accessing the filesystem
+like this can be slow on older computers, remotely mounted partitions, etc.
 
-Papis implements a very rudimentary caching system. A cache is created for
-every library. Inside the cache the whole information already converted
-into python is stored.
+To help with this, Papis implements a simple caching system. For each library,
+it creates a database (as defined by :confval:`database-backend`) that holds
+sufficient relevant information about the documents to avoid such slowdowns.
 
 These cache files are stored per default in:
 
@@ -133,7 +133,7 @@ Parsing a user query means going to the index and matching the query to
 what is found in the index. This means that the index can not in general
 have all the information that the info file of the documents includes.
 
-In other words, the whoosh index will store only certain fields from the
+In other words, the Whoosh index will store only certain fields from the
 documents' info files. The good news is that we can tell Papis exactly
 which fields we want to index. These flags are
 

--- a/doc/source/database_structure.rst
+++ b/doc/source/database_structure.rst
@@ -6,18 +6,18 @@ there can be many backends for the database system, including no database.
 
 Right now there are three types of databases that the user can use:
 
-- No database
+- No database:
     ::
 
       database-backend = papis
       use-cache = False
 
-- Simple cache based database.
+- Simple cache based database:
     ::
 
       database-backend = papis
 
-- `Whoosh <https://whoosh.readthedocs.io/en/latest>`__  based database.
+- `Whoosh <https://whoosh.readthedocs.io/en/latest>`__  based database:
     ::
 
       database-backend = whoosh
@@ -40,7 +40,7 @@ Papis implements a very rudimentary caching system. A cache is created for
 every library. Inside the cache the whole information already converted
 into python is stored.
 
-These cache files are stored per default in
+These cache files are stored per default in:
 
 ::
 
@@ -58,14 +58,13 @@ In such cases you will have to *clear the cache*.
 Clearing the cache
 ^^^^^^^^^^^^^^^^^^
 
-To clear the cache for a given library you can use the command ``cache``
-thusly
+To clear the cache for a given library you can use the command ``cache``:
 
 .. code::
 
     papis cache clear
 
-In order to clear and rebuild the cache (i.e., reset it), you can simply run
+In order to clear and rebuild the cache (i.e., reset it), you can simply run:
 
 .. code::
 
@@ -92,14 +91,14 @@ For illustration, here are some examples:
       papis open 'author : albert year : 05'
 
   - Add the restriction to the previous search that the usual matching matches
-    the substring 'licht' in addition to the previously selected
+    the substring 'licht' in addition to the previously selected:
 
     .. code::
 
       papis open 'author : albert year : 05 licht'
 
     This is not to be mixed with the restriction that the key `year` matches
-    `'05 licht'`, which will not match any year, i.e.
+    `'05 licht'`, which will not match any year, i.e.:
 
     .. code::
 
@@ -110,7 +109,7 @@ Disabling the cache
 ^^^^^^^^^^^^^^^^^^^
 
 You can disable the cache using the configuration setting ``use-cache``
-and set it to ``False``, e.g.
+and set it to ``False``, e.g.:
 
 .. code:: ini
 
@@ -144,20 +143,20 @@ which fields we want to index. These flags are
 - :confval:`whoosh-schema-prototype`
 
 The prototype is for advanced users. If you just want to, say, include
-the publisher to the fields that you can search in, then you can put
+the publisher to the fields that you can search in, then you can put:
 
 ::
 
   whoosh-schema-fields = ['publisher']
 
-and you will be able to find documents by their publisher.
-For example, without this line set for publisher, the query
+... and you will be able to find documents by their publisher.
+For example, without this line set for publisher, the query:
 
 ::
 
   papis open publisher:*
 
-will not return anything, since the publisher field is not being stored.
+... will not return anything, since the publisher field is not being stored.
 
 
 Query language
@@ -166,13 +165,13 @@ Query language
 The Whoosh database uses the Whoosh query language which is much more
 advanced than the query language in the `Papis database`_.
 
-The Whoosh query language supports both ``AND`` and ``OR``, for instance
+The Whoosh query language supports both ``AND`` and ``OR``, for instance:
 
 ::
 
   papis open '(author:einstein AND year:1905) OR title:einstein'
 
-will give papers of einstein in the year 1905 together with all papers
+... will give papers of einstein in the year 1905 together with all papers
 where einstein appears in the title.
 
 You can read more about the Whoosh query language

--- a/doc/source/database_structure.rst
+++ b/doc/source/database_structure.rst
@@ -149,14 +149,14 @@ the publisher to the fields that you can search in, then you can put:
 
   whoosh-schema-fields = ['publisher']
 
-... and you will be able to find documents by their publisher.
+and you will be able to find documents by their publisher.
 For example, without this line set for publisher, the query:
 
 ::
 
   papis open publisher:*
 
-... will not return anything, since the publisher field is not being stored.
+will not return anything, since the publisher field is not being stored.
 
 
 Query language
@@ -171,7 +171,7 @@ The Whoosh query language supports both ``AND`` and ``OR``, for instance:
 
   papis open '(author:einstein AND year:1905) OR title:einstein'
 
-... will give papers of einstein in the year 1905 together with all papers
+will give papers of einstein in the year 1905 together with all papers
 where einstein appears in the title.
 
 You can read more about the Whoosh query language

--- a/doc/source/database_structure.rst
+++ b/doc/source/database_structure.rst
@@ -32,9 +32,9 @@ You can select a database by using the flag :confval:`database-backend`.
 Papis database
 --------------
 
-The fact that there is no database means that Papis should crawl through
-the library folder and see which folders have an ``info.yaml`` file, which
-is quite bad for slow computers (and hard drives).
+Without a database, Papis would need to crawl through the library folder and see
+which folders have an ``info.yaml`` file, which is slow on older computers (and
+hard drives).
 
 Papis implements a very rudimentary caching system. A cache is created for
 every library. Inside the cache the whole information already converted
@@ -73,13 +73,12 @@ In order to clear and rebuild the cache (i.e., reset it), you can simply run:
 Query language
 ^^^^^^^^^^^^^^
 
-Since version ``v0.3`` there is a query language in place for the searching of
-documents. The queries can contain any field of the info file, e.g.,
-``author:einstein publisher : review`` will match documents that have ``author``
-match with ``einstein`` AND ``publisher`` match with ``review``. The AND part
-here is important, since only the ``AND`` filter is implemented in this simple
-query language. At the moment it is not possible to do an ``OR``. If you need
-this, you should consider using the `Whoosh database`_.
+Since version ``v0.3``, Papis implements a query language to search documents.
+Queries can contain any field of the info file, so that ``author:einstein
+publisher:review`` will match documents that have ``author`` match with
+``einstein`` AND ``publisher`` match with ``review``. Note that only the ``AND``
+filter is implemented in this simple query language and that ``OR`` is not
+supported. If you need this, consider using the `Whoosh database`_.
 
 For illustration, here are some examples:
 

--- a/doc/source/database_structure.rst
+++ b/doc/source/database_structure.rst
@@ -124,9 +124,8 @@ and set it to ``False``, e.g.:
 Whoosh database
 ---------------
 
-Papis can alternatively use the blazing fast and pure Python `Whoosh library
-<https://whoosh.readthedocs.io/en/latest>`__. Its performance is orders of
-magnitude better than the crude cache based database.
+Papis can alternatively use the performant `Whoosh library
+<https://whoosh.readthedocs.io/en/latest>`__.
 
 Of course, the performance comes at a cost. To achieve more performance,
 a database backend should create an index with information about the documents.

--- a/doc/source/default-settings.rst
+++ b/doc/source/default-settings.rst
@@ -13,11 +13,15 @@ General settings
     do not clutter your global configuration file. This is particularly useful
     if the library is shared with someone else (or just on a different machine)
     and you want them to have the same settings. For example, say you're sharing
-    a library with your friend Fulano. You have your library at::
+    a library with your friend Fulano. You have your library at:
+
+    .. code-block:: text
 
         ~/Documents/lib-with-fulano
 
-    and you've created a local configuration file at::
+    and you've created a local configuration file at:
+
+    .. code-block:: text
 
         ~/Documents/lib-with-fulano/.papis.config
 

--- a/doc/source/default-settings.rst
+++ b/doc/source/default-settings.rst
@@ -17,7 +17,7 @@ General settings
 
         ~/Documents/lib-with-fulano
 
-    and you've created a local configuration file at::
+    ... and you've created a local configuration file at::
 
         ~/Documents/lib-with-fulano/.papis.config
 
@@ -48,7 +48,7 @@ General settings
 
     This is the format of the short help indicator in external Papis
     commands. In general, for an external command, the first lines are expected
-    to resemble
+    to resemble:
 
     .. code:: python
 
@@ -79,7 +79,7 @@ General settings
     This setting controls the name of the document in the Papis format strings
     such as :confval:`match-format` or :confval:`header-format`. For instance,
     if you are managing videos, you might want to set this option to ``vid`` in
-    order to set  the :confval:`header-format` to
+    order to set  the :confval:`header-format` to:
 
     .. code:: ini
 
@@ -105,7 +105,7 @@ General settings
     If the :confval:`header-format` grows too complex, it can be
     stored in a separate file. This option should give the path to that file (in
     which case the ``header-format`` option will be ignored). For example, this
-    can be set to
+    can be set to:
 
     .. code:: ini
 
@@ -292,7 +292,7 @@ BibTeX options
     A list of additional keys, besides the known standard BibTeX keys from
     :data:`~papis.bibtex.bibtex_keys`, to add to the BibTeX export. This can be
     used to include keys such as ``doc_url`` or ``tags`` to the export by
-    setting
+    setting:
 
     .. code:: ini
 
@@ -314,7 +314,7 @@ BibTeX options
 
     A list of additional types, besides the known standard BibTeX types from
     :data:`~papis.bibtex.bibtex_types`, that should be allowed for a BibTeX export.
-    These types can be added as
+    These types can be added as:
 
     .. code:: ini
 
@@ -342,13 +342,13 @@ BibTeX options
     used for display purposes or for building the ``author`` key for the
     document. For example, when retrieving automatic author information from
     services like `Crossref <https://www.crossref.org>`__, Papis builds the
-    ``author`` using this setting. For instance, this can be set to
+    ``author`` using this setting. For instance, this can be set to:
 
     .. code:: ini
 
         multiple-authors-format = {au[family]} -- {au[given]}
 
-    which for the author ``{"family": "Einstein", "given": "Albert"}`` would
+    ... which for the author ``{"family": "Einstein", "given": "Albert"}`` would
     construct the string ``Einstein -- Albert``. In most circumstances, multiple
     authors are then concatenated together using
     :confval:`multiple-authors-separator`.
@@ -396,13 +396,13 @@ Add options
     is created. In BibLaTeX, the reference (or ref for short) is also sometimes
     called a citation key. The reference format is usually heavily customized
     by users, depending on their personal preferences. For example to use a
-    ``FirstAuthorYear`` format, set
+    ``FirstAuthorYear`` format, set:
 
     .. code:: ini
 
         ref-format = {doc[author_list][0][family]}{doc[year]}
 
-    However, any custom string can be used, e.g.
+    However, any custom string can be used, e.g.:
 
     .. code:: ini
 
@@ -421,7 +421,7 @@ Add options
         converted to their closest ASCII representation.
 
         If you want to add some punctuation, dots (``.``) and underscores (``_``)
-        can be escaped by a backslash. For example,
+        can be escaped by a backslash. For example:
 
         .. code:: ini
 
@@ -431,14 +431,14 @@ Add options
 
     Sets the default name for the folder of newly added documents. For example,
     if you want the folder of your documents to be named after the format
-    ``author-title`` then you should set it to
+    ``author-title`` then you should set it to:
 
     .. code:: ini
 
         add-folder-name = ``{doc[author]}-{doc[title]}``
 
     You can create formatted subfolders by using path separators
-    (i.e., ``/``) in this format string, e.g.
+    (i.e., ``/``) in this format string, e.g.:
 
     .. code:: ini
 
@@ -691,7 +691,7 @@ Open options
 
     This is the default key name for the marks in the *info file*. For
     example, if you set ``mark-key-name = bookmarks`` then you would have
-    in your ``info.yaml`` file
+    in your ``info.yaml`` file:
 
     .. code:: yaml
 
@@ -705,7 +705,7 @@ Open options
     This is the name of the mark to be passed to
     :confval:`mark-header-format` and other such settings, similarly
     to :confval:`format-doc-name`. For example, if we want to set
-    it to ``m``, then other settings must be consistent, e.g.
+    it to ``m``, then other settings must be consistent, e.g.:
 
     .. code:: ini
 
@@ -884,7 +884,7 @@ Databases
 
         default-query-string = author:"John Smith"
 
-    would do the trick. Note that each :confval:`database-backend`
+    ... would do the trick. Note that each :confval:`database-backend`
     will have a different search query, so this setting is specific to the
     default ``papis`` backend.
 
@@ -936,7 +936,7 @@ Terminal user interface (picker)
 These options are for the terminal user interface (TUI). The TUI is mainly used
 by the default Papis picker, but other small widgets also make use of some elements.
 The TUI can be heavily customized as well in the separate ``tui`` section. For
-example,
+example:
 
 .. code:: ini
 
@@ -1090,7 +1090,7 @@ limitation of fzf.
     contains the package ``colorama`` in it. Refer to the ``colorama``
     `documentation <https://github.com/tartley/colorama/blob/master/colorama/ansi.py#L49>`__.
     to see which colors are available. For instance, if you want the title in
-    red, you would put in your ``fzf-header-format``
+    red, you would put in your ``fzf-header-format``:
 
     .. code:: python
 
@@ -1102,7 +1102,7 @@ Preview window
 ``fzf`` has the disadvantage that it does not support multiline output and
 it matches only against what it shows on the screen. To get around this issue,
 we can try composing a ``fzf`` customization. The following will add a preview
-window to the picker
+window to the picker:
 
 .. code:: ini
 

--- a/doc/source/default-settings.rst
+++ b/doc/source/default-settings.rst
@@ -57,7 +57,7 @@ General settings
     .. code:: python
 
         #!/usr/bin/env python3
-        # papis-short-help: My awesome script fixes everything
+        # papis-short-help: My awesome script fixes everything.
 
 .. papis-config:: info-name
 

--- a/doc/source/default-settings.rst
+++ b/doc/source/default-settings.rst
@@ -1057,14 +1057,14 @@ integration for the picker.  A minimal terminal user interface is provided,
 together with options for its customization. You can set the :confval:`picktool`
 to ``fzf`` to select this picker.
 
-In comparison to the *built-in* Papis picker TUI, the advantage of the fzf
-picker is that it is much faster. However, a disadvantage is that it is
-restricted to one-line entries. It is also important to note that ``fzf`` will
-**only** match against what is shown on the terminal screen, as opposed to the
-Papis matcher, that can match against the **whole** title and **whole** author
-text, since this is controlled by the ``match-format`` setting.
-However, for the usual use cases it might not bother the user to have this
-limitation of fzf.
+In comparison to the *built-in* Papis picker TUI, the advantage of the ``fzf``
+picker is that it is much faster. However, a disadvantage is that Papis
+currently only supports one-line entries in ``fzf``. It is also important to
+note that ``fzf`` will **only** match against what is shown on the terminal
+screen, as opposed to the Papis matcher, that can match against the **whole**
+title and **whole** author text, since this is controlled by the
+``match-format`` setting. However, for the usual use cases it might not bother
+the user to have this limitation of ``fzf``.
 
 .. papis-config:: fzf-binary
 
@@ -1099,10 +1099,8 @@ limitation of fzf.
 Preview window
 ^^^^^^^^^^^^^^
 
-``fzf`` has the disadvantage that it does not support multiline output and
-it matches only against what it shows on the screen. To get around this issue,
-we can try composing a ``fzf`` customization. The following will add a preview
-window to the picker:
+``fzf`` can be configured to show additional information in a preview window. The
+following will add a preview window to the picker:
 
 .. code:: ini
 

--- a/doc/source/default-settings.rst
+++ b/doc/source/default-settings.rst
@@ -77,10 +77,9 @@ General settings
 .. papis-config:: format-doc-name
 
     This setting controls the name of the document in the Papis format strings
-    like in format strings such as :confval:`match-format` or
-    :confval:`header-format`. For instance, if you are managing
-    videos, you might want to set this option to ``vid`` in order to set  the
-    :confval:`header-format` to
+    such as :confval:`match-format` or :confval:`header-format`. For instance,
+    if you are managing videos, you might want to set this option to ``vid`` in
+    order to set  the :confval:`header-format` to
 
     .. code:: ini
 
@@ -116,7 +115,7 @@ General settings
 
     If *True*, this flag will allow unicode characters in your *info files*.
     Otherwise, the strings will be decoded and written as bytes. Unless you have
-    very strong reasons not to, this should always be set to *True* (we live
+    very strong reasons not to, this should always be set to *True* (we live in
     a unicode world after all!).
 
 .. papis-config:: unique-document-keys
@@ -135,7 +134,7 @@ General settings
 
     Papis sometimes will have to tell you which document it is processing. This
     format string can be used to display the document to the user in a
-    non-intrusive way. Preferable, this should be a short string that allows
+    non-intrusive way. Preferably, this should be a short string that allows
     easily identifying which document is being referenced.
 
 .. papis-config:: sort-field
@@ -254,8 +253,8 @@ Tools options
 
     * ``"papis"``: uses ``papis.picker.Picker`` to display and search
       through documents.
-    * ``"fzf"``: uses `fzf <https://github.com/junegunn/fzf>` to display and search
-      through documents.
+    * ``"fzf"``: uses `fzf <https://github.com/junegunn/fzf>`__ to display and
+      search through documents.
 
     Papis pickers use a plugin architecture similar to other components
     (see :ref:`plugin-architecture`) with the ``papis.picker`` entrypoint. Note
@@ -272,7 +271,7 @@ Tools options
 .. papis-config:: file-browser
 
     File browser used when opening a directory. It defaults to the default file
-    browser in your system. However, you can set it to different file browsers,
+    browser in your system. However, you can set it to a different file browser,
     such as ``dolphin``, ``thunar`` or ``ranger``, to name a few.
 
 .. _bibtex-options:
@@ -285,7 +284,7 @@ BibTeX options
     This option allows the user to set the key for the journal entry when using
     ``papis export --bibtex``. The intended use of such a setting is to allow
     selecting e.g. abbreviated journal titles for publishers that require it.
-    For example, if the document has a ``abbrev_journal_title`` key that should
+    For example, if the document has an ``abbrev_journal_title`` key that should
     be used instead of the default ``journal`` key.
 
 .. papis-config:: extra-bibtex-keys
@@ -326,7 +325,7 @@ BibTeX options
 
     A flag used to choose whether or not to allow direct Unicode characters in
     the document fields to be exported into the BibTeX text. Some engines, such
-    as `Biber <https://github.com/plk/biber>`__ support Unicode by default and
+    as `Biber <https://github.com/plk/biber>`__, support Unicode by default and
     should be used whenever possible.
 
 .. papis-config:: bibtex-export-file
@@ -369,14 +368,14 @@ BibTeX command options
 .. papis-config:: default-read-bibfile
     :section: bibtex
 
-    A path to a BibTex file that should be automatically read when using the
+    A path to a BibTeX file that should be automatically read when using the
     ``papis bibtex`` command. This should be equivalent to using
     ``papis bibtex read file.bib`` when used with :confval:`auto-read`.
 
 .. papis-config:: default-save-bibfile
     :section: bibtex
 
-    A path to a BibTex file that should be automatically saved when using the
+    A path to a BibTeX file that should be automatically saved when using the
     ``papis bibtex`` command. This should be equivalent to using
     ``papis bibtex save file.bib``.
 
@@ -430,7 +429,7 @@ Add options
 
 .. papis-config:: add-folder-name
 
-    Set the default name for the folder of newly added documents. For example,
+    Sets the default name for the folder of newly added documents. For example,
     if you want the folder of your documents to be named after the format
     ``author-title`` then you should set it to
 
@@ -453,15 +452,15 @@ Add options
 .. papis-config:: add-file-name
     :type: str
 
-    Set the default file name for newly added documents, similarly to
+    Sets the default file name for newly added documents, similarly to
     :confval:`add-folder-name`. If it is not set, the names of the
     files will be cleaned and taken *as-is*.
 
 .. papis-config:: add-subfolder
 
-    Configure a default for the ``--subfolder`` command-line option of ``papis add``.
-    Note that, this setting is not allowed to contain formatting options. However,
-    one can also specify nested sub-folders.
+    Configures a default for the ``--subfolder`` command-line option of ``papis
+    add``. Note that, this setting is not allowed to contain formatting options.
+    However, one can also specify nested sub-folders.
 
 .. papis-config:: add-confirm
 
@@ -494,7 +493,7 @@ Add options
 
 .. papis-config:: add-fetch-citations
 
-    A setting that controls the default for the ``--fetch-citations flag of
+    A setting that controls the default for the ``--fetch-citations`` flag of
     ``papis add``. If set to *True*, then the flag will be added by default
     and Papis will attempt to retrieve citations for the newly added document.
     In this case, the fetching can be disabled by using ``--no-fetch-citations``
@@ -573,8 +572,6 @@ Edit options
     Default value is set to the empty ``""``, which will return an empty notes
     file. If no file is found at the path to the template, then also an empty
     notes file will be generated.
-
-.. _marks-options:
 
 Doctor options
 --------------
@@ -681,6 +678,8 @@ Doctor options
 Open options
 ------------
 
+.. _marks-options:
+
 .. papis-config:: open-mark
 
     A setting that controls the default for the ``--mark`` flag of ``papis open``.
@@ -743,7 +742,7 @@ Open options
 
         mark-opener-format = zathura -P {mark[value]}
 
-Serve (Web App) options
+Serve (web app) options
 -----------------------
 
 .. papis-config:: serve-default-tag-sorting
@@ -862,12 +861,11 @@ Downloaders
 .. papis-config:: downloader-proxy
     :type: str
 
-    There is the possibility of download papers using a proxy. We use :mod:`requests`
-    to handle web queries, which has extensive documentation on how to use
-    proxies
-    `here <https://docs.python-requests.org/en/latest/user/advanced/#proxies>`__.
-    This value should give a URL that can be used as a proxy for both HTTP
-    and HTTPS.
+    It's possible to download papers using a proxy. We use :mod:`requests` to
+    handle web queries, which has extensive documentation on how to use proxies
+    `here
+    <https://docs.python-requests.org/en/latest/user/advanced/#proxies>`__. This
+    value should give a URL that can be used as a proxy for both HTTP and HTTPS.
 
 .. papis-config:: isbn-service
 
@@ -965,8 +963,8 @@ For styling the individual components, see the extensive documentation available
 .. papis-config:: status_line_style
     :section: tui
 
-    The style the status line should based on the ``prompt_toolkit`` styling,
-    e.g.``fg:#ff00aa bg:black``.
+    The style of the status line. The format is based on ``prompt_toolkit``
+    styling, e.g. ``fg:#ff00aa bg:black``.
 
 .. papis-config:: message_toolbar_style
     :section: tui
@@ -977,18 +975,18 @@ For styling the individual components, see the extensive documentation available
 .. papis-config:: options_list.selected_margin_style
     :section: tui
 
-    Style of the margin of the selected document in the picker.
+    The style of the margin of the selected document in the picker.
 
 .. papis-config:: options_list.unselected_margin_style
     :section: tui
 
-    Style of the margin of the unselected documents in the picker. If no
+    The style of the margin of the unselected documents in the picker. If no
     styling is desired on these elements, this setting can be empty.
 
 .. papis-config:: options_list.marked_margin_style
     :section: tui
 
-    Style of the margin of the marked documents in the picker. If no
+    The style of the margin of the marked documents in the picker. If no
     styling is desired on these elements, this setting can be empty.
 
 .. papis-config:: error_toolbar_style
@@ -1056,8 +1054,8 @@ FZF integration
 
 Papis ships with *out-of-the-box* `fzf <https://github.com/junegunn/fzf>`__
 integration for the picker.  A minimal terminal user interface is provided,
-together with options for its customization. You can set the picktool to
-``fzf`` to select this picker.
+together with options for its customization. You can set the :confval:`picktool`
+to ``fzf`` to select this picker.
 
 In comparison to the *built-in* Papis picker TUI, the advantage of the fzf
 picker is that it is much faster. However, a disadvantage is that it is
@@ -1065,8 +1063,8 @@ restricted to one-line entries. It is also important to note that ``fzf`` will
 **only** match against what is shown on the terminal screen, as opposed to the
 Papis matcher, that can match against the **whole** title and **whole** author
 text, since this is controlled by the ``match-format`` setting.
-However, for many uses it might not bother the user to have this limitation
-of fzf.
+However, for the usual use cases it might not bother the user to have this
+limitation of fzf.
 
 .. papis-config:: fzf-binary
 
@@ -1078,8 +1076,8 @@ of fzf.
 
 .. papis-config:: fzf-extra-bindings
 
-    Extra bindings to fzf as a Python list. Refer to the fzf documentation for
-    more details.
+    Extra key bindings to fzf as a Python list. Refer to the fzf documentation
+    for more details.
 
 .. papis-config:: fzf-header-format
 

--- a/doc/source/default-settings.rst
+++ b/doc/source/default-settings.rst
@@ -13,15 +13,11 @@ General settings
     do not clutter your global configuration file. This is particularly useful
     if the library is shared with someone else (or just on a different machine)
     and you want them to have the same settings. For example, say you're sharing
-    a library with your friend Fulano. You have your library at:
-
-    .. code-block:: text
+    a library with your friend Fulano. You have your library at::
 
         ~/Documents/lib-with-fulano
 
-    and you've created a local configuration file at:
-
-    .. code-block:: text
+    and you've created a local configuration file at::
 
         ~/Documents/lib-with-fulano/.papis.config
 

--- a/doc/source/default-settings.rst
+++ b/doc/source/default-settings.rst
@@ -1080,7 +1080,7 @@ of the document, as described by the :confval:`match-format` setting.
 
 .. papis-config:: fzf-header-format
 
-    Format for the entries for ``fzf`. Note that, if you want colors, you should
+    Format for the entries for ``fzf``. Note that, if you want colors, you should
     add the ``--ansi`` flag to :confval:`fzf-extra-flags` and include the colors
     in the :confval:`header-format` as ``ansi`` escape sequences.
 

--- a/doc/source/default-settings.rst
+++ b/doc/source/default-settings.rst
@@ -113,10 +113,10 @@ General settings
 
 .. papis-config:: info-allow-unicode
 
-    If *True*, this flag will allow unicode characters in your *info files*.
+    If *True*, this flag will allow Unicode characters in your *info files*.
     Otherwise, the strings will be decoded and written as bytes. Unless you have
     very strong reasons not to, this should always be set to *True* (we live in
-    a unicode world after all!).
+    a Unicode world after all!).
 
 .. papis-config:: unique-document-keys
 
@@ -1053,44 +1053,42 @@ FZF integration
 ---------------
 
 Papis ships with *out-of-the-box* `fzf <https://github.com/junegunn/fzf>`__
-integration for the picker.  A minimal terminal user interface is provided,
+integration in the form of a picker.  A minimal terminal user interface is provided,
 together with options for its customization. You can set the :confval:`picktool`
 to ``fzf`` to select this picker.
 
-In comparison to the *built-in* Papis picker TUI, the advantage of the ``fzf``
-picker is that it is much faster. However, a disadvantage is that Papis
-currently only supports one-line entries in ``fzf``. It is also important to
-note that ``fzf`` will **only** match against what is shown on the terminal
-screen, as opposed to the Papis matcher, that can match against the **whole**
-title and **whole** author text, since this is controlled by the
-``match-format`` setting. However, for the usual use cases it might not bother
-the user to have this limitation of ``fzf``.
+In comparison to the default Papis picker TUI, the ``fzf`` picker is generally
+much faster, can be configured to show helpful previews of documents, and use
+other fancy ``fzf`` features. However, a disadvantage is that Papis currently
+only supports one-line entries per document. It is also important to note that
+``fzf`` will **only** match against what is shown on the terminal screen. In
+contrast, the default ``papis`` picker can match against other fields
+of the document, as described by the :confval:`match-format` setting.
 
 .. papis-config:: fzf-binary
 
-    Path to or name of the fzf binary.
+    Path to or name of the ``fzf`` binary.
 
 .. papis-config:: fzf-extra-flags
 
-    Extra flags to be passed to fzf every time it gets called.
+    Extra flags to be passed to ``fzf`` every time it gets called.
 
 .. papis-config:: fzf-extra-bindings
 
-    Extra key bindings to fzf as a Python list. Refer to the fzf documentation
-    for more details.
+    Extra key bindings to ``fzf`` as a Python list. Refer to the ``fzf``
+    documentation for more details.
 
 .. papis-config:: fzf-header-format
 
-    Format for the entries for fzf.
-    Notice that if you want colors you should add the ``--ansi`` flag to
-    ``fzf-extra-flags`` and include the colors in the
-    :confval:`header-format` as ``ansi`` escape sequences.
+    Format for the entries for ``fzf`. Note that, if you want colors, you should
+    add the ``--ansi`` flag to :confval:`fzf-extra-flags` and include the colors
+    in the :confval:`header-format` as ``ansi`` escape sequences.
 
-    The Papis format string is given the additional variable ``c`` which
-    contains the package ``colorama`` in it. Refer to the ``colorama``
+    The Papis format string corresponding to this setting is given the additional
+    variable ``c``, which is the ``colorama`` library. Refer to the ``colorama``
     `documentation <https://github.com/tartley/colorama/blob/master/colorama/ansi.py#L49>`__.
     to see which colors are available. For instance, if you want the title in
-    red, you would put in your ``fzf-header-format``:
+    red, you would put in your :confval:`fzf-header-format`:
 
     .. code:: python
 

--- a/doc/source/default-settings.rst
+++ b/doc/source/default-settings.rst
@@ -79,7 +79,7 @@ General settings
     This setting controls the name of the document in the Papis format strings
     such as :confval:`match-format` or :confval:`header-format`. For instance,
     if you are managing videos, you might want to set this option to ``vid`` in
-    order to set  the :confval:`header-format` to:
+    order to set the :confval:`header-format` to:
 
     .. code:: ini
 
@@ -493,11 +493,11 @@ Add options
 
 .. papis-config:: add-fetch-citations
 
-    A setting that controls the default for the ``--fetch-citations`` flag of
-    ``papis add``. If set to *True*, then the flag will be added by default
-    and Papis will attempt to retrieve citations for the newly added document.
-    In this case, the fetching can be disabled by using ``--no-fetch-citations``
-    on an individual basis.
+    Controls the default for the ``--fetch-citations`` flag of ``papis add``. If
+    set to *True*, then the flag will be added by default and Papis will attempt
+    to retrieve citations for the newly added document. In this case, the
+    fetching can be disabled by using ``--no-fetch-citations`` on an individual
+    basis.
 
 .. papis-config:: auto-doctor
 
@@ -864,8 +864,8 @@ Downloaders
     It's possible to download papers using a proxy. We use :mod:`requests` to
     handle web queries, which has extensive documentation on how to use proxies
     `here
-    <https://docs.python-requests.org/en/latest/user/advanced/#proxies>`__. This
-    value should give a URL that can be used as a proxy for both HTTP and HTTPS.
+    <https://docs.python-requests.org/en/latest/user/advanced/#proxies>`__. The
+    present setting sets the URL used as a proxy for HTTP and HTTPS.
 
 .. papis-config:: isbn-service
 

--- a/doc/source/default-settings.rst
+++ b/doc/source/default-settings.rst
@@ -17,7 +17,7 @@ General settings
 
         ~/Documents/lib-with-fulano
 
-    ... and you've created a local configuration file at::
+    and you've created a local configuration file at::
 
         ~/Documents/lib-with-fulano/.papis.config
 
@@ -348,7 +348,7 @@ BibTeX options
 
         multiple-authors-format = {au[family]} -- {au[given]}
 
-    ... which for the author ``{"family": "Einstein", "given": "Albert"}`` would
+    which for the author ``{"family": "Einstein", "given": "Albert"}`` would
     construct the string ``Einstein -- Albert``. In most circumstances, multiple
     authors are then concatenated together using
     :confval:`multiple-authors-separator`.
@@ -884,7 +884,7 @@ Databases
 
         default-query-string = author:"John Smith"
 
-    ... would do the trick. Note that each :confval:`database-backend`
+    would do the trick. Note that each :confval:`database-backend`
     will have a different search query, so this setting is specific to the
     default ``papis`` backend.
 

--- a/doc/source/editors.rst
+++ b/doc/source/editors.rst
@@ -16,6 +16,6 @@ Emacs
 -----
 
 `papis.el <https://github.com/papis/papis.el>`__ is a compatibility layer for
-Papis that tries to use as much of the existing Emacs ecosystem as possible. If
-you are used to ``org-ref`` or ``org-cite``, it will work seamlessly with them
-while keeping your Papis library intact.
+Papis that tries to use as much of the existing Emacs ecosystem as possible. It
+seamlessly integrates with ``org-ref`` and ``org-cite`` while keeping your Papis
+library intact.

--- a/doc/source/editors.rst
+++ b/doc/source/editors.rst
@@ -16,7 +16,6 @@ Emacs
 -----
 
 `papis.el <https://github.com/papis/papis.el>`__ is a compatibility layer for
-Papis that tries to use as much of the existing packages as possible. In
-particular it tries to make use also of ``org-ref`` to try not to reinvent the
-wheel. If you are used to ``org-ref`` or ``org-cite`` it strives to work
-seamlessly with them and still have your Papis library intact.
+Papis that tries to use as much of the existing Emacs ecosystem as possible. If
+you are used to ``org-ref`` or ``org-cite``, it will work seamlessly with them
+while keeping your Papis library intact.

--- a/doc/source/editors.rst
+++ b/doc/source/editors.rst
@@ -1,24 +1,22 @@
 Editor support
 ==============
 
-There are some plugins for the major open source editors ``vim`` and ``emacs``.
+There are some plugins for the major open source editors ``vim``/``nvim`` and ``emacs``.
 
-1 VIM
------
+Vim and Neovim
+--------------
 
-There is a new well-maintained and high-quality package for neovim
+There is a new well-maintained and high-quality package for Neovim
 `papis.nvim <https://github.com/jghauser/papis.nvim>`__.
 
-If neovim is a deal breaker for you, you can take a look at the
+If Neovim is a deal breaker for you, you can take a look at the
 original ``vim`` plugin `papis-vim <https://github.com/papis/papis-vim>`__.
 
-2 Emacs
--------
+Emacs
+-----
 
 `papis.el <https://github.com/papis/papis.el>`__ is a compatibility layer for
-Papis that tries to use as much of the existing packages as possible.
-In particular it tries to make use also of ``org-ref``
-to try not to reinvent the wheel.
-If you are used to ``org-ref`` or ``org-cite`` it strives
-to work seamless with them and still have your Papis
-library intact.
+Papis that tries to use as much of the existing packages as possible. In
+particular it tries to make use also of ``org-ref`` to try not to reinvent the
+wheel. If you are used to ``org-ref`` or ``org-cite`` it strives to work
+seamlessly with them and still have your Papis library intact.

--- a/doc/source/editors.rst
+++ b/doc/source/editors.rst
@@ -1,7 +1,8 @@
 Editor support
 ==============
 
-There are some plugins for the major open source editors ``vim``/``nvim`` and ``emacs``.
+There are some plugins for the major open source editors ``vim``, ``neovim`` and
+``emacs``.
 
 Vim and Neovim
 --------------

--- a/doc/source/faq.rst
+++ b/doc/source/faq.rst
@@ -11,8 +11,13 @@ Here are some problems that users have come across often:
 
   .. code::
 
-    papis cache clear
+    papis cache update-newer
 
+  or (as a last resort)
+
+  .. code::
+
+    papis cache reset
 
 For responses to other frequently asked questions, check out our
 `GitHub issues labeled with faq <https://github.com/papis/papis/issues?utf8=%E2%9C%93&q=label:faq>`__.

--- a/doc/source/faq.rst
+++ b/doc/source/faq.rst
@@ -15,5 +15,5 @@ Here are some problems that users have come across often:
   will do.
 
 
-For more information you can also check the
-`github faq <https://github.com/papis/papis/issues?utf8=%E2%9C%93&q=label:faq>`__ link.
+For more frequently asked questions, check out our
+`GitHub issues labeled with faq <https://github.com/papis/papis/issues?utf8=%E2%9C%93&q=label:faq>`__.

--- a/doc/source/faq.rst
+++ b/doc/source/faq.rst
@@ -3,16 +3,15 @@ FAQ
 
 Here are some problems that users have come across often:
 
-- When I remove a folder manually in a library or I synchronize
+- **Question**: When I remove a folder manually in a library or I synchronize
   the library manually, I do not see the new papers in the library.
-  **Answer**: You probably need to update the cache because Papis did not
-  know anything about your changes in the library since you did it by yourself.
+
+  **Answer**: You probably need to update the cache because Papis did not know
+  anything about your changes in the library since you did it by yourself. Run:
 
   .. code::
 
     papis cache clear
-
-  will do.
 
 
 For more frequently asked questions, check out our

--- a/doc/source/faq.rst
+++ b/doc/source/faq.rst
@@ -14,5 +14,5 @@ Here are some problems that users have come across often:
     papis cache clear
 
 
-For more frequently asked questions, check out our
+For responses to other frequently asked questions, check out our
 `GitHub issues labeled with faq <https://github.com/papis/papis/issues?utf8=%E2%9C%93&q=label:faq>`__.

--- a/doc/source/git.rst
+++ b/doc/source/git.rst
@@ -4,11 +4,11 @@ Git support
 ===========
 
 Papis is made to work well with `git <https://git-scm.com/>`__ and has
-functionality in most of its command to interact with it. This functionality
+functionality in most of its commands to interact with it. This functionality
 can be turned on by default by using the :confval:`use-git`
 configuration setting. This guide gives a description of a possible workflow
 for using Git with Papis. This is not the only workflow, but it is the most
-obvious.
+obvious one.
 
 Let's say you have a library named ``books`` in the directory
 ``~/Documents/MyNiceBooks``. You could turn the ``books`` library into
@@ -77,7 +77,7 @@ To update the library from a remote repository, you can simply run
 Usual workflow
 --------------
 
-With all this in mind, assuming the you have a ``git`` repository set up in
+With all this in mind, assuming you have a ``git`` repository set up in
 the library folder, a ``papis git`` workflow could be based on the following.
 
 When adding a document that you know for sure you want in your library:
@@ -87,7 +87,7 @@ When adding a document that you know for sure you want in your library:
 
 2. Pull changes from the remote repository, maybe you pushed something
    on another machine (reference changes, etc.) and you do not have it on
-   you current machine. You would do something like
+   your current machine. You would do something like
 
     .. code:: sh
 

--- a/doc/source/git.rst
+++ b/doc/source/git.rst
@@ -12,14 +12,14 @@ obvious one.
 
 Let's say you have a library named ``books`` in the directory
 ``~/Documents/MyNiceBooks``. You could turn the ``books`` library into
-a Git repository by running
+a Git repository by running:
 
 .. code:: sh
 
     papis -l books git init
 
-which is completely equivalent to going into the library directory and running
-the commands there
+... which is completely equivalent to going into the library directory and running
+the commands there:
 
 .. code:: sh
 
@@ -27,7 +27,7 @@ the commands there
     git init
 
 As this is the first run, we can just add all the documents to the repository
-(equivalent to a ``git add .`` and a ``git commit -m '...'``)
+(equivalent to a ``git add .`` and a ``git commit -m '...'``):
 
 .. code:: sh
 
@@ -49,14 +49,14 @@ Interplay with other commands
 
 Some ``papis`` commands give you the opportunity of using Git to manage
 changes. For instance, if you are adding a new document, you could use
-the ``--git`` flag to also commit the document into Git like this
+the ``--git`` flag to also commit the document into Git like this:
 
 .. code:: sh
 
     papis add --git --set author 'Pedrito' --set title 'Super book' book.pdf
 
 In this case, Papis will do an automatic add + commit for the document. After
-that, you can push your library to a remote repository by running
+that, you can push your library to a remote repository by running:
 
 .. code:: sh
 
@@ -68,7 +68,7 @@ etc. also offer such functionality, and they all go through the ``--git`` flag.
 Updating the library
 --------------------
 
-To update the library from a remote repository, you can simply run
+To update the library from a remote repository, you can simply run:
 
 .. code:: sh
 
@@ -87,19 +87,19 @@ When adding a document that you know for sure you want in your library:
 
 2. Pull changes from the remote repository, maybe you pushed something
    on another machine (reference changes, etc.) and you do not have it on
-   your current machine. You would do something like
+   your current machine. You would do something like:
 
     .. code:: sh
 
         papis git pull
 
-3. Push what you just added
+3. Push what you just added:
 
     .. code:: sh
 
         papis git push
 
-4. Review the status of the library
+4. Review the status of the library:
 
     .. code:: sh
 
@@ -108,19 +108,19 @@ When adding a document that you know for sure you want in your library:
 
 When editing a document's info file:
 
-1. Edit the file and then take a look at the ``diff``
+1. Edit the file and then take a look at the ``diff``:
 
     .. code:: sh
 
         papis git diff
 
-2. Add the changes to the staging area
+2. Add the changes to the staging area:
 
     .. code:: sh
 
         papis git add --all
 
-3. Commit the changes
+3. Commit the changes:
 
     .. code:: sh
 

--- a/doc/source/git.rst
+++ b/doc/source/git.rst
@@ -18,7 +18,7 @@ a Git repository by running:
 
     papis -l books git init
 
-... which is completely equivalent to going into the library directory and running
+which is completely equivalent to going into the library directory and running
 the commands there:
 
 .. code:: sh

--- a/doc/source/git.rst
+++ b/doc/source/git.rst
@@ -77,15 +77,15 @@ To update the library from a remote repository, you can simply run:
 Usual workflow
 --------------
 
-With all this in mind, assuming you have a ``git`` repository set up in
-the library folder, a ``papis git`` workflow could be based on the following.
+Assuming you have a ``git`` repository set up in the library folder, a ``papis
+git`` workflow could be based on the following.
 
 When adding a document that you know for sure you want in your library:
 
 1. Add the document and commit it, either by ``papis add --git``
    or by using ``papis git add`` after adding it to the library.
 
-2. Pull changes from the remote repository, maybe you pushed something
+2. Pull changes from the remote repository. Maybe you pushed something
    on another machine (reference changes, etc.) and you do not have it on
    your current machine. You would do something like:
 

--- a/doc/source/hooks.rst
+++ b/doc/source/hooks.rst
@@ -1,7 +1,7 @@
 Hooks
 =====
 
-From version ``0.12`` Papis has a minimal hook infrastructure.
+From version ``v0.12`` Papis has a minimal hook infrastructure.
 Some parts of Papis define and run hooks so that users
 and plugin writers can also tap into this functionality.
 
@@ -12,12 +12,10 @@ they are implemented in the same way within the
 Writing hooks as a user
 -----------------------
 
-Right now the only way to add a hook as a user is using your
-``config.py`` configuration file, which gets loaded
-when your Papis configuration gets loaded.
+Right now the only way to add a hook as a user is using your ``config.py``
+configuration file, which loads along with your Papis configuration.
 
-As an example you can add a function to the ``on_edit_done``
-hook like
+As an example you can add a function to the ``on_edit_done`` hook like
 
 .. code:: python
 
@@ -28,7 +26,7 @@ hook like
 Writing hooks as a developer
 ----------------------------
 
-To add a hook as a plugin writer or a developer you can just add the *entrypoint*
+To add a hook as a plugin writer or developer you can just add the *entrypoint*
 to the ``pyproject.toml`` file. For instance for the ``on_edit_done`` hook you
 would write
 
@@ -43,8 +41,9 @@ Available hooks
 ``on_edit_done``
 ^^^^^^^^^^^^^^^^
 
-This hook is called by ``papis edit`` after editing has finished, but before it
-is saved to the database. The callbacks for this hook have the following format:
+This hook is called by ``papis edit`` after editing has finished, but before
+saving changes to the database. The callbacks for this hook have the following
+format:
 
 .. code:: python
 
@@ -64,4 +63,4 @@ for this hook have the following format:
         ...
 
 Note that the ``tmp_doc`` argument is not the final document. It will be moved to
-a final location inside the chosen library after the hook was called.
+a final location inside the chosen library after the hook has been called.

--- a/doc/source/hooks.rst
+++ b/doc/source/hooks.rst
@@ -15,7 +15,7 @@ Writing hooks as a user
 Right now the only way to add a hook as a user is using your ``config.py``
 configuration file, which loads along with your Papis configuration.
 
-As an example you can add a function to the ``on_edit_done`` hook like
+As an example you can add a function to the ``on_edit_done`` hook like:
 
 .. code:: python
 
@@ -28,7 +28,7 @@ Writing hooks as a developer
 
 To add a hook as a plugin writer or developer you can just add the *entrypoint*
 to the ``pyproject.toml`` file. For instance for the ``on_edit_done`` hook you
-would write
+would write:
 
 .. code:: toml
 

--- a/doc/source/hooks.rst
+++ b/doc/source/hooks.rst
@@ -15,7 +15,7 @@ Writing hooks as a user
 Right now the only way to add a hook as a user is using your ``config.py``
 configuration file, which loads along with your Papis configuration.
 
-As an example you can add a function to the ``on_edit_done`` hook like:
+For example you can add a function to the ``on_edit_done`` hook like:
 
 .. code:: python
 

--- a/doc/source/importing.rst
+++ b/doc/source/importing.rst
@@ -1,7 +1,7 @@
 Importing from BibTeX or Zotero
 ===============================
 
-Many users will want to import a library from a bibtex file
+Many users will want to import a library from a BibTeX file
 that another program such as ``zotero``, ``mendeley`` or
 ``jabref`` will have exported. These programs usually have a
 field called ``FILE`` or ``file`` that points to a path
@@ -20,4 +20,4 @@ You can also take a look at the
 in order to see a different workflow
 and different implementation of a converter script.
 `This <https://nicolasshu.com/zotero_and_papis.html>`__ blogpost
-explains the workflow using Papis with zotero and SyncThing.
+explains the workflow using Papis with Zotero and SyncThing.

--- a/doc/source/index.rst
+++ b/doc/source/index.rst
@@ -16,7 +16,7 @@ Papis: Command-line Bibliography Manager
       :link-type: ref
       :class-card: getting-started
 
-    .. grid-item-card:: :material-regular:`rocket_launch;2em` Quick Guide
+    .. grid-item-card:: :material-regular:`rocket_launch;2em` Quick guide
       :columns: 12 6 6 4
       :link: quick-guide
       :link-type: ref
@@ -42,7 +42,7 @@ Papis: Command-line Bibliography Manager
       :link-type: ref
       :class-card: getting-started
 
-    .. grid-item-card:: :material-regular:`laptop_chromebook;2em` Developer Docs
+    .. grid-item-card:: :material-regular:`laptop_chromebook;2em` Developer docs
       :columns: 12 6 6 4
       :link: developer-api-reference
       :link-type: ref

--- a/doc/source/index.rst
+++ b/doc/source/index.rst
@@ -60,7 +60,7 @@ of features. And for those who still want more, Papis makes it easy to write
 scripts that extend its features even further.
 
 Papis has grown over the years and there are now a number of projects that
-extend Papis' features or integrate it with other software.
+extend Papis' features or integrate it with other software:
 
 .. list-table::
    :widths: 33 67

--- a/doc/source/info_file.rst
+++ b/doc/source/info_file.rst
@@ -3,8 +3,8 @@
 The ``info.yaml`` file
 ======================
 
-At the heart of Papis is the information file. The info file contains all
-information about the documents.
+At the heart of Papis is the information file (or info file, for short).
+All information about documents is contained in info files.
 
 It uses the `YAML <https://yaml.org>`__ syntax to store information, which is a
 very human-readable language. It is quite format-free: Papis does not assume
@@ -12,8 +12,8 @@ that any special information should be there. However it will interpret the
 field ``files`` as the files linked to the document for the ``papis open``
 command. The ``files`` field should be formatted as a YAML list.
 
-For instance, when storing papers with Papis, you'd most probably like to store
-author and title in there like this:
+For instance, when storing papers with Papis, you likely want to store author
+and title in like this:
 
 .. code:: yaml
 
@@ -23,11 +23,10 @@ author and title in there like this:
   files:
     - document.pdf
 
-Here we have used the ``files`` field to tell Papis that the paper has a PDF
+Here, we have used the ``files`` field to tell Papis that the paper has a PDF
 document attached to it. You can of course attach many other documents so that
-you can open them when you are opening it with the ``papis open`` command. For
-instance if you have a paper with supporting information, you could store it
-like this:
+you can open them with ``papis open``. For instance, if you have a paper with
+supporting information, you could store it like this:
 
 .. code:: yaml
 

--- a/doc/source/info_file.rst
+++ b/doc/source/info_file.rst
@@ -27,7 +27,7 @@ Here we have used the ``files`` field to tell Papis that the paper has a PDF
 document attached to it. You can of course attach many other documents so that
 you can open them when you are opening it with the ``papis open`` command. For
 instance if you have a paper with supporting information, you could store it
-like such
+like this:
 
 .. code:: yaml
 
@@ -39,7 +39,7 @@ like such
     - supporting-information.pdf
 
 Therefore, in the folder where this document lives we have the following
-structure
+structure:
 
 ::
 

--- a/doc/source/info_file.rst
+++ b/doc/source/info_file.rst
@@ -23,7 +23,7 @@ author and title in there like this:
   files:
     - document.pdf
 
-Here we have used the ``files`` field to tell Papis that the paper has a pdf
+Here we have used the ``files`` field to tell Papis that the paper has a PDF
 document attached to it. You can of course attach many other documents so that
 you can open them when you are opening it with the ``papis open`` command. For
 instance if you have a paper with supporting information, you could store it

--- a/doc/source/info_file.rst
+++ b/doc/source/info_file.rst
@@ -3,19 +3,17 @@
 The ``info.yaml`` file
 ======================
 
-At the heart of Papis there is the information file. The info file contains
-all information about the documents.
+At the heart of Papis is the information file. The info file contains all
+information about the documents.
 
-It uses the `YAML <https://yaml.org>`__ syntax to store
-information, which is a very human-readable language.
-It is quite format-free:
-`papis` does not assume that any special information should be there.
-However it will interpret the field ``files`` as the files linked to the
-document for the ``papis open`` command. The ``files`` field
-should be formatted as a YAML list.
+It uses the `YAML <https://yaml.org>`__ syntax to store information, which is a
+very human-readable language. It is quite format-free: Papis does not assume
+that any special information should be there. However it will interpret the
+field ``files`` as the files linked to the document for the ``papis open``
+command. The ``files`` field should be formatted as a YAML list.
 
-For instance, if are storing papers with Papis, then you most probably would
-like to store author and title in there like this:
+For instance, when storing papers with Papis, you'd most probably like to store
+author and title in there like this:
 
 .. code:: yaml
 
@@ -25,11 +23,11 @@ like to store author and title in there like this:
   files:
     - document.pdf
 
-Here we have used the ``files`` field to tell Papis that the paper
-has a pdf document attached to it. You can of course attach many other documents
-so that you can open them when you are opening it with the ``papis open``
-command. For instance if you have a paper with supporting information, you
-could store it like such
+Here we have used the ``files`` field to tell Papis that the paper has a pdf
+document attached to it. You can of course attach many other documents so that
+you can open them when you are opening it with the ``papis open`` command. For
+instance if you have a paper with supporting information, you could store it
+like such
 
 .. code:: yaml
 

--- a/doc/source/info_file.rst
+++ b/doc/source/info_file.rst
@@ -6,11 +6,11 @@ The ``info.yaml`` file
 At the heart of Papis is the information file (or info file, for short).
 All information about documents is contained in info files.
 
-It uses the `YAML <https://yaml.org>`__ syntax to store information, which is a
-very human-readable language. It is quite format-free: Papis does not assume
-that any special information should be there. However it will interpret the
-field ``files`` as the files linked to the document for the ``papis open``
-command. The ``files`` field should be formatted as a YAML list.
+It uses the `YAML <https://yaml.org>`__ syntax, which is very human-readable.
+The information file is flexible: Papis does not assume that any specific
+information is contained in it, except for the ``papis_id``, which is
+automatically generated when missing. However, certain functionality requires
+additional keys (e.g. the ``files`` key is required by ``papis open``).
 
 For instance, when storing papers with Papis, you likely want to store author
 and title in like this:

--- a/doc/source/install.rst
+++ b/doc/source/install.rst
@@ -44,10 +44,10 @@ Arch Linux
 
 - The ``papis`` package is found in the Arch Linux AUR repository
   `here <https://aur.archlinux.org/packages/papis/>`__.
-  Thanks to `Joshua <https://jpellis.me/>`__ for maintaining this packages!.
+  Thanks to `Joshua <https://jpellis.me/>`__ for maintaining this package!
 - If you want to use the git version of ``papis`` instead, you can try
   the `papis-git <https://aur.archlinux.org/packages/papis-git/>`__ package.
-  Thanks to `Julian <https://julianhauser.com/>`__ for maintaining this packages!.
+  Thanks to `Julian <https://julianhauser.com/>`__ for maintaining this package!
 
 You can install either one with your favorite AUR helper, e.g.
 
@@ -140,11 +140,11 @@ rights on your computer you can simply type
 .. warning::
 
     If you install the package locally, the program ``papis`` will be installed
-    by default into your ``~/.local/bin`` directory, so that you will have to
+    by default into your ``~/.local/bin`` directory. You may have to
     set your ``PATH`` accordingly.
 
     One way of doing this in Bash shells (Linux, Ubuntu on Windows or Cygwin) is
-    by adding the following line to your ``~/.bashrc`` file::
+    by adding the following line to your ``~/.bashrc`` file:
 
     .. code:: sh
 

--- a/doc/source/install.rst
+++ b/doc/source/install.rst
@@ -141,7 +141,7 @@ rights on your computer you can simply type:
 
     If you install the package locally, the program ``papis`` will be installed
     into your ``~/.local/bin`` directory by default. You may have to set your
-    ``PATH`` accordingly.
+    ``PATH`` accordingly to have access to it.
 
     One way of doing this in Bash shells (Linux, Ubuntu on Windows or Cygwin) is
     by adding the following line to your ``~/.bashrc`` file:

--- a/doc/source/install.rst
+++ b/doc/source/install.rst
@@ -13,7 +13,7 @@ Using pip
 ---------
 
 The easiest way of installing Papis is using the ``PyPI`` repositories and
-the ``pip`` package manager. Open a terminal and type in:
+the ``pip`` package manager. Open a terminal and type:
 
 .. code:: sh
 
@@ -140,8 +140,8 @@ rights on your computer you can simply type:
 .. warning::
 
     If you install the package locally, the program ``papis`` will be installed
-    by default into your ``~/.local/bin`` directory. You may have to
-    set your ``PATH`` accordingly.
+    into your ``~/.local/bin`` directory by default. You may have to set your
+    ``PATH`` accordingly.
 
     One way of doing this in Bash shells (Linux, Ubuntu on Windows or Cygwin) is
     by adding the following line to your ``~/.bashrc`` file:

--- a/doc/source/install.rst
+++ b/doc/source/install.rst
@@ -73,7 +73,7 @@ For the development version, just clone the repository:
     git clone git@github.com:papis/papis.git
     cd papis
 
-... and start hacking it with:
+and start hacking it with:
 
 .. code:: sh
 
@@ -107,7 +107,7 @@ This Guix recipe was made by running the following command:
 
   guix import pypi papis@0.13 --recursive
 
-... manually fixing some dependencies and switching off some failing tests so
+manually fixing some dependencies and switching off some failing tests so
 that the package could be build with Guix. This can be used for newer versions
 until an official recipe in the main Guix repositories is published.
 
@@ -120,7 +120,7 @@ To install Papis from source, you can clone the repository using:
 
     git clone https://github.com/papis/papis.git
 
-... or download the
+or download the
 `zip file <https://github.com/papis/papis/archive/refs/heads/main.zip>`__.
 
 Go inside of the ``papis`` source folder and you can install it in a standard

--- a/doc/source/install.rst
+++ b/doc/source/install.rst
@@ -13,26 +13,26 @@ Using pip
 ---------
 
 The easiest way of installing Papis is using the ``PyPI`` repositories and
-the ``pip`` package manager. Open a terminal and type in
+the ``pip`` package manager. Open a terminal and type in:
 
 .. code:: sh
 
     pip install papis
 
 If you are on GNU/Linux-like systems you might need to type ``sudo`` to install
-Papis globally like
+Papis globally like:
 
 .. code:: sh
 
     sudo pip install papis
 
-If you prefer installing it locally then simply type
+If you prefer installing it locally then simply type:
 
 .. code:: sh
 
     pip install --user papis
 
-You can also **update** Papis with ``pip``
+You can also **update** Papis with ``pip``:
 
 .. code:: sh
 
@@ -49,7 +49,7 @@ Arch Linux
   the `papis-git <https://aur.archlinux.org/packages/papis-git/>`__ package.
   Thanks to `Julian <https://julianhauser.com/>`__ for maintaining this package!
 
-You can install either one with your favorite AUR helper, e.g.
+You can install either one with your favorite AUR helper, e.g.:
 
 .. code:: sh
 
@@ -66,14 +66,14 @@ Papis by running:
 
     nix-env -i papis
 
-For the development version, just clone the repository
+For the development version, just clone the repository:
 
 .. code:: sh
 
     git clone git@github.com:papis/papis.git
     cd papis
 
-and start hacking it with
+... and start hacking it with:
 
 .. code:: sh
 
@@ -95,43 +95,43 @@ If you are running the `Guix System <https://guix.gnu.org/>`__ or you have the
 `guix <https://guix.gnu.org/>`__ package manager installed and you would like
 to install ``papis`` the 'Guix way', you can use the included recipe from
 :download:`python-papis.scm <../../contrib/python-papis.scm>`. This recipe can
-be downloaded locally and installed using
+be downloaded locally and installed using:
 
 .. code:: sh
 
     guix package --install-from-file=python-papis.scm
 
-This Guix recipe was made by running the following command
+This Guix recipe was made by running the following command:
 
 .. code:: sh
 
   guix import pypi papis@0.13 --recursive
 
-manually fixing some dependencies and switching off some failing tests so
+... manually fixing some dependencies and switching off some failing tests so
 that the package could be build with Guix. This can be used for newer versions
 until an official recipe in the main Guix repositories is published.
 
 From source
 -----------
 
-To install Papis from source, you can clone the repository using
+To install Papis from source, you can clone the repository using:
 
 .. code:: sh
 
     git clone https://github.com/papis/papis.git
 
-or download the
+... or download the
 `zip file <https://github.com/papis/papis/archive/refs/heads/main.zip>`__.
 
 Go inside of the ``papis`` source folder and you can install it in a standard
-fashion. For example, using ``pip``
+fashion. For example, using ``pip``:
 
 .. code:: sh
 
     python -m pip install .
 
 If you want to install it locally because you don't have administrative
-rights on your computer you can simply type
+rights on your computer you can simply type:
 
 .. code:: sh
 

--- a/doc/source/library_structure.rst
+++ b/doc/source/library_structure.rst
@@ -1,13 +1,12 @@
 The library structure
 =====================
 
-One of the things that makes Papis interesting is the fact that its library
-structure is nearly nonexistent.
+The Papis library structure is very flexible. It is specified by directories
+(and, possibly, subdirectories) in the filesystem.
 
-A Papis library is linked to a directory, where all the documents are (and
-possibly sublibraries). What Papis does is simply go to the library folder
-and look for all subfolders that contain an information file, which by default
-is the ``info.yaml`` file.
+A Papis library is a directory containing subfolders with documents. Papis
+simply searches the library directory for (possibly nested) subfolders that
+contain an information file, which by default is an ``info.yaml`` file.
 
 Every subfolder that has an ``info.yaml`` file in it is a valid Papis document.
 As an example let us consider the following library:

--- a/doc/source/library_structure.rst
+++ b/doc/source/library_structure.rst
@@ -42,7 +42,7 @@ As an example let us consider the following library
 
 The first thing that you might notice is that there are many folders. Just to
 check that you understand exactly what is a document, please think about which
-of these pdfs is not a valid Papis document... That's right!
+of these PDFs is not a valid Papis document... That's right!
 ``folder1/paper.pdf`` is not a valid document since the ``folder1`` does not
 contain the ``info.yaml`` file. You see also that it does not matter how deep
 the folder structure is in your library: you can have a ``physics`` folder in

--- a/doc/source/library_structure.rst
+++ b/doc/source/library_structure.rst
@@ -10,7 +10,7 @@ and look for all subfolders that contain an information file, which by default
 is the ``info.yaml`` file.
 
 Every subfolder that has an ``info.yaml`` file in it is a valid Papis document.
-As an example let us consider the following library
+As an example let us consider the following library:
 
 ::
 
@@ -49,7 +49,7 @@ the folder structure is in your library: you can have a ``physics`` folder in
 which you have a ``newton`` folder in which you have a folder containing the
 actual book ``document.pdf`` plus some supplementary information
 ``supplements.pdf``.  In this case, inside the ``info.yaml`` you would have the
-following ``file`` section
+following ``file`` section:
 
 .. code:: yaml
 
@@ -57,4 +57,4 @@ following ``file`` section
   - document.pdf
   - supplements.pdf
 
-which tells Papis that this folder contains two relevant files.
+... which tells Papis that this folder contains two relevant files.

--- a/doc/source/library_structure.rst
+++ b/doc/source/library_structure.rst
@@ -40,7 +40,7 @@ As an example let us consider the following library:
           └── output.pdf
 
 First, you can see there are a lot of folders. Note that not all of them contain
-valid documents. The PDF in ``folder1/paper.pdf`` is not valid since the
+valid documents. The PDF in ``folder1/paper.pdf`` is not valid since
 ``folder1`` does not contain a ``info.yaml`` file. It does not matter how deep
 your library's folder structure is: you can have a ``physics`` folder in which
 you have a ``newton`` folder in which you have a folder containing the actual

--- a/doc/source/library_structure.rst
+++ b/doc/source/library_structure.rst
@@ -40,16 +40,14 @@ As an example let us consider the following library:
           ├── notes.tex
           └── output.pdf
 
-The first thing that you might notice is that there are many folders. Just to
-check that you understand exactly what is a document, please think about which
-of these PDFs is not a valid Papis document... That's right!
-``folder1/paper.pdf`` is not a valid document since the ``folder1`` does not
-contain the ``info.yaml`` file. You see also that it does not matter how deep
-the folder structure is in your library: you can have a ``physics`` folder in
-which you have a ``newton`` folder in which you have a folder containing the
-actual book ``document.pdf`` plus some supplementary information
-``supplements.pdf``.  In this case, inside the ``info.yaml`` you would have the
-following ``file`` section:
+First, you can see there are a lot of folders. Note that not all of them contain
+valid documents. The PDF in ``folder1/paper.pdf`` is not valid since the
+``folder1`` does not contain a ``info.yaml`` file. It does not matter how deep
+your library's folder structure is: you can have a ``physics`` folder in which
+you have a ``newton`` folder in which you have a folder containing the actual
+book ``document.pdf`` plus some supplementary information ``supplements.pdf``.
+In this case, inside the ``info.yaml`` you would have the following ``file``
+section:
 
 .. code:: yaml
 

--- a/doc/source/library_structure.rst
+++ b/doc/source/library_structure.rst
@@ -57,4 +57,4 @@ following ``file`` section:
   - document.pdf
   - supplements.pdf
 
-... which tells Papis that this folder contains two relevant files.
+which tells Papis that this folder contains two relevant files.

--- a/doc/source/library_structure.rst
+++ b/doc/source/library_structure.rst
@@ -1,13 +1,13 @@
 The library structure
 =====================
 
-One of the things that makes Papis interesting is the fact
-that its library structure is nearly nonexistent.
+One of the things that makes Papis interesting is the fact that its library
+structure is nearly nonexistent.
 
 A Papis library is linked to a directory, where all the documents are (and
-possibly sublibraries).  What Papis does is simply to go to the library folder
-and look for all subfolders that contain a information file, which by default
-is a ``info.yaml`` file.
+possibly sublibraries). What Papis does is simply go to the library folder
+and look for all subfolders that contain an information file, which by default
+is the ``info.yaml`` file.
 
 Every subfolder that has an ``info.yaml`` file in it is a valid Papis document.
 As an example let us consider the following library
@@ -40,15 +40,16 @@ As an example let us consider the following library
           ├── notes.tex
           └── output.pdf
 
-The first thing that you might notice is that there are many folders.
-Just to check that you understand exactly what is a document,
-please think about which of these pdfs is not a valid Papis document... That's
-right!, ``folder1/paper.pdf`` is not a valid document since the folder1 does not
-contain any ``info.yaml`` file. You see also that it does not matter how deep the
-folder structure is in your library: you can have a ``physics`` folder in which you
-have a ``newton`` folder in which you have a folder containing the actual book
-``document.pdf`` plus some supplementary information ``supplements.pdf``.  In this
-case, inside the ``info.yaml`` you would have the following ``file`` section
+The first thing that you might notice is that there are many folders. Just to
+check that you understand exactly what is a document, please think about which
+of these pdfs is not a valid Papis document... That's right!
+``folder1/paper.pdf`` is not a valid document since the ``folder1`` does not
+contain the ``info.yaml`` file. You see also that it does not matter how deep
+the folder structure is in your library: you can have a ``physics`` folder in
+which you have a ``newton`` folder in which you have a folder containing the
+actual book ``document.pdf`` plus some supplementary information
+``supplements.pdf``.  In this case, inside the ``info.yaml`` you would have the
+following ``file`` section
 
 .. code:: yaml
 

--- a/doc/source/papis_id.rst
+++ b/doc/source/papis_id.rst
@@ -39,7 +39,7 @@ For instance you can get the ``papis_id`` of a document using:
 
     id=$(papis list --id query)
 
-... and subsequently use the ``id`` variable to trigger other commands. For example,
+and subsequently use the ``id`` variable to trigger other commands. For example,
 you can open the files attached to the document using:
 
 .. code:: sh

--- a/doc/source/papis_id.rst
+++ b/doc/source/papis_id.rst
@@ -10,7 +10,7 @@ The ``papis_id`` is added automatically when using ``papis add`` or other comman
 but is not updated after the initial creation of the document. If you manually
 add a document into your library, e.g. by creating an ``info.yaml`` file without
 Papis, you will have to clear the library cache in order to trigger a rebuild
-using
+using:
 
 .. code:: sh
 
@@ -33,14 +33,14 @@ Use of ``papis_id`` in scripts
 Since the ``papis_id`` key is a unique (ish) identifier, it is quite useful for
 scripts that do not depend on the actual path to the document in your system.
 
-For instance you can get the ``papis_id`` of a document using
+For instance you can get the ``papis_id`` of a document using:
 
 .. code:: sh
 
     id=$(papis list --id query)
 
-and subsequently use the ``id`` variable to trigger other commands. For example,
-you can open the files attached to the document using
+... and subsequently use the ``id`` variable to trigger other commands. For example,
+you can open the files attached to the document using:
 
 .. code:: sh
 

--- a/doc/source/plugins.rst
+++ b/doc/source/plugins.rst
@@ -116,7 +116,7 @@ metadata (title, authors, etc.) through standard elements such as the
 `Dublin Core Metadata <https://www.dublincore.org/specifications/dublin-core/dces/>`__.
 We can however extend it for any specific downloader. For instance, some
 documents in the ACL Anthology provide a "code" field, with a link to e.g. a
-GitHub repository. We will try to extract code repository URL using
+GitHub repository. We will try to extract a code repository URL using
 :mod:`bs4`. An instance of :mod:`bs4` with the parsed HTML can be obtained and
 manipulated as follows:
 

--- a/doc/source/plugins.rst
+++ b/doc/source/plugins.rst
@@ -112,11 +112,11 @@ checks if a given URI matches a website URL, e.g.
 
 By default, a downloader implements a :meth:`~papis.downloaders.Downloader.get_data`
 method to retrieve metadata. This already does a good job in fetching basic
-metadata (title, authors, etc) through standard elements such as the
+metadata (title, authors, etc.) through standard elements such as the
 `Dublin Core Metadata <https://www.dublincore.org/specifications/dublin-core/dces/>`__.
 We can however extend it for any specific downloader. For instance, some
 documents in the ACL Anthology provide a "code" field, with a link to e.g. a
-Github repository. We will try to extract code repository URL using
+GitHub repository. We will try to extract code repository URL using
 :mod:`bs4`. An instance of :mod:`bs4` with the parsed HTML can be obtained and
 manipulated as follows
 
@@ -136,7 +136,7 @@ manipulated as follows
 
 Metadata can also be obtained from BibTeX by overriding the
 :meth:`~papis.downloaders.Downloader.get_bibtex_url` method. This can be useful
-if, for instance, the `get_data` method fails to correctly identify the abstract
+if, for instance, the ``get_data`` method fails to correctly identify the abstract
 section. In our example we can fix this by scraping the metadata found in the
 BibTeX file. Luckily, for ACL, the BibTeX URL is simply the document URL with a
 ``.bib`` extension. We can implement it as
@@ -148,7 +148,7 @@ BibTeX file. Luckily, for ACL, the BibTeX URL is simply the document URL with a
         return f"{url}.bib" if url is not None else url
 
 To download files from a remote resource, the downloader relies on
-`data["pdf_url"]` by default. However, if this does not exist or does not
+``data["pdf_url"]`` by default. However, if this does not exist or does not
 return the actual document PDF, we can override the
 :meth:`~papis.downloaders.Downloader.get_document_url` method.
 

--- a/doc/source/plugins.rst
+++ b/doc/source/plugins.rst
@@ -27,14 +27,14 @@ For example, the ``yaml`` exporter in ``papis.yaml`` is defined as:
             allow_unicode=True)
         return str(string)
 
-... and declared in ``pyproject.toml`` as:
+and declared in ``pyproject.toml`` as:
 
 .. code:: toml
 
     [project.entry-points."papis.exporter"]
     yaml = "papis.yaml:exporter"
 
-... where ``yaml`` is the name of the entrypoint, ``papis.yaml`` is the module
+where ``yaml`` is the name of the entrypoint, ``papis.yaml`` is the module
 in which it is located and ``exporter`` is the callable used to invoke the
 plugin, i.e. the format is ``<name> = "<module>:<callable>"``. The exporter can
 be retrieved by name using:

--- a/doc/source/plugins.rst
+++ b/doc/source/plugins.rst
@@ -17,7 +17,7 @@ objects that have been declared as
 (plugins) in the package
 `metadata <https://packaging.python.org/en/latest/guides/creating-and-discovering-plugins/>`__.
 
-For example, the ``yaml`` exporter in ``papis.yaml`` is defined as
+For example, the ``yaml`` exporter in ``papis.yaml`` is defined as:
 
 .. code:: python
 
@@ -27,17 +27,17 @@ For example, the ``yaml`` exporter in ``papis.yaml`` is defined as
             allow_unicode=True)
         return str(string)
 
-and declared in ``pyproject.toml`` as
+... and declared in ``pyproject.toml`` as:
 
 .. code:: toml
 
     [project.entry-points."papis.exporter"]
     yaml = "papis.yaml:exporter"
 
-where ``yaml`` is the name of the entrypoint, ``papis.yaml`` is the module
+... where ``yaml`` is the name of the entrypoint, ``papis.yaml`` is the module
 in which it is located and ``exporter`` is the callable used to invoke the
 plugin, i.e. the format is ``<name> = "<module>:<callable>"``. The exporter can
-be retrieved by name using
+be retrieved by name using:
 
 .. code:: python
 
@@ -77,7 +77,7 @@ about existing features and implementations.
 
 For a downloader, we create a new file in ``papis/downloaders`` and start writing
 a class that inherits from :class:`papis.downloaders.Downloader`. This can look
-something like
+something like:
 
 .. code:: python
 
@@ -102,7 +102,7 @@ something like
 
 The main way to recognize if a downloader can be used with a given URI is
 through the :meth:`~papis.downloaders.Downloader.match` method. This generally
-checks if a given URI matches a website URL, e.g.
+checks if a given URI matches a website URL, e.g.:
 
 .. code:: python
 
@@ -118,7 +118,7 @@ We can however extend it for any specific downloader. For instance, some
 documents in the ACL Anthology provide a "code" field, with a link to e.g. a
 GitHub repository. We will try to extract code repository URL using
 :mod:`bs4`. An instance of :mod:`bs4` with the parsed HTML can be obtained and
-manipulated as follows
+manipulated as follows:
 
 .. code:: python
 
@@ -139,7 +139,7 @@ Metadata can also be obtained from BibTeX by overriding the
 if, for instance, the ``get_data`` method fails to correctly identify the abstract
 section. In our example we can fix this by scraping the metadata found in the
 BibTeX file. Luckily, for ACL, the BibTeX URL is simply the document URL with a
-``.bib`` extension. We can implement it as
+``.bib`` extension. We can implement it as:
 
 .. code:: python
 
@@ -150,7 +150,7 @@ BibTeX file. Luckily, for ACL, the BibTeX URL is simply the document URL with a
 To download files from a remote resource, the downloader relies on
 ``data["pdf_url"]`` by default. However, if this does not exist or does not
 return the actual document PDF, we can override the
-:meth:`~papis.downloaders.Downloader.get_document_url` method.
+:meth:`~papis.downloaders.Downloader.get_document_url` method:
 
 .. code:: python
 
@@ -162,7 +162,7 @@ return the actual document PDF, we can override the
 
 Finally, to install the plugin and have it recognized by the extension system
 that Papis uses, it needs to be added to ``pyproject.toml``. This can be done with
-extending the ``papis.downloader`` entrypoint as follows
+extending the ``papis.downloader`` entrypoint as follows:
 
 .. code:: toml
 

--- a/doc/source/quick_guide.rst
+++ b/doc/source/quick_guide.rst
@@ -73,7 +73,7 @@ Finally, a situation that is unfortunately familiar to most: papers behind
 paywalls. The importer might be able to get the metadata automatically but fail
 at fetching the PDF. In this case, you might have to get the file yourself. You
 can use a slightly modified ``papis add`` command if you then want to create an
-entry in your library.
+entry in your library:
 
 .. code:: bash
 
@@ -109,7 +109,7 @@ Listing documents
 -----------------
 
 All the documents you add end up in folders inside your library. To find out
-where exactly a specific file is, use the ``papis list`` command.
+where exactly a specific file is, use the ``papis list`` command:
 
 .. code:: bash
 
@@ -196,7 +196,7 @@ Let's say you want to add the tag "physics" to all documents by Isaac Newton:
     papis tag --append physics newton
 
 Or maybe, you want to tag the documents used in a specific project. We could add
-the tag "project apple" to them using the command
+the tag "project apple" to them using the command:
 
 .. code:: bash
 
@@ -252,7 +252,7 @@ the tag "project", you can add a query:
 
     papis export --all --output project_apple.bib tags:"project apple"
 
-Papis supports exporting to several formats, which you can check out using
+Papis supports exporting to several formats, which you can check out using:
 
 .. code:: bash
 
@@ -290,7 +290,7 @@ init``. This resets everything, so that by running ``papis init`` again, you'll
 start anew.
 
 If you're unsure about the location of the library we've created for this quick
-guide, run the following command.
+guide, run the following command:
 
 .. code:: bash
 

--- a/doc/source/quick_guide.rst
+++ b/doc/source/quick_guide.rst
@@ -5,7 +5,7 @@ Quick guide
 
 In this quick guide, we'll create a library, download a couple documents, and
 then work on them by opening, tagging, updating, exporting, and organising them.
-In doing so, you will be introduced to the ``papis`` command and number of its
+In doing so, you will be introduced to the ``papis`` command and a number of its
 subcommands. These subcommands (which we'll simply call "commands" from now on)
 are run with ``papis COMMAND`` (where ``COMMAND`` is the command you want). To
 get a list of all commands, simply run ``papis --help``. If you want to get help

--- a/doc/source/scihub.rst
+++ b/doc/source/scihub.rst
@@ -21,7 +21,7 @@ Now you can type:
 
   papis scihub -h
 
-... and see the help message of the script.
+and see the help message of the script.
 
 Some usage examples are:
 

--- a/doc/source/scihub.rst
+++ b/doc/source/scihub.rst
@@ -1,13 +1,12 @@
-Scihub support
-==============
+Sci-Hub support
+===============
 
 .. image:: https://badge.fury.io/py/papis-scihub.svg
     :target: https://badge.fury.io/py/papis-scihub
 
-Papis has a script that uses the scihub platform to download scientific
-papers. Due to legal caution the script is not included directly
-as a ``papis`` command, and it has its own PyPi repository.
-
+Papis has a script that uses the Sci-Hub platform to download scientific papers.
+Due to legal caution the script is not included directly as a ``papis`` command,
+and it has its own PyPi repository.
 
 To install it, just type
 
@@ -26,19 +25,18 @@ and see the help message of the script.
 
 Some usage examples are:
 
-
   - Download via the doi number:
 
     .. code:: bash
 
-      papis scihub 10.1002/andp.19053220607 \\
+      papis scihub 10.1002/andp.19053220607 \
         add -d einstein_papers --folder-name photon_definition
 
-  - Download via a url that contains the doi number in the format ``.*/doi/<doinumber>``
+  - Download via a url that contains the doi number in the format ``.*/doi/<doinumber>``:
 
     .. code:: bash
 
-      papis scihub https://physicstoday.scitation.org/doi/10.1063/1.881498 \\
+      papis scihub https://physicstoday.scitation.org/doi/10.1063/1.881498 \
         add --folder-name important_paper
 
   - Download via the ``doi.org`` url:

--- a/doc/source/scihub.rst
+++ b/doc/source/scihub.rst
@@ -8,20 +8,20 @@ Papis has a script that uses the Sci-Hub platform to download scientific papers.
 Due to legal caution the script is not included directly as a ``papis`` command,
 and it has its own PyPI repository.
 
-To install it, just type
+To install it, just type:
 
 ::
 
   pip3 install papis-scihub
 
 
-Now you can type
+Now you can type:
 
 .. code:: bash
 
   papis scihub -h
 
-and see the help message of the script.
+... and see the help message of the script.
 
 Some usage examples are:
 

--- a/doc/source/scihub.rst
+++ b/doc/source/scihub.rst
@@ -6,7 +6,7 @@ Sci-Hub support
 
 Papis has a script that uses the Sci-Hub platform to download scientific papers.
 Due to legal caution the script is not included directly as a ``papis`` command,
-and it has its own PyPi repository.
+and it has its own PyPI repository.
 
 To install it, just type
 

--- a/doc/source/scihub.rst
+++ b/doc/source/scihub.rst
@@ -5,7 +5,7 @@ Sci-Hub support
     :target: https://badge.fury.io/py/papis-scihub
 
 Papis has a script that uses the Sci-Hub platform to download scientific papers.
-Due to legal caution the script is not included directly as a ``papis`` command,
+Due to legal caution, the script is not included directly as a ``papis`` command,
 and it has its own PyPI repository.
 
 To install it, just type:

--- a/doc/source/scripting.rst
+++ b/doc/source/scripting.rst
@@ -34,7 +34,7 @@ inside the ``~/.papis/scripts`` folder. In the latter case when you run:
 
     papis -h
 
-... you will see that there is another command besides the default commands called
+you will see that there is another command besides the default commands called
 ``mail``:
 
 ::
@@ -45,7 +45,7 @@ inside the ``~/.papis/scripts`` folder. In the latter case when you run:
       mail       Email a paper to my friend.
       ...        ...
 
-... where the description ``Email a paper to my friend.`` is there because
+where the description ``Email a paper to my friend.`` is there because
 we have defined the comment ``# papis-short-help: Email a paper to my friend.``
 in the header of the script.
 
@@ -55,7 +55,7 @@ Then, if you type:
 
     papis -l mylib mail this_paper
 
-... this will create a folder called ``this_paper`` with a selection of a
+this will create a folder called ``this_paper`` with a selection of a
 document, zip it and send it to whoever you choose to.
 
 Example: Accessing Papis from within mutt

--- a/doc/source/scripting.rst
+++ b/doc/source/scripting.rst
@@ -8,8 +8,7 @@ Example: Mail script
 --------------------
 
 Imagine you want to write a script to send papers to someone via the email
-client ``mutt`` (you can try to do it with another mail client). You could
-write the following script called ``papis-mail``:
+client ``mutt``. You could write the following script called ``papis-mail``:
 
 .. code:: sh
 
@@ -28,7 +27,7 @@ Papis defines environment variables such as ``PAPIS_LIB`` so that external
 scripts can make use of the user input.
 
 To use the script you can put it somewhere in your ``PATH`` or alternatively
-inside the ``~/.papis/scripts`` folder. In the latter case when you run:
+inside the ``~/.papis/scripts`` folder. In the latter case, when you run:
 
 ::
 
@@ -45,8 +44,8 @@ you will see that there is another command besides the default commands called
       mail       Email a paper to my friend.
       ...        ...
 
-where the description ``Email a paper to my friend.`` is there because
-we have defined the comment ``# papis-short-help: Email a paper to my friend.``
+Note the presence of the help text ``Email a paper to my friend.``, which
+we've defined in the comment ``# papis-short-help: Email a paper to my friend.``
 in the header of the script.
 
 Then, if you type:

--- a/doc/source/scripting.rst
+++ b/doc/source/scripting.rst
@@ -28,13 +28,13 @@ Papis defines environment variables such as ``PAPIS_LIB`` so that external
 scripts can make use of the user input.
 
 To use the script you can put it somewhere in your ``PATH`` or alternatively
-inside the ``~/.papis/scripts`` folder. In the latter case when you run
+inside the ``~/.papis/scripts`` folder. In the latter case when you run:
 
 ::
 
     papis -h
 
-you will see that there is another command besides the default commands called
+... you will see that there is another command besides the default commands called
 ``mail``:
 
 ::
@@ -45,17 +45,17 @@ you will see that there is another command besides the default commands called
       mail       Email a paper to my friend.
       ...        ...
 
-where the description ``Email a paper to my friend.`` is there because
+... where the description ``Email a paper to my friend.`` is there because
 we have defined the comment ``# papis-short-help: Email a paper to my friend.``
 in the header of the script.
 
-Then, if you type
+Then, if you type:
 
 ::
 
     papis -l mylib mail this_paper
 
-this will create a folder called ``this_paper`` with a selection of a
+... this will create a folder called ``this_paper`` with a selection of a
 document, zip it and send it to whoever you choose to.
 
 Example: Accessing Papis from within mutt
@@ -64,7 +64,7 @@ Example: Accessing Papis from within mutt
 You may want to pick documents to attach to your email in ``mutt``
 from the Papis interface.
 
-Add this code to your ``muttrc``
+Add this code to your ``muttrc``:
 
 ::
 
@@ -88,7 +88,7 @@ paper to the email, which you can rename to be more descriptive with
 Example: Define Papis mode in i3wm
 ----------------------------------
 
-This is an example of using Papis with the window manager `i3`.
+This is an example of using Papis with the window manager `i3`:
 
 ::
 
@@ -119,7 +119,7 @@ This is an example of using Papis with the window manager `i3`.
 Useful links
 ------------
 
-- `Get paper references with papis <https://alejandrogallo.github.io/blog/posts/getting-paper-references-with-papis/>`__
+- `Get paper references with papis <https://alejandrogallo.github.io/blog/posts/getting-paper-references-with-papis/>`__:
 
     .. code:: sh
 

--- a/doc/source/scripting.rst
+++ b/doc/source/scripting.rst
@@ -8,13 +8,13 @@ Example: Mail script
 --------------------
 
 Imagine you want to write a script to send papers to someone via the email
-client ``mutt`` (you can try to do it with another mail client), you could
+client ``mutt`` (you can try to do it with another mail client). You could
 write the following script called ``papis-mail``:
 
 .. code:: sh
 
     #! /usr/bin/env bash
-    # papis-short-help: Email a paper to my friend
+    # papis-short-help: Email a paper to my friend.
 
     folder_name=$1
     zip_name="${folder_name}.zip"
@@ -28,29 +28,25 @@ Papis defines environment variables such as ``PAPIS_LIB`` so that external
 scripts can make use of the user input.
 
 To use the script you can put it somewhere in your ``PATH`` or alternatively
-inside the ``~/.papis/scripts`` folder. If this is the case then you can run
+inside the ``~/.papis/scripts`` folder. In the latter case when you run
 
 ::
 
     papis -h
 
-and you will see that there is another command besides the default
-called ``mail``. In fact, you will see
+you will see that there is another command besides the default commands called
+``mail``:
 
-.. code::
+::
 
-    positional arguments:
-      command               For further information for every command, type in 'papis <command> -h'
-        add                 Add a document into a given library
-        .............       ..........................
-        mail                Email a paper to my friend
+    Commands:
+      add        Add a document into a given library.
+      ...        ...
+      mail       Email a paper to my friend.
+      ...        ...
 
-    optional arguments:
-      -h, --help            show this help message and exit
-      ... .........         .... ... ...... ....... ........... .. ..... ......
-
-where the description ``Email a paper to my friend`` is there because
-we have defined the comment ``# papis-short-help: Email a paper to my friend``
+where the description ``Email a paper to my friend.`` is there because
+we have defined the comment ``# papis-short-help: Email a paper to my friend.``
 in the header of the script.
 
 Then, if you type
@@ -130,9 +126,9 @@ Useful links
         citget() {
             query=$1
             shift
-            papis explore               \\
-                citations -s "$query" \\
-                pick                  \\
+            papis explore \
+                citations -s "$query" \
+                pick \
                 cmd "papis add --from doi {doc[doi]} $@"
         }
 

--- a/doc/source/shell_completion.rst
+++ b/doc/source/shell_completion.rst
@@ -10,7 +10,7 @@ in which the completions get installed, use the environment variables:
 
     PAPIS_<SHELL>_COMPLETION_DIR=my/custom/directory
 
-... where ``<SHELL>`` is the uppercase name of the shell (e.g. ``BASH``) and the
+where ``<SHELL>`` is the uppercase name of the shell (e.g. ``BASH``) and the
 paths are considered subdirectories of the chosen prefix. The default paths for
 each shell are given below.
 
@@ -51,6 +51,6 @@ Alternatively, the completion can be generated on-the-fly by running (see more i
 
    eval "$(_PAPIS_COMPLETE=<shell>_source papis)"
 
-... where ``<shell>`` is one of the shells supported by ``click``. Note that older
+where ``<shell>`` is one of the shells supported by ``click``. Note that older
 versions of ``click`` used ``source_<shell>`` instead for the values of
 ``_PAPIS_COMPLETE``.

--- a/doc/source/shell_completion.rst
+++ b/doc/source/shell_completion.rst
@@ -1,10 +1,10 @@
-Shell Completion
+Shell completion
 ================
 
 Papis has shell completion for ``bash``, ``fish`` and ``zsh`` through the
 `click framework <https://click.palletsprojects.com/en/latest/shell-completion/#shell-completion>`__
 that comes with it when installed through ``pip``. To control the directory
-in which the completions gets installed use the environment variables
+in which the completions get installed, use the environment variables
 
 .. code:: bash
 

--- a/doc/source/shell_completion.rst
+++ b/doc/source/shell_completion.rst
@@ -4,20 +4,20 @@ Shell completion
 Papis has shell completion for ``bash``, ``fish`` and ``zsh`` through the
 `click framework <https://click.palletsprojects.com/en/latest/shell-completion/#shell-completion>`__
 that comes with it when installed through ``pip``. To control the directory
-in which the completions get installed, use the environment variables
+in which the completions get installed, use the environment variables:
 
 .. code:: bash
 
     PAPIS_<SHELL>_COMPLETION_DIR=my/custom/directory
 
-where ``<SHELL>`` is the uppercase name of the shell (e.g. ``BASH``) and the
+... where ``<SHELL>`` is the uppercase name of the shell (e.g. ``BASH``) and the
 paths are considered subdirectories of the chosen prefix. The default paths for
 each shell are given below.
 
 * ``bash``: the completion script is installed in
   ``$PREFIX/share/bash-completion/completions`` and works directly with
   the `bash-completion <https://github.com/scop/bash-completion>`__ package.
-  It can also be sourced manually using (or added to your ``.bashrc``)
+  It can also be sourced manually using (or added to your ``.bashrc``):
 
     .. code:: bash
 
@@ -28,7 +28,7 @@ each shell are given below.
   automatically (see the
   `fish docs <https://fishshell.com/docs/current/completions.html#where-to-put-completions>`__
   for more details). It can also be sourced manually using (or added to your
-  ``config.fish``)
+  ``config.fish``):
 
     .. code:: bash
 
@@ -38,19 +38,19 @@ each shell are given below.
   which is sourced automatically starting with version ``5.0.7`` (see the
   `zsh docs <https://zsh.sourceforge.io/Doc/Release/Completion-System.html>`__
   for more details). It can also be sourced manually using (or added to your
-  ``.zshrc``)
+  ``.zshrc``):
 
     .. code:: bash
 
         source $PREFIX/share/zsh/site-functions/_papis
 
 Alternatively, the completion can be generated on-the-fly by running (see more in the
-`click docs <https://click.palletsprojects.com/en/latest/shell-completion/#shell-completion>`__)
+`click docs <https://click.palletsprojects.com/en/latest/shell-completion/#shell-completion>`__):
 
 .. code:: bash
 
    eval "$(_PAPIS_COMPLETE=<shell>_source papis)"
 
-where ``<shell>`` is one of the shells supported by ``click``. Note that older
+... where ``<shell>`` is one of the shells supported by ``click``. Note that older
 versions of ``click`` used ``source_<shell>`` instead for the values of
 ``_PAPIS_COMPLETE``.

--- a/doc/source/testing.rst
+++ b/doc/source/testing.rst
@@ -23,7 +23,7 @@ This is a set of environment variables used by the testing infrastructure.
   it acts the same as setting ``XDG_CACHE_HOME``. This overrides the default
   from :func:`papis.utils.get_cache_home` that uses ``platformdirs``.
 * ``PAPIS_DATABASE_BACKEND``: set to one of the supported database backends. Most
-  existing tests do no parametrize over the database backend, so this value lets
+  existing tests do not parametrize over the database backend, so this value lets
   us pick a different one.
 * ``PAPIS_UPDATE_RESOURCES``: one of "none", "remote", "local" or "both". This
   controls what resources are updated while running downloader tests (as explained

--- a/doc/source/testing.rst
+++ b/doc/source/testing.rst
@@ -183,7 +183,7 @@ argument to :meth:`~papis.testing.ResourceCache.get_remote_resource` or
 :meth:`~papis.testing.ResourceCache.get_local_resource`. The resource cache can
 also be accessed through a fixture called :func:`~papis.testing.resource_cache`
 that can be configured through the ``resource_setup`` marker. For example, we
-can write something like
+can write something like:
 
 .. code:: python
 

--- a/doc/source/web-application.rst
+++ b/doc/source/web-application.rst
@@ -1,7 +1,7 @@
-Web Application
+Web application
 ===============
 
-Since v0.12, Papis ships with an experimental, simple yet handy web application.
+Since ``v0.12``, Papis ships with an experimental, simple yet handy web application.
 
 You can start the web application by issuing the following command
 
@@ -15,7 +15,7 @@ Then input the following url in your browser
 
    http://localhost:8181
 
-This web application can be useful if you intend to read access to your
+This web application can be useful if you intend to access your
 documents from a tablet or from another computer.
 
 Further documentation will be available soon, but bear in mind

--- a/doc/source/web-application.rst
+++ b/doc/source/web-application.rst
@@ -15,8 +15,8 @@ Then input the following url in your browser:
 
    http://localhost:8181
 
-This web application can be useful if you intend to access your
-documents from a tablet or from another computer.
+You may find the web application useful when accessing your
+documents from a tablet or another computer.
 
 Further documentation will be available soon, but bear in mind
 that this web application is experimental, bug reports and

--- a/doc/source/web-application.rst
+++ b/doc/source/web-application.rst
@@ -3,13 +3,13 @@ Web application
 
 Since ``v0.12``, Papis ships with an experimental, simple yet handy web application.
 
-You can start the web application by issuing the following command
+You can start the web application by issuing the following command:
 
 ::
 
    papis serve --port 8181 --host localhost
 
-Then input the following url in your browser
+Then input the following url in your browser:
 
 ::
 

--- a/examples/scripts/papis-abbrev.py
+++ b/examples/scripts/papis-abbrev.py
@@ -1,5 +1,5 @@
 #! /usr/bin/env python3
-# papis-short-help: Abbreviate journal titles
+# papis-short-help: Abbreviate journal titles.
 # Copyright © 2017 Alejandro Gallo. GPLv3
 
 """

--- a/examples/scripts/papis-check.py
+++ b/examples/scripts/papis-check.py
@@ -1,5 +1,5 @@
 #! /usr/bin/env python3
-# papis-short-help: Check document keys
+# papis-short-help: Check document keys.
 # Copyright © 2018 Alejandro Gallo. GPLv3
 
 """

--- a/examples/scripts/papis-ga.py
+++ b/examples/scripts/papis-ga.py
@@ -1,5 +1,5 @@
 #! /usr/bin/env python3
-# papis-short-help: Git add <document>
+# papis-short-help: Git add <document>.
 # Copyright © 2017 Alejandro Gallo. GPLv3
 
 """

--- a/examples/scripts/papis-mail.sh
+++ b/examples/scripts/papis-mail.sh
@@ -1,5 +1,5 @@
 #! /usr/bin/env bash
-# papis-short-help: Email a paper to a friend
+# papis-short-help: Email a paper to a friend.
 # Copyright © 2017 Alejandro Gallo. GPLv3
 
 if [[ $1 = "-h" ]]; then

--- a/examples/scripts/papis-tags.py
+++ b/examples/scripts/papis-tags.py
@@ -1,5 +1,5 @@
 #! /usr/bin/env python3
-# papis-short-help: Search tags in the library
+# papis-short-help: Search tags in the library.
 # Copyright © 2018 Alejandro Gallo. GPLv3
 
 """

--- a/papis/api.py
+++ b/papis/api.py
@@ -21,8 +21,8 @@ def get_lib_name() -> str:
     """
     Get current library.
 
-    It either retrieves the library from the environment ``PAPIS_LIB`` variable,
-    the command-line arguments passed in by the user or the configuration
+    It either retrieves the library from the environment variable ``PAPIS_LIB``,
+    the command-line arguments passed in by the user, or the configuration
     files.
 
     :returns: the name of the library.
@@ -37,8 +37,8 @@ def set_lib_from_name(library: str) -> None:
     """
     Set current library.
 
-    It either sets the library from the environment ``PAPIS_LIB`` variable,
-    the command-line args passed by the user or the configuration files.
+    It either sets the library from the environment variable ``PAPIS_LIB``,
+    the command-line args passed by the user, or the configuration files.
 
     :param library: name of a library (as defined in the configuration files)
         or a path to an existing library.
@@ -51,7 +51,7 @@ def get_libraries() -> List[str]:
     Get all the libraries declared in the configuration files.
 
     A library in the configuration files is a section that has the ``dir``
-    or ``dirs`` keys defined.
+    or ``dirs`` key defined.
 
     :returns: a :class:`list` of library names.
 
@@ -86,6 +86,7 @@ def pick(items: Sequence[T],
     :param default_index: index used when no explicit item is picked.
     :param header_filter: a callable to stringify the given item for display.
     :param match_filter: a callable to stringify the given item for display.
+    :returns: a subset of *items* corresponding to the user selected ones.
     """
     import papis.pick
 
@@ -158,7 +159,7 @@ def get_documents_in_dir(
         directory: str,
         search: str = "") -> List[papis.document.Document]:
     """
-    Get documents contained in the given folder.
+    Get documents contained in the given *directory*.
 
     :param directory: a path to a folder containing documents.
     :param search: a search string used to filter the documents.
@@ -177,7 +178,7 @@ def get_documents_in_lib(
         library: Optional[str] = None,
         search: Union[Dict[str, Any], str] = "") -> List[papis.document.Document]:
     """
-    Get documents contained in the given library.
+    Get documents contained in the given *library*.
 
     :param library: a library name.
     :param search: a search parameter used to filter the documents.
@@ -225,7 +226,7 @@ def save_doc(doc: papis.document.Document) -> None:
     Save the document to disk.
 
     This commits the new document to the database and saves it to disk
-    by updating its *info.yaml* file.
+    by updating its ``info.yaml`` file.
 
     :param doc: an existing document.
     """

--- a/papis/api.py
+++ b/papis/api.py
@@ -68,7 +68,7 @@ def pick_doc(
     Pick a subset of documents from the given *documents*.
 
     :param documents: a sequence of documents.
-    :returns: a subset of *documents* corresponding to the user selected ones.
+    :returns: the subset of *documents* selected by the user.
     """
     import papis.pick
 
@@ -86,7 +86,7 @@ def pick(items: Sequence[T],
     :param default_index: index used when no explicit item is picked.
     :param header_filter: a callable to stringify the given item for display.
     :param match_filter: a callable to stringify the given item for display.
-    :returns: a subset of *items* corresponding to the user selected ones.
+    :returns: the subset of *items* selected by the user.
     """
     import papis.pick
 

--- a/papis/api.py
+++ b/papis/api.py
@@ -21,9 +21,9 @@ def get_lib_name() -> str:
     """
     Get current library.
 
-    It either retrieves the library from the environment variable ``PAPIS_LIB``,
-    the command-line arguments passed in by the user, or the configuration
-    files.
+    It retrieves the library from the environment variable ``PAPIS_LIB``, the
+    command-line arguments passed by the user, or the configuration files
+    (in this order of precedence).
 
     :returns: the name of the library.
 
@@ -37,8 +37,9 @@ def set_lib_from_name(library: str) -> None:
     """
     Set current library.
 
-    It either sets the library from the environment variable ``PAPIS_LIB``,
-    the command-line args passed by the user, or the configuration files.
+    It sets the library from the environment variable ``PAPIS_LIB``, the
+    command-line arguments passed by the user, or the configuration files
+    (in this order of precedence).
 
     :param library: name of a library (as defined in the configuration files)
         or a path to an existing library.

--- a/papis/arxiv.py
+++ b/papis/arxiv.py
@@ -231,7 +231,7 @@ def explorer(
 
 
     For example, to search for documents with the authors "Hummel" and
-    "Garnet Chan" (a maximum of 100 articles), use:
+    "Garnet Chan" (limited to a maximum of 100 articles), use:
 
     .. code:: sh
 

--- a/papis/arxiv.py
+++ b/papis/arxiv.py
@@ -230,7 +230,7 @@ def explorer(
     Look for documents on `arXiv.org <https://arxiv.org/>`__.
 
 
-    For example, to search for documents with the authors "Hummer" and
+    For example, to search for documents with the authors "Hummel" and
     "Garnet Chan" (a maximum of 100 articles), use
 
     .. code:: sh

--- a/papis/arxiv.py
+++ b/papis/arxiv.py
@@ -231,14 +231,14 @@ def explorer(
 
 
     For example, to search for documents with the authors "Hummel" and
-    "Garnet Chan" (a maximum of 100 articles), use
+    "Garnet Chan" (a maximum of 100 articles), use:
 
     .. code:: sh
 
         papis explore arxiv -a 'Hummel' -m 100 arxiv -a 'Garnet Chan' pick
 
     If you want to search for the exact author name 'John Smith', you should
-    enclose it in extra quotes, as in the example below
+    enclose it in extra quotes, as in the example below:
 
     .. code:: sh
 

--- a/papis/bibtex.py
+++ b/papis/bibtex.py
@@ -359,7 +359,7 @@ class Importer(papis.importer.Importer):
 def explorer(ctx: click.core.Context, bibfile: str) -> None:
     """Import documents from a BibTeX file.
 
-    This explorer can be used as
+    This explorer can be used as:
 
     .. code:: sh
 
@@ -410,7 +410,7 @@ def bibtexparser_entry_to_papis(entry: Dict[str, Any]) -> Dict[str, Any]:
 def bibtex_to_dict(bibtex: str) -> List[papis.document.DocumentLike]:
     """Convert a BibTeX file (or string) to a list of Papis-compatible dictionaries.
 
-    This will convert an entry like
+    This will convert an entry like:
 
     .. code:: tex
 
@@ -420,7 +420,7 @@ def bibtex_to_dict(bibtex: str) -> List[papis.document.DocumentLike]:
             ...,
         }
 
-    to a dictionary such as
+    ... to a dictionary such as:
 
     .. code:: python
 

--- a/papis/bibtex.py
+++ b/papis/bibtex.py
@@ -420,7 +420,7 @@ def bibtex_to_dict(bibtex: str) -> List[papis.document.DocumentLike]:
             ...,
         }
 
-    ... to a dictionary such as:
+    to a dictionary such as:
 
     .. code:: python
 

--- a/papis/cli.py
+++ b/papis/cli.py
@@ -192,13 +192,13 @@ def bypass(
         command_name: str) -> Callable[..., Any]:
     """Overwrite existing ``papis`` commands.
 
-    This function is specially important for developing scripts in ``papis``.
+    This function is especially important for developing scripts in ``papis``.
 
     For example, consider augmenting the ``add`` command, as seen
     when using ``papis add``. In this case, we may want to add some additional
     options or behavior before calling ``papis.commands.add``, but would like
     to avoid writing it from scratch. This function can then be used as follows
-    to allow this
+    to allow this:
 
     .. code:: python
 

--- a/papis/cli.py
+++ b/papis/cli.py
@@ -64,7 +64,7 @@ def query_option(**attrs: Any) -> DecoratorCallable:
         "-q", "--query",
         default=lambda: papis.config.getstring("default-query-string"),
         type=str,
-        help="Query for a document in the database",
+        help="Query for a document in the database.",
         **attrs)
 
 
@@ -74,12 +74,12 @@ def sort_option(**attrs: Any) -> DecoratorCallable:
         sort = click.option(
             "--sort", "sort_field",
             default=lambda: papis.config.get("sort-field"),
-            help="Sort documents with respect to the FIELD",
+            help="Sort documents with respect to the FIELD.",
             metavar="FIELD",
             **attrs)
         reverse = bool_flag(
             "--reverse", "sort_reverse",
-            help="Reverse sort order",
+            help="Reverse sort order.",
             default=lambda: papis.config.getboolean("sort-reverse"))
 
         return sort(reverse(f))
@@ -94,7 +94,7 @@ def doc_folder_option(**attrs: Any) -> DecoratorCallable:
         default=None,
         type=click.Path(exists=True),
         multiple=True,
-        help="Document folder on which to apply action",
+        help="Document folder on which to apply action.",
         **attrs)
 
 
@@ -102,13 +102,13 @@ def all_option(**attrs: Any) -> DecoratorCallable:
     """Adds a ``--all`` option as a :mod:`click` decorator."""
     return bool_flag(
         "-a", "--all", "_all",
-        help="Apply action to all matching documents",
+        help="Apply action to all matching documents.",
         **attrs)
 
 
 def git_option(**attrs: Any) -> DecoratorCallable:
     """Adds a ``--git`` option as a :mod:`click` decorator."""
-    git_help = attrs.pop("help", "Commit changes to git")
+    git_help = attrs.pop("help", "Commit changes to git.")
     return bool_flag(
         "--git/--no-git",
         default=lambda: papis.config.getboolean("use-git"),

--- a/papis/commands/add.py
+++ b/papis/commands/add.py
@@ -53,7 +53,7 @@ Examples
         papis add --link ~/Documents/interesting.pdf \\
             --from doi 10.10763/1.3237134
 
-  ... will add an entry into the Papis library, but the PDF document will remain at
+  will add an entry into the Papis library, but the PDF document will remain at
   ``~/Documents/interesting.pdf``. In the document's folder there will be a link
   to ``~/Documents/interesting.pdf`` instead of the file itself. Of course you
   always have to be sure that the document at ``~/Documents/interesting.pdf``

--- a/papis/commands/add.py
+++ b/papis/commands/add.py
@@ -1,10 +1,11 @@
 """
 The ``add`` command is one of the central commands of the ``papis``
-command-line interface It is a very versatile command with a fair amount of
+command-line interface. It is a very versatile command with a fair amount of
 options.
 
 There are also a few customization settings available for this command, which
-are described on the :ref:`configuration page <add-command-options>` for add.
+are described on the :ref:`configuration page <add-command-options>` for
+``add``.
 
 Examples
 ^^^^^^^^
@@ -37,7 +38,7 @@ Examples
 
         papis add ~/Documents/interesting.pdf --from doi 10.10763/1.3237134
 
-- Add paper to a library named ``machine-learning`` from ``arxiv.org``
+- Add a paper from ``arxiv.org`` to a library named ``machine-learning``
 
     .. code:: sh
 
@@ -52,23 +53,23 @@ Examples
         papis add --link ~/Documents/interesting.pdf \\
             --from doi 10.10763/1.3237134
 
-  will add an entry into the Papis library, but the PDF document will remain
-  at ``~/Documents/interesting.pdf``. In the document's folder
-  there will be a link to ``~/Documents/interesting.pdf`` instead of the
-  file itself. Of course you always have to be sure that the
-  document at ``~/Documents/interesting.pdf`` does not disappear, otherwise
-  you will end up without a document file.
+  will add an entry into the Papis library, but the PDF document will remain at
+  ``~/Documents/interesting.pdf``. In the document's folder there will be a link
+  to ``~/Documents/interesting.pdf`` instead of the file itself. Of course you
+  always have to be sure that the document at ``~/Documents/interesting.pdf``
+  does not disappear, otherwise you will end up without a document file.
 
-- Papis also tries to make sense of the inputs that you have passed
-  on the command-line. For instance you could provide only a DOI and
-  Papis will figure out if this is indeed a DOI and download available metadata
-  using Crossref. For example, you can try
+- Papis also tries to make sense of the inputs that you have passed on the
+  command-line. For instance you could provide only a DOI and Papis will figure
+  out if this is indeed a DOI and download available metadata using Crossref.
+  For example, you can try
 
     .. code:: sh
 
         papis add 10.1103/PhysRevLett.123.156401
 
-  Similarly, a wide array of known journal are recognized by URL, so you can try:
+  Similarly, a wide array of known journals are recognized by URL, so you can
+  try:
 
     .. code:: sh
 
@@ -94,7 +95,7 @@ Examples
             }"
         papis add --from bibtex "$(xclip -o)"
 
-Command-line Interface
+Command-line interface
 ^^^^^^^^^^^^^^^^^^^^^^
 
 .. click:: papis.commands.add:cli
@@ -131,7 +132,7 @@ logger = papis.logging.get_logger(__name__)
 
 class FromFolderImporter(papis.importer.Importer):
 
-    """Importer that gets files and data from a valid papis folder"""
+    """Importer that gets files and data from a valid papis folder."""
 
     def __init__(self, **kwargs: Any) -> None:
         super().__init__(name="folder", **kwargs)
@@ -154,7 +155,7 @@ class FromFolderImporter(papis.importer.Importer):
 class FromLibImporter(papis.importer.Importer):
 
     """Importer that queries a valid Papis library (also paths) and adds files
-    and data
+    and data.
     """
 
     def __init__(self, **kwargs: Any) -> None:
@@ -228,11 +229,11 @@ def run(paths: List[str],
         citations: Optional[papis.citations.Citations] = None,
         auto_doctor: bool = False) -> None:
     """
-    :param paths: Paths to the documents to be added
+    :param paths: Paths to the documents to be added.
     :param data: Data for the document to be added.
         If more data is to be retrieved from other sources, the data dictionary
         will be updated from these sources.
-    :param folder_name: Name of the folder where the document will be stored
+    :param folder_name: Name of the folder where the document will be stored.
     :param file_name: File name of the document's files to be stored.
     :param subfolder: Folder within the library where the document's folder
         should be stored.
@@ -410,76 +411,76 @@ def run(paths: List[str],
 
 @click.command(
     "add",
-    help="Add a document into a given library"
+    help="Add a document into a given library."
 )
 @click.help_option("--help", "-h")
 @click.argument("files", type=click.Path(), nargs=-1)
 @click.option(
     "-s", "--set", "set_list",
-    help="Set some information before",
+    help="Set some information before.",
     multiple=True,
     type=(str, str))
 @click.option(
     "-d", "--subfolder",
-    help="Subfolder in the library",
+    help="Subfolder in the library.",
     default=lambda: papis.config.getstring("add-subfolder"))
 @papis.cli.bool_flag(
     "-p", "--pick-subfolder",
-    help="Pick from existing subfolders")
+    help="Pick from existing subfolders.")
 @click.option(
     "--folder-name",
-    help="Name format for the document main folder",
+    help="Name format for the document main folder.",
     type=papis.cli.FormattedStringParamType(),
     default=lambda: papis.config.getformattedstring("add-folder-name"))
 @click.option(
     "--file-name",
-    help="File name format for the document",
+    help="File name format for the document.",
     type=papis.cli.FormattedStringParamType(),
     default=None)
 @click.option(
     "--from", "from_importer",
-    help="Add document from a specific importer",
+    help="Add document from a specific importer.",
     type=(click.Choice(papis.importer.available_importers()), str),
     nargs=2,
     multiple=True,
     default=(),)
 @papis.cli.bool_flag(
     "-b", "--batch",
-    help="Batch mode, do not prompt or otherwise")
+    help="Batch mode, do not prompt or otherwise.")
 @papis.cli.bool_flag(
     "--confirm/--no-confirm",
-    help="Ask to confirm before adding to the collection",
+    help="Ask to confirm before adding to the collection.",
     default=lambda: papis.config.getboolean("add-confirm"))
 @papis.cli.bool_flag(
     "--open/--no-open", "open_file",
-    help="Open files before adding them to the document",
+    help="Open files before adding them to the document.",
     default=lambda: papis.config.getboolean("add-open"))
 @papis.cli.bool_flag(
     "--edit/--no-edit",
-    help="Edit info file before adding document",
+    help="Edit info file before adding document.",
     default=lambda: papis.config.getboolean("add-edit"))
 @papis.cli.bool_flag(
     "--link/--no-link",
     help="Instead of copying the file to the library, create a link to "
-         "its original location",
+         "its original location.",
     default=False)
 @papis.cli.bool_flag(
     "--move/--no-move",
     help="Instead of copying the file to the library, "
-         "move it from its original location",
+         "move it from its original location.",
     default=False)
 @papis.cli.bool_flag(
     "--auto-doctor/--no-auto-doctor",
     help="Apply papis doctor to newly added documents.",
     default=lambda: papis.config.getboolean("auto-doctor"))
-@papis.cli.git_option(help="Git add and commit the new document")
+@papis.cli.git_option(help="Git add and commit the new document.")
 @papis.cli.bool_flag(
     "--download-files/--no-download-files",
-    help="Download file with importer if available or not",
+    help="Download file with importer if available or not.",
     default=lambda: papis.config.getboolean("add-download-files"))
 @papis.cli.bool_flag(
     "--fetch-citations/--no-fetch-citations",
-    help="Fetch citations from a DOI (Digital Object Identifier)",
+    help="Fetch citations from a DOI (Digital Object Identifier).",
     default=lambda: papis.config.getboolean("add-fetch-citations"))
 def cli(files: List[str],
         set_list: List[Tuple[str, str]],

--- a/papis/commands/add.py
+++ b/papis/commands/add.py
@@ -11,14 +11,14 @@ Examples
 ^^^^^^^^
 
 - Add a document located in ``~/Documents/interesting.pdf`` and name the
-  folder where it will be stored in the database ``interesting-paper-2021``
+  folder where it will be stored in the database ``interesting-paper-2021``:
 
     .. code:: sh
 
         papis add ~/Documents/interesting.pdf \\
             --folder-name interesting-paper-2021
 
-  if you want to directly add some metadata, like author, title and tags,
+  If you want to directly add some metadata, like author, title and tags,
   you can also run the following:
 
     .. code:: sh
@@ -38,7 +38,7 @@ Examples
 
         papis add ~/Documents/interesting.pdf --from doi 10.10763/1.3237134
 
-- Add a paper from ``arxiv.org`` to a library named ``machine-learning``
+- Add a paper from ``arxiv.org`` to a library named ``machine-learning``:
 
     .. code:: sh
 
@@ -46,14 +46,14 @@ Examples
             --from arxiv https://arxiv.org/abs/1712.03134
 
 - If you do not want copy the original PDFs into the library, you can
-  also tell Papis to just create a link to them, for example
+  also tell Papis to just create a link to them, for example:
 
     .. code:: sh
 
         papis add --link ~/Documents/interesting.pdf \\
             --from doi 10.10763/1.3237134
 
-  will add an entry into the Papis library, but the PDF document will remain at
+  ... will add an entry into the Papis library, but the PDF document will remain at
   ``~/Documents/interesting.pdf``. In the document's folder there will be a link
   to ``~/Documents/interesting.pdf`` instead of the file itself. Of course you
   always have to be sure that the document at ``~/Documents/interesting.pdf``
@@ -62,7 +62,7 @@ Examples
 - Papis also tries to make sense of the inputs that you have passed on the
   command-line. For instance you could provide only a DOI and Papis will figure
   out if this is indeed a DOI and download available metadata using Crossref.
-  For example, you can try
+  For example, you can try:
 
     .. code:: sh
 

--- a/papis/commands/add.py
+++ b/papis/commands/add.py
@@ -53,15 +53,15 @@ Examples
         papis add --link ~/Documents/interesting.pdf \\
             --from doi 10.10763/1.3237134
 
-  will add an entry into the Papis library, but the PDF document will remain at
-  ``~/Documents/interesting.pdf``. In the document's folder there will be a link
-  to ``~/Documents/interesting.pdf`` instead of the file itself. Of course you
-  always have to be sure that the document at ``~/Documents/interesting.pdf``
-  does not disappear, otherwise you will end up without a document file.
+  adds an entry to the Papis library, but the PDF document remains at
+  ``~/Documents/interesting.pdf``. The document's folder will contain a link
+  to ``~/Documents/interesting.pdf`` instead of the file itself. Make sure that
+  the document at ``~/Documents/interesting.pdf`` does not disappear, or
+  you will end up without a document file.
 
-- Papis also tries to make sense of the inputs that you have passed on the
-  command-line. For instance you could provide only a DOI and Papis will figure
-  out if this is indeed a DOI and download available metadata using Crossref.
+- Papis tries to make sense of the arguments with which it is provided.
+  For instance, you could only provide a DOI, and Papis will verify that
+  this is a valid DOI and download available metadata using Crossref.
   For example, you can try:
 
     .. code:: sh

--- a/papis/commands/addto.py
+++ b/papis/commands/addto.py
@@ -21,7 +21,7 @@ files can be similarly added using
 
 where the link needs to be to the actual remote PDF file.
 
-Command-line Interface
+Command-line interface
 ^^^^^^^^^^^^^^^^^^^^^^
 
 .. click:: papis.commands.addto:cli
@@ -92,22 +92,22 @@ def run(document: papis.document.Document,
 @click.command("addto")
 @click.help_option("--help", "-h")
 @papis.cli.query_argument()
-@papis.cli.git_option(help="Add and commit files")
+@papis.cli.git_option(help="Add and commit files.")
 @papis.cli.sort_option()
 @click.option("-f",
               "--files",
-              help="File fullpaths to documents",
+              help="File fullpaths to documents.",
               multiple=True,
               type=click.Path(exists=True))
-@click.option("-u", "--urls", help="URLs to documents", multiple=True)
+@click.option("-u", "--urls", help="URLs to documents.", multiple=True)
 @click.option("--file-name",
-              help="File name format for the document",
+              help="File name format for the document.",
               type=papis.cli.FormattedStringParamType(),
               default=None)
 @click.option(
     "--link/--no-link",
     help="Instead of copying the file to the library, create a link to "
-         "its original location",
+         "its original location.",
     default=False)
 @papis.cli.doc_folder_option()
 def cli(query: str,
@@ -119,7 +119,7 @@ def cli(query: str,
         sort_field: Optional[str],
         doc_folder: Tuple[str, ...],
         sort_reverse: bool) -> None:
-    """Add files to an existing document"""
+    """Add files to an existing document."""
     documents = papis.cli.handle_doc_folder_query_sort(
         query, doc_folder, sort_field, sort_reverse)
 

--- a/papis/commands/addto.py
+++ b/papis/commands/addto.py
@@ -6,20 +6,20 @@ Examples
 
 For instance imagine you have two PDF files, ``a.pdf`` and ``b.pdf``
 that you want to add to a document that matches with the query string
-"einstein photon definition". Then you would use
+"einstein photon definition". Then you would use:
 
 .. code:: sh
 
     papis addto 'einstein photon definition' -f a.pdf -f b.pdf
 
-where the ``-f`` flag needs to be repeated for every file that is added. Remote
-files can be similarly added using
+... where the ``-f`` flag needs to be repeated for every file that is added. Remote
+files can be similarly added using:
 
 .. code:: sh
 
     papis addto 'einstein photon definition' -u 'https://arxiv.org/pdf/2306.13122.pdf'
 
-where the link needs to be to the actual remote PDF file.
+... where the link needs to be to the actual remote PDF file.
 
 Command-line interface
 ^^^^^^^^^^^^^^^^^^^^^^

--- a/papis/commands/addto.py
+++ b/papis/commands/addto.py
@@ -12,14 +12,14 @@ that you want to add to a document that matches with the query string
 
     papis addto 'einstein photon definition' -f a.pdf -f b.pdf
 
-... where the ``-f`` flag needs to be repeated for every file that is added. Remote
+where the ``-f`` flag needs to be repeated for every file that is added. Remote
 files can be similarly added using:
 
 .. code:: sh
 
     papis addto 'einstein photon definition' -u 'https://arxiv.org/pdf/2306.13122.pdf'
 
-... where the link needs to be to the actual remote PDF file.
+where the link needs to be to the actual remote PDF file.
 
 Command-line interface
 ^^^^^^^^^^^^^^^^^^^^^^

--- a/papis/commands/bibtex.py
+++ b/papis/commands/bibtex.py
@@ -61,8 +61,8 @@ With this setup, you can just do::
 
     papis bibtex add -q einstein save
 
-Check references' quality
-^^^^^^^^^^^^^^^^^^^^^^^^^
+Check reference quality
+^^^^^^^^^^^^^^^^^^^^^^^
 
 When you're collaborating with someone, you might come across malformed
 or incomplete references. Most journals want to have all the DOIs

--- a/papis/commands/bibtex.py
+++ b/papis/commands/bibtex.py
@@ -8,7 +8,7 @@ the file using information from the library.
 Examples
 ^^^^^^^^
 
-You can use it to open some papers from the BibTeX file by calling
+You can use it to open some papers from the BibTeX file by calling:
 
 .. code:: sh
 
@@ -17,7 +17,7 @@ You can use it to open some papers from the BibTeX file by calling
 This is done by matching the entry in the BibTeX file with a document in your
 library and then opening the corresponding files. If no document can be found in
 the library, then the file cannot be opened, of course. To add papers to the
-BibTeX file (from the current library) you can call
+BibTeX file (from the current library) you can call:
 
 .. code:: sh
 
@@ -28,7 +28,7 @@ BibTeX file (from the current library) you can call
         save new_papers.bib    # Save in new_papers.bib
 
 To update some information that was modified in Papis'
-:ref:`YAML files <info-file>`, you can call
+:ref:`YAML files <info-file>`, you can call:
 
 .. code:: sh
 
@@ -79,7 +79,7 @@ are not cited in the ``.tex`` files by calling::
 and you can then filter them out using the ``filter-cited`` command.
 
 To monitor the health of the project's BibTeX file, you can add a simple target
-to the project's ``Makefile`` like
+to the project's ``Makefile`` like:
 
 .. code:: make
 
@@ -90,7 +90,7 @@ to the project's ``Makefile`` like
 Vim integration
 ^^^^^^^^^^^^^^^
 
-This command can also be easily used from Vim with these simple lines
+This command can also be easily used from Vim with these simple lines:
 
 .. code:: vim
 
@@ -108,7 +108,7 @@ This command can also be easily used from Vim with these simple lines
     command! -nargs=0 BibRef call PapisBibtexRef()
     command! -nargs=0 BibOpen exec "!papis bibtex open"
 
-And use like such: |asciicast|
+And use as such: |asciicast|
 
 .. |asciicast| image:: https://asciinema.org/a/8KbLQJSVYVYNXHVF3wgcxx5Cp.svg
    :target: https://asciinema.org/a/8KbLQJSVYVYNXHVF3wgcxx5Cp
@@ -352,7 +352,7 @@ def cli_edit(ctx: click.Context,
     Edit documents by adding keys or opening an editor.
 
     For example, you can run the following to add a special key ``__proj`` to
-    all the documents
+    all the documents:
 
     .. code:: sh
 
@@ -559,7 +559,7 @@ def cli_doctor(ctx: click.Context, key: List[str]) -> None:
     """
     Check BibTeX file for correctness.
 
-    This can check missing keys, e.g. by running
+    This can check missing keys, e.g. by running:
 
     .. code:: sh
 
@@ -589,7 +589,7 @@ def cli_filter_cited(ctx: click.Context, _files: List[str]) -> None:
     Filter cited documents from the BibTeX file.
 
     for example to filter cited documents in ``main.tex`` and save a unique
-    list of documents in ``cited.bib``, you can run
+    list of documents in ``cited.bib``, you can run:
 
     .. code:: sh
 
@@ -619,7 +619,7 @@ def cli_iscited(ctx: click.Context, _files: List[str]) -> None:
     Check which documents are not cited.
 
     For example, to print a list of documents that have not been cited in
-    both ``main.tex`` and ``chapter-2.tex``, run
+    both ``main.tex`` and ``chapter-2.tex``, run:
 
     .. code:: sh
 
@@ -650,7 +650,7 @@ def cli_import(ctx: click.Context, out: Optional[str], _all: bool) -> None:
     """
     Import documents from a BibTeX file to the current library.
 
-    For example, you can run
+    For example, you can run:
 
     .. code:: sh
 

--- a/papis/commands/bibtex.py
+++ b/papis/commands/bibtex.py
@@ -118,6 +118,7 @@ Command-line interface
 
 .. click:: papis.commands.bibtex:cli
     :prog: papis bibtex
+    :nested: full
 """
 
 import os

--- a/papis/commands/bibtex.py
+++ b/papis/commands/bibtex.py
@@ -8,14 +8,14 @@ the file using information from the library.
 Examples
 ^^^^^^^^
 
-You can use it for opening some papers from the BibTeX file by calling
+You can use it to open some papers from the BibTeX file by calling
 
 .. code:: sh
 
     papis bibtex read new_papers.bib open
 
 This is done by matching the entry in the BibTeX file with a document in your
-library and then opening the correspond files. If no document can be found in
+library and then opening the corresponding files. If no document can be found in
 the library, then the file cannot be opened, of course. To add papers to the
 BibTeX file (from the current library) you can call
 
@@ -34,8 +34,8 @@ To update some information that was modified in Papis'
 
     papis bibtex            \
         read new_papers.bib \ # Read bib file
-        update -f           \ # Update what has been read from papis library
-        save new_papers.bib   # save everything to new_papers.bib, overwriting
+        update -f           \ # Update what has been read from Papis library
+        save new_papers.bib   # Save everything to new_papers.bib, overwriting
 
 .. note::
 
@@ -61,8 +61,8 @@ With this setup, you can just do::
 
     papis bibtex add -q einstein save
 
-Check references quality
-^^^^^^^^^^^^^^^^^^^^^^^^
+Check references' quality
+^^^^^^^^^^^^^^^^^^^^^^^^^
 
 When you're collaborating with someone, you might come across malformed
 or incomplete references. Most journals want to have all the DOIs
@@ -113,7 +113,7 @@ And use like such: |asciicast|
 .. |asciicast| image:: https://asciinema.org/a/8KbLQJSVYVYNXHVF3wgcxx5Cp.svg
    :target: https://asciinema.org/a/8KbLQJSVYVYNXHVF3wgcxx5Cp
 
-Command-line Interface
+Command-line interface
 ^^^^^^^^^^^^^^^^^^^^^^
 
 .. click:: papis.commands.bibtex:cli
@@ -151,10 +151,10 @@ BIBTEX_EXPLORER = get_explorer_by_name("bibtex")
 @click.help_option("-h", "--help")
 @papis.cli.bool_flag(
     "--noar", "--no-auto-read", "no_auto_read",
-    help="Do not auto read the 'default-read-file' (must call 'read' explicitly)")
+    help="Do not auto read the 'default-read-file' (must call 'read' explicitly).")
 @click.pass_context
 def cli(ctx: click.Context, no_auto_read: bool) -> None:
-    """Interact with BibTeX files"""
+    """Interact with BibTeX files."""
     ctx.obj = {"documents": []}
 
     if no_auto_read:
@@ -179,7 +179,7 @@ if BIBTEX_EXPLORER:
 @papis.cli.query_option()
 @click.option(
     "-r", "--refs-file",
-    help="File with references to query in the database and then add",
+    help="File with references to query in the database and then add.",
     type=click.Path(exists=True),
     default=None)
 @click.pass_context
@@ -187,7 +187,7 @@ def cli_add(ctx: click.Context,
             query: str,
             _all: bool,
             refs_file: Optional[str]) -> None:
-    """Add documents from the library to the BibTeX file"""
+    """Add documents from the library to the BibTeX file."""
     from papis.api import get_documents_in_lib, pick_doc
 
     docs = []
@@ -226,17 +226,17 @@ def cli_add(ctx: click.Context,
 @click.help_option("-h", "--help")
 @papis.cli.all_option()
 @papis.cli.bool_flag("--from", "-f", "fromdb",
-                     help="Update the document from the library")
+                     help="Update the document from the library.")
 @papis.cli.bool_flag("-t", "--to", "todb",
-                     help="Update the library document from the BibTeX file")
+                     help="Update the library document from the BibTeX file.")
 @click.option("-k", "--keys",
-              help="Update only given keys (can be given multiple times)",
+              help="Update only given keys (can be given multiple times).",
               type=str,
               multiple=True)
 @click.pass_context
 def cli_update(ctx: click.Context, _all: bool,
                fromdb: bool, todb: bool, keys: List[str]) -> None:
-    """Update documents from and to the library"""
+    """Update documents from and to the library."""
     if fromdb and todb:
         logger.error("Cannot pass both '--from' and '--to'.")
         return
@@ -339,7 +339,7 @@ def cli_open(ctx: click.Context) -> None:
 @cli.command("edit")
 @click.help_option("-h", "--help")
 @click.option("-s", "--set", "set_tuples",
-              help="Update a document with key value pairs",
+              help="Update a document with key value pairs.",
               multiple=True,
               type=(str, papis.cli.FormattedStringParamType()),)
 @papis.cli.all_option()
@@ -432,7 +432,7 @@ def cli_rm(ctx: click.Context) -> None:
 
 @cli.command("ref")
 @click.help_option("-h", "--help")
-@click.option("-o", "--out", help="Output ref to a file", default=None)
+@click.option("-o", "--out", help="Output ref to a file.", default=None)
 @click.pass_context
 def cli_ref(ctx: click.Context, out: Optional[str]) -> None:
     """Print the reference for a document."""
@@ -459,7 +459,7 @@ def cli_ref(ctx: click.Context, out: Optional[str]) -> None:
     "bibfile",
     default=lambda: papis.config.getstring("default-save-bibfile", section="bibtex"),
     required=True, type=click.Path())
-@papis.cli.bool_flag("-f", "--force", help="Do not ask for confirmation when saving")
+@papis.cli.bool_flag("-f", "--force", help="Do not ask for confirmation when saving.")
 @click.pass_context
 def cli_save(ctx: click.Context, bibfile: str, force: bool) -> None:
     """Save the documents in the BibTeX format."""
@@ -481,11 +481,11 @@ def cli_save(ctx: click.Context, bibfile: str, force: bool) -> None:
 @cli.command("sort")
 @click.help_option("-h", "--help")
 @click.option("-k", "--key",
-              help="Field to order by",
+              help="Field to order by.",
               default=None,
               type=str,
               required=True)
-@papis.cli.bool_flag("-r", "--reverse", help="Reverse the sort order")
+@papis.cli.bool_flag("-r", "--reverse", help="Reverse the sort order.")
 @click.pass_context
 def cli_sort(ctx: click.Context, key: Optional[str], reverse: bool) -> None:
     """Sort the documents in the BibTeX file."""
@@ -498,11 +498,11 @@ def cli_sort(ctx: click.Context, key: Optional[str], reverse: bool) -> None:
 @cli.command("unique")
 @click.help_option("-h", "--help")
 @click.option("-k", "--key",
-              help="Field to test for uniqueness, default is ref",
+              help="Field to test for uniqueness, default is ref.",
               default="ref",
               type=str)
 @click.option("-o",
-              help="Output the discarded documents to a file",
+              help="Output the discarded documents to a file.",
               default=None,
               type=str)
 @click.pass_context
@@ -549,7 +549,7 @@ def cli_unique(ctx: click.Context, key: str, o: Optional[str]) -> None:
 @cli.command("doctor")
 @click.help_option("-h", "--help")
 @click.option("-k", "--key",
-              help="Field to test for uniqueness, default is ref",
+              help="Field to test for uniqueness, default is ref.",
               multiple=True,
               default=("doi", "url", "year", "title", "author"),
               type=str)
@@ -580,7 +580,7 @@ def cli_doctor(ctx: click.Context, key: List[str]) -> None:
 @cli.command("filter-cited")
 @click.help_option("-h", "--help")
 @click.option("-f", "--file", "_files",
-              help="Text file to check for references",
+              help="Text file to check for references.",
               multiple=True, required=True, type=str)
 @click.pass_context
 def cli_filter_cited(ctx: click.Context, _files: List[str]) -> None:
@@ -610,7 +610,7 @@ def cli_filter_cited(ctx: click.Context, _files: List[str]) -> None:
 @cli.command("iscited")
 @click.help_option("-h", "--help")
 @click.option("-f", "--file", "_files",
-              help="Text file to check for references",
+              help="Text file to check for references.",
               multiple=True, required=True, type=str)
 @click.pass_context
 def cli_iscited(ctx: click.Context, _files: List[str]) -> None:
@@ -642,7 +642,7 @@ def cli_iscited(ctx: click.Context, _files: List[str]) -> None:
 
 @cli.command("import")
 @click.help_option("-h", "--help")
-@click.option("-o", "--out", help="Out folder to export", default=None)
+@click.option("-o", "--out", help="Out folder to export.", default=None)
 @papis.cli.all_option()
 @click.pass_context
 def cli_import(ctx: click.Context, out: Optional[str], _all: bool) -> None:

--- a/papis/commands/browse.py
+++ b/papis/commands/browse.py
@@ -136,8 +136,8 @@ def run(document: papis.document.Document,
 @papis.cli.query_argument()
 @papis.cli.sort_option()
 @click.option("-k", "--key", default="",
-              help="Use this key in the document as an URL to open in"
-                   " the browser (e.g. doi, url, doc_url)")
+              help="Use this key as the URL to open in the browser "
+                   "(e.g. doi, url, doc_url).")
 @papis.cli.bool_flag(
     "-n", "--print", "_print",
     help="Just print out the URL, do not open it in a browser.")

--- a/papis/commands/browse.py
+++ b/papis/commands/browse.py
@@ -16,42 +16,42 @@ Examples
 
 By default, it will use the configuration option :confval:`browse-key`
 to try and form a URL to browse. You can bypass this option using the ``-k``
-flag issuing the command
+flag issuing the command:
 
 .. code:: sh
 
     papis browse -k doi einstein
 
-This will form a URL through the DOI of the document. Similarly,
+This will form a URL through the DOI of the document. Similarly:
 
 .. code:: sh
 
     papis browse -k isbn
 
-will form a URL through the ISBN of the document using
-`isbnsearch.org <https://isbnsearch.org/>`__. It can also use
+... will form a URL through the ISBN of the document using
+`isbnsearch.org <https://isbnsearch.org/>`__. It can also use:
 
 .. code:: sh
 
     papis browse -k ads
 
-to form a URL using the great `ADS service <https://ui.adsabs.harvard.edu/>`__
+... to form a URL using the great `ADS service <https://ui.adsabs.harvard.edu/>`__
 and there you can check for similar papers, citations, references and much more.
 Please note that for this to work the document should have a DOI attached to it.
-Using
+Using:
 
 .. code:: sh
 
     papis browse -k whatever
 
-will consider the key ``whatever`` from the document to be a valid URL,
-assuming at this point that you'll know what you're doing. Finally, the default
+... will consider the key ``whatever`` from the document to be a valid URL,
+assuming at this point that you'll know what you're doing. Finally, the default:
 
 .. code:: sh
 
     papis browse -k search-engine
 
-will do a ``search-engine`` search with the data of your paper and hopefully
+... will do a ``search-engine`` search with the data of your paper and hopefully
 you'll find it there.
 
 Command-line interface

--- a/papis/commands/browse.py
+++ b/papis/commands/browse.py
@@ -80,10 +80,11 @@ logger = papis.logging.get_logger(__name__)
 
 def run(document: papis.document.Document,
         browse: bool = True) -> Optional[str]:
-    """Browse document's url whenever possible and return the url
+    """Open the document's URL in the selected :confval:`browser`.
 
-    :document: Document object
-
+    :arg browse: if *True*, the URL is opened after it is found, instead of just
+        being returned.
+    :returns: the URL corresponding to this document.
     """
     url = None
     key = papis.config.getstring("browse-key")
@@ -135,11 +136,11 @@ def run(document: papis.document.Document,
 @papis.cli.query_argument()
 @papis.cli.sort_option()
 @click.option("-k", "--key", default="",
-              help="Use the value of the document's key to open in"
-                   " the browser, e.g. doi, url, doc_url ...")
+              help="Use this key in the document as an URL to open in"
+                   " the browser (e.g. doi, url, doc_url)")
 @papis.cli.bool_flag(
     "-n", "--print", "_print",
-    help="Just print out the url, do not open it with browser.")
+    help="Just print out the URL, do not open it in a browser.")
 @papis.cli.all_option()
 @papis.cli.doc_folder_option()
 def cli(query: str,
@@ -149,7 +150,7 @@ def cli(query: str,
         doc_folder: Tuple[str, ...],
         sort_field: Optional[str],
         sort_reverse: bool) -> None:
-    """Open document's url in a browser."""
+    """Open a document URL in a browser."""
     documents = papis.cli.handle_doc_folder_query_all_sort(query,
                                                            doc_folder,
                                                            sort_field,

--- a/papis/commands/browse.py
+++ b/papis/commands/browse.py
@@ -28,14 +28,14 @@ This will form a URL through the DOI of the document. Similarly:
 
     papis browse -k isbn
 
-... will form a URL through the ISBN of the document using
+will form a URL through the ISBN of the document using
 `isbnsearch.org <https://isbnsearch.org/>`__. It can also use:
 
 .. code:: sh
 
     papis browse -k ads
 
-... to form a URL using the great `ADS service <https://ui.adsabs.harvard.edu/>`__
+to form a URL using the great `ADS service <https://ui.adsabs.harvard.edu/>`__
 and there you can check for similar papers, citations, references and much more.
 Please note that for this to work the document should have a DOI attached to it.
 Using:
@@ -44,14 +44,14 @@ Using:
 
     papis browse -k whatever
 
-... will consider the key ``whatever`` from the document to be a valid URL,
+will consider the key ``whatever`` from the document to be a valid URL,
 assuming at this point that you'll know what you're doing. Finally, the default:
 
 .. code:: sh
 
     papis browse -k search-engine
 
-... will do a ``search-engine`` search with the data of your paper and hopefully
+will do a ``search-engine`` search with the data of your paper and hopefully
 you'll find it there.
 
 Command-line interface

--- a/papis/commands/browse.py
+++ b/papis/commands/browse.py
@@ -2,40 +2,40 @@
 This command will try its best to find a source in the internet for the
 document at hand.
 
-If the document has an URL key in its ``info.yaml`` file, it will use this URL
+If the document has a URL key in its ``info.yaml`` file, it will use this URL
 to open it in a browser.  Also if it has a ``doc_url`` key, or a DOI, it will try
 to compose URLs out of these to open it.
 
 If none of the above work, then it will try to use a search engine with the
 document's information (using the :confval:`browse-query-format`
-configuration option).  You can select which search engine you want to use
+configuration option). You can select which search engine you want to use
 with the :confval:`search-engine` setting.
 
 Examples
 ^^^^^^^^
 
 By default, it will use the configuration option :confval:`browse-key`
-to try and form an URL to browse. You can bypass this option using the ``-k``
+to try and form a URL to browse. You can bypass this option using the ``-k``
 flag issuing the command
 
 .. code:: sh
 
     papis browse -k doi einstein
 
-This will form an URL through the DOI of the document. Similarly,
+This will form a URL through the DOI of the document. Similarly,
 
 .. code:: sh
 
     papis browse -k isbn
 
-will form an URL through the ISBN of the document using
+will form a URL through the ISBN of the document using
 `isbnsearch.org <https://isbnsearch.org/>`__. It can also use
 
 .. code:: sh
 
     papis browse -k ads
 
-to form an URL using the great `ADS service <https://ui.adsabs.harvard.edu/>`__
+to form a URL using the great `ADS service <https://ui.adsabs.harvard.edu/>`__
 and there you can check for similar papers, citations, references and much more.
 Please note that for this to work the document should have a DOI attached to it.
 Using
@@ -54,7 +54,7 @@ assuming at this point that you'll know what you're doing. Finally, the default
 will do a ``search-engine`` search with the data of your paper and hopefully
 you'll find it there.
 
-Command-line Interface
+Command-line interface
 ^^^^^^^^^^^^^^^^^^^^^^
 
 .. click:: papis.commands.browse:cli
@@ -80,7 +80,7 @@ logger = papis.logging.get_logger(__name__)
 
 def run(document: papis.document.Document,
         browse: bool = True) -> Optional[str]:
-    """Browse document's url whenever possible and returns the url
+    """Browse document's url whenever possible and return the url
 
     :document: Document object
 
@@ -139,7 +139,7 @@ def run(document: papis.document.Document,
                    " the browser, e.g. doi, url, doc_url ...")
 @papis.cli.bool_flag(
     "-n", "--print", "_print",
-    help="Just print out the url, do not open it with browser")
+    help="Just print out the url, do not open it with browser.")
 @papis.cli.all_option()
 @papis.cli.doc_folder_option()
 def cli(query: str,
@@ -149,7 +149,7 @@ def cli(query: str,
         doc_folder: Tuple[str, ...],
         sort_field: Optional[str],
         sort_reverse: bool) -> None:
-    """Open document's url in a browser"""
+    """Open document's url in a browser."""
     documents = papis.cli.handle_doc_folder_query_all_sort(query,
                                                            doc_folder,
                                                            sort_field,

--- a/papis/commands/browse.py
+++ b/papis/commands/browse.py
@@ -3,7 +3,7 @@ This command will try its best to find a source in the internet for the
 document at hand.
 
 If the document has a URL key in its ``info.yaml`` file, it will use this URL
-to open it in a browser.  Also if it has a ``doc_url`` key, or a DOI, it will try
+to open it in a browser. If it has a ``doc_url`` key, or a DOI, it will try
 to compose URLs out of these to open it.
 
 If none of the above work, then it will try to use a search engine with the

--- a/papis/commands/cache.py
+++ b/papis/commands/cache.py
@@ -1,5 +1,5 @@
 """
-This command allows the user to interact with the Papis cache or database.
+This command allows the user to interact with the Papis cache (database).
 
 To clear the cache (remove it from the filesystem), you can run the following
 command

--- a/papis/commands/cache.py
+++ b/papis/commands/cache.py
@@ -41,6 +41,12 @@ the cache for those documents that have been synchronized by the means
 of synchronization that you are using, for instance using git, Syncthing,
 Dropbox, etc.
 
+Command-line interface
+^^^^^^^^^^^^^^^^^^^^^^
+
+.. click:: papis.commands.cache:cli
+    :prog: papis cache
+    :nested: full
 """
 import os
 from typing import Optional, Tuple
@@ -62,7 +68,7 @@ logger = papis.logging.get_logger(__name__)
 @click.help_option("--help", "-h")
 def cli() -> None:
     """
-    Manage the cache or database of a Papis library.
+    Manage the cache (database) of a Papis library.
     """
 
 

--- a/papis/commands/cache.py
+++ b/papis/commands/cache.py
@@ -1,5 +1,5 @@
 """
-This command allows the user to interact with the papis cache or papis database.
+This command allows the user to interact with the Papis cache or database.
 
 To clear the cache (remove it from the filesystem), you can run the following
 command
@@ -11,7 +11,7 @@ command
 This command is also useful for plugin developers.
 Let us suppose that you are editing the YAML file of a document at path
 ``/path/to/info.yaml``.
-If you are editing this file without the machinery of papis
+If you are editing this file without the machinery of Papis
 you might want to make Papis be aware of this change by using the ``update``
 subcommand. You might do
 

--- a/papis/commands/cache.py
+++ b/papis/commands/cache.py
@@ -2,7 +2,7 @@
 This command allows the user to interact with the Papis cache (database).
 
 To clear the cache (remove it from the filesystem), you can run the following
-command
+command:
 
 ::
 
@@ -13,13 +13,13 @@ Let us suppose that you are editing the YAML file of a document at path
 ``/path/to/info.yaml``.
 If you are editing this file without the machinery of Papis
 you might want to make Papis be aware of this change by using the ``update``
-subcommand. You might do
+subcommand. You might do:
 
 ::
 
     papis cache update --doc-folder /path/to
 
-or maybe by query
+... or maybe by query:
 
 ::
 
@@ -29,7 +29,7 @@ Furthermore, a noteworthy subcommand is ``update-newer``, which
 updates the cache for those documents whose info file is newer than
 the cache itself.  This subcommand has the same interface as most
 ``papis`` commands, so that if you want to check all documents you have to
-input
+input:
 
 ::
 

--- a/papis/commands/cache.py
+++ b/papis/commands/cache.py
@@ -12,7 +12,7 @@ This command is also useful for plugin developers.
 Let us suppose that you are editing the YAML file of a document at path
 ``/path/to/info.yaml``.
 If you are editing this file without the machinery of Papis
-you might want to make Papis be aware of this change by using the ``update``
+you might want to make Papis aware of this change by using the ``update``
 subcommand. You might do:
 
 ::

--- a/papis/commands/cache.py
+++ b/papis/commands/cache.py
@@ -19,7 +19,7 @@ subcommand. You might do:
 
     papis cache update --doc-folder /path/to
 
-... or maybe by query:
+or maybe by query:
 
 ::
 

--- a/papis/commands/citations.py
+++ b/papis/commands/citations.py
@@ -5,34 +5,34 @@ The ``citations`` command updates and creates the ``citations.yaml`` and
 Examples
 ^^^^^^^^
 
-- Create the ``citations.yaml`` file for a document that you pick
+- Create the ``citations.yaml`` file for a document that you pick:
 
     .. code:: sh
 
         papis citations --fetch-citations
 
-- Create the ``citations.yaml`` file for all documents matching an author
+- Create the ``citations.yaml`` file for all documents matching an author:
 
     .. code:: sh
 
         papis citations --all --fetch-citations 'author:einstein'
 
 - Overwrite the ``citations.yaml`` file with the ``--force`` flag for all
-  papers matching a query
+  papers matching a query:
 
     .. code:: sh
 
         papis citations --force --fetch-citations 'author:einstein'
 
 - Update the ``citations.yaml`` file with citations of documents existing in
-  your library
+  your library:
 
     .. code:: sh
 
         papis citations --all --update-from-database 'author:einstein'
 
 - Create the ``cited-by.yaml`` for all documents in your library (this might
-  take a while)
+  take a while):
 
     .. code:: sh
 

--- a/papis/commands/citations.py
+++ b/papis/commands/citations.py
@@ -1,6 +1,6 @@
 """
 The ``citations`` command updates and creates the ``citations.yaml`` and
-``cited.yaml`` files for every document.
+``cited-by.yaml`` files for every document.
 
 Examples
 ^^^^^^^^
@@ -38,7 +38,7 @@ Examples
 
         papis citations --fetch-cited-by --all
 
-Command-line Interface
+Command-line interface
 ^^^^^^^^^^^^^^^^^^^^^^
 
 .. click:: papis.commands.citations:cli
@@ -66,13 +66,13 @@ logger = papis.logging.get_logger(__name__)
 @papis.cli.query_argument()
 @papis.cli.sort_option()
 @papis.cli.bool_flag("-c", "--fetch-citations",
-                     help="Fetch and save citations from Crossref")
+                     help="Fetch and save citations from Crossref.")
 @papis.cli.bool_flag("-d", "--update-from-database",
-                     help="Fetch and save citations from database")
+                     help="Fetch and save citations from database.")
 @papis.cli.bool_flag("-b", "--fetch-cited-by",
-                     help="Fetch and save cited-by from database")
+                     help="Fetch and save cited-by from database.")
 @papis.cli.bool_flag("-f", "--force",
-                     help="Force action")
+                     help="Force action.")
 @papis.cli.all_option()
 @papis.cli.doc_folder_option()
 def cli(query: str,
@@ -84,7 +84,7 @@ def cli(query: str,
         fetch_citations: bool,
         fetch_cited_by: bool,
         update_from_database: bool) -> None:
-    """Handle document citations"""
+    """Handle document citations."""
     documents = papis.cli.handle_doc_folder_query_all_sort(query,
                                                            doc_folder,
                                                            sort_field,

--- a/papis/commands/config.py
+++ b/papis/commands/config.py
@@ -8,13 +8,13 @@ Examples
 The ``config`` command returns the value used by Papis. Therefore, if you
 have not customized some setting, it will return the default value. In contrast,
 if you have customized it, it will return the value set in the configuration
-file. For example, to find out to what your "default-library" is set to, call:
+file. For example, to find out what your "default-library" is set to, call:
 
 .. code::
 
     papis config default-library
 
-The ``config`` command can also be used to query a settings' default
+The ``config`` command can also be used to query a setting's default
 value. This is done by adding the ``--default`` flag. This ignores all
 settings set in your Papis configuration file (note, however, that
 settings set in a ``config.py`` script can count as default values). Check the
@@ -63,7 +63,7 @@ You can find a list of all available settings in the configuration section
 at :ref:`general-settings`. Commands and other plugins can define their own
 settings, which are documented separately.
 
-Command-line Interface
+Command-line interface
 ^^^^^^^^^^^^^^^^^^^^^^
 
 .. click:: papis.commands.config:cli
@@ -219,20 +219,20 @@ def run(
 @click.argument("options", nargs=-1)
 @click.option(
     "-s", "--section",
-    help="select a default section for the options",
+    help="Select a default section for the options.",
     default=None)
 @papis.cli.bool_flag(
     "-d", "--default",
     help="List default configuration setting values, instead of those in the "
-         "configuration file")
+         "configuration file.")
 @papis.cli.bool_flag(
     "--json", "print_json",
-    help="Print settings in a JSON format")
+    help="Print settings in a JSON format.")
 def cli(options: List[str],
         section: Optional[str],
         default: bool,
         print_json: bool) -> None:
-    """Print configuration values"""
+    """Print configuration values."""
     if len(options) == 1:
         # NOTE: a single option is printed directly for a bit of backwards
         # compatibility and easier use in shell scripts, so remove with care!

--- a/papis/commands/config.py
+++ b/papis/commands/config.py
@@ -33,7 +33,7 @@ settings can be accessed with:
     papis config --section bibtex
     papis config --default --section bibtex
 
-or with ``papis config`` (without the section argument) to show the settings
+... or with ``papis config`` (without the section argument) to show the settings
 available for all the known sections.
 
 You can also query a specific setting within a section. For example like this:

--- a/papis/commands/config.py
+++ b/papis/commands/config.py
@@ -33,7 +33,7 @@ settings can be accessed with:
     papis config --section bibtex
     papis config --default --section bibtex
 
-... or with ``papis config`` (without the section argument) to show the settings
+or with ``papis config`` (without the section argument) to show the settings
 available for all the known sections.
 
 You can also query a specific setting within a section. For example like this:

--- a/papis/commands/default.py
+++ b/papis/commands/default.py
@@ -15,13 +15,13 @@ Examples
         papis --set editor gedit --set opentool firefox open
 
 - If you want to list the libraries and pick one before sending a database
-  query to papis, use ``--pick-lib`` as such
+  query to Papis, use ``--pick-lib`` as such
 
     .. code:: sh
 
         papis --pick-lib open 'einstein relativity'
 
-Command-line Interface
+Command-line interface
 ^^^^^^^^^^^^^^^^^^^^^^
 
 .. click:: papis.commands.default:run
@@ -128,50 +128,50 @@ def generate_profile_writing_function(profiler: "cProfile.Profile",
 @click.version_option(version=papis.__version__)
 @papis.cli.bool_flag(
     "-v", "--verbose",
-    help="Make the output verbose (equivalent to --log DEBUG)",
+    help="Make the output verbose (equivalent to --log DEBUG).",
     default="PAPIS_DEBUG" in os.environ)
 @click.option(
     "--profile",
-    help="Print profiling information into file",
+    help="Print profiling information into file.",
     type=click.Path(),
     default=None)
 @click.option(
     "-l", "--lib",
-    help="Choose a library name or library path (unnamed library)",
+    help="Choose a library name or library path (unnamed library).",
     default=lambda: papis.config.getstring("default-library"))
 @click.option(
     "-c",
     "--config",
-    help="Configuration file to use",
+    help="Configuration file to use.",
     type=click.Path(exists=True),
     default=None)
 @papis.cli.bool_flag(
     "--pick-lib",
-    help="Pick library to use")
+    help="Pick library to use.")
 @click.option(
     "-s", "--set", "set_list",
     type=(str, str),
     multiple=True,
     help="Set key value, e.g., "
-         "--set info-name information.yaml --set opentool evince")
+         "'--set info-name information.yaml --set opentool evince'.")
 @click.option(
     "--color",
     type=click.Choice(["always", "auto", "no"]),
     default=os.environ.get("PAPIS_LOG_COLOR", "auto"),
-    help="Prevent the output from having color")
+    help="Prevent the output from having color.")
 @click.option(
     "--log",
-    help="Logging level",
+    help="Logging level.",
     type=click.Choice(["INFO", "DEBUG", "WARNING", "ERROR", "CRITICAL"]),
     default=os.environ.get("PAPIS_LOG_LEVEL", "INFO"))
 @click.option(
     "--logfile",
-    help="File to dump the log",
+    help="File to dump the log.",
     type=str,
     default=os.environ.get("PAPIS_LOG_FILE"))
 @click.option(
     "--np",
-    help="Use number of processors for multicore functionalities in papis",
+    help="Use number of processors for multicore functionalities in Papis.",
     type=str,
     default=None)
 @click.pass_context

--- a/papis/commands/default.py
+++ b/papis/commands/default.py
@@ -7,7 +7,7 @@ Examples
 
 - To override some configuration options, you can use the ``--set`` flag. For
   instance, if you want to override the ``editor`` used to edit files or the
-  ``opentool`` used to open documents, you can just type
+  ``opentool`` used to open documents, you can just type:
 
     .. code:: sh
 
@@ -15,7 +15,7 @@ Examples
         papis --set editor gedit --set opentool firefox open
 
 - If you want to list the libraries and pick one before sending a database
-  query to Papis, use ``--pick-lib`` as such
+  query to Papis, use ``--pick-lib`` as such:
 
     .. code:: sh
 

--- a/papis/commands/doctor.py
+++ b/papis/commands/doctor.py
@@ -38,7 +38,7 @@ implemented
 * ``refs``: checks that the document has a valid reference (i.e. one that would
   be accepted by BibTeX and only contains valid characters).
 
-If any custom checks are implemented, you can get a complete list at runtime from
+If any custom checks are implemented, you can get a complete list at runtime from:
 
 .. code:: sh
 
@@ -47,26 +47,26 @@ If any custom checks are implemented, you can get a complete list at runtime fro
 Examples
 ^^^^^^^^
 
-- To run all available checks over all available documents in the library use
+- To run all available checks over all available documents in the library use:
 
     .. code:: sh
 
         papis doctor --all-checks --all
 
-  This will likely generate too many results, but it can be useful to output in JSON
+  This will likely generate too many results, but it can be useful to output in JSON:
 
     .. code:: sh
 
         papis doctor --all-checks --all --json
 
-- To check if all the files of a document are present, use
+- To check if all the files of a document are present, use:
 
     .. code:: sh
 
         papis doctor --checks files einstein
 
 - To check if any unwanted HTML tags are present in your documents (especially
-  abstracts can be full of additional HTML or XML tags) use
+  abstracts can be full of additional HTML or XML tags) use:
 
     .. code:: sh
 
@@ -74,7 +74,7 @@ Examples
 
   The ``--explain`` flag can be used to give additional details of checks that
   failed. Some checks such as this also have automatic fixers. Here, we can just
-  remove all the HTML tags by writing
+  remove all the HTML tags by writing:
 
     .. code:: sh
 
@@ -82,7 +82,7 @@ Examples
 
 - If an automatic fix is not possible, some checks also have suggested
   commands or tips to fix the issue that was found. For example, if a key
-  does not exist in the document, it can suggest editing the file to add it.
+  does not exist in the document, it can suggest editing the file to add it:
 
     .. code:: sh
 
@@ -90,7 +90,7 @@ Examples
         >> Suggestion: papis edit --doc-folder /path/to/folder
 
   If this is the case, you can also run the following to automatically open
-  the ``info.yaml`` file for editing more complex changes
+  the ``info.yaml`` file for editing more complex changes:
 
     .. code:: sh
 
@@ -102,7 +102,7 @@ Implementing additional checks
 
 A check is just a function that takes a document and returns a list of errors.
 A skeleton implementation that gets added to ``config.py``
-(see :ref:`config_py`) can be implemented as follows
+(see :ref:`config_py`) can be implemented as follows:
 
 .. code:: python
 

--- a/papis/commands/doctor.py
+++ b/papis/commands/doctor.py
@@ -73,16 +73,16 @@ Examples
         papis doctor --explain --checks html-tags einstein
 
   The ``--explain`` flag can be used to give additional details of checks that
-  failed. Some checks such as this also have automatic fixers. Here, we can just
-  remove all the HTML tags by writing:
+  failed. This check, and some others, also have automatic fixers. Here, we can
+  just remove all the HTML tags by writing:
 
     .. code:: sh
 
         papis doctor --fix --checks html-tags einstein
 
 - If an automatic fix is not possible, some checks also have suggested
-  commands or tips to fix the issue that was found. For example, if a key
-  does not exist in the document, it can suggest editing the file to add it:
+  commands or tips to fix issues. For example, if a key does not exist
+  in the document, it can suggest editing the file to add it:
 
     .. code:: sh
 

--- a/papis/commands/doctor.py
+++ b/papis/commands/doctor.py
@@ -73,7 +73,7 @@ Examples
         papis doctor --explain --checks html-tags einstein
 
   The ``--explain`` flag can be used to give additional details of checks that
-  failed. Some fixes such as this also have automatic fixers. Here, we can just
+  failed. Some checks such as this also have automatic fixers. Here, we can just
   remove all the HTML tags by writing
 
     .. code:: sh
@@ -113,7 +113,7 @@ A skeleton implementation that gets added to ``config.py``
 
     register_check("my-custom-check", my_custom_check)
 
-Command-line Interface
+Command-line interface
 ^^^^^^^^^^^^^^^^^^^^^^
 
 .. click:: papis.commands.doctor:cli
@@ -145,7 +145,7 @@ CheckFn = Callable[[papis.document.Document], List["Error"]]
 
 
 class Error(NamedTuple):
-    """A detailed error error returned by a doctor check."""
+    """A detailed error returned by a doctor check."""
 
     #: Name of the check generating the error.
     name: str
@@ -1089,19 +1089,19 @@ def run(doc: papis.document.Document,
                                 + list(DEPRECATED_CHECK_NAMES)),
               help="Checks to run on every document.")
 @papis.cli.bool_flag("--json", "_json",
-                     help="Output the results in JSON format")
+                     help="Output the results in JSON format.")
 @papis.cli.bool_flag("--fix",
-                     help="Auto fix the errors with the auto fixer mechanism")
+                     help="Auto fix the errors with the auto fixer mechanism.")
 @papis.cli.bool_flag("-s", "--suggest",
-                     help="Suggest commands to be run for resolution")
+                     help="Suggest commands to be run for resolution.")
 @papis.cli.bool_flag("-e", "--explain",
-                     help="Give a short message for the reason of the error")
+                     help="Give a short message for the reason of the error.")
 @papis.cli.bool_flag("--edit",
                      help="Edit every file with the edit command.")
 @papis.cli.all_option()
 @papis.cli.doc_folder_option()
 @papis.cli.bool_flag("--all-checks", "all_checks",
-                     help="Run all available checks (ignores --checks)")
+                     help="Run all available checks (ignores --checks).")
 def cli(query: str,
         doc_folder: Tuple[str, ...],
         sort_field: Optional[str],
@@ -1114,7 +1114,7 @@ def cli(query: str,
         _json: bool,
         suggest: bool,
         all_checks: bool) -> None:
-    """Check for common problems in documents"""
+    """Check for common problems in documents."""
     documents = papis.cli.handle_doc_folder_query_all_sort(
         query, doc_folder, sort_field, sort_reverse, _all)
 

--- a/papis/commands/doctor.py
+++ b/papis/commands/doctor.py
@@ -73,7 +73,7 @@ Examples
         papis doctor --explain --checks html-tags einstein
 
   The ``--explain`` flag can be used to give additional details of checks that
-  failed. This check, and some others, also have automatic fixers. Here, we can
+  failed. This check (and some others) also has automatic fixers. Here, we can
   just remove all the HTML tags by writing:
 
     .. code:: sh

--- a/papis/commands/edit.py
+++ b/papis/commands/edit.py
@@ -3,7 +3,7 @@ This command edits the :ref:`info.yaml file <info-file>` of the documents.
 The editor used is defined by the :confval:`editor` configuration
 setting.
 
-Command-line Interface
+Command-line interface
 ^^^^^^^^^^^^^^^^^^^^^^
 
 .. click:: papis.commands.edit:cli
@@ -78,16 +78,16 @@ def edit_notes(document: papis.document.Document,
 @click.help_option("-h", "--help")
 @papis.cli.query_argument()
 @papis.cli.doc_folder_option()
-@papis.cli.git_option(help="Add changes made to the info file")
+@papis.cli.git_option(help="Add changes made to the info file.")
 @papis.cli.sort_option()
 @papis.cli.bool_flag(
     "-n", "--notes",
-    help="Edit notes associated to the document")
+    help="Edit notes associated to the document.")
 @papis.cli.all_option()
 @click.option(
     "-e",
     "--editor",
-    help="Editor to be used",
+    help="Editor to be used.",
     default=None)
 def cli(query: str,
         doc_folder: Tuple[str, ...],
@@ -97,7 +97,7 @@ def cli(query: str,
         editor: Optional[str],
         sort_field: Optional[str],
         sort_reverse: bool) -> None:
-    """Edit document information from a given library"""
+    """Edit document information from a given library."""
     documents = papis.cli.handle_doc_folder_query_all_sort(query,
                                                            doc_folder,
                                                            sort_field,

--- a/papis/commands/exec.py
+++ b/papis/commands/exec.py
@@ -26,7 +26,7 @@ Examples
 
         papis exec my-script.py -- -h
 
-Command-line Interface
+Command-line interface
 ^^^^^^^^^^^^^^^^^^^^^^
 
 .. click:: papis.commands.exec:cli

--- a/papis/commands/explore.py
+++ b/papis/commands/explore.py
@@ -5,9 +5,9 @@ for a project before adding it to the Papis libraries.
 Examples
 ^^^^^^^^
 
-Imagine you want to search for some papers online, but you don't want to
-go into a browser and look for it. The ``explore`` command gives you a way to do
-this using several services available online. More should be coming on the way!
+Imagine you want to search for some papers online but don't want to open the
+browser to look for them. The ``explore`` command gives you a way to do this
+using several online services.
 
 An excellent resource for this is `Crossref <https://www.crossref.org/>`__.
 You can use it by using the ``crossref`` subcommand:
@@ -27,7 +27,7 @@ Doing a simple:
 will tell you which commands are available. Let us suppose that you want to
 look for some documents on Crossref, say some papers of Schrodinger's, and
 you want to store them into a BibTeX file called ``lib.bib``. Then you could
-concatenate the commands ``crossref`` and ``export --format bibtex`` as such:
+concatenate the commands ``crossref`` and ``export --format bibtex``:
 
 .. code:: sh
 
@@ -64,7 +64,7 @@ the file ``special-picked-documents.bib``, and we could go on and on.
 
 If you want to follow up on these documents and get them to pick one again,
 you could use the ``yaml`` command to read in document information from a YAML
-file, e.g. the previously created ``docs.yaml``, do for example:
+file, e.g. the previously created ``docs.yaml``:
 
 .. code:: sh
 
@@ -177,7 +177,7 @@ def lib(ctx: click.Context,
 @click.option("--number", "-n",
               type=int,
               default=None,
-              help="Pick automatically the n-th document.")
+              help="Automatically pick the n-th document.")
 def pick(ctx: click.Context, number: Optional[int]) -> None:
     """
     Pick a document from the retrieved documents.

--- a/papis/commands/explore.py
+++ b/papis/commands/explore.py
@@ -6,7 +6,7 @@ Examples
 ^^^^^^^^
 
 Imagine you want to search for some papers online, but you don't want to
-go into a browser and look for it. The ``explore`` command gives you way to do
+go into a browser and look for it. The ``explore`` command gives you a way to do
 this using several services available online. More should be coming on the way!
 
 An excellent resource for this is `Crossref <https://www.crossref.org/>`__.
@@ -25,7 +25,7 @@ Doing a simple
     papis explore crossref -h
 
 will tell you which commands are available. Let us suppose that you want to
-look for some documents on Crossref, say some papers of Schroedinger's, and
+look for some documents on Crossref, say some papers of Schrodinger's, and
 you want to store them into a BibTeX file called ``lib.bib``. Then you could
 concatenate the commands ``crossref`` and ``export --format bibtex`` as such
 
@@ -37,7 +37,7 @@ This will store everything that you got from Crossref in the ``lib.bib`` file.
 However, ``explore`` is much more flexible than that. You can also pick just
 one document to store. For instance, let's assume that you don't want to store
 all retrieved documents but only one that you pick. The ``pick`` command will
-take care of it
+take care of it:
 
 .. code:: sh
 
@@ -49,7 +49,7 @@ More generally you could write something like
 .. code:: sh
 
     papis explore \\
-        crossref -a 'Schroedinger' \\
+        crossref -a 'Schrodinger' \\
         crossref -a 'Einstein' \\
         arxiv -a 'Felix Hummel' \\
         export --format yaml --out 'docs.yaml' \\
@@ -62,9 +62,9 @@ Hummel. At the end, all these documents will be stored in the ``docs.yaml`` file
 After that we pick one document from them and store the information in
 the file ``special-picked-documents.bib``, and we could go on and on.
 
-If you want to follow-up on these documents and get them again to pick one,
+If you want to follow up on these documents and get them to pick one again,
 you could use the ``yaml`` command to read in document information from a YAML
-file, e.g. the previously created ``docs.yaml``,
+file, e.g. the previously created ``docs.yaml``, do for example
 
 .. code:: sh
 
@@ -82,7 +82,7 @@ Papis template syntax.  In this case, the picked document gets fed into the
 Also this very document is opened by Firefox (in case the document does have a
 ``url``).
 
-Command-line Interface
+Command-line interface
 ^^^^^^^^^^^^^^^^^^^^^^
 
 .. click:: papis.commands.explore:cli
@@ -145,7 +145,7 @@ def get_explorer_by_name(name: str) -> Optional[click.Command]:
 @click.help_option("--help", "-h")
 @papis.cli.query_argument()
 @papis.cli.doc_folder_option()
-@click.option("--library", "-l", default=None, help="Papis library to look")
+@click.option("--library", "-l", default=None, help="Papis library to look in.")
 def lib(ctx: click.Context,
         query: str,
         doc_folder: Tuple[str, ...],
@@ -177,7 +177,7 @@ def lib(ctx: click.Context,
 @click.option("--number", "-n",
               type=int,
               default=None,
-              help="Pick automatically the n-th document")
+              help="Pick automatically the n-th document.")
 def pick(ctx: click.Context, number: Optional[int]) -> None:
     """
     Pick a document from the retrieved documents.
@@ -206,7 +206,7 @@ def pick(ctx: click.Context, number: Optional[int]) -> None:
 @papis.cli.doc_folder_option()
 @click.help_option("--help", "-h")
 @papis.cli.bool_flag("-b", "--cited-by",
-                     help="Use the cited-by citations")
+                     help="Use the cited-by citations.")
 @papis.cli.all_option()
 def citations(ctx: click.Context,
               query: str,
@@ -273,7 +273,7 @@ def cmd(ctx: click.Context, command: str) -> None:
     """
     Run a general command on the document list.
 
-    For example, to look for 200 Schroedinger papers with
+    For example, to look for 200 Schrodinger papers with
     `Crossref <https://www.crossref.org/>`__, pick one, and add it to the
     current library via ``papis-scihub``, you can call
 

--- a/papis/commands/explore.py
+++ b/papis/commands/explore.py
@@ -24,7 +24,7 @@ Doing a simple:
 
     papis explore crossref -h
 
-... will tell you which commands are available. Let us suppose that you want to
+will tell you which commands are available. Let us suppose that you want to
 look for some documents on Crossref, say some papers of Schrodinger's, and
 you want to store them into a BibTeX file called ``lib.bib``. Then you could
 concatenate the commands ``crossref`` and ``export --format bibtex`` as such:

--- a/papis/commands/explore.py
+++ b/papis/commands/explore.py
@@ -18,16 +18,16 @@ You can use it by using the ``crossref`` subcommand:
 
 If you issue this command, you will see some text but basically nothing
 will happen. This is because ``explore`` is conceived as a concatenating command.
-Doing a simple
+Doing a simple:
 
 .. code:: sh
 
     papis explore crossref -h
 
-will tell you which commands are available. Let us suppose that you want to
+... will tell you which commands are available. Let us suppose that you want to
 look for some documents on Crossref, say some papers of Schrodinger's, and
 you want to store them into a BibTeX file called ``lib.bib``. Then you could
-concatenate the commands ``crossref`` and ``export --format bibtex`` as such
+concatenate the commands ``crossref`` and ``export --format bibtex`` as such:
 
 .. code:: sh
 
@@ -44,7 +44,7 @@ take care of it:
     papis explore crossref -a 'Schrodinger' pick export --format bibtex --out 'lib.bib'
 
 Notice how the ``pick`` command is situated before the ``export``.
-More generally you could write something like
+More generally you could write something like:
 
 .. code:: sh
 
@@ -64,7 +64,7 @@ the file ``special-picked-documents.bib``, and we could go on and on.
 
 If you want to follow up on these documents and get them to pick one again,
 you could use the ``yaml`` command to read in document information from a YAML
-file, e.g. the previously created ``docs.yaml``, do for example
+file, e.g. the previously created ``docs.yaml``, do for example:
 
 .. code:: sh
 
@@ -154,7 +154,7 @@ def lib(ctx: click.Context,
     Query for documents in your library.
 
     For example, to query all the documents containing "einstein" in the "books"
-    library, you can call
+    library, you can call:
 
     .. code:: sh
 
@@ -183,7 +183,7 @@ def pick(ctx: click.Context, number: Optional[int]) -> None:
     Pick a document from the retrieved documents.
 
     For example, to open a picker with the documents in a BibTeX file,
-    you can call
+    you can call:
 
     .. code:: sh
 
@@ -217,7 +217,7 @@ def citations(ctx: click.Context,
     Query the citations for a paper.
 
     For example, to go through the citations of a paper and export it in a
-    YAML file, you can call
+    YAML file, you can call:
 
     .. code:: sh
 
@@ -254,7 +254,7 @@ def add(ctx: click.Context) -> None:
     """
     Add selected documents to the current library.
 
-    For example, to add documents from a BibTeX file, you can call
+    For example, to add documents from a BibTeX file, you can call:
 
     .. code:: sh
 
@@ -275,7 +275,7 @@ def cmd(ctx: click.Context, command: str) -> None:
 
     For example, to look for 200 Schrodinger papers with
     `Crossref <https://www.crossref.org/>`__, pick one, and add it to the
-    current library via ``papis-scihub``, you can call
+    current library via ``papis-scihub``, you can call:
 
     .. code:: sh
 

--- a/papis/commands/export.py
+++ b/papis/commands/export.py
@@ -21,19 +21,19 @@ or export all of them
 
 - Export all documents to BibTeX and save them into a ``lib.bib`` file
 
-.. code::
+.. code:: sh
 
     papis export --all --format bibtex --out lib.bib
 
 - Export a folder of one of the documents matching the word ``krebs``
   into a folder named ``interesting-document``
 
-.. code::
+.. code:: sh
 
     papis export --folder --out interesting-document krebs
 
-  this will create the folder ``interesting-document`` containing the
-  ``info.yaml`` file and the linked documents.
+This will create the folder ``interesting-document`` containing the
+``info.yaml`` file and the linked documents.
 
 .. note::
 
@@ -42,7 +42,7 @@ or export all of them
     is stored in the file system. This is done for the convenience of third
     party apps.
 
-Command-line Interface
+Command-line interface
 ^^^^^^^^^^^^^^^^^^^^^^
 
 .. click:: papis.commands.export:cli
@@ -102,16 +102,16 @@ def run(documents: List[papis.document.Document], to_format: str) -> str:
 @papis.cli.all_option()
 @papis.cli.bool_flag(
     "--folder",
-    help="Export document folder to share")
+    help="Export document folder to share.")
 @click.option(
     "-o",
     "--out",
-    help="Outfile or outdir",
+    help="Outfile or outdir.",
     default=None)
 @click.option(
     "-f",
     "--format", "fmt",
-    help="Format for the document",
+    help="Format for the document.",
     type=click.Choice(available_formats()),
     default="bibtex",)
 def cli(query: str,
@@ -122,7 +122,7 @@ def cli(query: str,
         out: str,
         fmt: str,
         _all: bool) -> None:
-    """Export a document from a given library"""
+    """Export a document from a given library."""
 
     documents = papis.cli.handle_doc_folder_query_all_sort(query,
                                                            doc_folder,
@@ -174,20 +174,20 @@ def cli(query: str,
 @click.help_option("--help", "-h")
 @click.option(
     "-f", "--format", "fmt",
-    help="Format for the document",
+    help="Format for the document.",
     type=click.Choice(available_formats()),
     default="bibtex",)
 @click.option(
     "-o",
     "--out",
-    help="Outfile to write information to",
+    help="Outfile to write information to.",
     type=click.Path(),
     default=None,)
 def explorer(ctx: click.Context, fmt: str, out: str) -> None:
     """
     Export retrieved documents into various formats.
 
-    For example, to query Crossref an export all 200 documents to a YAML file,
+    For example, to query Crossref and export all 200 documents to a YAML file,
     you can call
 
     .. code:: sh

--- a/papis/commands/export.py
+++ b/papis/commands/export.py
@@ -7,26 +7,26 @@ Examples
 
 Some examples of its usage are:
 
-- Export one of the documents matching the author with Einstein to BibTeX
+- Export one of the documents matching the author with Einstein to BibTeX:
 
 .. code:: sh
 
     papis export --format bibtex 'author : einstein'
 
-or export all of them
+... or export all of them:
 
 .. code:: sh
 
     papis export --format bibtex --all 'author : einstein'
 
-- Export all documents to BibTeX and save them into a ``lib.bib`` file
+- Export all documents to BibTeX and save them into a ``lib.bib`` file:
 
 .. code:: sh
 
     papis export --all --format bibtex --out lib.bib
 
 - Export a folder of one of the documents matching the word ``krebs``
-  into a folder named ``interesting-document``
+  into a folder named ``interesting-document``:
 
 .. code:: sh
 
@@ -188,7 +188,7 @@ def explorer(ctx: click.Context, fmt: str, out: str) -> None:
     Export retrieved documents into various formats.
 
     For example, to query Crossref and export all 200 documents to a YAML file,
-    you can call
+    you can call:
 
     .. code:: sh
 

--- a/papis/commands/export.py
+++ b/papis/commands/export.py
@@ -13,7 +13,7 @@ Some examples of its usage are:
 
     papis export --format bibtex 'author : einstein'
 
-... or export all of them:
+or export all of them:
 
 .. code:: sh
 

--- a/papis/commands/git.py
+++ b/papis/commands/git.py
@@ -18,7 +18,7 @@ Examples
 
     papis git commit -a
 
-Command-line Interface
+Command-line interface
 ^^^^^^^^^^^^^^^^^^^^^^
 
 .. click:: papis.commands.git:cli
@@ -33,5 +33,5 @@ import papis.commands.run
 
 cli = copy.deepcopy(papis.commands.run.cli)
 cli.name = "git"
-cli.help = "Run git command in a library or document folder"
+cli.help = "Run git command in a library or document folder."
 cli = click.option("--prefix", hidden=True, default="git", type=str)(cli)

--- a/papis/commands/init.py
+++ b/papis/commands/init.py
@@ -10,15 +10,15 @@ This command initializes a Papis library interactively.
 Examples
 ^^^^^^^^
 
-- To create a new library at a given directory, just run
+- To create a new library at a given directory, run:
 
     .. code:: sh
 
         papis init /path/to/my/library
 
-  and answer the questions interactively.
+  ... and answer the questions interactively.
 
-- To create a library in the current directory, just run
+- To create a library in the current directory, run:
 
     .. code:: sh
 

--- a/papis/commands/init.py
+++ b/papis/commands/init.py
@@ -24,7 +24,7 @@ Examples
 
         papis init
 
-Command-line Interface
+Command-line interface
 ^^^^^^^^^^^^^^^^^^^^^^
 
 .. click:: papis.commands.init:cli
@@ -102,7 +102,7 @@ def _is_git_repository(path: str) -> bool:
     nargs=1,
 )
 def cli(dir_path: Optional[str]) -> None:
-    """Initialize a papis library"""
+    """Initialize a Papis library."""
 
     from papis.tui.utils import confirm, prompt
 

--- a/papis/commands/init.py
+++ b/papis/commands/init.py
@@ -16,7 +16,7 @@ Examples
 
         papis init /path/to/my/library
 
-  ... and answer the questions interactively.
+  and answer the questions interactively.
 
 - To create a library in the current directory, run:
 

--- a/papis/commands/init.py
+++ b/papis/commands/init.py
@@ -10,7 +10,7 @@ This command initializes a Papis library interactively.
 Examples
 ^^^^^^^^
 
-- To create a new library at a given directory, run:
+- To create a new library in a given directory, run:
 
     .. code:: sh
 

--- a/papis/commands/list.py
+++ b/papis/commands/list.py
@@ -24,7 +24,7 @@ Examples
         papis list --all --template bibitem.template
 
 - For scripting, printing the id of a series of documents is valuable in order
-  to further use the id in other scripts.
+  to further use the id in other scripts:
 
     .. code:: sh
 
@@ -33,7 +33,7 @@ Examples
         papis edit papis_id:${papis_id}
         # etc.
 
-- List various plugins and extensions that Papis sees
+- List various plugins and extensions that Papis sees:
 
     .. code:: sh
 

--- a/papis/commands/list.py
+++ b/papis/commands/list.py
@@ -42,7 +42,7 @@ Examples
         papis list --exporters
         papis list --doctors
 
-Command-line Interface
+Command-line interface
 ^^^^^^^^^^^^^^^^^^^^^^
 
 .. click:: papis.commands.list:cli
@@ -201,55 +201,55 @@ run = list_documents
 @papis.cli.query_argument()
 @papis.cli.bool_flag(
     "-i", "--info", "show_info",
-    help="Show the info file for each document")
+    help="Show the info file for each document.")
 @papis.cli.bool_flag(
     "--id", "show_id",
-    help="Show the papis id for each document")
+    help="Show the papis id for each document.")
 @papis.cli.bool_flag(
     "-f", "--file", "show_files",
-    help="Show the files for each document")
+    help="Show the files for each document.")
 @papis.cli.bool_flag(
     "-d", "--dir", "show_dir",
-    help="Show the folder name containing each document")
+    help="Show the folder name containing each document.")
 @papis.cli.bool_flag(
     "-n", "--notes", "show_notes",
-    help="Show notes files for each document")
+    help="Show notes files for each document.")
 @click.option(
     "--format", "show_format",
-    help="Show documents using a custom format, e.g. '{doc[year]} {doc[title]}",
+    help="Show documents using a custom format, e.g. '{doc[year]} {doc[title]}'.",
     type=papis.cli.FormattedStringParamType(),
     default="")
 @papis.cli.bool_flag(
     "--paths", "show_paths",
-    help="List configuration paths used by papis")
+    help="List configuration paths used by papis.")
 @papis.cli.bool_flag(
     "--libraries", "show_libraries",
-    help="List defined libraries")
+    help="List defined libraries.")
 @papis.cli.bool_flag(
     "--exporters", "show_exporters",
-    help="List available exporters")
+    help="List available exporters.")
 @papis.cli.bool_flag(
     "--explorers", "show_explorers",
-    help="List available explorers")
+    help="List available explorers.")
 @papis.cli.bool_flag(
     "--importers", "show_importers",
-    help="List available importers")
+    help="List available importers.")
 @papis.cli.bool_flag(
     "--downloaders", "show_downloaders",
-    help="List available downloaders")
+    help="List available downloaders.")
 @papis.cli.bool_flag(
     "--pickers", "show_pickers",
-    help="List available pickers")
+    help="List available pickers.")
 @papis.cli.bool_flag(
     "--doctors", "show_doctor",
-    help="List available doctor checks")
+    help="List available doctor checks.")
 @click.option(
     "--template",
-    help="Template file containing a papis format to list documents",
+    help="Template file containing a papis format to list documents.",
     default=None)
 @papis.cli.bool_flag(
     "--quiet",
-    help="Do not show short descriptions for plugins (exporters, etc.)",
+    help="Do not show short descriptions for plugins (exporters, etc.).",
     default=False)
 @papis.cli.all_option()
 @papis.cli.sort_option()
@@ -275,7 +275,7 @@ def cli(query: str,
         doc_folder: Tuple[str, ...],
         sort_field: Optional[str],
         sort_reverse: bool) -> None:
-    """List document metadata"""
+    """List document metadata."""
 
     objects = list_plugins(
         show_paths=show_paths,

--- a/papis/commands/merge.py
+++ b/papis/commands/merge.py
@@ -117,7 +117,7 @@ def run(keep: papis.document.Document,
          " at once, call the picker twice to get two documents.")
 @papis.cli.bool_flag(
     "-k", "--keep", "keep_both",
-    help="Do not erase any document.")
+    help="Keep both documents.")
 @click.option("-o",
               "--out",
               help="Create the resulting document in this path.",

--- a/papis/commands/merge.py
+++ b/papis/commands/merge.py
@@ -46,11 +46,11 @@ Examples
         papis merge --keep "belief revision"
 
     After deciding which changes to apply, Papis will prompt for files that
-    should be moved to the resulting location. The files can be chosen entering
-    the numbers that precede the documents.
+    should be moved to the resulting location. The files can be chosen by
+    entering the numbers that precede the documents.
 
 
-Command-line Interface
+Command-line interface
 ^^^^^^^^^^^^^^^^^^^^^^
 
 .. click:: papis.commands.merge:cli
@@ -109,20 +109,20 @@ def run(keep: papis.document.Document,
 @papis.cli.sort_option()
 @papis.cli.bool_flag(
     "-s", "--second",
-    help="Keep the second document after merge and erase the first, "
-         "the default is keep the first")
+    help="Keep the second document after merge and erase the first "
+         "(the default is to keep the first).")
 @papis.cli.bool_flag(
     "-p", "--pick",
     help="If your picker does not support picking two documents"
-         " at once, call twice the picker to get two documents")
+         " at once, call the picker twice to get two documents.")
 @papis.cli.bool_flag(
     "-k", "--keep", "keep_both",
-    help="Do not erase any document")
+    help="Do not erase any document.")
 @click.option("-o",
               "--out",
-              help="Create the resulting document in this path",
+              help="Create the resulting document in this path.",
               default=None)
-@papis.cli.git_option(help="Merge in git")
+@papis.cli.git_option(help="Merge in git.")
 def cli(query: str,
         sort_field: Optional[str],
         out: Optional[str],
@@ -131,7 +131,7 @@ def cli(query: str,
         keep_both: bool,
         sort_reverse: bool,
         pick: bool) -> None:
-    """Merge two documents from a given library"""
+    """Merge two documents from a given library."""
     documents = papis.database.get().query(query)
 
     if sort_field:

--- a/papis/commands/mv.py
+++ b/papis/commands/mv.py
@@ -1,7 +1,7 @@
 """
 This command can be used to move a document to a new folder.
 
-Command-line Interface
+Command-line interface
 ^^^^^^^^^^^^^^^^^^^^^^
 
 .. click:: papis.commands.mv:cli
@@ -64,7 +64,7 @@ def cli(query: str,
         sort_field: Optional[str],
         doc_folder: Tuple[str, ...],
         sort_reverse: bool) -> None:
-    """Move a document into some other path"""
+    """Move a document into some other path."""
     # Leave this imports here for performance
     import prompt_toolkit
     import prompt_toolkit.completion

--- a/papis/commands/open.py
+++ b/papis/commands/open.py
@@ -42,13 +42,13 @@ convention to what suits you.
 Examples
 ^^^^^^^^
 
-- Open a PDF file linked to a document matching the string ``bohm``
+- Open a PDF file linked to a document matching the string ``bohm``:
 
     .. code:: sh
 
         papis open bohm
 
-- Open the folder where this last document is stored
+- Open the folder where this last document is stored:
 
     .. code:: sh
 
@@ -56,7 +56,7 @@ Examples
 
   The file browser used is given by the :confval:`file-browser` setting.
 
-- Open a mark defined in the info file
+- Open a mark defined in the info file:
 
     .. code:: sh
 

--- a/papis/commands/open.py
+++ b/papis/commands/open.py
@@ -5,7 +5,7 @@ With it you can open documents, folders or marks.
 Marks
 ^^^^^
 
-One special thing about this command is the ability to use marks for
+One special feature about this command is the ability to use marks for
 documents. As you would imagine, it is in general difficult to create marks for
 any kind of data. For instance, if our library consists of PDF files and EPUB
 files, we would like to define bookmarks in order to go back to them at some

--- a/papis/commands/open.py
+++ b/papis/commands/open.py
@@ -5,9 +5,8 @@ With it you can open documents, folders or marks.
 Marks
 ^^^^^
 
-One special feature about this command is the ability to use marks for
-documents. As you would imagine, it is in general difficult to create marks for
-any kind of data. For instance, if our library consists of PDF files and EPUB
+One of this command's special features is the ability to use marks for
+documents. For instance, if our library consists of PDF files and EPUB
 files, we would like to define bookmarks in order to go back to them at some
 later point.
 
@@ -33,7 +32,7 @@ defining a ``marks`` list in a document. Let us look at a concrete example:
     type: book
     year: '2009'
 
-This book has defined two marks. Each mark has a name and a value. If you tell
+This book has two defined marks. Each mark has a name and a value. If you tell
 the ``open`` command to open marks, it will look for the marks and open the
 value (page number). This is the default behavior. However, if you go to the
 :ref:`configuration <marks-options>`, you'll see that you can change the

--- a/papis/commands/open.py
+++ b/papis/commands/open.py
@@ -5,11 +5,11 @@ With it you can open documents, folders or marks.
 Marks
 ^^^^^
 
-One of special things about this command is the possibility of
-creating marks for documents. As you would imagine, it is in general
-difficult to create marks for any kind of data. For instance,
-if our library consists of PDF files and EPUB files, we would like to define
-bookmarks in order to go back to them at some later point.
+One special thing about this command is the ability to use marks for
+documents. As you would imagine, it is in general difficult to create marks for
+any kind of data. For instance, if our library consists of PDF files and EPUB
+files, we would like to define bookmarks in order to go back to them at some
+later point.
 
 How you define marks can be customized through the marks configuration
 settings :ref:`here <marks-options>`. The default way of doing it is just by
@@ -33,11 +33,11 @@ defining a ``marks`` list in a document. Let us look at a concrete example:
     type: book
     year: '2009'
 
-This book has defined two marks. Each mark has a name and a value.
-If you tell the ``open`` command to open marks, then it will look for
-the marks and open the value (page number). This is the default behavior.
-However, if you go to the :ref:`configuration <marks-options>`
-you'll see that you can change the convention to what suits you.
+This book has defined two marks. Each mark has a name and a value. If you tell
+the ``open`` command to open marks, it will look for the marks and open the
+value (page number). This is the default behavior. However, if you go to the
+:ref:`configuration <marks-options>`, you'll see that you can change the
+convention to what suits you.
 
 Examples
 ^^^^^^^^
@@ -62,7 +62,7 @@ Examples
 
         papis open --mark bohm
 
-Command-line Interface
+Command-line interface
 ^^^^^^^^^^^^^^^^^^^^^^
 
 .. click:: papis.commands.open:cli
@@ -155,19 +155,19 @@ def run(document: papis.document.Document,
 @papis.cli.all_option()
 @click.option(
     "--tool",
-    help="Tool for opening the file (opentool)",
+    help="Tool for opening the file (opentool).",
     default="")
 @papis.cli.bool_flag(
     "-d", "--dir", "folder",
-    help="Open directory")
+    help="Open directory.")
 @papis.cli.bool_flag(
     "-m", "--mark/--no-mark",
-    help="Open mark",
+    help="Open mark.",
     default=lambda: papis.config.getboolean("open-mark"))
 def cli(query: str, doc_folder: Tuple[str, ...], tool: str, folder: bool,
         sort_field: Optional[str], sort_reverse: bool, _all: bool,
         mark: bool) -> None:
-    """Open document from a given library"""
+    """Open document from a given library."""
     if tool:
         papis.config.set("opentool", papis.config.escape_interp(tool))
 

--- a/papis/commands/rename.py
+++ b/papis/commands/rename.py
@@ -14,7 +14,7 @@ Examples
 - Rename folders for documents whose author is "Rick Astley". You can then either
   enter a new folder name or accept Papis' suggestion. The suggested folder name
   will be generated according to :confval:`add-folder-name` or, if this option
-  isn't set, the current folder name. For example:
+  isn't set, the current folder name.
 
    .. code:: sh
 
@@ -22,7 +22,7 @@ Examples
 
 - You can use ``--folder-name`` to pass in your desired name. This option
   supports Papis formatting patterns. You will be asked for confirmation
-  before the folder is renamed. For example:
+  before the folder is renamed.
 
    .. code:: sh
 

--- a/papis/commands/rename.py
+++ b/papis/commands/rename.py
@@ -14,7 +14,7 @@ Examples
 - Rename folders for documents whose author is "Rick Astley". You can then either
   enter a new folder name or accept Papis' suggestion. The suggested folder name
   will be generated according to :confval:`add-folder-name` or, if this option
-  isn't set, the current folder name.
+  isn't set, the current folder name. For example:
 
    .. code:: sh
 
@@ -22,7 +22,7 @@ Examples
 
 - You can use ``--folder-name`` to pass in your desired name. This option
   supports Papis formatting patterns. You will be asked for confirmation
-  before the folder is renamed.
+  before the folder is renamed. For example:
 
    .. code:: sh
 

--- a/papis/commands/rename.py
+++ b/papis/commands/rename.py
@@ -46,7 +46,7 @@ Examples
 
         papis rename --all author:"Rick Astley"
 
-Command-line Interface
+Command-line interface
 ^^^^^^^^^^^^^^^^^^^^^^
 
 .. click:: papis.commands.rename:cli
@@ -106,15 +106,15 @@ def run(document: papis.document.Document,
 
 
 @click.command("rename")
+@click.help_option("-h", "--help")
 @click.option(
     "--folder-name",
-    help="Name format for the document main folder",
+    help="Name format for the document main folder.",
     type=papis.cli.FormattedStringParamType(),
     default=lambda: papis.config.getformattedstring("add-folder-name"))
 @papis.cli.bool_flag(
     "-b", "--batch",
-    help="Batch mode, do not prompt")
-@click.help_option("--help", "-h")
+    help="Batch mode, do not prompt.")
 @papis.cli.all_option()
 @papis.cli.query_argument()
 @papis.cli.git_option()
@@ -128,7 +128,7 @@ def cli(query: str,
         sort_field: Optional[str],
         doc_folder: Tuple[str, ...],
         sort_reverse: bool) -> None:
-    """Rename document folders"""
+    """Rename document folders."""
     if not folder_name:
         logger.warning("No folder name format specified, so no documents can be "
                        "renamed. Set either the configuration option "

--- a/papis/commands/rm.py
+++ b/papis/commands/rm.py
@@ -1,5 +1,11 @@
 """
-Command-line Interface
+The command to remove Papis documents. Can also be used to remove files within
+documents, rather than an entire document.
+
+Prompts for confirmation before removing, showing information about what is
+being removed.
+
+Command-line interface
 ^^^^^^^^^^^^^^^^^^^^^^
 
 .. click:: papis.commands.rm:cli
@@ -73,18 +79,18 @@ def run(document: papis.document.Document,
 @click.command("rm")
 @click.help_option("-h", "--help")
 @papis.cli.query_argument()
-@papis.cli.git_option(help="Remove in git")
+@papis.cli.git_option(help="Remove in git.")
 @papis.cli.sort_option()
 @papis.cli.doc_folder_option()
 @papis.cli.bool_flag(
     "--file", "_file",
-    help="Remove files from a document instead of the whole folder")
+    help="Remove files from a document instead of the whole folder.")
 @papis.cli.bool_flag(
     "-n", "--notes", "_notes",
-    help="Remove the notes file from a document instead of the whole folder")
+    help="Remove the notes file from a document instead of the whole folder.")
 @papis.cli.bool_flag(
     "-f", "--force",
-    help="Do not confirm removal")
+    help="Do not confirm removal.")
 @papis.cli.all_option()
 def cli(query: str,
         git: bool,
@@ -96,7 +102,7 @@ def cli(query: str,
         sort_field: Optional[str],
         sort_reverse: bool) -> None:
     """
-    Delete a document, a file, or a notes-file
+    Remove a document, a file, or a notes-file.
     """
 
     documents = papis.cli.handle_doc_folder_query_all_sort(query,

--- a/papis/commands/rm.py
+++ b/papis/commands/rm.py
@@ -1,6 +1,9 @@
 """
-The command to remove entire Papis documents or just remove files within
-documents.
+A simple command that can remove entire Papis documents from your library or
+just remove files within a document.
+
+This command should be used with care, since it will remove the document from
+your filesystem, not just from Papis' database.
 
 Command-line interface
 ^^^^^^^^^^^^^^^^^^^^^^

--- a/papis/commands/rm.py
+++ b/papis/commands/rm.py
@@ -1,9 +1,6 @@
 """
-The command to remove Papis documents. Can also be used to remove files within
-documents, rather than an entire document.
-
-Prompts for confirmation before removing, showing information about what is
-being removed.
+The command to remove entire Papis documents or just remove files within
+documents.
 
 Command-line interface
 ^^^^^^^^^^^^^^^^^^^^^^

--- a/papis/commands/run.py
+++ b/papis/commands/run.py
@@ -4,19 +4,19 @@ This command can be used to run shell commands in the directory of your library.
 Examples
 ^^^^^^^^
 
-- List all files in the library directory
+- List all files in the library directory:
 
     .. code:: sh
 
         papis run ls
 
-- Find a file in the library directory using the ``find`` command
+- Find a file in the library directory using the ``find`` command:
 
     .. code:: sh
 
         papis run find -name 'document.pdf'
 
-- Find all PDFs in the document folders matching "einstein"
+- Find all PDFs in the document folders matching "einstein":
 
     .. code:: sh
 
@@ -27,7 +27,7 @@ Examples
 
     In this example you could also use pipes. For instance, to print the
     absolute path to the files, in Linux you can use the command
-    ``readlink -f`` and a pipe ``|`` to do this, i.e.
+    ``readlink -f`` and a pipe ``|`` to do this, i.e.:
 
     .. code:: sh
 
@@ -37,7 +37,7 @@ Examples
 - Replace some text in all ``info.yaml`` files by something.
   For instance imagine you want to replace all ``note`` field names
   in the ``info.yaml`` files by ``_note`` so that the ``note`` field
-  does not get exported. You can do
+  does not get exported. You can do:
 
     .. code:: sh
 

--- a/papis/commands/run.py
+++ b/papis/commands/run.py
@@ -1,5 +1,5 @@
 r"""
-This command is useful to issue commands in the directory of your library.
+This command can be used to run shell commands in the directory of your library.
 
 Examples
 ^^^^^^^^
@@ -10,7 +10,7 @@ Examples
 
         papis run ls
 
-- Find a file the library directory using the ``find`` command
+- Find a file in the library directory using the ``find`` command
 
     .. code:: sh
 
@@ -44,7 +44,7 @@ Examples
         papis run -a -- sed -i 's/^note:/_note:/' info.yaml
 
 
-Command-line Interface
+Command-line interface
 ^^^^^^^^^^^^^^^^^^^^^^
 
 .. click:: papis.commands.run:cli
@@ -77,7 +77,7 @@ def run(folder: str, command: Optional[List[str]] = None) -> None:
 @click.help_option("--help", "-h")
 @click.option(
     "--pick", "-p",
-    help="Give a query to pick a document to run the command in its folder",
+    help="Give a query to pick a document to run the command in its folder.",
     metavar="<QUERY>",
     type=str,
     default="")
@@ -89,7 +89,7 @@ def run(folder: str, command: Optional[List[str]] = None) -> None:
     default=None,
     type=str,
     metavar="<PREFIX>",
-    help="Prefix shell commands by a prefix command")
+    help="Prefix shell commands by a prefix command.")
 @click.argument("run_command", metavar="<COMMANDS>", nargs=-1)
 def cli(run_command: List[str],
         pick: str,
@@ -98,7 +98,7 @@ def cli(run_command: List[str],
         prefix: Optional[str],
         doc_folder: Tuple[str, ...],
         _all: bool) -> None:
-    """Run an arbitrary shell command in the library or command folder"""
+    """Run an arbitrary shell command in the library or command folder."""
 
     documents = []
 

--- a/papis/commands/tag.py
+++ b/papis/commands/tag.py
@@ -49,7 +49,7 @@ Examples
   This adds TAG1 to all documents matching the QUERY rather than opening the
   picker to let you choose one.
 
-Command-line Interface
+Command-line interface
 ^^^^^^^^^^^^^^^^^^^^^^
 
 .. click:: papis.commands.tag:cli
@@ -75,7 +75,7 @@ logger = papis.logging.get_logger(__name__)
 @papis.cli.bool_flag(
     "-d",
     "--drop",
-    help="Drop all tags",
+    help="Drop all tags.",
     default=False,
 )
 @click.option(
@@ -83,7 +83,7 @@ logger = papis.logging.get_logger(__name__)
     "--add",
     "--append",
     "to_add",
-    help="Add a tag",
+    help="Add a tag.",
     multiple=True,
     type=str,
 )
@@ -91,7 +91,7 @@ logger = papis.logging.get_logger(__name__)
     "-r",
     "--remove",
     "to_remove",
-    help="Remove a tag",
+    help="Remove a tag.",
     multiple=True,
     type=str,
 )
@@ -99,7 +99,7 @@ logger = papis.logging.get_logger(__name__)
     "-n",
     "--rename",
     "to_rename",
-    help="Rename a tag (<OLD-TAG NEW-TAG>)",
+    help="Rename a tag (<OLD-TAG NEW-TAG>).",
     multiple=True,
     type=(str, str),
 )

--- a/papis/commands/update.py
+++ b/papis/commands/update.py
@@ -464,7 +464,7 @@ def run(
           papis.cli.FormattedStringParamType(),
           papis.cli.FormattedStringParamType()),
 )
-@papis.cli.bool_flag("-b", "--batch", help="Batch mode, do not prompt and skip documents with errors.")
+@papis.cli.bool_flag("-b", "--batch", help="Do not prompt, and skip documents containing errors.")
 def cli(
     query: str,
     git: bool,

--- a/papis/commands/update.py
+++ b/papis/commands/update.py
@@ -464,7 +464,11 @@ def run(
           papis.cli.FormattedStringParamType(),
           papis.cli.FormattedStringParamType()),
 )
-@papis.cli.bool_flag("-b", "--batch", help="Do not prompt, and skip documents containing errors.")
+@papis.cli.bool_flag(
+    "-b",
+    "--batch",
+    help="Do not prompt, and skip documents containing errors."
+)
 def cli(
     query: str,
     git: bool,

--- a/papis/commands/update.py
+++ b/papis/commands/update.py
@@ -37,7 +37,7 @@ Examples
   query, rather than allowing you to pick one individual document to update.
 
 - Update a document automatically and interactively (searching by DOI in
-  Crossref or in other sources...)
+  Crossref or in other sources...):
 
     .. code:: sh
 
@@ -97,7 +97,7 @@ Examples
     This removes all tags.
 
 - There is also a convenience option ``--rename`` if you want to rename
-  a list item. It's equivalent to doing ``--remove`` and ``--append`` sequentially.
+  a list item. It's equivalent to doing ``--remove`` and ``--append`` sequentially:
 
     .. code:: sh
 

--- a/papis/commands/update.py
+++ b/papis/commands/update.py
@@ -68,7 +68,7 @@ Examples
 
         papis update --append author ", Albert" Einstein
 
-    This appends ", Einstein" to the existing author string.
+    This appends ", Albert" to the existing author string.
 
 - You can also append an item to a list:
 
@@ -94,7 +94,7 @@ Examples
 
         papis update --drop tags
 
-    This removes the all tags.
+    This removes all tags.
 
 - There is also a convenience option ``--rename`` if you want to rename
   a list item. It's equivalent to doing ``--remove`` and ``--append`` sequentially.
@@ -120,7 +120,7 @@ Examples
   updated to a set that contains a dictionary.
 
 
-Command-line Interface
+Command-line interface
 ^^^^^^^^^^^^^^^^^^^^^^
 
 .. click:: papis.commands.update:cli
@@ -405,7 +405,7 @@ def run(
 @papis.cli.doc_folder_option()
 @papis.cli.all_option()
 @papis.cli.sort_option()
-@papis.cli.bool_flag("--auto", help="Try to parse information from different sources")
+@papis.cli.bool_flag("--auto", help="Try to parse information from different sources.")
 @papis.cli.bool_flag(
     "--auto-doctor/--no-auto-doctor",
     help="Apply papis doctor to newly added documents.",
@@ -414,7 +414,7 @@ def run(
 @click.option(
     "--from",
     "from_importer",
-    help="Add document from a specific importer ({})".format(
+    help="Add document from a specific importer ({}).".format(
         ", ".join(papis.importer.available_importers())
     ),
     type=(click.Choice(papis.importer.available_importers()), str),
@@ -464,7 +464,7 @@ def run(
           papis.cli.FormattedStringParamType(),
           papis.cli.FormattedStringParamType()),
 )
-@papis.cli.bool_flag("-b", "--batch", help="Batch mode, do not prompt or otherwise")
+@papis.cli.bool_flag("-b", "--batch", help="Batch mode, do not prompt and do not abort on error.")
 def cli(
     query: str,
     git: bool,
@@ -482,7 +482,7 @@ def cli(
     to_remove: List[Tuple[str, str]],
     to_rename: List[Tuple[str, str, str]],
 ) -> None:
-    """Update document metadata"""
+    """Update document metadata."""
     success = True
 
     documents = papis.cli.handle_doc_folder_query_all_sort(

--- a/papis/commands/update.py
+++ b/papis/commands/update.py
@@ -464,7 +464,7 @@ def run(
           papis.cli.FormattedStringParamType(),
           papis.cli.FormattedStringParamType()),
 )
-@papis.cli.bool_flag("-b", "--batch", help="Batch mode, do not prompt and do not abort on error.")
+@papis.cli.bool_flag("-b", "--batch", help="Batch mode, do not prompt and skip documents with errors.")
 def cli(
     query: str,
     git: bool,

--- a/papis/config.py
+++ b/papis/config.py
@@ -172,7 +172,7 @@ def register_default_settings(settings_dictionary: PapisConfigType) -> None:
 
     Notice that you can define sections or global options. For instance,
     let us suppose that a script called ``foobar`` defines some
-    configuration options. In the script there could be the following defined:
+    configuration options. The script might define the following:
 
     .. code:: python
 

--- a/papis/config.py
+++ b/papis/config.py
@@ -181,7 +181,7 @@ def register_default_settings(settings_dictionary: PapisConfigType) -> None:
         options = {"foobar": { "command": "open"}}
         papis.config.register_default_settings(options)
 
-    ... which can then be accessed globally through:
+    which can then be accessed globally through:
 
     .. code:: python
 
@@ -496,7 +496,7 @@ def getformattedstring(key: str, section: Optional[str] = None) -> FormattedStri
         multiple-authors-format.python = {au[family]}, {au[given]}
         multiple-authors-format.jinja2 = {{ au[family] }}, {{ au[given] }}
 
-    ... i.e. like ``key[.formatter]``. If no formatter is provided in the key name,
+    i.e. like ``key[.formatter]``. If no formatter is provided in the key name,
     the default formatter is used, as defined by :confval:`formatter`.
     Formatters are checked in alphabetical order and the last one is returned.
 

--- a/papis/config.py
+++ b/papis/config.py
@@ -172,7 +172,7 @@ def register_default_settings(settings_dictionary: PapisConfigType) -> None:
 
     Notice that you can define sections or global options. For instance,
     let us suppose that a script called ``foobar`` defines some
-    configuration options. In the script there could be the following defined
+    configuration options. In the script there could be the following defined:
 
     .. code:: python
 
@@ -181,7 +181,7 @@ def register_default_settings(settings_dictionary: PapisConfigType) -> None:
         options = {"foobar": { "command": "open"}}
         papis.config.register_default_settings(options)
 
-    which can then be accessed globally through
+    ... which can then be accessed globally through:
 
     .. code:: python
 
@@ -496,7 +496,7 @@ def getformattedstring(key: str, section: Optional[str] = None) -> FormattedStri
         multiple-authors-format.python = {au[family]}, {au[given]}
         multiple-authors-format.jinja2 = {{ au[family] }}, {{ au[given] }}
 
-    i.e. like ``key[.formatter]``. If no formatter is provided in the key name,
+    ... i.e. like ``key[.formatter]``. If no formatter is provided in the key name,
     the default formatter is used, as defined by :confval:`formatter`.
     Formatters are checked in alphabetical order and the last one is returned.
 

--- a/papis/crossref.py
+++ b/papis/crossref.py
@@ -287,20 +287,20 @@ def doi_to_data(doi_string: str) -> Dict[str, Any]:
 @click.command("crossref")
 @click.pass_context
 @click.help_option("--help", "-h")
-@click.option("--query", "-q", help="General query", default="")
-@click.option("--author", "-a", help="Author of the query", default="")
-@click.option("--title", "-t", help="Title of the query", default="")
+@click.option("--query", "-q", help="General query.", default="")
+@click.option("--author", "-a", help="Author of the query.", default="")
+@click.option("--title", "-t", help="Title of the query.", default="")
 @click.option(
-    "--max", "-m", "_ma", help="Maximum number of results", default=20)
+    "--max", "-m", "_ma", help="Maximum number of results.", default=20)
 @click.option(
-    "--filter", "-f", "_filters", help="Filters to apply", default=(),
+    "--filter", "-f", "_filters", help="Filters to apply.", default=(),
     type=(click.Choice(list(_filter_names)), str),
     multiple=True)
 @click.option(
-    "--order", "-o", help="Order of appearance according to sorting",
+    "--order", "-o", help="Order of appearance according to sorting.",
     default="desc", type=click.Choice(list(_order_values)), show_default=True)
 @click.option(
-    "--sort", "-s", help="Sorting parameter", default="score",
+    "--sort", "-s", help="Sorting parameter.", default="score",
     type=click.Choice(list(_sort_values)), show_default=True)
 def explorer(
         ctx: click.core.Context,

--- a/papis/crossref.py
+++ b/papis/crossref.py
@@ -315,7 +315,7 @@ def explorer(
     Look for documents on `Crossref <https://www.crossref.org/>`__.
 
     For example, to look for a document with the author "Albert Einstein" and
-    export it to a BibTeX file, you can call
+    export it to a BibTeX file, you can call:
 
     .. code:: sh
 

--- a/papis/database/whoosh.py
+++ b/papis/database/whoosh.py
@@ -1,4 +1,4 @@
-"""This is the whoosh interface to Papis.
+"""This is the Whoosh interface to Papis.
 
 For future Papis developers here are some considerations.
 
@@ -24,7 +24,7 @@ string should look like the following:
         "tags": TEXT(stored=True),
     }
 
-where all the fields are explained in the whoosh
+where all the fields are explained in the Whoosh
 `documentation <https://whoosh.readthedocs.io/en/latest/schema.html>`__.
 
 After this Schema is created, the folders of the library are traversed
@@ -228,7 +228,7 @@ class Database(DatabaseBase):
         return open_dir(self.index_dir)
 
     def _create_schema(self) -> "Schema":
-        """Creates and returns whoosh schema to be applied to the library"""
+        """Creates and returns Whoosh schema to be applied to the library"""
         from whoosh.fields import Schema
         logger.debug("Creating schema.")
 
@@ -237,7 +237,7 @@ class Database(DatabaseBase):
 
     def _get_schema_init_fields(self) -> Dict[str, "FieldType"]:
         """
-        :returns: the keyword arguments to be passed to the whoosh schema object
+        :returns: the keyword arguments to be passed to the Whoosh schema object
             (see :meth:`_create_schema`).
         """
         # NOTE: these are imported here so that `eval` sees them

--- a/papis/database/whoosh.py
+++ b/papis/database/whoosh.py
@@ -24,7 +24,7 @@ string should look like the following:
         "tags": TEXT(stored=True),
     }
 
-where all the fields are explained in the whoosh
+... where all the fields are explained in the whoosh
 `documentation <https://whoosh.readthedocs.io/en/latest/schema.html>`__.
 
 After this Schema is created, the folders of the library are traversed

--- a/papis/database/whoosh.py
+++ b/papis/database/whoosh.py
@@ -24,7 +24,7 @@ string should look like the following:
         "tags": TEXT(stored=True),
     }
 
-... where all the fields are explained in the whoosh
+where all the fields are explained in the whoosh
 `documentation <https://whoosh.readthedocs.io/en/latest/schema.html>`__.
 
 After this Schema is created, the folders of the library are traversed

--- a/papis/dblp.py
+++ b/papis/dblp.py
@@ -162,11 +162,11 @@ def is_valid_dblp_key(key: str) -> bool:
 @click.help_option("--help", "-h")
 @click.option(
     "--query", "-q",
-    help="General query",
+    help="General query.",
     default="")
 @click.option(
     "--max", "-m", "max_results",
-    help="Maximum number of results",
+    help="Maximum number of results.",
     default=30)
 def explorer(
         ctx: click.core.Context,

--- a/papis/dblp.py
+++ b/papis/dblp.py
@@ -176,7 +176,7 @@ def explorer(
     Look for documents on `dblp.org <https://dblp.org/>`__.
 
     For example, to look for a document with the author "Albert Einstein" and
-    export it to a BibTeX file, you can call
+    export it to a BibTeX file, you can call:
 
     .. code:: sh
 

--- a/papis/dissemin.py
+++ b/papis/dissemin.py
@@ -74,7 +74,7 @@ def explorer(ctx: click.core.Context, query: str) -> None:
     Look for documents on `dissem.in <https://dissem.in/>`__.
 
     For example, to look for a document with the author "Albert Einstein" and
-    open it with Firefox, you can call
+    open it with Firefox, you can call:
 
     .. code:: sh
 

--- a/papis/docmatcher.py
+++ b/papis/docmatcher.py
@@ -203,7 +203,7 @@ def parse_query(query_string: str) -> List[ParseResult]:
 
         'hello author : Einstein    title: "Fancy Title: Part 1" tags'
 
-    ... which will result in:
+    which will result in:
 
     .. code:: python
 

--- a/papis/docmatcher.py
+++ b/papis/docmatcher.py
@@ -12,7 +12,7 @@ logger = papis.logging.get_logger(__name__)
 class ParseResult(NamedTuple):
     """Result from parsing a search string.
 
-    For example, a search string such as ``"author:einstein"`` will result in
+    For example, a search string such as ``"author:einstein"`` will result in:
 
     .. code:: python
 
@@ -203,7 +203,7 @@ def parse_query(query_string: str) -> List[ParseResult]:
 
         'hello author : Einstein    title: "Fancy Title: Part 1" tags'
 
-    which will result in
+    ... which will result in:
 
     .. code:: python
 

--- a/papis/document.py
+++ b/papis/document.py
@@ -67,7 +67,7 @@ def keyconversion_to_data(conversions: Sequence[KeyConversionPair],
 
         data = {"id": "10.1103/physrevb.89.140501"}
 
-    ... which contains the DOI of a document with the wrong key. We can then write
+    which contains the DOI of a document with the wrong key. We can then write
     the following rules:
 
     .. code:: python
@@ -81,7 +81,7 @@ def keyconversion_to_data(conversions: Sequence[KeyConversionPair],
 
         new_data = keyconversion_to_data(conversions, data)
 
-    ... to rename the ``"id"`` key to the standard ``"doi"`` key used by ``papis``
+    to rename the ``"id"`` key to the standard ``"doi"`` key used by ``papis``
     and a URL. Any number of such rules can be written, depending on the
     complexity of the incoming data. Note that any errors raised on the
     application of the *action* will be silently ignored and the corresponding

--- a/papis/document.py
+++ b/papis/document.py
@@ -61,14 +61,14 @@ def keyconversion_to_data(conversions: Sequence[KeyConversionPair],
     JSON data obtained from a website API and standard ``papis`` key names and
     formatting. The implementation is completely generic.
 
-    For example, we have the simple dictionary
+    For example, we have the simple dictionary:
 
     .. code:: python
 
         data = {"id": "10.1103/physrevb.89.140501"}
 
-    which contains the DOI of a document with the wrong key. We can then write
-    the following rules
+    ... which contains the DOI of a document with the wrong key. We can then write
+    the following rules:
 
     .. code:: python
 
@@ -81,7 +81,7 @@ def keyconversion_to_data(conversions: Sequence[KeyConversionPair],
 
         new_data = keyconversion_to_data(conversions, data)
 
-    to rename the ``"id"`` key to the standard ``"doi"`` key used by ``papis``
+    ... to rename the ``"id"`` key to the standard ``"doi"`` key used by ``papis``
     and a URL. Any number of such rules can be written, depending on the
     complexity of the incoming data. Note that any errors raised on the
     application of the *action* will be silently ignored and the corresponding

--- a/papis/format.py
+++ b/papis/format.py
@@ -115,20 +115,20 @@ class PythonFormatter(Formatter):
     :confval:`formatter` setting in the configuration file. The
     formatted string has access to the ``doc`` variable, that is always a
     :class:`papis.document.Document`. A string using this formatter can look
-    like
+    like:
 
     .. code:: python
 
         "{doc[year]} - {doc[author_list][0][family]} - {doc[title]}"
 
     Note, however, that according to PEP 3101 some simple formatting is not
-    possible. For example, the following is not allowed
+    possible. For example, the following is not allowed:
 
     .. code:: python
 
         "{doc[title].lower()}"
 
-    and should be replaced with
+    ... and should be replaced with:
 
     .. code:: python
 
@@ -138,13 +138,13 @@ class PythonFormatter(Formatter):
     "u" for :meth:`str.upper`, "t" for :meth:`str.title`, "c" for
     :meth:`str.capitalize`, "y" that uses ``slugify`` (through
     :func:`papis.paths.normalize_path`). Additionally, the following
-    syntax is available to select subsets from a string
+    syntax is available to select subsets from a string:
 
     .. code:: python
 
         "{doc[title]:1.3S}"
 
-    which will select the ``words[1:3]`` from the title (words are split by
+    ... which will select the ``words[1:3]`` from the title (words are split by
     single spaces).
     """
 
@@ -185,7 +185,7 @@ class Jinja2Formatter(Formatter):
     :confval:`formatter` setting in the configuration file. The
     formatted string has access to the ``doc`` variable, that is always a
     :class:`papis.document.Document`. A string using this formatter can look
-    like
+    like:
 
     .. code:: python
 
@@ -194,13 +194,13 @@ class Jinja2Formatter(Formatter):
     This formatter supports the whole range of Jinja2 control structures and
     `filters <https://jinja.palletsprojects.com/en/3.1.x/templates/#filters>`__
     so more advanced string processing is possible. For example, we can titlecase
-    the title using
+    the title using:
 
     .. code:: python
 
         "{{ doc.title | title }}"
 
-    or give a default value if a key is missing in the document using
+    ... or give a default value if a key is missing in the document using:
 
     .. code:: python
 

--- a/papis/format.py
+++ b/papis/format.py
@@ -128,7 +128,7 @@ class PythonFormatter(Formatter):
 
         "{doc[title].lower()}"
 
-    ... and should be replaced with:
+    and should be replaced with:
 
     .. code:: python
 
@@ -144,7 +144,7 @@ class PythonFormatter(Formatter):
 
         "{doc[title]:1.3S}"
 
-    ... which will select the ``words[1:3]`` from the title (words are split by
+    which will select the ``words[1:3]`` from the title (words are split by
     single spaces).
     """
 
@@ -200,7 +200,7 @@ class Jinja2Formatter(Formatter):
 
         "{{ doc.title | title }}"
 
-    ... or give a default value if a key is missing in the document using:
+    or give a default value if a key is missing in the document using:
 
     .. code:: python
 

--- a/papis/isbn.py
+++ b/papis/isbn.py
@@ -82,7 +82,7 @@ def explorer(ctx: click.core.Context, query: str, service: str) -> None:
     Look for documents using `isbnlib <https://isbnlib.readthedocs.io/en/latest/>`__.
 
     For example, to look for a document with the author "Albert Einstein" and
-    open it with Firefox, you can call
+    open it with Firefox, you can call:
 
     .. code:: sh
 

--- a/papis/json.py
+++ b/papis/json.py
@@ -25,6 +25,8 @@ def explorer(ctx: click.Context, jsonfile: str) -> None:
 
     For example, you can call
 
+    .. code:: sh
+
         papis explore json 'lib.json' pick
     """
     logger.info("Reading JSON file '%s'...", jsonfile)

--- a/papis/json.py
+++ b/papis/json.py
@@ -23,7 +23,7 @@ def explorer(ctx: click.Context, jsonfile: str) -> None:
     """
     Import documents from a JSON file.
 
-    For example, you can call
+    For example, you can call:
 
     .. code:: sh
 

--- a/papis/sphinx_ext.py
+++ b/papis/sphinx_ext.py
@@ -1,6 +1,6 @@
 """A collection of Papis-specific Sphinx extensions.
 
-This can be included directly into the ``conf.py`` file as a normal extension, i.e.
+This can be included directly into the ``conf.py`` file as a normal extension, i.e.:
 
 .. code:: python
 
@@ -51,7 +51,7 @@ class PapisConfig(Directive):
 
         .. papis-config:: config-value-name
 
-    and has the following optional arguments.
+    ... and has the following optional arguments:
 
     * ``:section:``: The section in which the configuration value is given. The
       section defaults to :func:`~papis.config.get_general_settings_name`.
@@ -73,7 +73,7 @@ class PapisConfig(Directive):
             stored. It is a relative path in the document's main folder.
 
     In text, these configuration values can be referenced using standard role
-    references, e.g.
+    references, e.g.:
 
     .. code-block:: rst
 
@@ -148,7 +148,7 @@ def make_link_resolve(
         revision: str) -> Callable[[str, Dict[str, Any]], Optional[str]]:
     """Create a function that can be used with ``sphinx.ext.linkcode``.
 
-    This can be used in the ``conf.py`` file as
+    This can be used in the ``conf.py`` file as:
 
     .. code:: python
 

--- a/papis/sphinx_ext.py
+++ b/papis/sphinx_ext.py
@@ -51,7 +51,7 @@ class PapisConfig(Directive):
 
         .. papis-config:: config-value-name
 
-    ... and has the following optional arguments:
+    and has the following optional arguments:
 
     * ``:section:``: The section in which the configuration value is given. The
       section defaults to :func:`~papis.config.get_general_settings_name`.

--- a/papis/strings.py
+++ b/papis/strings.py
@@ -4,14 +4,14 @@ from typing import Any, Optional, NamedTuple, Tuple, Union
 class FormattedString(NamedTuple):
     """A tuple that defines a ``(formatter, string)`` pair.
 
-    In a configuration file, a formatted string can be defined as::
+    In a configuration file, a formatted string can be defined as:
 
     .. code:: ini
 
         key = formatted_value
         other_key.formatter = other_formatted_value
 
-    where the first key will use the default :confval:`formatter` and the second
+    ... where the first key will use the default :confval:`formatter` and the second
     key will use the specified formatter. These keys can be read using
     :func:`papis.config.getformattedstring`.
 

--- a/papis/strings.py
+++ b/papis/strings.py
@@ -11,7 +11,7 @@ class FormattedString(NamedTuple):
         key = formatted_value
         other_key.formatter = other_formatted_value
 
-    ... where the first key will use the default :confval:`formatter` and the second
+    where the first key will use the default :confval:`formatter` and the second
     key will use the specified formatter. These keys can be read using
     :func:`papis.config.getformattedstring`.
 

--- a/papis/testing.py
+++ b/papis/testing.py
@@ -183,7 +183,7 @@ class TemporaryConfiguration:
     ``XDG_CACHE_HOME``). This is meant to be used by tests to create a default
     environment in which to run.
 
-    It can be used in the standard way as
+    It can be used in the standard way as:
 
     .. code:: python
 
@@ -430,7 +430,7 @@ class ResourceCache:
       conversion (used in :meth:`get_local_resource`).
     * ``"both"``: both local and remote resources are updated.
 
-    Resources can then be retrieved as
+    Resources can then be retrieved as:
 
     .. code:: python
 
@@ -564,7 +564,7 @@ def _doctest_tmp_config(request: SubRequest) -> Iterator[None]:
 def tmp_config(request: SubRequest) -> Iterator[TemporaryConfiguration]:
     """A fixture that creates a :class:`TemporaryConfiguration`.
 
-    Additional keyword arguments can be passed using the ``config_setup`` marker
+    Additional keyword arguments can be passed using the ``config_setup`` marker:
 
     .. code:: python
 
@@ -589,7 +589,7 @@ def tmp_config(request: SubRequest) -> Iterator[TemporaryConfiguration]:
 def tmp_library(request: SubRequest) -> Iterator[TemporaryLibrary]:
     """A fixture that creates a :class:`TemporaryLibrary`.
 
-    Additional keyword arguments can be passed using the ``library_setup`` marker
+    Additional keyword arguments can be passed using the ``library_setup`` marker:
 
     .. code:: python
 

--- a/papis/yaml.py
+++ b/papis/yaml.py
@@ -120,7 +120,7 @@ def exporter(documents: List[papis.document.Document]) -> str:
 def explorer(ctx: click.Context, yamlfile: str) -> None:
     """Import documents from a YAML file.
 
-    For example, you can call
+    For example, you can call:
 
     .. code:: sh
 

--- a/papis/yaml.py
+++ b/papis/yaml.py
@@ -105,7 +105,7 @@ def yaml_to_list(yaml_path: str,
 
 
 def exporter(documents: List[papis.document.Document]) -> str:
-    """Convert document to the YAML format"""
+    """Convert document to the YAML format."""
     string = yaml.dump_all(
         [papis.document.to_dict(document) for document in documents],
         allow_unicode=True)
@@ -122,6 +122,8 @@ def explorer(ctx: click.Context, yamlfile: str) -> None:
 
     For example, you can call
 
+    .. code:: sh
+
         papis explore yaml 'lib.yaml' pick
     """
     logger.info("Reading YAML file '%s'...", yamlfile)
@@ -136,7 +138,7 @@ def explorer(ctx: click.Context, yamlfile: str) -> None:
 
 class Importer(papis.importer.Importer):
 
-    """Importer that parses a YAML file"""
+    """Importer that parses a YAML file."""
 
     def __init__(self, uri: str) -> None:
         super().__init__(name="yaml", uri=uri)


### PR DESCRIPTION
Hi, I have worked on this PR for a long time after noticing some particularly glaring mistakes in the docs, and then decided to read through the *entire* docs and fix all mistakes I can find :smile:

In hindsight I should have done this in smaller pieces.

My goal is that this should be safe to merge, what I've done (in order of importance:)

1. Fix formatting errors, e.g. codeblocks have paragraph text
    - And a couple logical errors in examples and such.
3. Fix grammar mistakes
    - But there are some cases where I reasoned if something is written in a needlessly confusing way, I touch it up to aid readability.
4. Improve consistency
    - Most prominently and creating a lot of diffs: some `click` short-help messages conclude with a period and others don't. I went for period at the end always, because the `-h` flag does that whether we want it or not.