### PR TITLE
Export (over)write outfile by default, add `--append` and `--batch` flags

### DIFF
--- a/doc/source/default_settings.rst
+++ b/doc/source/default_settings.rst
@@ -282,10 +282,10 @@ BibTeX options
 .. papis-config:: bibtex-journal-key
 
     This option allows the user to set the key for the journal entry when using
-    ``papis export --bibtex``. The intended use of such a setting is to allow
-    selecting e.g. abbreviated journal titles for publishers that require it.
-    For example, if the document has an ``abbrev_journal_title`` key that should
-    be used instead of the default ``journal`` key.
+    ``papis export --format bibtex``. The intended use is to allow selecting
+    e.g. abbreviated journal titles for publishers that require it. For
+    example, if the document has an ``abbrev_journal_title`` key that should be
+    used instead of the default ``journal`` key.
 
 .. papis-config:: extra-bibtex-keys
 

--- a/papis/commands/export.py
+++ b/papis/commands/export.py
@@ -13,17 +13,24 @@ Some examples of its usage are:
 
     papis export --format bibtex 'author : einstein'
 
-or export all of them:
+- Note that BibTeX is the default format. The ``--format`` flag can be omitted:
 
 .. code:: sh
 
-    papis export --format bibtex --all 'author : einstein'
+    papis export 'author : einstein'
 
-- Export all documents to BibTeX and save them into a ``lib.bib`` file:
+- Export all documents with author Einstein to BibTeX:
 
 .. code:: sh
 
-    papis export --all --format bibtex --out lib.bib
+    papis export --all 'author : einstein'
+
+- Export all documents in your default library to BibTeX and save them into a
+  ``lib.bib`` file:
+
+.. code:: sh
+
+    papis export --all --out lib.bib
 
 - Export a folder of one of the documents matching the word ``krebs``
   into a folder named ``interesting-document``:

--- a/papis/commands/export.py
+++ b/papis/commands/export.py
@@ -155,39 +155,31 @@ def cli(query: str,
     ret_string = run(documents, to_format=fmt)
 
     if ret_string and not folder:
-        if out is not None:
-            if append:
-                if os.path.exists(out):
-                    logger.info("Appending to '%s'.", out)
-                else:
-                    logger.info("Writing to '%s'.", out)
-
-                with open(out, "a") as fd:
-                    fd.write(ret_string)
-                return
-
-            if os.path.exists(out) and not batch:
-                if papis.tui.utils.confirm(f"File '{out}' already exists. Overwrite?"):
-                    logger.info("Overwriting '%s'.", out)
-                    with open(out, "w") as fd:
-                        fd.write(ret_string)
-                else:
-                    logger.info("Aborting.")
-                return
-
-            if os.path.exists(out):
-                # Batch write
-                logger.info("Overwriting '%s'.", out)
-            else:
-                logger.info("Writing to '%s'.", out)
-
-            with open(out, "w") as fd:
-                fd.write(ret_string)
-            return
-        else:
+        if out is None:
             logger.info("Dumping to STDOUT.")
             click.echo(ret_string)
             return
+
+        mode = "a" if append else "w"
+
+        if os.path.exists(out):
+            if append:
+                msg = f"Appending to '{out}'."
+            else:
+                if not batch:
+                    prompt = f"File '{out}' already exists. Overwrite?"
+                    if not papis.tui.utils.confirm(prompt):
+                        logger.info("Aborting.")
+                        return
+                msg = f"Overwriting '{out}'."
+        else:
+            msg = f"Writing to '{out}'."
+
+        logger.info(msg)
+        with open(out, mode) as fd:
+            fd.write(ret_string)
+
+        return
 
     import shutil
     for document in documents:


### PR DESCRIPTION
- [x] implementation
    - done but append formats badly
        - may be in the scope of another issue and PR (see 2 comments below)
- [x] docs
- [x] tests (should I add any?)

Issue: #988 