### PR TITLE
Improve `papis mv`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -57,6 +57,27 @@ papis open 'title:^Quantum'
 Note that this new query syntax still uses the `match-format` configuration setting
 for free-form terms in the query (i.e. ones not using a `key:value` format).
 
+### Major: Improve `mv` command ([#2822](https://github.com/papis/papis/pull/2822))
+
+The `mv` command has been completely rewritten with many new features. It now
+works similarly to the Unix `mv` command for moving document folders: if the
+target folder already exists, the document's folder is moved *into* it (e.g.
+`papis mv --to existing-folder query` places the document at
+`existing-folder/<doc-folder>`); if the target does not exist, the document is
+renamed to that name. When no target is given, it defaults to the
+`add-folder-name` pattern, which means `papis mv query` now does
+everything that `papis rename` used to do.
+
+The new `--to` flag accepts formatting patterns (e.g.
+`papis mv --to "{doc[year]}" query`). The command now also allows moving documents
+between libraries by specifying a target library.
+
+The new command performs pre-flight checks on all planned moves before touching
+any files. Issues such as duplicate target paths, nesting a document inside
+another document's folder, or missing source folders are warned about upfront. The
+user can abort, skip problematic moves, or fix collisions interactively. A new
+`--batch` flag allows skipping all interactive prompts.
+
 ## Other noteworthy features
 
 - Remove undocumented `dirs` option (only allow one `dir` per library).

--- a/papis/commands/mv.py
+++ b/papis/commands/mv.py
@@ -1,111 +1,489 @@
 """
-This command can be used to move a document to a new folder.
+The ``mv`` command is used to move document folders around your library (or to
+another library).
 
-Command-line interface
+It will (except when run with ``--all``) bring up the picker with a list of
+documents that match the query. You can then select the document or documents
+you'd like to move.
+
+The command works similarly to the Unix
+`mv <https://en.wikipedia.org/wiki/Mv_(Unix)>`__ command. Hence, when the
+specified target folder exists, the document's current main folder is moved into
+the target folder. If the specified target folder doesn't exist, then the
+current folder is renamed to the target folder name. Unlike Unix ``mv``, if a
+target folder isn't given, it defaults to the :confval:`add-folder-name` pattern,
+so ``papis mv QUERY`` renames matching documents to their default folder names.
+
+Folder names are cleaned, so that characters that can lead to invalid file paths
+are avoided (see :confval:`doc-paths-extra-chars` for a list of allowed characters
+and how to change it). This cleaning applies to all path components,
+including any literal subfolders passed to ``--to``. This means and you cannot use
+the ``mv`` command to move docs into a folder containing excluded characters.
+
+The ``mv`` command will first check whether moving the folders as specified will
+fail. If any errors are encountered, they are displayed and you will
+be prompted whether you want to abort or move the unproblematic documents (if any
+exist).
+
+Examples
+^^^^^^^^
+
+- Query documents by author "Rick Astley" and move some of them. After picking
+  the relevant documents, they will be renamed to their default names
+  specified by the :confval:`add-folder-name` option.
+
+   .. code:: sh
+
+        papis mv author:"Rick Astley"
+
+- You can use ``--to`` to pass the path of the target folder, relative to the
+  library root. Here we'll move a document by the author "Rick Astley" to a
+  folder named ``rick-astley``:
+
+   .. code:: sh
+
+        papis mv --to rick-astley author:"Rick Astley"
+
+  If the folder "rick-astley" doesn't exist, then the document's folder will be
+  renamed to that so that the new folder becomes "rick-astley". If the folder
+  "rick-astley" exists, then the document's folder will be moved into it. If, say,
+  the document's folder is currently "rick-s-the-best", then the new folder will
+  be "rick-astley/rick-s-the-best".
+
+  If multiple selected documents resolve to the exact same folder name, Papis will
+  warn you and skip those documents. Consider the above case when the target folder
+  doesn't exist. Here, each document would be renamed to ``rick-astley``, causing
+  Papis to skip the documents to avoid collisions. In contrast, if the target folder
+  already exists, each document will be placed into its own subfolder (e.g.
+  "rick-astley/rick-s-the-best" and "rick-astley/rick-s-very-cool"), so there is
+  no risk of collision.
+
+- You can use formatting patterns to generate the folder names. For instance, to
+  organise all documents by author "Rick Astley" by year, you can use this command:
+
+   .. code:: sh
+
+        papis mv --to "{doc[year]}" --all author:"Rick Astley"
+
+  Note that the ``--all`` flag means that the picker isn't shown and all
+  documents matching the query will be moved.
+
+- You can use the ``--batch`` flag to skip all prompts. You will not be
+  prompted if there are problematic moves and all unproblematic moves will
+  happen automatically. If an unexpected error occurs while moving a
+  document (e.g. a permission error), the command logs a warning and
+  continues with the next document instead of aborting.
+
+   .. code:: sh
+
+        papis mv --batch --all author:"Rick Astley"
+
+Command-line Interface
 ^^^^^^^^^^^^^^^^^^^^^^
 
 .. click:: papis.commands.mv:cli
     :prog: papis mv
 """
+
 from __future__ import annotations
 
-import os
-from typing import TYPE_CHECKING
+import collections
+import shutil
+from pathlib import Path
+from typing import TYPE_CHECKING, NamedTuple
 
 import click
 
 import papis.cli
 import papis.config
+import papis.database
+import papis.document
+import papis.git
 import papis.logging
+import papis.paths
+import papis.tui.utils
+from papis.exceptions import DocumentFolderNotFound
+from papis.strings import AnyString, no_documents_retrieved_message
 
 if TYPE_CHECKING:
     from papis.document import Document
 
+
+class PlannedMove(NamedTuple):
+    document: Document
+    source: Path
+    target: Path
+
+
 logger = papis.logging.get_logger(__name__)
 
 
