### PR TITLE
Always follow ref-format. Fixes #1067

### DIFF
--- a/papis/commands/add.py
+++ b/papis/commands/add.py
@@ -264,13 +264,12 @@ def run(paths: list[str],
     # reference building
     # NOTE: this needs to go before any papis.format calls, so that those can
     # potentially use the 'ref' key in the format patterns.
-    if "ref" not in data:
-        from papis.bibtex import create_reference
+    from papis.bibtex import create_reference
 
-        new_ref = create_reference(data)
-        if new_ref:
-            logger.info("Created reference '%s'.", new_ref)
-            tmp_document["ref"] = new_ref
+    new_ref = create_reference(data, True)
+    if new_ref:
+        logger.info("Created reference '%s'.", new_ref)
+        tmp_document["ref"] = new_ref
 
     if auto_doctor:
         logger.info("Running doctor auto-fixers on document: '%s'.",

--- a/tests/commands/test_add.py
+++ b/tests/commands/test_add.py
@@ -97,6 +97,7 @@ def test_add_auto_doctor_run(tmp_library: TemporaryLibrary) -> None:
 
     # add document with auto-doctor on
     papis.config.set("doctor-default-checks", ["keys-missing", "key-type", "refs"])
+
     run(paths, data=data, auto_doctor=True)
 
     # check that all the broken fields are fixed
@@ -105,7 +106,7 @@ def test_add_auto_doctor_run(tmp_library: TemporaryLibrary) -> None:
 
     assert doc["author_list"] == [{"given": "Werner", "family": "Kutzelnigg"}]
     assert isinstance(doc["year"], int) and doc["year"] == 2009
-    assert doc["ref"] == "2FJT2E3A"
+    assert doc["ref"] == "How_many_body_p_Kutzel_2009"
 
 
 def test_add_set_cli(tmp_library: TemporaryLibrary) -> None:


### PR DESCRIPTION
Ignore ref provided by import data, and always follow ref-format when adding a new reference.

I did some limited testing and this seems to work. Following feedback in #1067, I did not bother adding a config flag to restore the previous behavior for now, but I could work on that if necessary. 