### PR TITLE
fix slugify always replacing hyphens

### DIFF
--- a/papis/paths.py
+++ b/papis/paths.py
@@ -88,14 +88,24 @@ def normalize_path(path: str, *,
     else:
         regex_pattern = fr"[^a-zA-Z0-9.{extra_chars}]+"
 
+    # fix slugify forcefully replacing hyphens
+    if "-" in extra_chars:
+        placeholder = "slugifyhyphenfixer"
+        path = path.replace("\u2010", placeholder).replace("-", placeholder)
+
+        def replace_hyphen(s: str) -> str:
+            return s.replace(placeholder, "-")
+    else:
+        def replace_hyphen(s: str) -> str: return s
+
     import slugify
 
-    return str(slugify.slugify(
+    return replace_hyphen(str(slugify.slugify(
         path,
         word_boundary=True,
         separator=separator,
         regex_pattern=regex_pattern,
-        lowercase=lowercase))
+        lowercase=lowercase)))
 
 
 def is_relative_to(path: PathLike, other: PathLike) -> bool:

--- a/papis/paths.py
+++ b/papis/paths.py
@@ -94,12 +94,13 @@ def normalize_path(path: str, *,
     # see https://github.com/un33k/python-slugify/issues/107
     if "-" in extra_chars:
         path = path.replace("\u2010", _SLUGIFY_HYPHEN_PLACEHOLDER).\
-                    replace("-", _SLUGIFY_HYPHEN_PLACEHOLDER)
+               replace("-", _SLUGIFY_HYPHEN_PLACEHOLDER)
 
         def replace_hyphen(s: str) -> str:
             return s.replace(_SLUGIFY_HYPHEN_PLACEHOLDER, "-")
     else:
-        def replace_hyphen(s: str) -> str: return s
+        def replace_hyphen(s: str) -> str:
+            return s
 
     import slugify
 

--- a/papis/paths.py
+++ b/papis/paths.py
@@ -94,7 +94,7 @@ def normalize_path(path: str, *,
     # see https://github.com/un33k/python-slugify/issues/107
     if "-" in extra_chars:
         path = path.replace("\u2010", _SLUGIFY_HYPHEN_PLACEHOLDER).\
-               replace("-", _SLUGIFY_HYPHEN_PLACEHOLDER)
+            replace("-", _SLUGIFY_HYPHEN_PLACEHOLDER)
 
         def replace_hyphen(s: str) -> str:
             return s.replace(_SLUGIFY_HYPHEN_PLACEHOLDER, "-")

--- a/papis/paths.py
+++ b/papis/paths.py
@@ -18,6 +18,8 @@ PathLike = Union[pathlib.Path, str]
 # NOTE: private error codes for Windows
 WIN_ERROR_PRIVILEGE_NOT_HELD = 1314
 
+_SLUGIFY_HYPHEN_PLACEHOLDER = "slugifyhyphenfixer"
+
 
 def unique_suffixes(chars: Optional[str] = None, skip: int = 0) -> Iterator[str]:
     """Creates an infinite list of suffixes based on *chars*.
@@ -91,11 +93,11 @@ def normalize_path(path: str, *,
     # fix slugify forcefully replacing hyphens
     # see https://github.com/un33k/python-slugify/issues/107
     if "-" in extra_chars:
-        placeholder = "slugifyhyphenfixer"
-        path = path.replace("\u2010", placeholder).replace("-", placeholder)
+        path = path.replace("\u2010", _SLUGIFY_HYPHEN_PLACEHOLDER).\
+                    replace("-", _SLUGIFY_HYPHEN_PLACEHOLDER)
 
         def replace_hyphen(s: str) -> str:
-            return s.replace(placeholder, "-")
+            return s.replace(_SLUGIFY_HYPHEN_PLACEHOLDER, "-")
     else:
         def replace_hyphen(s: str) -> str: return s
 

--- a/papis/paths.py
+++ b/papis/paths.py
@@ -89,6 +89,7 @@ def normalize_path(path: str, *,
         regex_pattern = fr"[^a-zA-Z0-9.{extra_chars}]+"
 
     # fix slugify forcefully replacing hyphens
+    # see https://github.com/un33k/python-slugify/issues/107
     if "-" in extra_chars:
         placeholder = "slugifyhyphenfixer"
         path = path.replace("\u2010", placeholder).replace("-", placeholder)

--- a/tests/test_paths.py
+++ b/tests/test_paths.py
@@ -36,6 +36,15 @@ def test_normalize_path(tmp_config: TemporaryConfiguration) -> None:
     assert normalize_path("масса и енергиа.pdf") == "massa-i-energia.pdf"
     assert normalize_path("الامير الصغير.pdf") == "lmyr-lsgyr.pdf"
 
+    assert (
+        normalize_path("post-truth: a meta‐analysis", extra_chars=" ", separator="")
+        == "posttruth a metaanalysis"
+    )
+    assert (
+        normalize_path("post-truth: a meta‐analysis", extra_chars="-", separator=" ")
+        == "post-truth a meta-analysis"
+    )
+
 
 def test_normalize_path_config(tmp_config: TemporaryConfiguration) -> None:
     import papis.config


### PR DESCRIPTION
Slugify reserves the hyphen-minus character and always replaces it with the separator, even if the regex pattern excludes it https://github.com/un33k/python-slugify/issues/107. This fixes the problem by doing pre-processing if the hyphen-minus is included in `extra-chars`, as suggested in the issue. It does it for both the hyphen-minus (\u002d) and the hyphen (\u2010).