-def run(document: Document,
-        new_folder_path: str,
-        git: bool = False) -> None:
-    from papis.document import describe
+def _check_not_nested(target: Path, lib_dir: Path) -> str | None:
+    """Check that *target* would not be placed inside another document folder.
 
-    folder = document.get_main_folder()
-    if not folder:
-        from papis.exceptions import DocumentFolderNotFound
-        raise DocumentFolderNotFound(describe(document))
+    Walks up from *target.parent* to *lib_dir*. If any ancestor is a
+    document folder, this is considered an error.
 
-    if git:
-        from papis.git import mv as git_mv
-        git_mv(folder, new_folder_path)
+    :param target: the target path for the document
+    :param lib_dir: the root directory of the target library.
+    :returns: ``None`` if not nested in a document folder, an error string otherwise
+    """
+    current = target.parent
+    while current not in {lib_dir, current.parent}:
+        if papis.document.is_document_folder(current):
+            return f"would nest inside another document's folder: {current}"
+        current = current.parent
+    return None
+
+
+def _check_target_already_exists(path: Path) -> str | None:
+    """Check that *path* doesn't already exist.
+
+    :returns: ``None`` if the path doesn't already exist, an error string otherwise
+    """
+    if path.exists():
+        return f"target already exists: {path}"
+    return None
+
+
+def _rename_target_interactively(
+    document: Document,
+    default_target: Path,
+    lib_dir: Path,
+) -> Path:
+    """Prompt the user to rename until a valid target is found.
+
+    :param document: the document being moved.
+    :param default_target: the default/computed target path (absolute).
+    :param lib_dir: the root directory of the target library.
+    :returns: a valid absolute target path.
+    """
+    while True:
+        new_name = papis.tui.utils.prompt(
+            f"Folder name for '{papis.document.describe(document)}'",
+            default=str(default_target.relative_to(lib_dir)),
+        )
+        new_target = Path(
+            papis.paths.get_document_folder(
+                document, str(lib_dir), folder_name_format=new_name
+            )
+        )
+
+        error = _check_not_nested(new_target, lib_dir)
+        if error is None:
+            error = _check_target_already_exists(new_target)
+        if error is None:
+            return new_target
+
+        logger.warning(
+            "'%s': %s.",
+            papis.document.describe(document),
+            error,
+        )
+
+
+def _register_move(
+    move: PlannedMove,
+    moves: dict[Path, PlannedMove],
+    conflicts: dict[Path, list[PlannedMove]],
+) -> None:
+    """Insert *move* into *moves*, or bump it to *conflicts* on collision.
+
+    Resolves the move's target path and checks whether it is already claimed.
+    If the slot is free the move goes into *moves*; if occupied the existing
+    occupant is moved to *conflicts* together with the new move.
+    """
+    target_path = move.target.resolve()
+    if target_path in moves:
+        existing = moves.pop(target_path)
+        conflicts[target_path] = [existing, move]
+    elif target_path in conflicts:
+        conflicts[target_path].append(move)
     else:
-        import shutil
-        shutil.move(folder, new_folder_path)
+        moves[target_path] = move
 
-    from papis.database import get_database
-    db = get_database()
-    db.delete(document)
 
-    new_document_folder = os.path.join(
-        new_folder_path,
-        os.path.basename(folder))
-    logger.debug("New document folder: '%s'.", new_document_folder)
+def run(
+    document: Document,
+    target_path_abs: str,
+    target_library: str | None = None,
+    git: bool = False,
+) -> None:
+    """Move a document's folder to *target_path_abs*.
 
-    document.set_folder(new_document_folder)
-    db.add(document)
+    :param document: the document to move.
+    :param target_path_abs: the target folder path (absolute)
+    :param target_library: name of the target library. If ``None``, uses the current
+        library.
+    :param git: if ``True``, record the move in git history.
+    :raises DocumentFolderNotFound: if the document has no main folder on disk.
+    :raises FileNotFoundError: if the source folder does not exist.
+    :raises FileExistsError: if the target folder already exists. This will also be
+        raised if the target folder is the same as the source folder.
+    """
+    if target_library is None:
+        target_library = papis.config.get_lib_name()
+
+    source_lib_dir = Path(papis.config.get_lib().path)
+
+    target_lib_dir = Path(papis.config.get_lib_from_name(target_library).path)
+
+    doc_folder_old = document.get_main_folder()
+    if not doc_folder_old:
+        raise DocumentFolderNotFound(papis.document.describe(document))
+
+    main_folder_old = Path(doc_folder_old)
+    main_folder_new = Path(target_path_abs)
+
+    if not main_folder_old.exists():
+        raise FileNotFoundError(f"Source folder does not exist: '{main_folder_old}'")
+
+    if main_folder_new.exists():
+        raise FileExistsError(f"Target folder already exists: '{main_folder_new}'")
+
+    source_library = papis.config.get_lib_name()
+    papis.config.set_lib_from_name(target_library)
+
+    main_folder_new.parent.mkdir(
+        parents=True,
+        exist_ok=True,
+        # NOTE: 0o755 is default, but explicitness is needed to avoid type error
+        mode=papis.config.getint("dir-umask") or 0o755,
+    )
+
+    papis.config.set_lib_from_name(source_library)
+
+    if target_lib_dir == source_lib_dir:
+        if git:
+            papis.git.mv_and_commit_resource(
+                str(main_folder_old),
+                str(main_folder_new),
+                f"Move '{papis.document.describe(document)}'",
+            )
+        else:
+            shutil.move(main_folder_old, main_folder_new)
+    else:
+        shutil.move(doc_folder_old, main_folder_new)
+
+        if git:
+            papis.git.remove(str(source_lib_dir), str(main_folder_old))
+            papis.git.commit(
+                str(source_lib_dir),
+                f"Remove '{papis.document.describe(document)}' "
+                f"(moved to '{target_library}' library)",
+            )
+
+            papis.git.add_and_commit_resource(
+                str(target_lib_dir),
+                str(main_folder_new),
+                f"Add '{papis.document.describe(document)}'",
+            )
+
+    source_db = papis.database.get()
+    source_db.delete(document)
+
+    target_db = papis.database.get(library_name=target_library)
+
+    document.set_folder(str(main_folder_new))
+
+    target_db.add(document)
+
+    logger.info(
+        "Moved document '%s' to '%s' (library '%s').",
+        papis.document.describe(document),
+        main_folder_new,
+        target_library,
+    )
 
 
 @click.command("mv")
 @click.help_option("--help", "-h")
