### PR TITLE
usenix: Hardcode BibTeX URL to avoid requests

### DIFF
--- a/tests/downloaders/test_usenix.py
+++ b/tests/downloaders/test_usenix.py
@@ -7,10 +7,12 @@ from papis.downloaders.usenix import Downloader
 
 from papis.testing import TemporaryConfiguration, ResourceCache
 
-USENIX_LINK_URLS = (
-    "https://www.usenix.org/conference/usenixsecurity22/presentation/bulekov",
-    "https://www.usenix.org/conference/nsdi22/presentation/goyal",
-    )
+USENIX_LINK_URLS = [
+    ("https://www.usenix.org/conference/usenixsecurity22/presentation/bulekov",
+     "https://www.usenix.org/biblio/export/bibtex/277148"),
+    ("https://www.usenix.org/conference/nsdi22/presentation/goyal",
+     "https://www.usenix.org/biblio/export/bibtex/276958"),
+]
 
 
 def download_bibtex(cache: ResourceCache, down: Downloader, infile: str) -> None:
@@ -25,7 +27,7 @@ def test_usenix_match() -> None:
         "https://usenix.org/conference",
         "http://usenix.org/conference",
         "https://usenix.org/bogus22/link/author",
-        ) + USENIX_LINK_URLS
+        ) + tuple(url for url, _ in USENIX_LINK_URLS)
     invalid_urls = (
         "https://usewin.org/article/123",
         "https://usenix.com/article/123",
@@ -38,11 +40,11 @@ def test_usenix_match() -> None:
         assert Downloader.match(url) is None
 
 
-@pytest.mark.parametrize("url", USENIX_LINK_URLS)
+@pytest.mark.parametrize(("url", "bibtex"), USENIX_LINK_URLS)
 def test_usenix_fetch(tmp_config: TemporaryConfiguration,
                       resource_cache: ResourceCache,
                       monkeypatch: MonkeyPatch,
-                      url: str) -> None:
+                      url: str, bibtex: str) -> None:
     cls = papis.downloaders.get_downloader_by_name("usenix")
     assert cls is Downloader
 
@@ -55,6 +57,7 @@ def test_usenix_fetch(tmp_config: TemporaryConfiguration,
     outfile = "USENIX_{}_Out.json".format(uid)
 
     monkeypatch.setattr(down, "download_document", lambda: None)
+    monkeypatch.setattr(down, "get_bibtex_url", lambda: bibtex)
     monkeypatch.setattr(down, "download_bibtex",
                         lambda: download_bibtex(resource_cache, down, infile))
 


### PR DESCRIPTION
Given the recent failures: https://github.com/papis/papis/actions/runs/16225887703
It seems like the CI might have been IP blocked or something, so this hardcodes the BibTeX URL to avoid making more requests.