### PR TITLE
updated and reworked nix CI actions 

### DIFF
--- a/.github/actions/nix-setup/action.yml
+++ b/.github/actions/nix-setup/action.yml
@@ -1,0 +1,25 @@
+name: setup nix and nix store cache
+runs:
+  using: "composite"
+  steps:
+    - name: Install nix
+      uses: nixbuild/nix-quick-install-action@v34
+    - name: Restore and save nix store from cache
+      uses: nix-community/cache-nix-action@v6.1.3
+      with:
+        # save a new cache every time the ci file or the flake changes
+        primary-key: nix-cache-${{ hashFiles('.github/workflows/nix-flake.yaml', 'flake.nix', 'flake.lock') }}
+        # if no hit, restore current versions of individual caches
+        restore-prefixes-first-match: nix-cache-
+        # purge all versions of the cache
+        purge: true
+        purge-prefixes: nix-cache-
+        # created more than 0 seconds ago relative to the start of the `Post Restore` phase
+        purge-created: 0
+        # except the version with the `primary-key`, if it exists
+        purge-primary-key: never
+        # and collect garbage in the Nix store until it reaches this size in bytes
+        gc-max-store-size: 0M
+    - name: check installed nix version
+      run: which nix; nix build --version
+      shell: bash

--- a/.github/actions/nix-test/action.yml
+++ b/.github/actions/nix-test/action.yml
@@ -1,0 +1,23 @@
+name: run tests with nix
+runs:
+  using: "composite"
+  steps:      
+    - run: nix flake check
+      shell: bash
+    - name: install papis from nix flake into profile.
+      # this also persists the papis package as gcroot, so it is not garbage
+      # collected and is persisted in the cache
+      run: nix profile install '.#papis'
+      shell: bash
+    - name: run unit tests in nix devShell
+      run: nix develop --command bash -c "python -m pytest -v papis tests"
+      shell: bash
+    - name: persist devshell as gcroot, s.t., it is cached
+      run: |
+        rm /nix/var/nix/gcroots/devshell || true
+        ln -s $(nix develop --command bash -c 'echo $NIX_GCROOT') /nix/var/nix/gcroots/devshell
+      shell: bash
+    # now the cache-nix-action post code runs and persists the nix store,
+    # after running garbage collection. Since we have both papis installed as
+    # profile and the devshell saved as gcroot, the cache should contain all
+    # nix derivations need for papis. This should speed up the CI quite a bit.

--- a/.github/workflows/nix-flake-update-pr.yml
+++ b/.github/workflows/nix-flake-update-pr.yml
@@ -1,0 +1,31 @@
+name: Nix flake update PR
+
+on:
+  workflow_dispatch:
+  schedule:
+    # first of the month at 16:00 UTC
+    - cron: "00 16 1 * *"
+
+jobs:
+  update-nix-flake:
+    name: nix flake update and test
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+      pull-requests: write
+    steps:
+      - uses: actions/checkout@v5
+      - name: setup nix
+        uses: ./.github/actions/nix-setup
+      - name: update nix flake inputs
+        run: |
+          nix flake update
+          git status
+      - name: run tests with nix
+        uses: ./.github/actions/nix-test
+      - name: create pull request
+        uses: peter-evans/create-pull-request@v7
+        with:
+          branch: update-nix-flake
+          title: "Chore: Update nix flake inputs"
+      # requires allowing PRs from github actions: https://github.com/peter-evans/create-pull-request?tab=readme-ov-file#workflow-permissions

--- a/.github/workflows/nix-flake.yml
+++ b/.github/workflows/nix-flake.yml
@@ -19,35 +19,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v5
-      - name: check nix flake inputs
-        uses: DeterminateSystems/flake-checker-action@v12
-        with:
-          # fail the workflow if the flake inputs are outdated?
-          fail-mode: true
-          send-statistics: false
-      - name: Install nix
-        uses: nixbuild/nix-quick-install-action@v34
-      - name: Restore and save Nix Store from cache
-        uses: nix-community/cache-nix-action@v6.1.3
-        with:
-          # save a new cache every time the ci file or the flake changes
-          primary-key: nix-cache-${{ hashFiles('.github/workflows/nix-flake.yaml', 'flake.nix', 'flake.lock') }}
-          # if no hit, restore current versions of individual caches
-          restore-prefixes-first-match: nix-cache-
-          # purge all versions of the cache
-          purge: true
-          purge-prefixes: nix-cache-
-          # created more than 0 seconds ago relative to the start of the `Post Restore` phase
-          purge-created: 0
-          # except the version with the `primary-key`, if it exists
-          purge-primary-key: never
-          # and collect garbage in the Nix store until it reaches this size in bytes
-          gc-max-store-size: 0M
-          # TODO: find out how to also cache dev depenendencies (i.e., nix develop)
-      - name: check installed nix version
-        run: which nix; nix build --version
-      - run: nix flake check
-      - name: install papis from nix flake.
-        run: nix profile install '.#papis'
-      - name: run unit tests in nix devShell
-        run: nix develop --command bash -c "python -m pytest -v papis tests"
+      - name: setup nix
+        uses: ./.github/actions/nix-setup
+      - name: run tests with nix
+        uses: ./.github/actions/nix-test

--- a/flake.lock
+++ b/flake.lock
@@ -20,11 +20,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1761373498,
+        "lastModified": 1742069588,
         "narHash": "sha256-Q/uhWNvd7V7k1H1ZPMy/vkx3F8C13ZcdrKjO7Jv7v0c=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "6a08e6bb4e46ff7fcbb53d409b253f6bad8a28ce",
+        "rev": "c80f6a7e10b39afcc1894e02ef785b1ad0b0d7e5",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
This replaces the PR #1092

* remove determinate nix installer and switch to upstream nix using the nixbuild/nix-quick-install action
* introduce nix store caching using nix-community/cache-nix-action
* removed the flake-checker-action
* new: add a separate workflow to open a PR once a month with an updated nix flake.

Note: this also reverted to a previous version of nixpkgs in the flake.lock, s.t., the workflow will open a PR for testing.
**After the merge**, trigger the new workflow manually, which opens a PR to move flake.lock back to latest nixpkgs.