### PR TITLE
ci: clean up nix-related ci workflow

### DIFF
--- a/.github/workflows/nix-flake.yml
+++ b/.github/workflows/nix-flake.yml
@@ -15,12 +15,39 @@ concurrency:
 
 jobs:
   test-nix-flake:
-    name: Test
+    name: Test with nix flake
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v5
-    - uses: DeterminateSystems/nix-installer-action@main
-    - uses: DeterminateSystems/flake-checker-action@main
-    - run: nix build
-    - run: nix flake check
-    - run: nix develop --command bash -c "python -m pytest -v papis tests"
+      - uses: actions/checkout@v5
+      - name: check nix flake inputs
+        uses: DeterminateSystems/flake-checker-action@v12
+        with:
+          # fail the workflow if the flake inputs are outdated?
+          fail-mode: true
+          send-statistics: false
+      - name: Install nix
+        uses: nixbuild/nix-quick-install-action@v34
+      - name: Restore and save Nix Store from cache
+        uses: nix-community/cache-nix-action@v6.1.3
+        with:
+          # save a new cache every time the ci file or the flake changes
+          primary-key: nix-cache-${{ hashFiles('.github/workflows/nix-flake.yaml', 'flake.nix', 'flake.lock') }}
+          # if no hit, restore current versions of individual caches
+          restore-prefixes-first-match: nix-cache-
+          # purge all versions of the cache
+          purge: true
+          purge-prefixes: nix-cache-
+          # created more than 0 seconds ago relative to the start of the `Post Restore` phase
+          purge-created: 0
+          # except the version with the `primary-key`, if it exists
+          purge-primary-key: never
+          # and collect garbage in the Nix store until it reaches this size in bytes
+          gc-max-store-size: 0M
+          # TODO: find out how to also cache dev depenendencies (i.e., nix develop)
+      - name: check installed nix version
+        run: which nix; nix build --version
+      - run: nix flake check
+      - name: install papis from nix flake.
+        run: nix profile install '.#papis'
+      - name: run unit tests in nix devShell
+        run: nix develop --command bash -c "python -m pytest -v papis tests"


### PR DESCRIPTION
* remove determinate nix installer and switch to upstream nix using the nixbuild/nix-quick-install action
* introduce nix store caching using nix-community/cache-nix-action
* fail workflow if nixpkgs is outdated using flake-checker-action