+@click.option(
+    "-t",
+    "--to",
+    help="Path relative to the library root",
+    default=None,
+    type=papis.cli.FormatPatternParamType(),
+)
+@click.option(
+    "--target-library",
+    help="Target library",
+    default=lambda: papis.config.get_lib_name(),  # noqa: PLW0108
+    type=str,
+)
+@papis.cli.bool_flag(
+    "-b",
+    "--batch",
+    help="Do not prompt. Warnings are logged but moves proceed automatically.",
+)
 @papis.cli.query_argument()
 @papis.cli.git_option()
 @papis.cli.sort_option()
 @papis.cli.doc_folder_option()
-def cli(query: str,
-        git: bool,
-        sort_field: str | None,
-        doc_folder: tuple[str, ...],
-        sort_reverse: bool) -> None:
-    """Move a document into some other path."""
-    # Leave this imports here for performance
-    import prompt_toolkit
-    import prompt_toolkit.completion
+@papis.cli.all_option()
+def cli(
+    query: str,
+    git: bool,
+    _all: bool,
+    to: AnyString | None,
+    target_library: str,
+    batch: bool,
+    sort_field: str | None,
+    doc_folder: tuple[str, ...],
+    sort_reverse: bool,
+) -> None:
+    """Move a document into another folder."""
 
-    documents = papis.cli.handle_doc_folder_query_sort(query,
-                                                       doc_folder,
-                                                       sort_field,
-                                                       sort_reverse)
+    documents = papis.cli.handle_doc_folder_query_all_sort(
+        query, doc_folder, sort_field, sort_reverse, _all
+    )
     if not documents:
-        from papis.strings import no_documents_retrieved_message
         logger.warning(no_documents_retrieved_message)
         return
 
-    document = documents[0]
+    source_library = papis.config.get_lib_name()
+    papis.config.set_lib_from_name(target_library)
 
-    lib_dir = os.path.expanduser(papis.config.get_lib().path)
+    if to is None:
+        to = papis.config.getformatpattern("add-folder-name")
 
-    completer = prompt_toolkit.completion.PathCompleter(
-        only_directories=True,
-        get_paths=lambda: [lib_dir]
-    )
+    target_lib_dir = Path(papis.config.get_lib_from_name(target_library).path)
 
-    try:
-        new_folder = os.path.join(
-            lib_dir,
-            prompt_toolkit.prompt(
-                message=(
-                    "Enter directory  : (Tab completion enabled)\n"
-                    f"Current directory: ({document.get_main_folder_name()})\n >"),
-                completer=completer,
-                complete_while_typing=True
-            ))
-    except Exception as exc:
-        logger.error("Failed to choose directory.", exc_info=exc)
+    moves: dict[Path, PlannedMove] = {}
+    conflicts: dict[Path, list[PlannedMove]] = collections.defaultdict(list)
+
+    # Gather moves, detect disk conflicts + selection collisions
+    for document in documents:
+        main_folder_old_str = document.get_main_folder()
+        if not main_folder_old_str:
+            logger.warning(
+                "'%s': source folder not defined. Cannot move.",
+                papis.document.describe(document),
+            )
+            continue
+
+        main_folder_old = Path(main_folder_old_str)
+        if not main_folder_old.exists():
+            logger.warning(
+                "'%s': source folder does not exist on disk. Cannot move: %s.",
+                papis.document.describe(document),
+                main_folder_old,
+            )
+            continue
+
+        target_abs_path = Path(
+            papis.paths.get_document_folder(
+                document, target_lib_dir, folder_name_format=to
+            )
+        )
+
+        if main_folder_old == target_abs_path:
+            logger.info(
+                "Skipping '%s': source and target are the same.",
+                papis.document.describe(document),
+            )
+            continue
+
+        # Resolve rename vs move-into semantics
+        if target_abs_path.is_dir():
+            main_folder_new = target_abs_path / main_folder_old.name
+        else:
+            main_folder_new = target_abs_path
+
+        # Check for nesting or disk conflict
+        error = _check_not_nested(main_folder_new, target_lib_dir)
+        if error is None:
+            error = _check_target_already_exists(main_folder_new)
+        if error:
+            logger.warning(
+                "'%s': %s.",
+                papis.document.describe(document),
+                error,
+            )
+            if batch:
+                continue
+            logger.warning("You can skip this document or rename it manually.")
+            if papis.tui.utils.confirm(
+                "Skip this document? Answer 'no' to rename it instead.",
+                yes=True,
+            ):
+                continue
+
+            main_folder_new = _rename_target_interactively(
+                document, main_folder_new, target_lib_dir
+            )
+
+        move = PlannedMove(document, main_folder_old, main_folder_new)
+        _register_move(move, moves, conflicts)
+
+    # Resolve selection collisions.
+    #
+    # At this point every target path is in one of two lists
+    #   moves[path]     - a single PlannedMove, no collision
+    #   conflicts[path] - list of PlannedMove that want the same folder
+    # The loop below lets the user rename colliding moves. Paths that collide again
+    # stay in the loop for another round.
+    while conflicts:
+        if batch:
+            for conflict_group in conflicts.values():
+                for c in conflict_group:
+                    logger.warning(
+                        "'%s': duplicate target folder. Skipping: %s → %s.",
+                        papis.document.describe(c.document),
+                        c.source,
+                        c.target,
+                    )
+            break
+
+        resolved: list[PlannedMove] = []
+
+        for conflict_path, conflict_group in list(conflicts.items()):
+            msg_lines = [
+                f"{len(conflict_group)} documents want the same"
+                f" target folder '{conflict_path}':"
+            ]
+            for c in conflict_group:
+                msg_lines.append(f"    - '{papis.document.describe(c.document)}'")
+
+            logger.warning("\n".join(msg_lines))
+
+            logger.warning("You can skip these documents or rename them manually.")
+            if papis.tui.utils.confirm("Skip these documents?", yes=True):
+                del conflicts[conflict_path]
+                continue
+
+            for c in conflict_group:
+                new_target = _rename_target_interactively(
+                    c.document, c.target, target_lib_dir
+                )
+                resolved.append(PlannedMove(c.document, c.source, new_target))
+
+            del conflicts[conflict_path]
+
+        new_conflicts: dict[Path, list[PlannedMove]] = collections.defaultdict(list)
+        for move in resolved:
+            _register_move(move, moves, new_conflicts)
+
+        if not new_conflicts:
+            break
+
+        conflicts = new_conflicts
+
+    if not moves:
+        logger.info("No valid moves to perform.")
         return
 
