### PR TITLE
Fix: `update --rename` and `tag --rename` and add new value only if old one exists

### DIFF
--- a/papis/commands/tag.py
+++ b/papis/commands/tag.py
@@ -175,6 +175,9 @@ def cli(
             success = run_rename(ctx.data, to_rename_tuples, key_types, False)
 
         if success:
+            from papis.document import describe
+            logger.info("Processing tags in '%s.'", describe(document))
+
             processed_documents.append((document, ctx.data))
 
         if not success:
@@ -190,5 +193,3 @@ def cli(
 
     for document, data in processed_documents:
         run(document, data=data, git=git, auto_doctor=False)
-
-    logger.info("Updated tags in %d documents", len(processed_documents))

--- a/papis/commands/update.py
+++ b/papis/commands/update.py
@@ -569,7 +569,7 @@ def cli(
 
         if success:
             from papis.document import describe
-            logger.info("Updating %s.", describe(document))
+            logger.info("Processing '%s.'", describe(document))
 
             # get metadata from importers and merge them all together
             if from_importer:


### PR DESCRIPTION
This fixes a bunch of things with `papis update` and `papis tag`. Mostly, there's currently a bug with `--rename`. This command first removes an old value from a list and then appends the new value. Before, it appended the value whenever the removing succeeded. Unfortunately, success doesn't actually indicate that something was removed, leading to the new value being added when the old value didn't exist.

While I was fixing that I also:
- made messages to users consistent and less confusing. Before, we said we're 'Updating' documents even when no changes to them are made. Now it just says 'Processing'. Messages are also now similar for both the `update` and `tag` command.
- there was a type error that I fixed