### PR TITLE
Workaround to make the usenix downloader usable in face of cloudlflare

### DIFF
--- a/papis/downloaders/usenix.py
+++ b/papis/downloaders/usenix.py
@@ -40,19 +40,27 @@ class Downloader(papis.downloaders.Downloader):
         self.logger.debug("Parsed URL: %s.", path_components)
         return path_components[2] + "-" + path_components[4]
 
+    def _ensure_raw_data(self) -> None:
+        if not self._raw_data:
+            resp = self.session.get(self.uri, cookies=self.cookies)
+            self._raw_data = resp.content.decode("utf-8")
+            if not self._raw_data:
+                self.logger.warning("Failed to fetch data from '%s'.", self.uri)
+
     def get_document_url(self) -> Optional[str]:
         import bs4
 
+        # make sure self._raw_data is available
+        self._ensure_raw_data()
         if not self._raw_data:
-            self._raw_data = self.session.get(self.uri).content.decode("utf-8")
-            if not self._raw_data:
-                self.logger.warning("Failed to fetch data from '%s'.", self.uri)
-                return None
+            return None
 
         soup = bs4.BeautifulSoup(self._raw_data, "html.parser")
         extension = (
             self.expected_document_extensions[0]
-            if self.expected_document_extensions else "")
+            if self.expected_document_extensions
+            else ""
+        )
 
         a = list(
             filter(
@@ -61,12 +69,13 @@ class Downloader(papis.downloaders.Downloader):
                     and t.get("content", "").endswith(extension)
                 ),
                 soup.find_all("meta"),
-            ))
+            )
+        )
 
         if not a:
             self.logger.warning(
-                "No 'citation_pdf_url' URL found in this usenix page: '%s'.",
-                self.uri)
+                "No 'citation_pdf_url' URL found in this usenix page: '%s'.", self.uri
+            )
             return None
 
         self.logger.debug("Found HTML tag: '%s'", a[0])
@@ -80,26 +89,75 @@ class Downloader(papis.downloaders.Downloader):
         o = urlparse(self.uri)
         import bs4
 
+        # make sure self._raw_data is available
+        self._ensure_raw_data()
         if not self._raw_data:
-            self._raw_data = self.session.get(self.uri).content.decode("utf-8")
-            if not self._raw_data:
-                self.logger.warning("Failed to fetch data from '%s'.", self.uri)
-                return None
+            return None
 
         soup = bs4.BeautifulSoup(self._raw_data, "html.parser")
+        re_matcher = re.compile(r"/biblio/export/bibtex/([0-9]+)$")
 
         a = list(
             filter(
-                lambda t: re.match(r"/biblio/export/bibtex/([0-9]+)$",
-                                   t.get("href", "")),
+                lambda t: re_matcher.match(t.get("href", "")),
                 soup.find_all("a"),
-            ))
+            )
+        )
 
         if not a:
-            self.logger.warning("No BibTeX URL found in this usenix page: '%s'.",
-                                self.uri)
+            self.logger.warning(
+                "No BibTeX URL found in this usenix page: '%s'.", self.uri
+            )
             return None
 
         bib_path = a[0].get("href", "")
         bib_url = o._replace(path=bib_path)
         return bib_url.geturl()
+
+    def download_bibtex(self) -> None:
+        """Download and store that BibTeX data from :meth:`get_bibtex_url`.
+        If that doesn't work, e.g., because cloudflare doesn't like papis for
+        some reason, try to find the inline bibtex content and use that instead.
+
+        Use :meth:`get_bibtex_data` to access the metadata from the BibTeX URL.
+        """
+        url = self.get_bibtex_url()
+        if not url:
+            return
+        self.logger.info("Downloading BibTeX from '%s'.", url)
+
+        response = self.session.get(url, cookies=self.cookies)
+        self.bibtex_data = response.content.decode().strip()
+        if self.bibtex_data.startswith("<!DOCTYPE html>"):
+            self.logger.debug("downloaded bibtex data: %s", self.bibtex_data)
+            self.bibtex_data = None
+
+        if self.bibtex_data:
+            return
+
+        # fallback to trying to fetch the bibtex from the _raw_data itself
+        # make sure self._raw_data is available
+        self._ensure_raw_data()
+        if not self._raw_data:
+            return None
+        # setup html parser
+        import bs4
+
+        soup = bs4.BeautifulSoup(self._raw_data, "html.parser")
+
+        # find the bibtex div
+        finds = list(
+            filter(
+                lambda t: "bibtex-text-entry" in t.get("class", ""),
+                soup.find_all("div"),
+            )
+        )
+
+        if finds:
+            div = finds[0]
+            text = div.text.replace("<br/>", "\n")
+            # self.logger.debug("got bibtex from html: %s", text)
+
+            self.bibtex_data = text
+        else:
+            self.logger.debug("failed to identify bibtex content in usenix html page!")

--- a/papis/downloaders/usenix.py
+++ b/papis/downloaders/usenix.py
@@ -129,7 +129,7 @@ class Downloader(papis.downloaders.Downloader):
         response = self.session.get(url, cookies=self.cookies)
         self.bibtex_data = response.content.decode().strip()
         if self.bibtex_data.startswith("<!DOCTYPE html>"):
-            self.logger.debug("downloaded bibtex data: %s", self.bibtex_data)
+            self.logger.debug("Downloaded BibTeX data:\n%s", self.bibtex_data)
             self.bibtex_data = None
 
         if self.bibtex_data:
@@ -156,8 +156,6 @@ class Downloader(papis.downloaders.Downloader):
         if finds:
             div = finds[0]
             text = div.text.replace("<br/>", "\n")
-            # self.logger.debug("got bibtex from html: %s", text)
-
             self.bibtex_data = text
         else:
-            self.logger.debug("failed to identify bibtex content in usenix html page!")
+            self.logger.debug("Failed to identify BibTeX content in USENIX HTML page!")

--- a/papis/utils.py
+++ b/papis/utils.py
@@ -435,9 +435,9 @@ def get_matching_importer_or_downloader(
                         importer.fetch_data()
                     except NotImplementedError:
                         importer.fetch()
-            except Exception:
+            except Exception as exc:
                 logger.debug("%s (%s) failed to fetch query: '%s'.",
-                             name, importer.name, uri)
+                             name, importer.name, uri, exc_info=exc)
             else:
                 logger.info(
                     "{c.Back.BLACK}{c.Fore.GREEN}%s (%s) fetched data for query '%s'!"


### PR DESCRIPTION
For some reason cloudflare blocks only the access to the bibtex file, but not to the pdf or the html page itself. So while the downloader fails because it doesn't have access to the bibtex file, we can work around this by using the inline bibtex information that usenix provides on the html page they serve. This is not ideal, but seems to work for now.