### PR TITLE
Fix missing import when picking libs

### DIFF
--- a/papis/pick/__init__.py
+++ b/papis/pick/__init__.py
@@ -188,8 +188,10 @@ def pick_library(libs: list[str] | None = None, *,
 
     :arg libs: a list of libraries to pick from.
     """
+    from papis.api import get_libraries
+
     if libs is None:
-        libs = papis.api.get_libraries()
+        libs = get_libraries()
 
     if header_format is None:
         header_format = papis.config.getformatpattern("library-header-format")


### PR DESCRIPTION
Introduced in #1064. 

Doing some `import papis.SUBMODULE` seems to trick `mypy` and other things that would catch that into thinking that `papis.OTHERMODULE` is also imported.. quite annoying..

Fixes #1071 