-    logger.info("New document folder: '%s'.", new_folder)
-
-    if not os.path.exists(new_folder):
-        logger.info("Creating path '%s'.", new_folder)
-        os.makedirs(new_folder, mode=papis.config.getint("dir-umask") or 0o666)
-
-    run(document, new_folder, git=git)
+    # Move
+    papis.config.set_lib_from_name(source_library)
+    for move in moves.values():
+        try:
+            run(move.document, str(move.target), target_library=target_library, git=git)
+        except Exception as exc:
+            if batch:
+                logger.warning(
+                    "Failed to move '%s': %s",
+                    papis.document.describe(move.document),
+                    exc,
+                )
+                continue
+            raise

--- a/papis/document.py
+++ b/papis/document.py
@@ -11,6 +11,7 @@ import papis.logging
 
 if TYPE_CHECKING:
     from collections.abc import Callable, Sequence
+    from pathlib import Path
     from typing import Literal
 
     from papis.strings import AnyString
@@ -576,6 +577,19 @@ def from_folder(folder_path: str) -> Document:
     :param folder_path: absolute path to a valid ``papis`` folder.
     """
     return Document(folder=folder_path)
+
+
+def is_document_folder(path: Path) -> bool:
+    """Check whether *path* is an existing document folder.
+
+    A folder is considered a document folder if it contains an info file
+    (see :confval:`info-name`).
+
+    :param path: absolute path to a folder on the filesystem.
+    :returns: *True* if the folder contains a document info file.
+    """
+    info_name = papis.config.getstring("info-name")
+    return path.joinpath(info_name).exists()
 
 
 def to_json(document: Document) -> str:

--- a/tests/commands/test_mv.py
+++ b/tests/commands/test_mv.py
@@ -1,30 +1,690 @@
+"""Tests for papis.commands.mv."""
+
 from __future__ import annotations
 
+import logging
 import os
-import tempfile
+import shutil
 from typing import TYPE_CHECKING
 
 import papis.database
+import papis.document
+import papis.tui.utils
+from papis.commands.mv import cli
+from papis.testing import PapisRunner, TemporaryLibrary
 
 if TYPE_CHECKING:
-    from papis.testing import TemporaryLibrary
+    from pathlib import Path
+
+    from _pytest.monkeypatch import MonkeyPatch
+
+    from papis.database.base import Database
 
 
-def test_mv_run(tmp_library: TemporaryLibrary) -> None:
+import pytest
+
+
+def _doc_by_author(db: Database, author: str) -> papis.document.Document:
+    """Find a document by author. Assumes unique match for simplicity."""
+    return next(d for d in db.get_all_documents() if d["author"] == author)
+
+
+def _setup_runner_db_doc() -> tuple[PapisRunner, Database, papis.document.Document]:
+    """Return a runner, the current DB, and Turing's document."""
+    db = papis.database.get()
+    return PapisRunner(), db, _doc_by_author(db, "Turing, A. M.")
+
+
+def _assert_moved(old_folder: str, expected_folder: str) -> None:
+    """Assert the move completed correctly on disk and in the DB."""
+    assert not os.path.exists(old_folder)
+    assert os.path.exists(expected_folder)
+
+    matches = [
+        doc
+        for doc in papis.database.get().get_all_documents()
+        if doc.get_main_folder() == expected_folder
+    ]
+    assert len(matches) == 1
+    assert matches[0].get_main_folder() == expected_folder
+
+
+# ---------------------------------------------------------------------------
+# Tests for cli()
+# ---------------------------------------------------------------------------
+
+
+def test_to_renames_folder(tmp_library: TemporaryLibrary) -> None:
+    """--to renames the document folder."""
+    cli_runner, _, doc = _setup_runner_db_doc()
+    old_folder = doc.get_main_folder()
+    assert old_folder
+
+    result = cli_runner.invoke(
+        cli, ["--to", "renamed-turing", "Turing"], catch_exceptions=False
+    )
+    assert result.exit_code == 0, result.output
+
+    expected = os.path.join(tmp_library.libdir, "renamed-turing")
+    _assert_moved(old_folder, expected)
+
+
+def test_to_with_formatpattern(tmp_library: TemporaryLibrary) -> None:
+    """--to with a format pattern produces the expected folder."""
+    cli_runner, _, doc = _setup_runner_db_doc()
+    old_folder = doc.get_main_folder()
+    assert old_folder
+
+    result = cli_runner.invoke(
+        cli, ["--to", "{doc[year]}", "Turing"], catch_exceptions=False
+    )
+    assert result.exit_code == 0, result.output
+
+    expected = os.path.join(tmp_library.libdir, "1937")
+    _assert_moved(old_folder, expected)
+
+
+def test_without_to_renames_to_default(tmp_library: TemporaryLibrary) -> None:
+    """Without --to, the default folder name is used."""
+    cli_runner, _, doc = _setup_runner_db_doc()
+    old_folder = doc.get_main_folder()
+    assert old_folder
+    doc_id = doc["papis_id"]
+
+    result = cli_runner.invoke(cli, ["Turing"], catch_exceptions=False)
+    assert result.exit_code == 0, result.output
+
+    assert not os.path.exists(old_folder)
+    expected = os.path.join(tmp_library.libdir, doc_id)
+    assert os.path.exists(expected)
+
+
+def test_to_slugification_of_special_chars(tmp_library: TemporaryLibrary) -> None:
+    """--to slugifies the target folder name."""
+    cli_runner, _, doc = _setup_runner_db_doc()
+
+    old_folder = doc.get_main_folder()
+    assert old_folder
+
+    result = cli_runner.invoke(
+        cli, ["--to", "Rick Astley", "Turing"], catch_exceptions=False
+    )
+    assert result.exit_code == 0, result.output
+
+    expected = os.path.join(tmp_library.libdir, "rick-astley")
+    _assert_moved(old_folder, expected)
+
+
+def test_to_existing_dir_moves_into(tmp_library: TemporaryLibrary) -> None:
+    """--to pointing to an existing directory moves into it."""
+    cli_runner, _, doc = _setup_runner_db_doc()
+    old_folder = doc.get_main_folder()
+    assert old_folder
+    old_basename = os.path.basename(old_folder)
+
+    target_dir = os.path.join(tmp_library.libdir, "papers-archive")
+    os.makedirs(target_dir)
+
+    result = cli_runner.invoke(
+        cli, ["--to", "papers-archive", "Turing"], catch_exceptions=False
+    )
+    assert result.exit_code == 0, result.output
+
+    expected = os.path.join(target_dir, old_basename)
+    _assert_moved(old_folder, expected)
+
+
+def test_to_same_folder_is_skipped(tmp_library: TemporaryLibrary) -> None:
+    """Moving to the same folder is a no-op."""
+    cli_runner, _, _ = _setup_runner_db_doc()
+
+    # moving to this first, since the default folder name is something
+    # that would be slugified, making renaming to the same name impossible
+    result = cli_runner.invoke(
+        cli, ["--to", "turing-folder", "Turing"], catch_exceptions=False
+    )
+    assert result.exit_code == 0, result.output
+
+    folder_path = os.path.join(tmp_library.libdir, "turing-folder")
+    result = cli_runner.invoke(
+        cli, ["--to", "turing-folder", "Turing"], catch_exceptions=False
+    )
+    assert result.exit_code == 0, result.output
+    assert os.path.exists(folder_path)
+
+
+def test_to_existing_other_doc_folder_warns(
+    tmp_library: TemporaryLibrary,
+    caplog: pytest.LogCaptureFixture,
+    monkeypatch: MonkeyPatch,
+) -> None:
+    """Moving to another doc folder warns about nesting."""
+    caplog.set_level(logging.WARNING)
+    cli_runner, db, doc = _setup_runner_db_doc()
+    old_folder = doc.get_main_folder()
+    assert old_folder
+
+    # Find another doc (Krishnamurti) and pre-move it to a clean slugified name
+    krish = next(d for d in db.get_all_documents() if d["author"] == "J. Krishnamurti")
+    assert krish.get_main_folder()
+    result = cli_runner.invoke(
+        cli, ["--to", "krish-doc", "Krishnamurti"], catch_exceptions=False
+    )
+    assert result.exit_code == 0, result.output
+
+    # Now try to move Turing into Krish's folder
+    def mock_confirm(msg: str, **kwargs: object) -> bool:
+        return True  # skip
+
+    with monkeypatch.context() as m:
+        m.setattr(papis.tui.utils, "confirm", mock_confirm)
+        result = cli_runner.invoke(
+            cli, ["--to", "krish-doc", "Turing"], catch_exceptions=False
+        )
+        assert result.exit_code == 0, result.output
+
+    warning_messages = [r.message for r in caplog.records]
+    assert any("would nest inside another document" in msg for msg in warning_messages)
+    assert os.path.exists(old_folder)
+
+
+def test_to_target_already_exists_warns(
+    tmp_library: TemporaryLibrary,
+    caplog: pytest.LogCaptureFixture,
+    monkeypatch: MonkeyPatch,
+) -> None:
+    """Disk conflict warns."""
+    caplog.set_level(logging.WARNING)
+    cli_runner, _, doc = _setup_runner_db_doc()
+    old_folder = doc.get_main_folder()
+    assert old_folder
+    old_basename = os.path.basename(old_folder)
+
+    # Pre-create target dir with a subfolder matching the doc's name
+    target_dir = os.path.join(tmp_library.libdir, "target-dir")
+    os.makedirs(os.path.join(target_dir, old_basename))
+
+    def mock_confirm(msg: str, **kwargs: object) -> bool:
+        return True  # skip
+
+    with monkeypatch.context() as m:
+        m.setattr(papis.tui.utils, "confirm", mock_confirm)
+        result = cli_runner.invoke(
+            cli, ["--to", "target-dir", "Turing"], catch_exceptions=False
+        )
+        assert result.exit_code == 0, result.output
+
+    warning_messages = [r.message for r in caplog.records]
+    assert any("target already exists" in msg for msg in warning_messages)
+
+
+@pytest.mark.skipif(
+    os.environ.get("PAPIS_DATABASE_BACKEND") == "whoosh",
+    reason="Whoosh cannot query documents whose folders have been deleted",
+)
+def test_source_folder_missing_warns(
+    tmp_library: TemporaryLibrary, caplog: pytest.LogCaptureFixture
+) -> None:
+    """Missing source folder warns."""
+    caplog.set_level(logging.WARNING)
+    cli_runner, _, doc = _setup_runner_db_doc()
+    old_folder = doc.get_main_folder()
+    assert old_folder
+    shutil.rmtree(old_folder)
+
+    result = cli_runner.invoke(
+        cli, ["--to", "target", "Turing"], catch_exceptions=False
+    )
+    assert result.exit_code == 0, result.output
+
+    warning_messages = [r.message for r in caplog.records]
+    assert any("does not exist on disk" in msg for msg in warning_messages)
+
+
+def test_batch_skips_confirm_with_warnings(
+    tmp_library: TemporaryLibrary,
+    caplog: pytest.LogCaptureFixture,
+    monkeypatch: MonkeyPatch,
+) -> None:
+    """Batch mode skips confirm prompts, warns, and moves valid docs."""
+    caplog.set_level(logging.WARNING)
+    cli_runner, db, _ = _setup_runner_db_doc()
+
+    # there are two test_author docs, we delete one to trigger a warning
+    docs = [d for d in db.get_all_documents() if d["author"] == "test_author"]
+    assert len(docs) >= 2
+    warned_doc = docs[0]
+    valid_doc = docs[1]
+    warned_folder = warned_doc.get_main_folder()
+    assert warned_folder
+    valid_old_folder = valid_doc.get_main_folder()
+    assert valid_old_folder
+    valid_id = valid_doc["papis_id"]
+    shutil.rmtree(warned_folder)
+
+    confirm_called = False
+
+    def track_confirm(*args: object, **kwargs: object) -> bool:
+        nonlocal confirm_called
+        confirm_called = True
+        return True
+
+    with monkeypatch.context() as m:
+        m.setattr(papis.tui.utils, "confirm", track_confirm)
+        result = cli_runner.invoke(
+            cli, ["--batch", "--all", "test_author"], catch_exceptions=False
+        )
+        assert result.exit_code == 0, result.output
+
+    assert not confirm_called
+    warning_messages = [r.message for r in caplog.records]
+    assert len(warning_messages) == 1
+    assert "source folder does not exist on disk" in warning_messages[0]
+
+    # this works since that's the papis_id is the default folder name
+    expected = os.path.join(tmp_library.libdir, valid_id)
+    _assert_moved(valid_old_folder, expected)
+
+
+def test_multiple_docs_moved(tmp_library: TemporaryLibrary) -> None:
+    """Multiple docs moved into a directory each get their own subfolder."""
+    cli_runner, db, _ = _setup_runner_db_doc()
+
+    docs = [d for d in db.get_all_documents() if d["author"] == "test_author"]
+    assert len(docs) >= 2
+
+    old_folders: list[str] = []
+    for doc in docs:
+        folder = doc.get_main_folder()
+        assert folder is not None
+        old_folders.append(folder)
+
+    target_dir = os.path.join(tmp_library.libdir, "batch-target")
+    os.makedirs(target_dir)
+
+    result = cli_runner.invoke(
+        cli,
+        ["--to", "batch-target", "--all", "test_author"],
+        catch_exceptions=False,
+    )
+    assert result.exit_code == 0, result.output
+
+    # Both docs moved into target dir
+    for old_folder in old_folders:
+        old_basename = os.path.basename(old_folder)
+        expected = os.path.join(target_dir, old_basename)
+        assert not os.path.exists(old_folder)
+        assert os.path.exists(expected)
+
+
+def test_no_documents_returns_early(
+    tmp_library: TemporaryLibrary, caplog: pytest.LogCaptureFixture
+) -> None:
+    """No matching documents returns early with a warning."""
+    caplog.set_level(logging.WARNING)
+    cli_runner, _, _ = _setup_runner_db_doc()
+
+    result = cli_runner.invoke(cli, ["nonexistent_author_xyz"], catch_exceptions=False)
+    assert result.exit_code == 0
+
+    warning_messages = [r.message for r in caplog.records]
+    assert any("No documents retrieved" in msg for msg in warning_messages)
+
+
+def test_selection_conflict_batch_warns_and_skips(
+    tmp_library: TemporaryLibrary, caplog: pytest.LogCaptureFixture
+) -> None:
+    """Batch mode: selection conflicts trigger warnings and docs stay put."""
+    caplog.set_level(logging.WARNING)
+    cli_runner, db, _ = _setup_runner_db_doc()
+
+    docs = [d for d in db.get_all_documents() if d["author"] == "test_author"]
+    assert len(docs) >= 2
+    old_folders = [d.get_main_folder() for d in docs]
+
+    result = cli_runner.invoke(
+        cli,
+        ["--batch", "--all", "--to", "same-target", "test_author"],
+        catch_exceptions=False,
+    )
+    assert result.exit_code == 0, result.output
+
+    warning_messages = [r.message for r in caplog.records]
+    for doc in docs:
+        assert any(
+            doc["title"] in msg and "duplicate target" in msg
+            for msg in warning_messages
+        )
+
+    # Neither doc was moved
+    for folder in old_folders:
+        assert folder and os.path.exists(folder)
+
+
+def test_selection_conflict_user_skips(
+    tmp_library: TemporaryLibrary,
+    caplog: pytest.LogCaptureFixture,
+    monkeypatch: MonkeyPatch,
+) -> None:
+    """Non-batch: when user skips the conflicting docs, docs stay put."""
+    caplog.set_level(logging.WARNING)
+    cli_runner, db, _ = _setup_runner_db_doc()
+
+    docs = [d for d in db.get_all_documents() if d["author"] == "test_author"]
+    assert len(docs) >= 2
+    old_folders = [d.get_main_folder() for d in docs]
+
+    def confirm_skip(msg: str, **kwargs: object) -> bool:
+        return True  # skip
+
+    with monkeypatch.context() as m:
+        m.setattr(papis.tui.utils, "confirm", confirm_skip)
+        result = cli_runner.invoke(
+            cli,
+            ["--all", "--to", "same-target", "test_author"],
+            catch_exceptions=False,
+        )
+        assert result.exit_code == 0, result.output
+
+    # Neither doc moved
+    for folder in old_folders:
+        assert folder and os.path.exists(folder)
+
+
+def test_selection_conflict_user_renames(
+    tmp_library: TemporaryLibrary,
+    monkeypatch: MonkeyPatch,
+) -> None:
+    """Non-batch: user chooses to rename, types valid names, docs move."""
+    cli_runner, db, _ = _setup_runner_db_doc()
+
+    docs = [d for d in db.get_all_documents() if d["author"] == "test_author"]
+    assert len(docs) >= 2
+
+    old0 = docs[0].get_main_folder()
+    old1 = docs[1].get_main_folder()
+    assert old0 and old1
+
+    # First confirm: don't skip. Then prompt for new names.
+    prompt_count = 0
+    new_names = ["doc-one", "doc-two"]
+
+    def confirm_no_skip(msg: str, **kwargs: object) -> bool:
+        return False  # don't skip
+
+    def mock_prompt(msg: str, **kwargs: object) -> str:
+        nonlocal prompt_count
+        name = new_names[prompt_count]
+        prompt_count += 1
+        return name
+
+    with monkeypatch.context() as m:
+        m.setattr(papis.tui.utils, "confirm", confirm_no_skip)
+        m.setattr(papis.tui.utils, "prompt", mock_prompt)
+        result = cli_runner.invoke(
+            cli,
+            ["--all", "--to", "same-target", "test_author"],
+            catch_exceptions=False,
+        )
+        assert result.exit_code == 0, result.output
+
+    # Both docs moved to renamed folders
+    assert not os.path.exists(old0)
+    assert os.path.exists(os.path.join(tmp_library.libdir, "doc-one"))
+    assert not os.path.exists(old1)
+    assert os.path.exists(os.path.join(tmp_library.libdir, "doc-two"))
+
+
+def test_selection_conflict_rename_loops_on_collision(
+    tmp_library: TemporaryLibrary,
+    monkeypatch: MonkeyPatch,
+) -> None:
+    """Renamed target collides with existing path triggers reprompting."""
+    cli_runner, db, _ = _setup_runner_db_doc()
+
+    docs = [d for d in db.get_all_documents() if d["author"] == "test_author"]
+    assert len(docs) >= 2
+
+    old0 = docs[0].get_main_folder()
+    old1 = docs[1].get_main_folder()
+    assert old0 and old1
+
+    # Pre-create a folder that the rename will collide with
+    os.makedirs(os.path.join(tmp_library.libdir, "existing-folder"))
+
+    prompt_index = 0
+    renames = ["existing-folder", "doc-one", "doc-two"]
+
+    def confirm_no_skip(msg: str, **kwargs: object) -> bool:
+        return False
+
+    def mock_prompt(msg: str, **kwargs: object) -> str:
+        nonlocal prompt_index
+        name = renames[prompt_index]
+        prompt_index += 1
+        return name
+
+    with monkeypatch.context() as m:
+        m.setattr(papis.tui.utils, "confirm", confirm_no_skip)
+        m.setattr(papis.tui.utils, "prompt", mock_prompt)
+        result = cli_runner.invoke(
+            cli,
+            ["--all", "--to", "same-target", "test_author"],
+            catch_exceptions=False,
+        )
+        assert result.exit_code == 0, result.output
+
+    # doc1: first rename "existing-folder" collides → re-prompt → "doc-two"
+    # doc2: "doc-one" is free → moved
+    assert not os.path.exists(old0)
+    assert os.path.exists(os.path.join(tmp_library.libdir, "doc-one"))
+    assert not os.path.exists(old1)
+    assert os.path.exists(os.path.join(tmp_library.libdir, "doc-two"))
+
+
+def test_batch_continues_on_execution_error(
+    tmp_library: TemporaryLibrary,
+    caplog: pytest.LogCaptureFixture,
+    monkeypatch: MonkeyPatch,
+) -> None:
+    """Batch mode: one move fails mid-moving, the rest still move."""
+    caplog.set_level(logging.WARNING)
+    cli_runner, db, _ = _setup_runner_db_doc()
+
+    docs = [d for d in db.get_all_documents() if d["author"] == "test_author"]
+    assert len(docs) >= 2
+
+    old0 = docs[0].get_main_folder()
+    old1 = docs[1].get_main_folder()
+    assert old0 and old1
+
+    # Fail the first move only
+    original_move = shutil.move
+    call_count = 0
+
+    def flaky_move(src: str, dst: str, **kwargs: object) -> str:
+        nonlocal call_count
+        call_count += 1
+        if call_count == 1:
+            raise OSError("Simulated error")
+        return original_move(src, dst)
+
+    with monkeypatch.context() as m:
+        m.setattr(papis.tui.utils, "confirm", lambda *a, **kw: True)
+        m.setattr(shutil, "move", flaky_move)
+        result = cli_runner.invoke(
+            cli,
+            ["--batch", "--all", "test_author"],
+            catch_exceptions=False,
+        )
+        assert result.exit_code == 0, result.output
+
+    warning_messages = [r.message for r in caplog.records]
+    assert any("Failed to move" in msg for msg in warning_messages)
+
+    # First doc stays put, second moved
+    assert os.path.exists(old0)
+    assert not os.path.exists(old1)
+
+
+def test_to_default_from_target_library(tmp_library: TemporaryLibrary) -> None:
+    """The default folder pattern comes from the target library."""
+    import papis.config
+
+    cli_runner, _, doc = _setup_runner_db_doc()
+    old_folder = doc.get_main_folder()
+    assert old_folder
+
+    # Set up a second library with a different add-folder-name
+    target_lib_name = "target-lib"
+    target_lib_dir = os.path.join(tmp_library.tmpdir, "target-lib")
+    os.makedirs(target_lib_dir)
+    papis.config.set("dir", target_lib_dir, section=target_lib_name)
+    papis.config.set(
+        "add-folder-name",
+        "custom-{doc[year]}",
+        section=target_lib_name,
+    )
+
+    result = cli_runner.invoke(
+        cli,
+        ["--target-library", target_lib_name, "Turing"],
+        catch_exceptions=False,
+    )
+    assert result.exit_code == 0, result.output
+
+    # Doc moved out of source library
+    assert not os.path.exists(old_folder)
+
+    # Doc landed in target library with target library's folder pattern
+    assert os.path.exists(os.path.join(target_lib_dir, "custom-1937"))
+
+
+# ---------------------------------------------------------------------------
+# Tests for run()
+# ---------------------------------------------------------------------------
+
+
+def test_creates_parent_directories(tmp_library: TemporaryLibrary) -> None:
+    """Parent directories are created when needed."""
     from papis.commands.mv import run
 
