### PR TITLE
Update completion scripts generated by click

### DIFF
--- a/contrib/shell_completion/click/fish/papis.fish
+++ b/contrib/shell_completion/click/fish/papis.fish
@@ -1,9 +1,5 @@
 function _papis_completion;
-    set -l response;
-
-    for value in (env _PAPIS_COMPLETE=fish_complete COMP_WORDS=(commandline -cp) COMP_CWORD=(commandline -t) papis);
-        set response $response $value;
-    end;
+    set -l response (env _PAPIS_COMPLETE=fish_complete COMP_WORDS=(commandline -cp) COMP_CWORD=(commandline -t) papis);
 
     for completion in $response;
         set -l metadata (string split "," $completion);

--- a/contrib/shell_completion/click/zsh/_papis
+++ b/contrib/shell_completion/click/zsh/_papis
@@ -31,5 +31,11 @@ _papis_completion() {
     fi
 }
 
-compdef _papis_completion papis;
+if [[ $zsh_eval_context[-1] == loadautofunc ]]; then
+    # autoload from fpath, call function directly
+    _papis_completion "$@"
+else
+    # eval/source/. command, register function for later
+    compdef _papis_completion papis
+fi
 


### PR DESCRIPTION
Re-ran the click shell completion generator things and noticed that they have a few changes.

cc @jghauser @tuurep Haven't tested if this fixes the two-tab issue, but can't hurt.