### PR TITLE
Show HTTP errors from importers

### DIFF
--- a/papis/arxiv.py
+++ b/papis/arxiv.py
@@ -133,7 +133,8 @@ def get_data(
             max_results=max_results,
             id_list=id_list.split(";"),
             )
-    except arxiv.arxiv.HTTPError:
+    except arxiv.ArxivError as exc:
+        logger.error("Failed to download metadata from arXiv.", exc_info=exc)
         return []
 
     client = arxiv.Client()
@@ -300,7 +301,9 @@ class Downloader(papis.downloaders.Downloader):
             client = arxiv.Client()
             try:
                 results = list(client.results(arxiv.Search(id_list=[self.arxivid])))
-            except arxiv.arxiv.HTTPError:
+            except arxiv.ArxivError as exc:
+                self.logger.error(
+                    "Failed to download metadata from arXiv.", exc_info=exc)
                 results = []
 
             if len(results) > 1:

--- a/papis/downloaders/__init__.py
+++ b/papis/downloaders/__init__.py
@@ -357,6 +357,7 @@ class Downloader(papis.importer.Importer):
         url = self.get_document_url()
         if not url:
             return
+
         self.logger.info("Downloading file from '%s'.", url)
 
         response = self.session.get(url, cookies=self.cookies)

--- a/papis/utils.py
+++ b/papis/utils.py
@@ -476,8 +476,9 @@ def get_matching_importer_by_name(
     if download_files is None:
         download_files = False
 
-    import_mgr = papis.importer.get_import_mgr()
+    import requests
 
+    import_mgr = papis.importer.get_import_mgr()
     result = []
     for name, uri in name_and_uris:
         try:
@@ -494,6 +495,11 @@ def get_matching_importer_by_name(
 
             if importer.ctx:
                 result.append(importer)
+        except requests.exceptions.RequestException as exc:
+            # NOTE: this is probably some HTTP error, so we better let the
+            # user know if there's something wrong with their network
+            logger.error("Failed to match importer '%s': '%s'.",
+                         name, uri, exc_info=exc)
         except Exception as exc:
             logger.debug("Failed to match importer '%s': '%s'.",
                          name, uri, exc_info=exc)


### PR DESCRIPTION
When downloading metadata from importers using `get_matching_importer_by_name`, errors were only shown in debug mode. This made for some rather opaque issues when an importer would just fail to download something due to network issues.

This makes errors from `requests.exceptions.RequestException` louder so that they can be seen and debugged. Also added some more error messages for the arXiv importer, since that's where this started :grin:

xref: https://github.com/papis/papis/discussions/1031