-    db = papis.database.get()
-    docs = db.get_all_documents()
+    _, _, doc = _setup_runner_db_doc()
+    old_folder = doc.get_main_folder()
+    assert old_folder
 
-    doc = docs[0]
-    title = doc["title"]
+    new_folder = os.path.join(tmp_library.libdir, "year", "2024", "papers")
+    run(doc, new_folder, git=False)
 
-    folder = doc.get_main_folder()
-    assert folder is not None
-    folder = os.path.basename(folder)
+    _assert_moved(old_folder, new_folder)
 
-    with tempfile.TemporaryDirectory(dir=tmp_library.tmpdir) as new_dir:
-        run(doc, new_dir)
 
-        query_doc, = db.query_dict({"title": title})
-        assert query_doc.get_main_folder() == os.path.join(new_dir, folder)
+def test_move_preserves_source_on_failure(
+    tmp_library: TemporaryLibrary, monkeypatch: MonkeyPatch
+) -> None:
+    """Source folder is preserved when the move fails."""
+    from papis.commands.mv import run
+
+    _, _, doc = _setup_runner_db_doc()
+    old_folder = doc.get_main_folder()
+    assert old_folder
+
+    def failing_move(src: str | Path, dst: str | Path) -> Path:
+        raise OSError("Simulated move failure")
+
+    with monkeypatch.context() as m:
+        m.setattr(shutil, "move", failing_move)
+        try:
+            run(doc, os.path.join(tmp_library.libdir, "new-folder"), git=False)
+        except OSError:
+            pass
+
+    assert os.path.exists(old_folder)
+
+
+@pytest.mark.skipif(
+    not shutil.which("git"), reason="Test requires 'git' executable to be in the PATH"
+)
+@pytest.mark.library_setup(use_git=True)
+def test_run_with_git_commits(tmp_library: TemporaryLibrary) -> None:
+    """Git tracks the move when git=True."""
+    import subprocess
+
+    from papis.commands.mv import run
+
+    _, _, doc = _setup_runner_db_doc()
+    old_folder = doc.get_main_folder()
+    assert old_folder
+
+    result = subprocess.run(
+        ["git", "log", "--oneline"],
+        cwd=tmp_library.libdir,
+        capture_output=True,
+        text=True,
+        check=True,
+    )
+    commits_before = len(result.stdout.strip().split("\n"))
+
+    new_folder = os.path.join(tmp_library.libdir, "moved-turing")
+    run(doc, new_folder, git=True)
+
+    assert not os.path.exists(old_folder)
+    assert os.path.exists(new_folder)
+
+    result = subprocess.run(
+        ["git", "log", "--oneline"],
+        cwd=tmp_library.libdir,
+        capture_output=True,
+        text=True,
+        check=True,
+    )
+    commits_after = len(result.stdout.strip().split("\n"))
+    assert commits_after == commits_before + 1
+
+    result = subprocess.run(
+        ["git", "log", "-1", "--format=%B"],
+        cwd=tmp_library.libdir,
+        capture_output=True,
+        text=True,
+        check=True,
+    )
+    assert "Move" in result.stdout
+    assert "On Computable Numbers" in result.stdout
+
+
+def test_raises_when_source_missing(tmp_library: TemporaryLibrary) -> None:
+    """run() raises FileNotFoundError when source is missing."""
+    from papis.commands.mv import run
+
+    _, _, doc = _setup_runner_db_doc()
+    old_folder = doc.get_main_folder()
+    assert old_folder
+    shutil.rmtree(old_folder)
+
+    with pytest.raises(FileNotFoundError):
+        run(doc, os.path.join(tmp_library.libdir, "new-folder"), git=False)
+
+
+def test_raises_when_target_is_same_folder(tmp_library: TemporaryLibrary) -> None:
+    """run() raises FileExistsError when target is the source folder."""
+    from papis.commands.mv import run
+
+    _, _, doc = _setup_runner_db_doc()
+    same_folder = doc.get_main_folder()
+    assert same_folder
+
+    with pytest.raises(FileExistsError):
+        run(doc, same_folder, git=False)
+
+
+def test_raises_when_target_exists(tmp_library: TemporaryLibrary) -> None:
+    """run() raises FileExistsError when target already exists."""
+    from papis.commands.mv import run
+
+    _, _, doc = _setup_runner_db_doc()
+
+    new_folder = os.path.join(tmp_library.libdir, "already-exists")
+    os.makedirs(new_folder)
+
+    with pytest.raises(FileExistsError):
+        run(doc, new_folder, git=False)


