### PR TITLE
Rename FormattedString to FormatPattern

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,11 +22,11 @@ configuration key
     ref-format.jinja2 = {{ doc.author_list | slice(3) | join("", attribute="family") }}{{ doc.year }}
 ```
 
-The syntax is always `key[.formatter]`. The formatted strings are searched
+The syntax is always `key[.formatter]`. The format patterns are searched
 alphabetically and the last one is picked, i.e. if both `key.python` and
 `key.jinja2` are provided, the `python` version will be chosen regardless of the
-order in the configuration file. If no formatter is provided for a formatted
-string of this type, then it will fall back to the default formatter set by the
+order in the configuration file. If no formatter is provided for a format
+pattern of this type, then it will fall back to the default formatter set by the
 `formatter` setting. All default settings are now clearly marked as using the
 `python` formatter, so they no longer need to be rewritten when changing formatters.
 

--- a/doc/source/configuration.rst
+++ b/doc/source/configuration.rst
@@ -75,7 +75,7 @@ all the options and more extensive descriptions):
 
 .. warning::
 
-   Many configuration options use special formatted strings that can depend on
+   Many configuration options use special format patterns that can depend on
    the document that is being worked on. When using these, make sure to also
    set the :confval:`formatter` to your desired choice. Below, we
    are using the default ``python`` formatter that is based on :meth:`str.format`.

--- a/doc/source/default_settings.rst
+++ b/doc/source/default_settings.rst
@@ -152,7 +152,7 @@ General settings
 
 .. papis-config:: formatter
 
-    Picks the formatter for templated strings in the configuration file and
+    Picks the formatter for format patterns in the configuration file and
     in various strings presented to the user. Supported formatters are
 
     * ``"python"``: based on :class:`papis.format.PythonFormatter`.
@@ -447,7 +447,7 @@ Add options
     This setting should aim to result in unique (sub)folder names.
     If a (sub)folder name is not unique and the document does not appear to
     be a duplicate, a suffix ``-a``, ``-b``, etc. is added to the name.
-    If this setting is ``None`` the template ``{doc[papis_id]}`` is used.
+    If this setting is ``None`` the pattern ``{doc[papis_id]}`` is used.
 
 .. papis-config:: add-file-name
     :type: str

--- a/doc/source/developer_reference.rst
+++ b/doc/source/developer_reference.rst
@@ -93,7 +93,7 @@ Developer API reference
 ``papis.format``
 ----------------
 
-.. autoclass:: papis.strings.FormattedString
+.. autoclass:: papis.strings.FormatPattern
 
 .. automodule:: papis.format
     :members:

--- a/papis/bibtex.py
+++ b/papis/bibtex.py
@@ -494,7 +494,7 @@ def create_reference(doc: Dict[str, Any], force: bool = False) -> str:
 
     # Otherwise, try to generate one somehow
     try:
-        ref_format = papis.config.getformattedstring("ref-format")
+        ref_format = papis.config.getformatpattern("ref-format")
         ref = papis.format.format(ref_format, doc, default="")
     except ValueError:
         ref = ""

--- a/papis/cli.py
+++ b/papis/cli.py
@@ -11,7 +11,7 @@ import papis.database
 DecoratorCallable = Callable[..., Any]
 
 
-class FormattedStringParamType(click.ParamType):
+class FormatPatternParamType(click.ParamType):
     #: Name of the parameter type (shown in the command-line).
     name: str = "formatted-text"
 
@@ -20,11 +20,11 @@ class FormattedStringParamType(click.ParamType):
                 param: Optional[click.Parameter],
                 ctx: Optional[click.Context]) -> Any:
         """See :meth:`click.ParamType.convert`."""
-        from papis.strings import FormattedString
+        from papis.strings import FormatPattern
 
         # NOTE: this is required to handle default values which have a formatter
         # already set and we do not want to remove it
-        if isinstance(value, FormattedString):
+        if isinstance(value, FormatPattern):
             return value
 
         return str(value)

--- a/papis/cli.py
+++ b/papis/cli.py
@@ -13,7 +13,7 @@ DecoratorCallable = Callable[..., Any]
 
 class FormatPatternParamType(click.ParamType):
     #: Name of the parameter type (shown in the command-line).
-    name: str = "formatted-text"
+    name: str = "pattern"
 
     def convert(self,
                 value: Any,
@@ -30,7 +30,7 @@ class FormatPatternParamType(click.ParamType):
         return str(value)
 
     def __repr__(self) -> str:
-        return "FORMATTEDSTRING"
+        return "FORMATPATTERN"
 
 
 def bool_flag(*args: Any, **kwargs: Any) -> DecoratorCallable:

--- a/papis/commands/add.py
+++ b/papis/commands/add.py
@@ -430,12 +430,12 @@ def run(paths: List[str],
 @click.option(
     "--folder-name",
     help="Name format for the document main folder.",
-    type=papis.cli.FormattedStringParamType(),
-    default=lambda: papis.config.getformattedstring("add-folder-name"))
+    type=papis.cli.FormatPatternParamType(),
+    default=lambda: papis.config.getformatpattern("add-folder-name"))
 @click.option(
     "--file-name",
     help="File name format for the document.",
-    type=papis.cli.FormattedStringParamType(),
+    type=papis.cli.FormatPatternParamType(),
     default=None)
 @click.option(
     "--from", "from_importer",

--- a/papis/commands/add.py
+++ b/papis/commands/add.py
@@ -264,7 +264,7 @@ def run(paths: List[str],
 
     # reference building
     # NOTE: this needs to go before any papis.format calls, so that those can
-    # potentially use the 'ref' key in the formatted strings.
+    # potentially use the 'ref' key in the format patterns.
     if "ref" not in data:
         new_ref = papis.bibtex.create_reference(data)
         if new_ref:

--- a/papis/commands/addto.py
+++ b/papis/commands/addto.py
@@ -102,7 +102,7 @@ def run(document: papis.document.Document,
 @click.option("-u", "--urls", help="URLs to documents.", multiple=True)
 @click.option("--file-name",
               help="File name format for the document.",
-              type=papis.cli.FormattedStringParamType(),
+              type=papis.cli.FormatPatternParamType(),
               default=None)
 @click.option(
     "--link/--no-link",

--- a/papis/commands/bibtex.py
+++ b/papis/commands/bibtex.py
@@ -342,7 +342,7 @@ def cli_open(ctx: click.Context) -> None:
 @click.option("-s", "--set", "set_tuples",
               help="Update a document with key value pairs.",
               multiple=True,
-              type=(str, papis.cli.FormattedStringParamType()),)
+              type=(str, papis.cli.FormatPatternParamType()),)
 @papis.cli.all_option()
 @click.pass_context
 def cli_edit(ctx: click.Context,
@@ -385,7 +385,7 @@ def cli_edit(ctx: click.Context,
 
         if set_tuples:
             for k, v in set_tuples:
-                kp, vp = papis.strings.process_formatted_string_pair(k, v)
+                kp, vp = papis.strings.process_format_pattern_pair(k, v)
                 try:
                     located[kp] = papis.format.format(vp, located)
                 except papis.format.FormatFailedError as exc:

--- a/papis/commands/browse.py
+++ b/papis/commands/browse.py
@@ -114,7 +114,7 @@ def run(document: papis.document.Document,
         import urllib.parse
         params = {
             "q": papis.format.format(
-                papis.config.getformattedstring("browse-query-format"),
+                papis.config.getformatpattern("browse-query-format"),
                 document,
                 default="{} {}".format(document["author"], document["title"]))
         }

--- a/papis/commands/explore.py
+++ b/papis/commands/explore.py
@@ -268,7 +268,7 @@ def add(ctx: click.Context) -> None:
 @click.command("cmd")
 @click.pass_context
 @click.help_option("--help", "-h")
-@click.argument("command", type=papis.cli.FormattedStringParamType())
+@click.argument("command", type=papis.cli.FormatPatternParamType())
 def cmd(ctx: click.Context, command: str) -> None:
     """
     Run a general command on the document list.

--- a/papis/commands/explore.py
+++ b/papis/commands/explore.py
@@ -77,7 +77,7 @@ file, e.g. the previously created ``docs.yaml``:
 In this last example, we read the documents from ``docs.yaml`` and pick a
 document, which we then feed into the ``explore cmd`` command.  This command
 accepts a string to issue a general shell command and allows formatting with the
-Papis template syntax.  In this case, the picked document gets fed into the
+Papis format syntax.  In this case, the picked document gets fed into the
 ``papis scihub`` command which tries to download the document using ``scihub``.
 Also this very document is opened by Firefox (in case the document does have a
 ``url``).

--- a/papis/commands/list.py
+++ b/papis/commands/list.py
@@ -217,7 +217,7 @@ run = list_documents
 @click.option(
     "--format", "show_format",
     help="Show documents using a custom format, e.g. '{doc[year]} {doc[title]}'.",
-    type=papis.cli.FormattedStringParamType(),
+    type=papis.cli.FormatPatternParamType(),
     default="")
 @papis.cli.bool_flag(
     "--paths", "show_paths",

--- a/papis/commands/open.py
+++ b/papis/commands/open.py
@@ -108,7 +108,7 @@ def run(document: papis.document.Document,
             logger.debug("Getting document's marks.")
             marks = document[papis.config.getstring("mark-key-name")]
             if marks:
-                _mark_fmt = papis.config.getformattedstring("mark-header-format")
+                _mark_fmt = papis.config.getformatpattern("mark-header-format")
                 _mark_name = papis.config.getstring("mark-format-name")
                 _mark_opener = papis.config.getstring("mark-opener-format")
                 if not _mark_fmt:

--- a/papis/commands/rename.py
+++ b/papis/commands/rename.py
@@ -110,8 +110,8 @@ def run(document: papis.document.Document,
 @click.option(
     "--folder-name",
     help="Name format for the document main folder.",
-    type=papis.cli.FormattedStringParamType(),
-    default=lambda: papis.config.getformattedstring("add-folder-name"))
+    type=papis.cli.FormatPatternParamType(),
+    default=lambda: papis.config.getformatpattern("add-folder-name"))
 @papis.cli.bool_flag(
     "-b", "--batch",
     help="Batch mode, do not prompt.")

--- a/papis/commands/update.py
+++ b/papis/commands/update.py
@@ -142,7 +142,7 @@ import papis.importer
 import papis.logging
 import papis.strings
 import papis.utils
-from papis.strings import AnyString, process_formatted_string_pair
+from papis.strings import AnyString, process_format_pattern_pair
 
 logger = papis.logging.get_logger(__name__)
 
@@ -176,7 +176,7 @@ def run_set(
     from papis.paths import normalize_path
 
     for key, value in to_set:
-        key, value = process_formatted_string_pair(key, value)
+        key, value = process_format_pattern_pair(key, value)
         value = papis.format.format(value, document, default=str(value))
         value = try_parsing_str(key, value)
 
@@ -226,7 +226,7 @@ def run_append(
     processed_lists = set()
     supported_keys = key_types.keys() | document
     for key, value in to_append:
-        key, value = process_formatted_string_pair(key, value)
+        key, value = process_format_pattern_pair(key, value)
 
         if key in supported_keys:
             value = papis.format.format(value, document, default=str(value))
@@ -282,7 +282,7 @@ def run_remove(
     """
     success = True
     for key, value in to_remove:
-        key, value = process_formatted_string_pair(key, value)
+        key, value = process_format_pattern_pair(key, value)
 
         if key in document:
             if isinstance(document.get(key), list):
@@ -428,7 +428,7 @@ def run(
     "to_set",
     help="Set the key to the given value.",
     multiple=True,
-    type=(str, papis.cli.FormattedStringParamType()),
+    type=(str, papis.cli.FormatPatternParamType()),
 )
 @click.option(
     "-d",
@@ -444,7 +444,7 @@ def run(
     "to_append",
     help="Append a value to a document key.",
     multiple=True,
-    type=(str, papis.cli.FormattedStringParamType()),
+    type=(str, papis.cli.FormatPatternParamType()),
 )
 @click.option(
     "-r",
@@ -452,7 +452,7 @@ def run(
     "to_remove",
     help="Remove an item from a list.",
     multiple=True,
-    type=(str, papis.cli.FormattedStringParamType()),
+    type=(str, papis.cli.FormatPatternParamType()),
 )
 @click.option(
     "-n",
@@ -461,8 +461,8 @@ def run(
     help="Rename an item in a list.",
     multiple=True,
     type=(str,
-          papis.cli.FormattedStringParamType(),
-          papis.cli.FormattedStringParamType()),
+          papis.cli.FormatPatternParamType(),
+          papis.cli.FormatPatternParamType()),
 )
 @papis.cli.bool_flag(
     "-b",

--- a/papis/config.py
+++ b/papis/config.py
@@ -8,7 +8,7 @@ import platformdirs
 import papis.exceptions
 import papis.library
 import papis.logging
-from papis.strings import FormattedString
+from papis.strings import FormatPattern
 
 logger = papis.logging.get_logger(__name__)
 
@@ -483,10 +483,10 @@ def getstring(key: str, section: Optional[str] = None) -> str:
     return str(result)
 
 
-def getformattedstring(key: str, section: Optional[str] = None) -> FormattedString:
-    """Retrieve a formatted string value from the configuration file.
+def getformatpattern(key: str, section: Optional[str] = None) -> FormatPattern:
+    """Retrieve a format pattern from the configuration file.
 
-    Formatted strings use the :class:`~papis.strings.FormattedString` class to
+    Format patterns use the :class:`~papis.strings.FormatPattern` class to
     define a string that should be formatted by a specific
     :class:`~papis.format.Formatter`. For configuration options, such strings
     can be defined in the configuration file as::
@@ -501,17 +501,17 @@ def getformattedstring(key: str, section: Optional[str] = None) -> FormattedStri
     Formatters are checked in alphabetical order and the last one is returned.
 
         >>> set("add-open", "hello world")
-        >>> r = getformattedstring("add-open")
+        >>> r = getformatpattern("add-open")
         >>> r.formatter
         'python'
 
-        >>> set("add-open", FormattedString("python", "hello world"))
-        >>> r = getformattedstring("add-open")
+        >>> set("add-open", FormatPattern("python", "hello world"))
+        >>> r = getformatpattern("add-open")
         >>> r.formatter
         'python'
 
         >>> set("add-open.python", "hello world")
-        >>> r = getformattedstring("add-open")
+        >>> r = getformatpattern("add-open")
         >>> r.formatter
         'python'
     """
@@ -531,10 +531,10 @@ def getformattedstring(key: str, section: Optional[str] = None) -> FormattedStri
     if result is None:
         result = general_get(key, section=section, data_type=str)
 
-    if isinstance(result, FormattedString):
+    if isinstance(result, FormatPattern):
         return result
     elif isinstance(result, str):
-        return FormattedString(formatter, result)
+        return FormatPattern(formatter, result)
     else:
         raise ValueError(f"Key '{key}' should be a string: '{result}'")
 

--- a/papis/database/cache.py
+++ b/papis/database/cache.py
@@ -81,7 +81,7 @@ def match_document(
     else:
         from papis.format import format
 
-        match_format = match_format or papis.config.getformattedstring("match-format")
+        match_format = match_format or papis.config.getformatpattern("match-format")
         match_string = format(match_format, document)
 
     return search.match(match_string)

--- a/papis/defaults.py
+++ b/papis/defaults.py
@@ -2,11 +2,11 @@ import sys
 import os
 from typing import Any, Dict
 
-from papis.strings import FormattedString
+from papis.strings import FormatPattern
 
 
-def _f(value: str) -> FormattedString:
-    return FormattedString("python", value)
+def _f(value: str) -> FormatPattern:
+    return FormatPattern("python", value)
 
 
 def get_default_opener() -> str:

--- a/papis/docmatcher.py
+++ b/papis/docmatcher.py
@@ -4,7 +4,7 @@ from typing import Any, ClassVar, List, NamedTuple, Optional, Pattern, Protocol
 import papis.config
 import papis.document
 import papis.logging
-from papis.strings import AnyString, FormattedString
+from papis.strings import AnyString, FormatPattern
 
 logger = papis.logging.get_logger(__name__)
 
@@ -89,7 +89,7 @@ class DocMatcher:
     matcher: ClassVar[Optional[MatcherCallable]] = None
     #: A format string (defaulting to :confval:`match-format`) used
     #: to match the parsed search results if no document key is present.
-    match_format: ClassVar[FormattedString] = FormattedString(None, "")
+    match_format: ClassVar[FormatPattern] = FormatPattern(None, "")
 
     @classmethod
     def return_if_match(
@@ -172,7 +172,7 @@ class DocMatcher:
         if search is None:
             search = cls.search
 
-        cls.match_format = papis.config.getformattedstring("match-format")
+        cls.match_format = papis.config.getformatpattern("match-format")
         cls.parsed_search = parse_query(search)
 
         return cls.parsed_search

--- a/papis/document.py
+++ b/papis/document.py
@@ -168,7 +168,7 @@ def author_list_to_author(
 
     if multiple_authors_format is None:
         multiple_authors_format = (
-            papis.config.getformattedstring("multiple-authors-format"))
+            papis.config.getformatpattern("multiple-authors-format"))
 
     if separator is None or multiple_authors_format is None:
         raise ValueError(
@@ -545,7 +545,7 @@ def describe(document: Union[Document, Dict[str, Any]]) -> str:
         :confval:`document-description-format`.
     """
     return papis.format.format(
-        papis.config.getformattedstring("document-description-format"),
+        papis.config.getformatpattern("document-description-format"),
         document, default=document.get("title", str(document)))
 
 

--- a/papis/document.py
+++ b/papis/document.py
@@ -500,7 +500,7 @@ def to_dict(document: Document) -> Dict[str, Any]:
 
 
 def dump(document: Document) -> str:
-    """Dump the document into a formatted string.
+    """Dump the document into a string.
 
     The format of the string is not fixed and is meant to be used to display the
     document entries in a consistent way across ``papis``.

--- a/papis/format.py
+++ b/papis/format.py
@@ -338,10 +338,10 @@ def format(fmt: papis.strings.AnyString,
     Arguments match those of :meth:`Formatter.format`.
     """
     if isinstance(fmt, str):
-        fmt = papis.strings.FormattedString(None, fmt)
+        fmt = papis.strings.FormatPattern(None, fmt)
 
     formatter = get_formatter(fmt.formatter)
-    return formatter.format(fmt.value, doc, doc_key=doc_key,
+    return formatter.format(fmt.pattern, doc, doc_key=doc_key,
                             additional=additional,
                             default=default)
 

--- a/papis/format.py
+++ b/papis/format.py
@@ -20,10 +20,10 @@ class InvalidFormatterError(ValueError):
 
 
 class FormatFailedError(Exception):
-    """An exception that is thrown when a format string fails to be interpolated.
+    """An exception that is thrown when a format pattern fails to be interpolated.
 
     This can happen due to lack of data (e.g. missing fields in the document)
-    or invalid format strings (e.g. passed to the wrong formatter).
+    or invalid format patterns (e.g. passed to the wrong formatter).
     """
 
 
@@ -47,11 +47,11 @@ class Formatter:
                additional: Optional[Dict[str, Any]] = None,
                default: Optional[str] = None) -> str:
         """
-        :param fmt: a format string understood by the formatter.
+        :param fmt: a format pattern understood by the formatter.
         :param doc: an object convertible to a document.
-        :param doc_key: the name of the document in the format string. By
+        :param doc_key: the name of the document in the format pattern. By
             default, this falls back to :confval:`format-doc-name`.
-        :param default: an optional string to use as a default value if the
+        :param default: an optional pattern to use as a default value if the
             formatting fails. If no default is given, a :exc:`FormatFailedError`
             will be raised.
         :param additional: a :class:`dict` of additional entries to pass to the
@@ -109,12 +109,12 @@ class _PythonStringFormatter(string.Formatter):
 
 class PythonFormatter(Formatter):
     """Construct a string using a `PEP 3101 <https://peps.python.org/pep-3101/>`__