### PR DESCRIPTION
---
~~For now this PR is just a placeholder to discuss things~~
---

I want to take another stab at improving `papis mv` based on the work done by @kiike (thanks! :heart:) in #826. I think the work in that PR is moving things in the right direction and I'd like to push it over the finish line. There was a lengthy discussion at the time on how to best do this, and I've come up with the below proposal based on what was said then. I would love getting feedback on this from anyone but especially those involved in the discussion at the time (@pmiam, @alexfikl, @kiike (though I think you don't use Papis anymore)).

In short, I want to achieve all of kiike's goals, but I think something along the lines of @pmiam's syntax proposal is most minimal/understandable.

## `papis mv -t/--to`
1. `papis mv -t somefolder QUERY`
  - moves folder to somefolder (a rename)
  - if you do this with multiple documents, you will get a warning about overwriting after the first mv operation (at the latest)
2. `papis mv -t somefolder/ QUERY`
  - moves folder *into* somefolder (a move)

Both versions should:
- should support format patterns
- should allow `somefolder/subfolder(/)`
- should split at `/` and sanitize the rest

Note that @pmiam proposed globs '*' instead of trailing `/`. I think that could lead to issues with regular shell globbing. Trailing `/` don't present that problem and are how e.g. `rsync` does it.

## `papis mv QUERY`

This command uses the `add-folder-name` option to determine the target folder name.

## General requirements

In general, `papis mv` should:
- handle multiple files (from picker or with `--all`) (with confirmation or without when using `--batch`)
- handle git
   - automatic commit after mv
- warn about overwrites (but not when using `--batch`?)
- use stuff from `papis.paths` wherever possible

## Regarding `papis rename`

At the time I thought we should preserve `papis rename`, but now I think we should remove it. The command is confusing (since it's unclear whether it acts on folders or files, see #894), and its current functionality should be included it `papis mv`. Renaming of files (and notes) should be done by `papis update`.

## Questions and remarks

- The `--batch` flag in general removes all need to interactively approve things. However, we might want to be able to move a ton of docs at once but still be warned about overwrites. What should we do? Having `--batch` for this but with overwrite warnings is inconsistent with other uses of `--batch`. Maybe we just live with the fact that the user will have to press 'ok' a bunch of times?
- The proposed implementation has no way of moving folder into another folder and renaming it to the `add-folder-name` option
  - You would need to specify the format pattern explicitly, e.g. `papis mv -t somefolder/{doc[author]}-{doc[title]}`
  - I guess that's fine?
- As mentioned by @alexfikl in the original discussion, what should we do on failure: abort or continue?
- The proposed syntax is inconsistent with `papis add`, which has `--subfolder` and `--folder-name` arguments
  - I think the old syntax is rather confusing, and I would prefer adding `-t/--to` to `papis add` and maybe eventually deprecate the old arguments