-    (*str.format* based) format string.
+    (*str.format* based) format pattern.
 
     This formatter is named ``"python"`` and can be set using the
     :confval:`formatter` setting in the configuration file. The
-    formatted string has access to the ``doc`` variable, that is always a
-    :class:`papis.document.Document`. A string using this formatter can look
+    format pattern has access to the ``doc`` variable, that is always a
+    :class:`papis.document.Document`. A pattern using this formatter can look
     like:
 
     .. code:: python
@@ -170,7 +170,7 @@ class PythonFormatter(Formatter):
             return self.psf.format(fmt, **{doc_name: doc}, **additional)
         except Exception as exc:
             if default is not None:
-                logger.warning("Could not format string '%s' for document '%s'",
+                logger.warning("Could not format pattern '%s' for document '%s'",
                                fmt, papis.document.describe(doc), exc_info=exc)
                 return default
             else:
@@ -183,8 +183,8 @@ class Jinja2Formatter(Formatter):
 
     This formatter is named ``"jinja2"`` and can be set using the
     :confval:`formatter` setting in the configuration file. The
-    formatted string has access to the ``doc`` variable, that is always a
-    :class:`papis.document.Document`. A string using this formatter can look
+    format pattern has access to the ``doc`` variable, that is always a
+    :class:`papis.document.Document`. A pattern using this formatter can look
     like:
 
     .. code:: python
@@ -268,7 +268,7 @@ class Jinja2Formatter(Formatter):
             return str(env.from_string(fmt).render(**{doc_name: doc}, **additional))
         except Exception as exc:
             if default is not None:
-                logger.warning("Could not format string '%s' for document '%s'",
+                logger.warning("Could not format pattern '%s' for document '%s'",
                                fmt, papis.document.describe(doc), exc_info=exc)
                 return default
             else:

--- a/papis/fzf.py
+++ b/papis/fzf.py
@@ -137,7 +137,7 @@ class Picker(papis.pick.Picker[T]):
             [fzf, "--bind", ",".join(bindings)]
             + papis.config.getlist("fzf-extra-flags"))
 
-        _fmt = papis.config.getformattedstring("fzf-header-format")
+        _fmt = papis.config.getformatpattern("fzf-header-format")
 
         def _header_filter(d: T) -> str:
             if isinstance(d, papis.document.Document):

--- a/papis/notes.py
+++ b/papis/notes.py
@@ -32,7 +32,7 @@ def notes_path(doc: papis.document.Document) -> str:
 
     if not has_notes(doc):
         notes_name = papis.format.format(
-            papis.config.getformattedstring("notes-name"), doc,
+            papis.config.getformatpattern("notes-name"), doc,
             default="notes.tex")
         doc["notes"] = normalize_path(notes_name)
         papis.api.save_doc(doc)

--- a/papis/paths.py
+++ b/papis/paths.py
@@ -6,7 +6,7 @@ from warnings import warn
 
 import papis.config
 import papis.logging
-from papis.strings import AnyString, FormattedString
+from papis.strings import AnyString, FormatPattern
 from papis.document import DocumentLike
 from papis.document import from_data
 
@@ -167,7 +167,7 @@ def get_document_file_name(
 
     if file_name_format is None:
         try:
-            file_name_format = papis.config.getformattedstring("add-file-name")
+            file_name_format = papis.config.getformatpattern("add-file-name")
         except ValueError:
             file_name_format = None
 
@@ -237,16 +237,16 @@ def get_document_folder(
 
     if folder_name_format is None:
         try:
-            folder_name_format = papis.config.getformattedstring("add-folder-name")
+            folder_name_format = papis.config.getformatpattern("add-folder-name")
         except ValueError:
             folder_name_format = None
 
     if isinstance(folder_name_format, str):
-        folder_name_format = FormattedString(None, folder_name_format)
+        folder_name_format = FormatPattern(None, folder_name_format)
 
     # try to get a folder name from folder_name_format
     if folder_name_format:
-        tmp_path = os.path.normpath(os.path.join(dirname, folder_name_format.value))
+        tmp_path = os.path.normpath(os.path.join(dirname, folder_name_format.pattern))
 
         # NOTE: the folder_name_format can contain subfolders, so we go through
         # them one by one and expand them here to get the full path
@@ -260,7 +260,7 @@ def get_document_folder(
 
             try:
                 tmp_component = papis.format.format(
-                    FormattedString(folder_name_format.formatter, tmp_component),
+                    FormatPattern(folder_name_format.formatter, tmp_component),
                     doc)
             except papis.format.FormatFailedError as exc:
                 logger.error("Could not format path for document.", exc_info=exc)
@@ -365,7 +365,7 @@ def rename_document_files(
     """
     if file_name_format is None:
         try:
-            file_name_format = papis.config.getformattedstring("add-file-name")
+            file_name_format = papis.config.getformatpattern("add-file-name")
         except ValueError:
             file_name_format = None
 

--- a/papis/pick.py
+++ b/papis/pick.py
@@ -99,15 +99,15 @@ def pick_doc(
     :arg documents: a sequence of documents.
     :returns: a subset of *documents* that was picked.
     """
-    from papis.strings import FormattedString
+    from papis.strings import FormatPattern
 
     header_format_path = papis.config.get("header-format-file")
     if header_format_path is not None:
         with open(os.path.expanduser(header_format_path)) as fd:
-            header_format = FormattedString(None, fd.read().rstrip())
+            header_format = FormatPattern(None, fd.read().rstrip())
     else:
-        header_format = papis.config.getformattedstring("header-format")
-    match_format = papis.config.getformattedstring("match-format")
+        header_format = papis.config.getformatpattern("header-format")
+    match_format = papis.config.getformatpattern("match-format")
 
     from functools import partial
 
@@ -149,7 +149,7 @@ def pick_library(libs: Optional[List[str]] = None) -> List[str]:
     if libs is None:
         libs = papis.api.get_libraries()
 
-    header_format = papis.config.getformattedstring("library-header-format")
+    header_format = papis.config.getformatpattern("library-header-format")
 
     def header_filter(lib: str) -> str:
         library = papis.config.get_lib_from_name(lib)

--- a/papis/strings.py
+++ b/papis/strings.py
@@ -1,72 +1,72 @@
 from typing import Any, Optional, NamedTuple, Tuple, Union
 
 
-class FormattedString(NamedTuple):
+class FormatPattern(NamedTuple):
     """A tuple that defines a ``(formatter, string)`` pair.
 
-    In a configuration file, a formatted string can be defined as:
+    In a configuration file, a format pattern can be defined as:
 
     .. code:: ini
 
-        key = formatted_value
-        other_key.formatter = other_formatted_value
+        key = pattern
+        other_key.formatter = other_pattern
 
     where the first key will use the default :confval:`formatter` and the second
     key will use the specified formatter. These keys can be read using
-    :func:`papis.config.getformattedstring`.
+    :func:`papis.config.getformatpattern`.
 
     .. autoattribute:: formatter
-    .. autoattribute:: value
+    .. autoattribute:: pattern
     """
 
-    #: The formatter that should be used on the string :attr:`value`. If none
+    #: The formatter that should be used on the string :attr:`pattern`. If none
     #: is provided, the default formatter is used, as defined by
     #: :confval:`formatter`.
     formatter: Optional[str]
-    #: Value of the
-    value: str
+    #: Pattern that should be evaluated by the *formatter*.
+    pattern: str
 
     def __str__(self) -> str:
-        return self.value
+        return self.pattern
 
     def __repr__(self) -> str:
-        return repr(self.value)
+        return repr(self.pattern)
 
     def __bool__(self) -> bool:
-        return bool(self.value)
+        return bool(self.pattern)
 
-    # NOTE: __eq__ and __hash__ are implemented to ensure that formatted
-    # strings can be used in 'click.option' with 'click.Choice'. This is not
+    # NOTE: __eq__ and __hash__ are implemented to ensure that format
+    # pattern can be used in 'click.option' with 'click.Choice'. This is not
     # very intuitive, as strings with the same text, but different formatters
     # will be equal. However, this is only an issue if the formatters use the
     # same templating language.
 
     def __eq__(self, other: Any) -> bool:
         if isinstance(other, str):
-            return self.value == other
-        elif isinstance(other, FormattedString):
-            return self.value == other.value
+            return self.pattern == other
+        elif isinstance(other, FormatPattern):
+            return self.pattern == other.pattern
         else:
             return False
 
     def __hash__(self) -> int:
-        return hash(self.value)
+        return hash(self.pattern)
 
 
-AnyString = Union[str, FormattedString]
+AnyString = Union[str, FormatPattern]
 
 
-def process_formatted_string_pair(
+def process_format_pattern_pair(
     key: str,
-    value: AnyString
-) -> Tuple[str, FormattedString]:
+    pattern: AnyString
+) -> Tuple[str, FormatPattern]:
     """
     :param key: a document key in the format ``key[.formatter]``.
-    :param value: an unformatted value.
+    :param pattern: an unformatted pattern.
 
-    :returns: a ``(key, value)`` pair, where the formatter was removed from the
-        *key* and the *value* is guaranteed to be a :class:`FormattedString`. If the
-        *value* already defines a formatter, it is overwritten by the one defined
+    :returns: a ``(key, pattern)`` pair, where the formatter was removed from the
+        *key* and the *pattern* is guaranteed to be a :class:`FormatPattern`. If the
+        *pattern* already defines a formatter, it is overwritten by the one defined
         by the *key*.
     """
     if "." in key:
@@ -74,13 +74,13 @@ def process_formatted_string_pair(
     else:
         formatter = None
 
-    if isinstance(value, FormattedString):
+    if isinstance(pattern, FormatPattern):
         if formatter is not None:
-            value = FormattedString(formatter, value.value)
+            pattern = FormatPattern(formatter, pattern.pattern)
     else:
-        value = FormattedString(formatter, value)
+        pattern = FormatPattern(formatter, pattern)
 
-    return key, value
+    return key, pattern
 
 
 no_documents_retrieved_message = "No documents retrieved"

--- a/tests/test_format.py
+++ b/tests/test_format.py
@@ -34,11 +34,11 @@ def test_python_formatter(tmp_config: TemporaryConfiguration) -> None:
     assert papis.format.format("{doc[title]:2S}", data) == "The Phantom"
 
     # test out a jinja2 format
-    from papis.strings import FormattedString
+    from papis.strings import FormatPattern
     assert len(papis.format.FORMATTER) == 1
     assert (
         papis.format.format(
-            FormattedString("jinja2", "{{ doc.author }}: {{ doc.title }}"),
+            FormatPattern("jinja2", "{{ doc.author }}: {{ doc.title }}"),
             document)
         == "Fulano: A New Hope")
     assert len(papis.format.FORMATTER) == 2
@@ -70,10 +70,10 @@ def test_jinja_formatter(tmp_config: TemporaryConfiguration) -> None:
 
     # test out a python format
     assert len(papis.format.FORMATTER) == 1
-    from papis.strings import FormattedString
+    from papis.strings import FormatPattern
     assert (
         papis.format.format(
-            FormattedString("python", "{doc[author]}: {doc[title]}"),
+            FormatPattern("python", "{doc[author]}: {doc[title]}"),
             document)
         == "Fulano: A New Hope")
     assert len(papis.format.FORMATTER) == 2
@@ -89,7 +89,7 @@ def test_overwritten_keys(tmp_config: TemporaryConfiguration) -> None:
         "author": "Fulano", "year": 2020, "title": "A New Hope"
     })
 
-    fmt = papis.config.getformattedstring("ref-format")
+    fmt = papis.config.getformatpattern("ref-format")
     assert fmt.formatter == "jinja2"
 
     ref = papis.format.format(fmt, document)


### PR DESCRIPTION
@jghauser This tries to update the "formatted string" naming to "format pattern" as you suggested a while ago. I search a bit through the docs, but might have missed some. Let me know what you think :grin: 

Fixes #1012.