### PR TITLE
Allow papis update to rename files

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -78,6 +78,26 @@ another document's folder, or missing source folders are warned about upfront. T
 user can abort, skip problematic moves, or fix collisions interactively. A new
 `--batch` flag allows skipping all interactive prompts.
 
+### Minor: papis update can rename files ([1108](https://github.com/papis/papis/pull/1108))
+
+The `papis update` command has been reworked quite extensively and has some new
+interesting functionality. First, updating document files will also rename these
+files on disk. For example, running
+```bash
+papis update --set files 0:my-new-file.pdf QUERY
+```
+will change the first file in the document to `my-new-file.pdf` and rename it
+on disk from its previous name. This also applies to `notes` in the document.
+
+Second, we can also reset certain values to their defaults (as defined in the
+configuration file). For example, to update some document references according to
+`ref-format`, use
+```bash
+papis update --all --reset ref QUERY
+```
+for a bulk operation. This can also be applied to `author`, `files`, and `notes`.
+For more information, see the documentation of the `papis update command`.
+
 ## Other noteworthy features
 
 - Remove undocumented `dirs` option (only allow one `dir` per library).

--- a/papis/cli.py
+++ b/papis/cli.py
@@ -18,12 +18,20 @@ if TYPE_CHECKING:
     # NOTE: these were introduced in click 8.4.0. We cannot use them directly
     # in the class definitions because they're evaluated eagerly there.
     FormatPatternParamTypeBase = click.ParamType[str | FormatPattern]  # type: ignore[type-arg]
-    LibraryParamTypeBase = click.ParamType[str]  # type: ignore[type-arg]
+    StringParamTypeBase = click.ParamType[str]  # type: ignore[type-arg]
 else:
     FormatPatternParamTypeBase = click.ParamType
-    LibraryParamTypeBase = click.ParamType
+    StringParamTypeBase = click.ParamType
 
 DecoratorCallable = Callable[..., Any]
+
+
+class KeyParamType(StringParamTypeBase):
+    name: str = "key"
+
+
+class ValueParamType(StringParamTypeBase):
+    name: str = "value"
 
 
 class FormatPatternParamType(FormatPatternParamTypeBase):
@@ -47,7 +55,7 @@ class FormatPatternParamType(FormatPatternParamTypeBase):
         return "FORMATPATTERN"
 
 
-class LibraryParamType(LibraryParamTypeBase):
+class LibraryParamType(StringParamTypeBase):
     name: str = "library"
 
     def shell_complete(self,  # ruff:ignore[no-self-use]

--- a/papis/commands/add.py
+++ b/papis/commands/add.py
@@ -361,7 +361,7 @@ def run(paths: list[str],
     "-s", "--set", "set_list",
     help="Set some information before.",
     multiple=True,
-    type=(str, str))
+    type=(papis.cli.KeyParamType(), papis.cli.ValueParamType()))
 @click.option(
     "-d", "--subfolder",
     help="Subfolder in the library.",

--- a/papis/commands/bibtex.py
+++ b/papis/commands/bibtex.py
@@ -226,7 +226,7 @@ def cli_add(ctx: click.Context,
                      help="Update the library document from the BibTeX file.")
 @click.option("-k", "--keys",
               help="Update only given keys (can be given multiple times).",
-              type=str,
+              type=papis.cli.KeyParamType(),
               multiple=True)
 @click.pass_context
 def cli_update(ctx: click.Context, _all: bool,
@@ -342,7 +342,7 @@ def cli_open(ctx: click.Context) -> None:
 @click.option("-s", "--set", "set_tuples",
               help="Update a document with key value pairs.",
               multiple=True,
-              type=(str, papis.cli.FormatPatternParamType()),)
+              type=(papis.cli.KeyParamType(), papis.cli.FormatPatternParamType()),)
 @papis.cli.all_option()
 @click.pass_context
 def cli_edit(ctx: click.Context,
@@ -491,7 +491,7 @@ def cli_save(ctx: click.Context, bibfile: str, force: bool) -> None:
 @click.option("-k", "--key",
               help="Field to order by.",
               default=None,
-              type=str,
+              type=papis.cli.KeyParamType(),
               required=True)
 @papis.cli.bool_flag("-r", "--reverse", help="Reverse the sort order.")
 @click.pass_context
@@ -508,7 +508,7 @@ def cli_sort(ctx: click.Context, key: str | None, reverse: bool) -> None:
 @click.option("-k", "--key",
               help="Field to test for uniqueness, default is ref.",
               default="ref",
-              type=str)
+              type=papis.cli.KeyParamType())
 @click.option("-o",
               help="Output the discarded documents to a file.",
               default=None,
@@ -562,7 +562,7 @@ def cli_unique(ctx: click.Context, key: str, o: str | None) -> None:
               help="Key to check exists in all documents",
               multiple=True,
               default=("doi", "url", "year", "title", "author"),
-              type=str)
+              type=papis.cli.KeyParamType())
 @click.pass_context
 def cli_doctor(ctx: click.Context, key: list[str]) -> None:
     """
@@ -592,7 +592,9 @@ def cli_doctor(ctx: click.Context, key: list[str]) -> None:
 @click.help_option("-h", "--help")
 @click.option("-f", "--file", "_files",
               help="Text file to check for references.",
-              multiple=True, required=True, type=str)
+              multiple=True,
+              required=True,
+              type=click.Path(exists=True))
 @click.pass_context
 def cli_filter_cited(ctx: click.Context, _files: list[str]) -> None:
     """
@@ -622,7 +624,9 @@ def cli_filter_cited(ctx: click.Context, _files: list[str]) -> None:
 @click.help_option("-h", "--help")
 @click.option("-f", "--file", "_files",
               help="Text file to check for references.",
-              multiple=True, required=True, type=str)
+              multiple=True,
+              required=True,
+              type=click.Path(exists=True))
 @click.pass_context
 def cli_iscited(ctx: click.Context, _files: list[str]) -> None:
     """

--- a/papis/commands/default.py
+++ b/papis/commands/default.py
@@ -86,7 +86,7 @@ def generate_profile_writing_function(profiler: cProfile.Profile,
     help="Pick library to use.")
 @click.option(
     "-s", "--set", "set_list",
-    type=(str, str),
+    type=(papis.cli.KeyParamType(), papis.cli.ValueParamType()),
     multiple=True,
     help="Set key value, e.g., "
          "'--set info-name information.yaml --set opentool evince'.")
@@ -108,7 +108,7 @@ def generate_profile_writing_function(profiler: cProfile.Profile,
 @click.option(
     "--np",
     help="Use number of processors for multicore functionalities in Papis.",
-    type=str,
+    type=int,
     default=None)
 @click.pass_context
 def run(ctx: click.Context,

--- a/papis/commands/rename.py
+++ b/papis/commands/rename.py
@@ -30,7 +30,6 @@ Examples
 
   This will give you a folder named "rick-astley-never-gonna".
 
-
 - To stop Papis from asking for confirmation, use the ``--batch`` flag:
 
    .. code:: sh

--- a/papis/commands/tag.py
+++ b/papis/commands/tag.py
@@ -58,60 +58,64 @@ Command-line interface
 """
 from __future__ import annotations
 
-from typing import Any
+from typing import TYPE_CHECKING
 
 import click
 
 import papis.cli
 import papis.logging
+from papis.commands.update import _OrderedCommand
+
+if TYPE_CHECKING:
+    from papis.strings import AnyString
 
 logger = papis.logging.get_logger(__name__)
 
 
-@click.command("tag")
+@click.command("tag", cls=_OrderedCommand)
 @click.help_option("--help", "-h")
 @papis.cli.git_option()
 @papis.cli.bool_flag(
-    "-d",
-    "--drop",
+    "-d", "--drop",
     help="Drop all tags.",
     default=False,
 )
 @click.option(
-    "-p",
-    "--add",
-    "--append",
-    "to_add",
+    "-p", "--add", "--append", "to_append",
     help="Add a tag.",
     multiple=True,
-    type=str,
+    type=papis.cli.FormatPatternParamType(),
 )
 @click.option(
-    "-r",
-    "--remove",
-    "to_remove",
+    "-r", "--remove", "to_remove",
     help="Remove a tag.",
     multiple=True,
-    type=str,
+    type=papis.cli.FormatPatternParamType(),
 )
 @click.option(
-    "-n",
-    "--rename",
-    "to_rename",
+    "-n", "--rename", "to_rename",
     help="Rename a tag (<OLD-TAG NEW-TAG>).",
     multiple=True,
-    type=(str, str),
+    type=(papis.cli.FormatPatternParamType(), papis.cli.FormatPatternParamType()),
+)
+@papis.cli.bool_flag(
+    "-b",
+    "--batch",
+    help="Do not prompt, and skip documents containing errors."
 )
 @papis.cli.doc_folder_option()
 @papis.cli.all_option()
 @papis.cli.sort_option()
 @papis.cli.query_argument()
+@click.pass_context
 def cli(
+    ctx: click.Context,
     git: bool,
     drop: bool,
-    to_add: list[str],
-    to_remove: list[str],
-    to_rename: list[tuple[str, str]],
+    to_append: list[AnyString],
+    to_remove: list[AnyString],
+    to_rename: list[tuple[AnyString, AnyString]],
+    batch: bool,
     sort_field: str | None,
     sort_reverse: bool,
     query: str,
@@ -122,74 +126,68 @@ def cli(
     Change a document's tags.
     """
 
-    # if do_tag:
+    # retrieve documents
     documents = papis.cli.handle_doc_folder_query_all_sort(
         query, doc_folder, sort_field, sort_reverse, _all
     )
-
     if not documents:
         from papis.strings import no_documents_retrieved_message
         logger.warning(no_documents_retrieved_message)
         return
 
-    from papis.commands.update import run, run_append, run_drop, run_remove, run_rename
+    # retrieve user provided operations
+    from papis.commands.update import (
+        OperationError,
+        _apply_operations,
+        _process_command_line_operations,
+    )
 
+    operations = _process_command_line_operations(
+        ctx.obj["param"],
+        to_set=(),
+        to_reset=(),
+        to_drop=("tags",) if drop else (),
+        to_append=(("tags", value) for value in to_append),
+        to_remove=(("tags", value) for value in to_remove),
+        to_rename=(("tags", from_value, to_value) for from_value, to_value in to_rename)
+    )
+
+    from papis.document import describe
     field_types: dict[str, type] = {"tags": list}
 
-    from papis.importer import Context
-
-    success = True
-    processed_documents: list[Any] = []
+    processed_documents = []
     for document in documents:
         tags = document.get("tags", [])
         if not isinstance(tags, list):
-            processed_documents.clear()
-            logger.error(
-                "The document with papis_id '%s' contains tags that aren't "
-                "defined as a list of items. As `papis tag` only supports "
-                "lists, tagging has been aborted and no documents have been "
-                "changed. You can use `papis doctor --checks field-type --fix` to "
-                "convert all your tags to use lists.",
-                document["papis_id"],
-            )
-            break
+            logger.info("[%s] Document tags are not a list: %s. You can use "
+                        "'papis doctor --checks field-type --fix' to automatically "
+                        "convert all tags to lists.",
+                        describe(document), type(tags))
+            if batch:
+                logger.error("'papis tag' only supports list tags. Skipping...")
+                continue
+            else:
+                logger.error("'papis tag' only supports list tags. Aborting...")
+                ctx.exit(1)
 
-        ctx = Context()
+        try:
+            new_data = _apply_operations(
+                document, operations,
+                field_types=field_types,
+                continue_on_error=batch)
+        except OperationError:
+            if batch:
+                logger.error("[%s] Failed to apply changes to document. Continuing...",
+                             describe(document))
+                continue
+            else:
+                logger.error("[%s] Failed to apply changes to document. Aborting...",
+                             describe(document))
+                ctx.exit(1)
 
-        ctx.data.update(document)
-        if drop and success:
-            run_drop(ctx.data, ["tags"])
+        processed_documents.append((document, new_data))
 
-        if to_add and success:
-            to_add_tuples = [("tags", tag) for tag in to_add]
-            success = run_append(ctx.data, to_add_tuples, field_types, False)
-
-        if to_remove and success:
-            to_remove_tuples = [("tags", tag) for tag in to_remove]
-            success, _ = run_remove(ctx.data, to_remove_tuples, False)
-
-        if to_rename:
-            to_rename_tuples = [
-                ("tags", old_tag, new_tag) for old_tag, new_tag in to_rename
-            ]
-            success = run_rename(ctx.data, to_rename_tuples, field_types, False)
-
-        if success:
-            from papis.document import describe
-            logger.info("Processing tags in '%s.'", describe(document))
-
-            processed_documents.append((document, ctx.data))
-
-        if not success:
-            processed_documents.clear()
-            logger.error(
-                "Papis has encountered an unexpected error while processing "
-                "document '%s'. Tagging has been aborted and no documents have "
-                "been changed. Please report this bug at "
-                "https://github.com/papis/papis.",
-                document["papis_id"],
-            )
-            break
+    from papis.commands.update import run
 
     for document, data in processed_documents:
-        run(document, data=data, git=git, auto_doctor=False)
+        run(document, data=data, git=git, auto_doctor=False, overwrite=True)

--- a/papis/commands/tag.py
+++ b/papis/commands/tag.py
@@ -58,60 +58,64 @@ Command-line interface
 """
 from __future__ import annotations
 
-from typing import Any
+from typing import TYPE_CHECKING
 
 import click
 
 import papis.cli
 import papis.logging
+from papis.commands.update import _OrderedCommand
+
+if TYPE_CHECKING:
+    from papis.strings import AnyString
 
 logger = papis.logging.get_logger(__name__)
 
 
-@click.command("tag")
+@click.command("tag", cls=_OrderedCommand)
 @click.help_option("--help", "-h")
 @papis.cli.git_option()
 @papis.cli.bool_flag(
-    "-d",
-    "--drop",
+    "-d", "--drop",
     help="Drop all tags.",
     default=False,
 )
 @click.option(
-    "-p",
-    "--add",
-    "--append",
-    "to_add",
+    "-p", "--add", "--append", "to_append",
     help="Add a tag.",
     multiple=True,
-    type=str,
+    type=papis.cli.FormatPatternParamType(),
 )
 @click.option(
-    "-r",
-    "--remove",
-    "to_remove",
+    "-r", "--remove", "to_remove",
     help="Remove a tag.",
     multiple=True,
-    type=str,
+    type=papis.cli.FormatPatternParamType(),
 )
 @click.option(
-    "-n",
-    "--rename",
-    "to_rename",
+    "-n", "--rename", "to_rename",
     help="Rename a tag (<OLD-TAG NEW-TAG>).",
     multiple=True,
-    type=(str, str),
+    type=(papis.cli.FormatPatternParamType(), papis.cli.FormatPatternParamType()),
+)
+@papis.cli.bool_flag(
+    "-b",
+    "--batch",
+    help="Do not prompt, and skip documents containing errors."
 )
 @papis.cli.doc_folder_option()
 @papis.cli.all_option()
 @papis.cli.sort_option()
 @papis.cli.query_argument()
+@click.pass_context
 def cli(
+    ctx: click.Context,
     git: bool,
     drop: bool,
-    to_add: list[str],
-    to_remove: list[str],
-    to_rename: list[tuple[str, str]],
+    to_append: list[AnyString],
+    to_remove: list[AnyString],
+    to_rename: list[tuple[AnyString, AnyString]],
+    batch: bool,
     sort_field: str | None,
     sort_reverse: bool,
     query: str,
@@ -122,74 +126,85 @@ def cli(
     Change a document's tags.
     """
 
-    # if do_tag:
+    # retrieve documents
     documents = papis.cli.handle_doc_folder_query_all_sort(
         query, doc_folder, sort_field, sort_reverse, _all
     )
-
     if not documents:
         from papis.strings import no_documents_retrieved_message
         logger.warning(no_documents_retrieved_message)
         return
 
-    from papis.commands.update import run, run_append, run_drop, run_remove, run_rename
+    # retrieve user provided operations
+    from papis.commands.update import (
+        _apply_operations,
+        _process_command_line_operations,
+    )
+
+    operations = _process_command_line_operations(
+        ctx.obj["param"],
+        to_set=(),
+        to_reset=(),
+        to_drop=("tags",) if drop else (),
+        to_append=(("tags", value) for value in to_append),
+        to_remove=(("tags", value) for value in to_remove),
+        to_rename=(("tags", from_value, to_value) for from_value, to_value in to_rename)
+    )
+
+    from papis.commands.update import ApplyStatus, run
+    from papis.document import describe
+    from papis.tui.utils import confirm as ask_confirm
 
     field_types: dict[str, type] = {"tags": list}
 
-    from papis.importer import Context
+    ret = 0
+    updated = 0
+    for i, document in enumerate(documents):
+        logger.info("[%d/%d] Applying metadata changes for document: %s.",
+                    i + 1, len(documents), describe(document))
 
-    success = True
-    processed_documents: list[Any] = []
-    for document in documents:
         tags = document.get("tags", [])
         if not isinstance(tags, list):
-            processed_documents.clear()
-            logger.error(
-                "The document with papis_id '%s' contains tags that aren't "
-                "defined as a list of items. As `papis tag` only supports "
-                "lists, tagging has been aborted and no documents have been "
-                "changed. You can use `papis doctor --checks field-type --fix` to "
-                "convert all your tags to use lists.",
-                document["papis_id"],
-            )
-            break
+            logger.info("Document tags are not a list: %s. You can use "
+                        "'papis doctor --checks field-type --fix' to automatically "
+                        "convert all tags to lists.",
+                        type(tags))
+            logger.error("'papis tag' only supports list tags. Skipping...")
 
-        ctx = Context()
+            ret = 1
+            continue
 
-        ctx.data.update(document)
-        if drop and success:
-            run_drop(ctx.data, ["tags"])
+        try:
+            new_data, status = _apply_operations(
+                document, operations,
+                field_types=field_types)
+        except Exception as exc:
+            logger.error("Failed to apply metadata changes to document: %s.",
+                         describe(document), exc_info=exc)
+            ret = 1
+            continue
 
-        if to_add and success:
-            to_add_tuples = [("tags", tag) for tag in to_add]
-            success = run_append(ctx.data, to_add_tuples, field_types, False)
+        if ApplyStatus.Failed in status:
+            ret = 1
 
-        if to_remove and success:
-            to_remove_tuples = [("tags", tag) for tag in to_remove]
-            success, _ = run_remove(ctx.data, to_remove_tuples, False)
+        if ApplyStatus.Changed not in status:
+            continue
 
-        if to_rename:
-            to_rename_tuples = [
-                ("tags", old_tag, new_tag) for old_tag, new_tag in to_rename
-            ]
-            success = run_rename(ctx.data, to_rename_tuples, field_types, False)
+        if ApplyStatus.Failed in status:
+            if not batch and ask_confirm(
+                "Encountered errors while updating document tags. Skip it?"
+            ):
+                continue
 
-        if success:
-            from papis.document import describe
-            logger.info("Processing tags in '%s.'", describe(document))
+        try:
+            run(document, data=new_data, git=git, auto_doctor=False, overwrite=True)
+        except Exception as exc:
+            logger.error("Failed to apply metadata changes to document: %s.",
+                         describe(document), exc_info=exc)
+            ret = 1
+            continue
 
-            processed_documents.append((document, ctx.data))
+        updated += 1
 
-        if not success:
-            processed_documents.clear()
-            logger.error(
-                "Papis has encountered an unexpected error while processing "
-                "document '%s'. Tagging has been aborted and no documents have "
-                "been changed. Please report this bug at "
-                "https://github.com/papis/papis.",
-                document["papis_id"],
-            )
-            break
-
-    for document, data in processed_documents:
-        run(document, data=data, git=git, auto_doctor=False)
+    logger.info("Updated %d / %d documents.", updated, len(documents))
+    ctx.exit(ret)

--- a/papis/commands/update.py
+++ b/papis/commands/update.py
@@ -1,19 +1,21 @@
 """
 This command allows you to update the document metadata stored in the
-``info.yaml`` file. With it, you can either change individual values manually
+``info.yaml`` file. With it, you can either set individual fields' values manually
 or update a document with information automatically retrieved from a variety
-of sources.
+of sources. The command also renames files and notes on disk when needed.
 
-When using it to add information, Papis formatting patterns and Python
-expressions can be used. See below examples for more information. The command
-also tries to sanitise filenames so that they don't contain any problematic
-characters.
+Papis formatting patterns and Python expressions can be used. See below examples
+for more information. The command also sanitises filenames so that they don't
+contain any problematic characters (see :confval:`doc-paths-extra-chars`).
 
-Normally, ``papis update`` will prompt you when it encounters an error. If you
-want to continue errors without input and apply as many changes as possible,
-use the ``--batch`` flag. With this in mind, the command is mostly meant to be
-used to apply sweeping changes to a larger number of documents. If you just
-want to update a single document, ``papis edit`` might be more appropriate.
+By default, ``papis update`` will prompt you when it encounters an error. If you
+want to skip errors automatically and apply as many changes as possible,
+use the ``--batch`` flag.
+
+This command is mostly meant to be used to apply sweeping changes across a large
+number of documents. If you just want to update a single document, ``papis edit``
+might be more appropriate.
+
 
 Examples
 ^^^^^^^^
@@ -37,25 +39,10 @@ Examples
 
 
   The ``--all`` flag means that the operation is applied to all documents that
-  match the query, rather than allowing you to pick one individual document to
+  match the query, rather than opening the picker to select individual documents to
   update.
 
-- Update a document automatically and interactively (searching by DOI in
-  Crossref or in other sources...):
-
-    .. code:: sh
-
-        papis update --auto "author:dyson"
-
-- Update your document from a DOI using the importer functionality as
-
-    .. code:: sh
-
-        papis update --from doi '10.1103/PhysRev.47.777' 'author:einstein'
-
-  For a list of all supported importers use ``papis update --list-importers``.
-
-- Add the ", Albert" to the author string of a documents matching 'Einstein':
+- Add ", Albert" to the author string of a documents matching 'Einstein':
 
     .. code:: sh
 
@@ -65,20 +52,19 @@ Examples
   formatter. Here, it is used to get the existing author "Albert" and then add
   the string ", Einstein" to end up with "Einstein, Albert".
 
-- Reset keys to their default values using:
+- Reset a field to its default value using:
 
     .. code:: sh
 
         papis update --reset ref Einstein
 
-  This will reset the value to the default value defined for the key. In the
-  above case the "ref" is set to the format described by :confval:`ref-format`.
-  Other supported keys are: "author" (gets updated from ``author_list`` and
-  :confval:`multiple-authors-format`), "notes" (using :confval:`notes-name`),
-  and "files" (using :confval:`add-file-name`). Other keys do not support this
-  as they do not have any well-defined default.
+  This will reset the value to the default value defined for the field. Here, the "ref"
+  is set to :confval:`ref-format`. Other fields that can be reset are: "author" (gets
+  updated from ``author_list`` and :confval:`multiple-authors-format`), "notes"
+  (using :confval:`notes-name`), and "files" (using :confval:`add-file-name`). Other
+  fields do not support this as they do not have any well-defined default.
 
-- The ``--append`` option can be used to append a string to an existing key:
+- The ``--append`` option can be used to append to a string value:
 
     .. code:: sh
 
@@ -99,9 +85,9 @@ Examples
     doesn't yet exist, it will be created. The new tag will only be appended to
     the list if the tag does not already exist (as an exact case-sensitive match).
 
-    The ``--append`` flag needs to know the type of the key it is appending to.
-    If the key exists in the document, then the value set in the document
-    determines the type. If the key doesn't exist in the document, the command
+    The ``--append`` flag needs to know the type of the field it is appending to.
+    If the field exists in the document, then the value set in the document
+    determines the type. If the field doesn't exist in the document, the command
     looks at the list of types defined in the :confval:`document-field-types`
     (and :confval:`document-field-types-extend`) configuration option. If the
     type cannot be determined in either of these two ways, the command will
@@ -114,7 +100,7 @@ Examples
 
         papis update --remove tags physics 'author:einstein'
 
-- To remove a key-value pair entirely, use ``--drop``. For example, to remove all
+- To remove a field entirely, use ``--drop``. For example, to remove all
   tags from documents use
 
     .. code:: sh
@@ -122,7 +108,9 @@ Examples
         papis update --drop tags 'author:einstein'
 
 - There is also a convenience option ``--rename`` if you want to rename
-  a list item. It's equivalent to doing ``--remove`` and ``--append``, but as
+  a list item. It's equivalent to doing ``--remove`
+and`
+--append``, but as
   a single operation:
 
     .. code:: sh
@@ -133,8 +121,8 @@ Examples
   not be added to the list if the original tag doesn't exist.
 
 - The ``--batch`` flag suppresses interactive prompts and skips any document
-  that cannot be fully updated. This is useful when applying the same operation
-  across many documents where some may not have the expected keys or values:
+  for which an update operation has failed. This is useful when applying the same
+  operation across many documents where some may not have the expected keys or values:
 
     .. code:: sh
 
@@ -147,42 +135,67 @@ Examples
 
   More specifically, ``--batch`` suppresses prompts for the following errors:
 
-  * An operation on a key fails (e.g. trying to ``--remove`` a value that is
+  * An operation on a field fails (e.g. trying to ``--remove`` a value that is
     not in the list, ``--append`` to a key of unknown type, or a type
     conversion error from ``--set``). The affected key retains its original
     value and the remaining keys for that document are still processed.
   * A file rename fails (e.g. the file on disk is missing or cannot be moved).
     The whole document is skipped.
 
-  In all cases the command exits with a non-zero status if any document was
-  skipped.
+  In all cases the command exits with a non-zero status (indicating a failure) if
+  any document was skipped.
 
-Advanced Examples
-^^^^^^^^^^^^^^^^^
+- Update a document automatically and interactively (searching by DOI in
+  Crossref or in other sources...):
 
-- When you update the ``files`` or ``notes`` keys, the corresponding files on
-  disk are also renamed to match the new value:
+    .. code:: sh
+
+        papis update --auto "author:dyson"
+
+- Update your document from a DOI using the importer functionality:
+
+    .. code:: sh
+
+        papis update --from doi '10.1103/PhysRev.47.777' 'author:einstein'
+
+  For a list of all supported importers use ``papis update --list-importers``.
+
+- When you update the ``files`
+or`
+notes`` fields, the corresponding files on
+  disk are renamed to match the new value:
 
     .. code:: sh
 
         papis update --set notes "my-new-notes.tex" Einstein
 
-  This renames the ``notes`` file on disk from its current name to
-  ``my-new-notes.tex`` and updates the ``info.yaml`` file accordingly. The same
-  applies when updating ``files``:
+  This updates the ``info.yaml`
+file and renames the`
+notes`` file on disk from
+  its current name to ``my-new-notes.tex``
+. The same applies when updating``
+files``:
 
     .. code:: sh
 
-        papis update --set files 0:einstein-new.pdf Einstein
+        papis update --rename files einstein-old.pdf einstein-new.pdf Einstein
 
-  This renames the first file in the document's file list to ``einstein-new.pdf``
-  on disk. If the rename fails (e.g. the file does not exist or there is a
-  permissions error), the metadata is not updated and an error is reported.
+  This renames the file ``einstein-old.pdf`
+to`
+einstein-new.pdf`` in the
+  ``info.yaml`` file and on disk. If the rename fails (e.g. the file does not exist
+  or there is a permissions error), the metadata is not updated and an error is
+  reported.
 
   Note that the ``--reset`` option also triggers a rename when used with
-  ``notes`` or ``files``. It renames the files to the names derived from the
+  ``notes`
+or`
+files``. It renames the files to the names derived from the
   configured :confval:`notes-name` and :confval:`add-file-name` formats
   respectively.
+
+Advanced Examples
+^^^^^^^^^^^^^^^^^
 
 - As an advanced feature, ``papis update`` also supports the parsing of Python
   expressions (such as lists or dictionaries). This can be used as follows:
@@ -194,15 +207,16 @@ Advanced Examples
   Because the above string is a valid Python expression, ``author_list`` is
   updated to a list that contains a dictionary.
 
-- You can use ``--set`` to set a value into a list at a given position:
+- You can use ``--set`` to set a value in a list at a given position:
 
     .. code:: sh
 
         papis update --set files 0:some-new-file.pdf Einstein
 
-  This special syntax for ``--set`` only works with keys that are known to be
-  lists (as before, based on :confval:`document-field-types` and
-  :confval:`document-field-types-extend`). If the key is not a list, then the
+  This command will rename the first entry in the list of files. This special
+  syntax for ``--set`` only works with keys that are known to be lists (as
+  determined based on :confval:`document-field-types` and
+  :confval:`document-field-types-extend`). If the field is not a list, then the
   value is treated as a string. This might be unexpected, so make sure you are
   using it for list keys only.
 
@@ -212,6 +226,7 @@ Command-line interface
 .. click:: papis.commands.update:cli
     :prog: papis update
 """
+
 from __future__ import annotations
 
 import ast

--- a/papis/commands/update.py
+++ b/papis/commands/update.py
@@ -9,8 +9,11 @@ expressions can be used. See below examples for more information. The command
 also tries to sanitise filenames so that they don't contain any problematic
 characters.
 
-Normally, ``papis update`` will abort on encountering an error. If you want to
-skip errors and apply as many changes as possible, use the ``--batch`` flag.
+Normally, ``papis update`` will prompt you when it encounters an error. If you
+want to continue errors without input and apply as many changes as possible,
+use the ``--batch`` flag. With this in mind, the command is mostly meant to be
+used to apply sweeping changes to a larger number of documents. If you just
+want to update a single document, ``papis edit`` might be more appropriate.
 
 Examples
 ^^^^^^^^
@@ -33,8 +36,9 @@ Examples
         papis update --all --set journal "Mass and Energy" "journal:'Energy and Mass'"
 
 
-  The ``--all`` flag means that the tag is applied to all documents that match the
-  query, rather than allowing you to pick one individual document to update.
+  The ``--all`` flag means that the operation is applied to all documents that
+  match the query, rather than allowing you to pick one individual document to
+  update.
 
 - Update a document automatically and interactively (searching by DOI in
   Crossref or in other sources...):
@@ -43,14 +47,13 @@ Examples
 
         papis update --auto "author:dyson"
 
-- Update your library from a BibTeX file, where many entries may be listed:
+- Update your document from a DOI using the importer functionality as
 
     .. code:: sh
 
-        papis update --from bibtex libraryfile.bib
+        papis update --from doi '10.1103/PhysRev.47.777' 'author:einstein'
 
-  Papis will try to look for documents in your library that match these
-  entries and will ask you for each entry whether you want to update it.
+  For a list of all supported importers use ``papis update --list-importers``.
 
 - Add the ", Albert" to the author string of a documents matching 'Einstein':
 
@@ -60,71 +63,148 @@ Examples
 
   The ``papis update`` command tries to format input strings using the configured
   formatter. Here, it is used to get the existing author "Albert" and then add
-  the string ", Einstein" to end up with "Einstein, Albert"
+  the string ", Einstein" to end up with "Einstein, Albert".
 
-- The above can also be achieved with the ``--append`` option:
+- Reset keys to their default values using:
+
+    .. code:: sh
+
+        papis update --reset ref Einstein
+
+  This will reset the value to the default value defined for the key. In the
+  above case the "ref" is set to the format described by :confval:`ref-format`.
+  Other supported keys are: "author" (gets updated from ``author_list`` and
+  :confval:`multiple-authors-format`), "notes" (using :confval:`notes-name`),
+  and "files" (using :confval:`add-file-name`). Other keys do not support this
+  as they do not have any well-defined default.
+
+- The ``--append`` option can be used to append a string to an existing key:
 
     .. code:: sh
 
         papis update --append author ", Albert" Einstein
 
-    This appends ", Albert" to the existing author string.
+  This appends ", Albert" to the existing author value. Note that it will be
+  appended to the existing value only if it does not already end with that
+  exact string (case-sensitive). This avoids appending duplicates by mistake, as
+  in the case of lists (below).
 
 - You can also append an item to a list:
 
     .. code:: sh
 
-        papis update --append tags physics
+        papis update --append tags physics 'author:einstein'
 
-    This adds the tag 'physics' to the existing list of tags. If the list
-    doesn't yet exist, it will be created. All duplicate items will be removed
-    from the list.
+    This adds the tag "physics" to the existing list of tags. If the list
+    doesn't yet exist, it will be created. The new tag will only be appended to
+    the list if the tag does not already exist (as an exact case-sensitive match).
 
-    As you might have guessed, the ``--append`` flag needs to know the type of
-    the key it is appending to. It does this by looking at the
-    :confval:`document-field-types` (and :confval:`document-field-types-extend`)
-    configuration options. If the key you are appending to is not in that list,
-    the command will fail.
+    The ``--append`` flag needs to know the type of the key it is appending to.
+    If the key exists in the document, then the value set in the document
+    determines the type. If the key doesn't exist in the document, the command
+    looks at the list of types defined in the :confval:`document-field-types`
+    (and :confval:`document-field-types-extend`) configuration option. If the
+    type cannot be determined in either of these two ways, the command will
+    fail.
 
-- To remove an item from a list, use ``--remove``:
-
-    .. code:: sh
-
-        papis update --remove tags physics
-
-    If the tag "physics" is in the list of tags, this command removes it.
-
-- To remove a key-value pair entirely, use ``--drop``:
+- To remove an item from a list, use ``--remove``. For example, to remove the
+  "physics" tag from the list of document tags, use
 
     .. code:: sh
 
-        papis update --drop tags
+        papis update --remove tags physics 'author:einstein'
 
-    This removes all tags.
+- To remove a key-value pair entirely, use ``--drop``. For example, to remove all
+  tags from documents use
+
+    .. code:: sh
+
+        papis update --drop tags 'author:einstein'
 
 - There is also a convenience option ``--rename`` if you want to rename
-  a list item. It's equivalent to doing ``--remove`` and ``--append`` sequentially:
+  a list item. It's equivalent to doing ``--remove`` and ``--append``, but as
+  a single operation:
 
     .. code:: sh
 
         papis update --rename tags physics philosophy
 
-  This renames the tag 'physics' to 'philosophy'. Note that this option being a
-  combination of ``--remove`` and ``--append``, it will append the desired values
-  even if the value to be removed didn't exist. Thus, the above command will add
-  the tag "philosophy" even if the tag "physics" didn't exist before the
-  operation.
+  This renames the tag "physics" to "philosophy". Note that the new tag will
+  not be added to the list if the original tag doesn't exist.
 
-- As an advanced feature, ``papis update`` also supports the parsing of python
+- The ``--batch`` flag suppresses interactive prompts and skips any document
+  that cannot be fully updated. This is useful when applying the same operation
+  across many documents where some may not have the expected keys or values:
+
+    .. code:: sh
+
+        papis update --all --batch --remove tags obsolete "tags:obsolete"
+
+  Without ``--batch``, if a document does not have "obsolete" in its tag list
+  (or has no ``tags`` key at all), the command pauses and asks whether to
+  continue. With ``--batch``, an error is logged, the document is skipped and the
+  command moves on to the next one.
+
+  More specifically, ``--batch`` suppresses prompts for the following errors:
+
+  * An operation on a key fails (e.g. trying to ``--remove`` a value that is
+    not in the list, ``--append`` to a key of unknown type, or a type
+    conversion error from ``--set``). The affected key retains its original
+    value and the remaining keys for that document are still processed.
+  * A file rename fails (e.g. the file on disk is missing or cannot be moved).
+    The whole document is skipped.
+
+  In all cases the command exits with a non-zero status if any document was
+  skipped.
+
+Advanced Examples
+^^^^^^^^^^^^^^^^^
+
+- When you update the ``files`` or ``notes`` keys, the corresponding files on
+  disk are also renamed to match the new value:
+
+    .. code:: sh
+
+        papis update --set notes "my-new-notes.tex" Einstein
+
+  This renames the ``notes`` file on disk from its current name to
+  ``my-new-notes.tex`` and updates the ``info.yaml`` file accordingly. The same
+  applies when updating ``files``:
+
+    .. code:: sh
+
+        papis update --set files 0:einstein-new.pdf Einstein
+
+  This renames the first file in the document's file list to ``einstein-new.pdf``
+  on disk. If the rename fails (e.g. the file does not exist or there is a
+  permissions error), the metadata is not updated and an error is reported.
+
+  Note that the ``--reset`` option also triggers a rename when used with
+  ``notes`` or ``files``. It renames the files to the names derived from the
+  configured :confval:`notes-name` and :confval:`add-file-name` formats
+  respectively.
+
+- As an advanced feature, ``papis update`` also supports the parsing of Python
   expressions (such as lists or dictionaries). This can be used as follows:
 
     .. code:: sh
 
         papis update --set author_list "[{'family': 'Einstein', 'given': 'Albert'}]"
 
-  Because the above string is a valid python expression, ``author_list`` is
-  updated to a set that contains a dictionary.
+  Because the above string is a valid Python expression, ``author_list`` is
+  updated to a list that contains a dictionary.
 
+- You can use ``--set`` to set a value into a list at a given position:
+
+    .. code:: sh
+
+        papis update --set files 0:some-new-file.pdf Einstein
+
+  This special syntax for ``--set`` only works with keys that are known to be
+  lists (as before, based on :confval:`document-field-types` and
+  :confval:`document-field-types-extend`). If the key is not a list, then the
+  value is treated as a string. This might be unexpected, so make sure you are
+  using it for list keys only.
 
 Command-line interface
 ^^^^^^^^^^^^^^^^^^^^^^
@@ -135,7 +215,9 @@ Command-line interface
 from __future__ import annotations
 
 import ast
-from typing import TYPE_CHECKING, Any
+import enum
+import os
+from typing import TYPE_CHECKING, Any, NamedTuple
 
 import click
 
@@ -144,262 +226,630 @@ import papis.config
 import papis.logging
 
 if TYPE_CHECKING:
-    from collections.abc import Sequence
+    from collections.abc import Iterable, Sequence
 
-    from papis.document import Document, DocumentLike
-    from papis.strings import AnyString
+    from papis.document import Document
+    from papis.strings import AnyString, FormatPattern
 
 logger = papis.logging.get_logger(__name__)
 
 
-def try_parsing_str(key: str, value: str) -> str:
-    """
-    Tries to parse the input string as a python expression.
+class OperationError(Exception):
+    """Error occurring during validation or application of an operation."""
 
-    :returns: The parsed input string if string is a python expression,
-        otherwise an unchanged string.
+
+@enum.unique
+class OperationType(enum.Enum):
+    """Supported types of operations on document keys."""
+    Set = enum.auto()
+    Reset = enum.auto()
+    Drop = enum.auto()
+    Append = enum.auto()
+    Remove = enum.auto()
+    Rename = enum.auto()
+
+
+class Operation(NamedTuple):
+    """Operation on document keys."""
+    optype: OperationType
+    key: str
+    value: FormatPattern
+
+    to_value: FormatPattern
+
+
+def _try_eval_value(key: str, value: str) -> Any:
+    """Try to use :func:`ast.literal_eval` to evaluate the given string.
+
+    :returns: *value* if the evaluation gives an error, and the evaluated value
+        otherwise.
     """
     try:
-        value = ast.literal_eval(value)
+        return ast.literal_eval(value)
     except (SyntaxError, ValueError):
-        logger.debug("Value '%s' of key '%s' is not a python expression.", value, key)
-    return value
+        logger.debug("Value for key '%s' is not a Python expression: '%s'", key, value)
+        return value
 
 
-def run_set(
-    document: DocumentLike,
-    to_set: Sequence[tuple[str, AnyString]],
-    field_types: dict[str, type],
-) -> None:
+def _try_parse_list_element(key: str, value: str) -> tuple[int | None, Any]:
+    """Parse a string of the form ``n:list_element`` from *value*.
+
+    :returns: a tuple ``(index, list_element)`` if the parsing succeeded or
+        a dummy value of ``(None, value)`` otherwise.
     """
-    Processes a list of ``to_set`` tuples and applies the resulting changes to the
-    input document. Each tuple is (KEY, VALUE) and results in setting the KEY to
-    the VALUE in the document.
-    """
-    from papis.format import format
-    from papis.paths import normalize_path_part
-    from papis.strings import process_format_pattern_pair
+    if ":" not in value:
+        return None, value
 
-    for orig_key, orig_value in to_set:
-        key, vformat = process_format_pattern_pair(orig_key, orig_value)
-        value = format(vformat, document, default=str(vformat))
-        value = try_parsing_str(key, value)
+    index, value = value.split(":", maxsplit=1)
+    if not index.isdigit():
+        return None, value
 
-        if isinstance(value, int) and field_types.get(key) is str:
-            value = str(value)
-        if key == "notes" and isinstance(value, str):
-            # TODO: handle renames/deletions of files on disk
-            document[key] = normalize_path_part(value)
-            logger.warning(
-                "Document note renamed in the info.yaml file. This does not "
-                "rename any files on disk."
-            )
-        elif key == "files" and isinstance(value, list):
-            # TODO: handle renames/deletions of files on disk
-            document[key] = []
-            for file in value:
-                if isinstance(file, str):
-                    document[key].append(normalize_path_part(file))
-                else:
-                    document[key].append(value)
-            logger.warning(
-                "Document files renamed in the info.yaml file. This does not "
-                "rename any files on disk."
-            )
-        elif key == "ref" and isinstance(value, str):
-            from papis.bibtex import ref_cleanup
-            document[key] = ref_cleanup(value)
-        else:
-            document[key] = value
+    return int(index), _try_eval_value(key, value)
 
 
-def run_append(
-    document: DocumentLike,
-    to_append: Sequence[tuple[str, AnyString]],
-    field_types: dict[str, type],
-    batch: bool,
-) -> bool:
-    """
-    Processes a list of ``to_append`` tuples and applies the resulting changes
-    to the input document. Each tuple is (KEY, VALUE) and results in appending
-    the VALUE to the KEY item.
+def _apply_operation_set(
+        data: dict[str, Any], key: str, vformat: FormatPattern, *,
+        field_types: dict[str, type]
+    ) -> None:
+    """Update the *key* with the given *vformat* in *data* (in place).
 
-    :returns: A boolean indicating whether the update was successful.
+    This function also supports some custom behavior:
+
+    * If setting the ``ref`` key, then :func:`papis.bibtex.ref_cleanup` is
+      automatically called to clean up the value.
+    * If the *key* has a known type (defined by :confval:`document-field-types`),
+      then the *value* is automatically converted to that type. This operation
+      can fail and an :exc:`OperationError` is raised.
+    * If the *value* has the special form ``n:element``, then this is used as an
+      indication to insert the ``element`` into the n-th position of the list
+      given by *key*.
+
+    The value is always evaluated to a Python expression using :func:`ast.literal_eval`
+    if possible.
+
+    :raises OperationError: if any of these operations is not possible or fails
+        in some way.
     """
     from papis.format import format
-    from papis.paths import normalize_path_part
-    from papis.strings import process_format_pattern_pair
+    value: Any = format(vformat, data, default=str(vformat))
 
-    success = True
-    processed_lists = set()
-    supported_keys = field_types.keys() | document
-    for orig_key, orig_value in to_append:
-        key, vformat = process_format_pattern_pair(orig_key, orig_value)
+    if key == "ref":
+        from papis.bibtex import ref_cleanup
+        value = ref_cleanup(value)
+    else:
+        eval_value = _try_eval_value(key, value)
+        if (cls := field_types.get(key)) is not None:
+            # NOTE: special syntax for lists: `n:value`, where `n` denotes
+            # the list index to insert this value at
+            doc_value = data.get(key)
+            if issubclass(cls, list):
+                index, list_value = _try_parse_list_element(key, value)
+                if index is not None:
+                    if not isinstance(doc_value, list):
+                        raise OperationError(
+                            f"cannot use list syntax 'n:value' for document key "
+                            f"'{key}' that is not a list ({type(doc_value)})")
 
-        if key not in supported_keys:
-            logger.error(
-                "We cannot append to key '%s', because we do not know the "
-                "intended type. Please use `papis update --set` instead or "
-                "add the key type to the `document-field-types` configuration "
-                "setting (or `document-field-types-extend`)",
-                key,
-            )
-            if not batch:
-                success = False
-                break
+                    if not 0 <= index < len(doc_value):
+                        raise OperationError(
+                            f"list index out of bounds for key '{key}' "
+                            f"in value '{value}' (length {len(doc_value)})"
+                        )
 
-        value = format(vformat, document, default=str(vformat))
-        type_doc = type(document.get(key))
-        type_conf = field_types.get(key)
-        if type_doc is str or (type_doc is type(None) and type_conf is str):
-            document[key] = document.setdefault(key, "") + value
-        elif type_doc is list or (type_doc is type(None) and type_conf is list):
-            value = try_parsing_str(key, value)
-            if key == "files":
-                value = normalize_path_part(str(value))
-            document.setdefault(key, []).append(value)
-            processed_lists.add(key)
-        else:
-            logger.error(
-                "Items of key '%s' have the type '%s', for which Papis "
-                "doesn't support the append operation.",
-                key,
-                type(document[key]).__name__
-                if document.get(key)
-                else field_types[key].__name__,
-            )
-            if not batch:
-                success = False
-                break
+                    eval_value = list(doc_value)
+                    eval_value[index] = list_value
 
-    for key in processed_lists:
-        document[key] = list(set(document[key]))
-
-    return success
-
-
-def run_remove(
-    document: DocumentLike,
-    to_remove: Sequence[tuple[str, AnyString]],
-    batch: bool
-) -> tuple[bool, bool]:
-    """
-    Processes a list of ``to_remove`` tuples and applies the resulting changes
-    to the input document. Each tuple is (KEY, VALUE) and results in removing
-    the VALUE from the KEY item.
-
-    :returns: A tuple of (success, any_removed) where success indicates whether
-        the operation completed without errors, and any_removed indicates whether
-        any items were actually removed.
-    """
-    from papis.strings import process_format_pattern_pair
-
-    success = True
-    any_removed = False
-    for orig_key, orig_value in to_remove:
-        key, value = process_format_pattern_pair(orig_key, orig_value)
-
-        if key in document:
-            if isinstance(document.get(key), list):
-                try:
-                    document[key].remove(value)
-                    any_removed = True
-                except ValueError:
-                    try:
-                        document[key].remove(int(str(value)))
-                        any_removed = True
-                    except ValueError:
-                        pass  # do nothing if there is nothing to remove
+            if type(eval_value) is cls:
+                value = eval_value
             else:
-                logger.error(
-                    "You're trying to remove an item from '%s', which has the "
-                    "type '%s'. `papis update --remove` only supports lists.",
-                    key,
-                    type(document.get(key)).__name__,
-                )
-                if not batch:
-                    success = False
+                # TODO: this assumes that the constructor for cls is sufficiently
+                # simple to allow directly converting the value. Better way?
+                try:
+                    value = cls(value)
+                except Exception:
+                    try:
+                        value = cls(eval_value)
+                    except Exception:
+                        raise OperationError(
+                            f"failed to convert '{key}' value to {cls}: {value}"
+                        ) from None
+        else:
+            # TODO: do we want to do this? It seems a bit too smart for its own
+            # good. Maybe we should let the user decide using a `type:value`
+            # sort of syntax if they really want to do that.
+            value = eval_value
+
+    logger.debug("Setting key '%s': %s (%s)", key, value, type(value))
+    data[key] = value
+
+
+def _apply_operation_reset(
+        data: dict[str, Any], key: str, *,
+        folder: str
+    ) -> None:
+    """Reset the *key* to its default value (in place).
+
+    Most keys do not have a predefined default value. The following keys are
+    supported:
+    * ``ref``: the reference is recreated using :func:`papis.bibtex.create_reference`.
+    * ``author``: the author is regenerated from ``author_list``, if available.
+    * ``notes``: the notes file is renamed using :confval:`notes-name`.
+    * ``files``: all files are renamed using :confval:`add-file-name`
+
+    :raises OperationError: if any of these operations is not possible or fails
+        in some way.
+    """
+    from papis.format import format
+
+    if key == "ref":
+        from papis.bibtex import create_reference
+        value: Any = create_reference(data, force=True)
+    elif key == "author":
+        from papis.document import author_list_to_author
+        value = author_list_to_author(data)
+    elif key == "notes":
+        # NOTE: we do not check if the notes file exists, since it is usually
+        # created on demand using the name from the document
+        notes_name_format = papis.config.getformatpattern("notes-name")
+        value = format(notes_name_format, data)
+    elif key == "files":
+        # NOTE: we pop the document files so that `rename_document_files` thinks
+        # the new set we give is is brand new and starts the suffixes at 0
+        files = data.pop("files", None)
+        if files:
+            files = [os.path.join(folder, filename) for filename in files]
+            for filename in files:
+                if not os.path.exists(filename):
+                    raise OperationError(
+                        f"file '{os.path.basename(filename)}' does not exist")
+
+            from papis.paths import rename_document_files
+            file_name_format = papis.config.getformatpattern("add-file-name")
+            if not file_name_format:
+                raise OperationError(
+                    "cannot reset 'files' ('add-file-name' not defined in config)")
+
+            value = rename_document_files(
+                data, files, file_name_format=file_name_format
+            )
+        else:
+            value = None
+    else:
+        raise OperationError(f"cannot reset key '{key}' (no known default)")
+
+    data[key] = value
+
+
+def _apply_operation_drop(
+        data: dict[str, Any], key: str
+    ) -> None:
+    """Remove the *key* from *data* (in place)."""
+    if key not in data:
+        raise OperationError(f"key '{key}' not in document")
+
+    _ = data.pop(key)
+
+
+def _apply_operation_append(
+        data: dict[str, Any], key: str, vformat: FormatPattern, *,
+        field_types: dict[str, type],
+    ) -> None:
+    """Append a *value* to the *key* in *data* (in place).
+
+    A key can only be appended to if its type is known through
+    :confval:`document-field-types`. This type must then match the actual type
+    of the value in *data*. If they match, then
+    * If the type is :class:`str`, then the *value* is simply concatenated at the
+      end of the string (no separator is added) if the string does not already
+      end with *value*.
+    * If the type is :class:`list`, then the *value* is appended to the list if
+      it does not exist in the list already.
+
+    The value is always evaluated to a Python expression using :func:`ast.literal_eval`
+    if possible.
+
+    :raises OperationError: if any of these operations is not possible or fails
+        in some way.
+    """
+    if key not in field_types and key not in data:
+        logger.info(
+            "Please use `papis update --set` instead or add the key type "
+            "to the `document-field-types` configuration setting "
+            "(or `document-field-types-extend`)."
+        )
+        raise OperationError(f"cannot append to key '{key}' of unknown type")
+
+    from papis.format import format
+    value: Any = format(vformat, data, default=str(vformat))
+
+    field_type = field_types.get(key)
+    doc_type = type(data[key]) if key in data else None
+    if doc_type and field_type and doc_type is not field_type:
+        raise OperationError(
+            f"key '{key}' does not have expected type '{field_type.__name__}': "
+            f"{doc_type.__name__}"
+        )
+
+    field_type = field_type or doc_type
+    assert field_type is not None
+
+    if issubclass(field_type, str):
+        doc_value = data.get(key, "")
+        if not doc_value.endswith(value):
+            value = f"{doc_value}{value}"
+    elif issubclass(field_type, list):
+        doc_value = data.get(key, [])
+
+        # NOTE: ensure we do not add duplicates to the list, but if there are any
+        # just leave them alone (maybe a job for `papis doctor`)
+        if value in doc_value:
+            value = doc_value
+        else:
+            value = _try_eval_value(key, value)
+            if value in doc_value:
+                value = doc_value
+            else:
+                value = [*doc_value, value]
+    else:
+        raise OperationError(
+            f"cannot append to key '{key}' of type '{field_type.__name__}'")
+
+    data[key] = value
+
+
+def _apply_operation_remove(
+    data: dict[str, Any], key: str, vformat: FormatPattern
+    ) -> int:
+    """Remove the *value* from the *key* in *data* (in place).
+
+    This operation removes a given value from a list in *data*. If the given
+    key is not a list, then the operation is not allowed.
+
+    :raises OperationError: if any of these operations is not possible or fails
+        in some way.
+    """
+
+    if key not in data:
+        raise OperationError(f"cannot remove from non-existent key '{key}'")
+
+    doc_value = data[key]
+    if not isinstance(doc_value, list):
+        raise OperationError(f"key '{key}' is not a list: {type(doc_value)}")
+
+    from papis.format import format
+    value = format(vformat, data, default=str(vformat))
+
+    try:
+        idx = doc_value.index(value)
+    except ValueError:
+        value = _try_eval_value(key, value)
+        try:
+            idx = doc_value.index(value)
+        except ValueError:
+            raise OperationError(f"key '{key}' does not contain '{value}'") from None
+
+    data[key].pop(idx)
+    return idx
+
+
+def _apply_operation_rename(
+        data: dict[str, Any],
+        key: str, from_vformat: FormatPattern, to_vformat: FormatPattern
+    ) -> None:
+    """Rename an element from a list in *data* (in place).
+
+    If the given *key* is not a list, then this operation is not allowed. Also,
+    if the value to be removed from the list does not exist, it will not be
+    added.
+
+    :raises OperationError: if any of these operations is not possible or fails
+        in some way.
+    """
+    from papis.format import format
+
+    idx = _apply_operation_remove(data, key, from_vformat)
+
+    # NOTE: if we get here, it means that the value was in the document, so we
+    # can proceed to insert it back in.
+    to_value: Any = format(to_vformat, data, default=str(to_vformat))
+    to_value = _try_eval_value(key, to_value)
+
+    data[key].insert(idx, to_value)
+
+
+def _process_command_line_operations(
+        options: Sequence[_Option], *,
+        to_set: Iterable[tuple[str, AnyString]],
+        to_reset: Iterable[str],
+        to_drop: Iterable[str],
+        to_append: Iterable[tuple[str, AnyString]],
+        to_remove: Iterable[tuple[str, AnyString]],
+        to_rename: Iterable[tuple[str, AnyString, AnyString]],
+    ) -> Sequence[tuple[str, Sequence[Operation]]]:
+    """
+    :returns: a sequence of ``(key, ops)`` aggregated from the input iterables.
+    """
+    from papis.strings import process_format_pattern_pair
+
+    to_set = iter(to_set)
+    to_reset = iter(to_reset)
+    to_drop = iter(to_drop)
+    to_append = iter(to_append)
+    to_remove = iter(to_remove)
+    to_rename = iter(to_rename)
+
+    ops: dict[str, list[Operation]] = {}
+    for option in options:
+        if option.name == "to_set":
+            key, value = next(to_set)
+            key, value = process_format_pattern_pair(key, value)
+
+            ops.setdefault(key, []).append(
+                Operation(OperationType.Set, key, value, value))
+        elif option.name == "to_reset":
+            key = next(to_reset)
+            key, value = process_format_pattern_pair(key, "")
+
+            ops.setdefault(key, []).append(
+                Operation(OperationType.Reset, key, value, value))
+        elif option.name in {"to_drop", "drop"}:
+            # NOTE: "drop" is added to handle `papis tag`, which just has a
+            # --drop flag, but not a `--drop key` type option
+            key = next(to_drop)
+            key, value = process_format_pattern_pair(key, "")
+
+            ops.setdefault(key, []).append(
+                Operation(OperationType.Drop, key, value, value))
+        elif option.name == "to_append":
+            key, value = next(to_append)
+            key, value = process_format_pattern_pair(key, value)
+
+            ops.setdefault(key, []).append(
+                Operation(OperationType.Append, key, value, value))
+        elif option.name == "to_remove":
+            key, value = next(to_remove)
+            key, value = process_format_pattern_pair(key, value)
+
+            ops.setdefault(key, []).append(
+                Operation(OperationType.Remove, key, value, value))
+        elif option.name == "to_rename":
+            key, from_value, to_value = next(to_rename)
+            key, from_value = process_format_pattern_pair(key, from_value)
+            key, to_value = process_format_pattern_pair(key, to_value)
+
+            ops.setdefault(key, []).append(
+                Operation(OperationType.Rename, key, from_value, to_value))
+        else:
+            logger.debug("Unsupported option: %s.", option.name)
+
+    return tuple((key, tuple(value)) for key, value in ops.items())
+
+
+def _apply_operations(
+        document: Document,
+        key_ops: Sequence[tuple[str, Sequence[Operation]]], *,
+        field_types: dict[str, type] | None = None,
+        continue_on_error: bool = False,
+    ) -> dict[str, Any]:
+    if field_types is None:
+        field_types = {}
+
+    # NOTE: we need to make a deepcopy here, since the document can have nested
+    # lists and dictionaries and we do not want to worry about it when applying
+    from copy import deepcopy
+    new_data = deepcopy(dict(document))
+
+    from papis.document import describe
+    folder = document.get_main_folder()
+
+    if not folder:
+        from papis.exceptions import DocumentFolderNotFound
+        raise DocumentFolderNotFound(describe(document))
+
+    from papis.tui.utils import confirm as ask_confirm
+
+    for key, ops in key_ops:
+        orig_value = new_data.get(key)
+
+        for op in ops:
+            try:
+                if op.optype == OperationType.Set:
+                    _apply_operation_set(
+                        new_data, op.key, op.value, field_types=field_types)
+                elif op.optype == OperationType.Reset:
+                    _apply_operation_reset(
+                        new_data, op.key, folder=folder)
+                elif op.optype == OperationType.Drop:
+                    _apply_operation_drop(new_data, op.key)
+                elif op.optype == OperationType.Append:
+                    _apply_operation_append(
+                        new_data, op.key, op.value, field_types=field_types)
+                elif op.optype == OperationType.Remove:
+                    _apply_operation_remove(new_data, op.key, op.value)
+                elif op.optype == OperationType.Rename:
+                    _apply_operation_rename(new_data, op.key, op.value, op.to_value)
+                else:
+                    raise TypeError(f"unknown operation type: {type(op)}")
+            except OperationError as exc:
+                logger.error("Failed '%s' operation on key '%s': %s (doc: %s).",
+                             op.optype.name, key, exc,
+                             describe(document))
+
+                if continue_on_error:
+                    # restore value and move on to the next key
+                    if orig_value is None:
+                        new_data.pop(key, None)
+                    else:
+                        new_data[key] = orig_value
+
                     break
-        else:
-            logger.info(
-                "Document doesn't have key '%s', cannot remove '%s' from it. "
-                "Continuing...",
-                key,
-                value,
-            )
+                else:
+                    if ask_confirm(
+                        "Updating document failed with the above error. Continue?"
+                    ):
+                        break
+                    else:
+                        raise
 
-    return success, any_removed
-
-
-def run_drop(document: DocumentLike, to_remove: Sequence[str]) -> None:
-    """
-    Processes a list of ``to_drop`` strings and applies the resulting changes
-    to the input document. Each string is a KEY whose value is set to None
-    (and then later in ``run()`` dropped from the document entirely).
-
-    """
-    for key in to_remove:
-        if key in document:
-            document[key] = None
-        else:
-            logger.info(
-                "Document doesn't have key '%s', cannot remove it. Continuing...", key
-            )
+    return new_data
 
 
-def run_rename(
-    document: DocumentLike,
-    to_rename: Sequence[
-        tuple[str, AnyString, AnyString]],
-    field_types: dict[str, type],
-    batch: bool,
-) -> bool:
-    """
-    Processes a list of ``to_rename`` tuples and applies the resulting changes
-    to the input document. Each tuple is (KEY, VALUE_OLD, VALUE_NEW) and results in
-    rename the KEY's VALUE_OLD to VALUE_NEW.
+def _rename_files_safely(folder: str,
+                         from_files: Sequence[str],
+                         to_files: Sequence[str]) -> None:
+    import shutil
+    import tempfile
 
+    # NOTE: this does a two-phase rename that is safe-ish against collisions
+    #
+    # Phase 1: move every original file into a temporary directory.
+    #   On error, if any of the moves fail, we roll back everything.
+    #
+    # Phase 2: move each file from the temp directory to its final destination.
+    #   On error, if any of the moves fails, we roll back everything.
+    #
+    # NOTE: the rollbacks can still fail, in which case we're in trouble. However,
+    # this is meant to guard against overwriting files, not against power blackouts
+    # or other catastrophic failures..
 
-    :returns: A boolean indicating whether the update was successful.
-    """
-    to_remove = [(x[0], x[1]) for x in to_rename]
-    to_append = [(x[0], x[2]) for x in to_rename]
+    with tempfile.TemporaryDirectory(prefix="papis-update-tmp-") as tmpdirname:
+        to_rename: list[tuple[str, str]] = []
 
-    success, any_removed = run_remove(document, to_remove, batch)
-    if success and any_removed:
-        success = run_append(document, to_append, field_types, batch)
-    return success
+        # Phase 1: move original out of the folder into temp
+        try:
+            for from_file, to_file in zip(from_files, to_files, strict=True):
+                if from_file == to_file:
+                    continue
+
+                orig_path = os.path.join(folder, from_file)
+                if not os.path.exists(orig_path):
+                    raise FileNotFoundError(f"document file not found: {from_file}")
+
+                tmp_path = os.path.join(tmpdirname, from_file)
+                shutil.move(orig_path, tmp_path)
+
+                to_rename.append((tmp_path, os.path.join(folder, to_file)))
+        except Exception:
+            # if an error occurred, just move back the files we've handled so far
+            for from_path, _ in to_rename:
+                from_file = os.path.basename(from_path)
+                to_path = os.path.join(folder, from_file)
+                shutil.move(from_path, to_path)
+
+            raise
+
+        # Phase 2: move from temp to final destinations.
+        renamed: list[tuple[str, str]] = []
+        try:
+            while to_rename:
+                from_path, to_path = to_rename[-1]
+                shutil.move(from_path, to_path)
+
+                to_rename.pop()
+                renamed.append((from_path, to_path))
+        except Exception:
+            # move back the files that got renamed into *folder*
+            for from_path, to_path in reversed(renamed):
+                from_file = os.path.basename(from_path)
+                orig_path = os.path.join(folder, from_file)
+                shutil.move(to_path, orig_path)
+
+            # move back the files still in the tmpdir back to *folder*
+            for from_path, _ in to_rename:
+                from_file = os.path.basename(from_path)
+                orig_path = os.path.join(folder, from_file)
+                shutil.move(from_path, orig_path)
+
+            raise
 
 
 def run(
     document: Document,
-    data: dict[str, Any] | None = None,
+    data: dict[str, Any] | None = None, *,
     git: bool = False,
     auto_doctor: bool = False,
+    overwrite: bool = False,
 ) -> None:
-    """
-    Updates the document in the Papis library.
+    """Updates a document in the Papis library with the given *data*.
 
-    :returns: None
+    The entries in *data* can be further modified or not ignored when updating
+    the *document*. The following rules apply:
+
+    * If a value in *data* is *None*, then it will be removed from the *document*.
+    * If *auto_doctor* is *True*, then all the default auto-fixers
+      (see :confval:`doctor-default-checks`) will be applied to the document. This
+      can modify keys that are not in *data*.
+    * If the *notes* or *files* keys are updated, any paths in *data* will be
+      further normalized using :func:`~papis.paths.normalize_path_part`.
     """
+    from papis.document import describe
+
     if data is None:
         data = {}
 
     folder = document.get_main_folder()
     info = document.get_info_file()
 
-    from papis.document import describe
-
     if not folder or not info:
         from papis.exceptions import DocumentFolderNotFound
 
         raise DocumentFolderNotFound(describe(document))
 
+    from papis.paths import normalize_path_part
+
+    # normalize new document files
+    if "files" in data:
+        data["files"] = [normalize_path_part(filename) for filename in data["files"]]
+
+    if "notes" in data:
+        data["notes"] = normalize_path_part(data["notes"])
+
+    # gather all files to rename
+    from_files = list(document.get("files", []))
+    to_files = list(data.get("files", []))
+
+    if to_files and len(set(to_files)) != len(to_files):
+        raise ValueError(f"updated files are not unique: {to_files}")
+
+    if from_files and len(set(from_files)) != len(from_files):
+        raise ValueError(f"existing files are not unique: {from_files}")
+
+    # NOTE: if they're not the same length, we do not want to rename files. This
+    # is done here, so that adding notes works as expected and they're all renamed
+    # atomically if possible. Note that this can never happen when calling from cli()
+    if len(from_files) != len(to_files):
+        from_files.clear()
+        to_files.clear()
+
+    if (to_notes := data.get("notes")) and (from_notes := document.get("notes")):
+        if os.path.exists(os.path.join(folder, from_notes)):
+            from_files.append(from_notes)
+            to_files.append(to_notes)
+
+    # rename files
+    # FIXME: this is not great, since len == len is a bad heuristic to figure out
+    # if files are renamed. Ideally, we would get a `update_files: dict[str, str]`
+    # argument to let us know exactly what needs renaming.
+    if from_files and len(from_files) == len(to_files):
+        _rename_files_safely(folder, from_files, to_files)
+
+    # update document metadata
+    if overwrite:
+        document.clear()
     document.update(data)
 
     # delete all keys that do not have a value
-    to_drop = [k for k, v in document.items() if not v]
-    [document.pop(k) for k in to_drop]
+    for key in list(document):
+        value = document[key]
+
+        # NOTE: remove any False-y keys from the document, but not:
+        # * 0 as an integer
+        # * False as a boolean
+        if (
+                value is None
+                or (isinstance(value, str) and not value)
+                or (isinstance(value, (list, dict)) and not value)):
+            del document[key]
 
     if auto_doctor:
         from papis.doctor import fix_errors
@@ -410,7 +860,6 @@ def run(
         fix_errors(document)
 
     from papis.api import save_doc
-
     save_doc(document)
 
     if git:
@@ -426,14 +875,50 @@ def run(
             logger.error("%s", exc)
 
 
-@click.command("update")
+# NOTE: these classes are a hack to allow us to recover the real argument order
+# from click. By default, when using `multiple=True`, click aggregates all the
+# flags into lists for the same type, so any order is lost. Only the parser
+# seems to know the original order, so we get it from there.
+
+class _Option(NamedTuple):
+    """A :class:`click.Option` look-alike that remembers the argument name."""
+    name: str | None
+
+
+class _TrackingOptionParser(click.parser._OptionParser):
+    """A modified option parser that remembers the argument order."""
+
+    def parse_args(self, args: list[str]) -> Any:
+        opts, args, order = super().parse_args(args)
+        if self.ctx is not None:
+            self.ctx.ensure_object(dict)
+            self.ctx.obj["param"] = [_Option(param.name) for param in order]
+
+        return opts, args, order
+
+
+class _OrderedCommand(click.Command):
+    """A modified command that uses ``_TrackingOptionParser``."""
+
+    def make_parser(self, ctx: click.Context) -> Any:
+        parser = _TrackingOptionParser(ctx)
+        for param in self.get_params(ctx):
+            param.add_to_parser(parser, ctx)
+
+        return parser
+
+
+@click.command("update", cls=_OrderedCommand)
 @click.help_option("--help", "-h")
 @papis.cli.git_option()
 @papis.cli.query_argument()
 @papis.cli.doc_folder_option()
 @papis.cli.all_option()
 @papis.cli.sort_option()
-@papis.cli.bool_flag("--auto", help="Try to gather metadata from different sources.")
+@papis.cli.bool_flag(
+    "--auto",
+    help="Automatically select importers and downloaders based on document metadata."
+)
 @papis.cli.bool_flag(
     "--auto-doctor/--no-auto-doctor",
     help="Apply automatic doctor fixes to newly added documents.",
@@ -450,44 +935,40 @@ def run(
 )
 @papis.cli.bool_flag("--list-importers", help="List all supported importers.")
 @click.option(
-    "-s",
-    "--set",
-    "to_set",
+    "-s", "--set", "to_set",
     help="Set the key to the given value.",
     multiple=True,
-    type=(str, papis.cli.FormatPatternParamType()),
+    type=(papis.cli.KeyParamType(), papis.cli.FormatPatternParamType()),
 )
 @click.option(
-    "-d",
-    "--drop",
-    "to_drop",
+    "--reset", "to_reset",
+    help="Reset keys to their default values.",
+    multiple=True,
+    type=papis.cli.KeyParamType(),
+)
+@click.option(
+    "-d", "--drop", "to_drop",
     help="Drop a key from the document.",
     multiple=True,
-    type=str,
+    type=papis.cli.KeyParamType(),
 )
 @click.option(
-    "-p",
-    "--append",
-    "to_append",
+    "-p", "--append", "to_append",
     help="Append a value to a document key.",
     multiple=True,
-    type=(str, papis.cli.FormatPatternParamType()),
+    type=(papis.cli.KeyParamType(), papis.cli.FormatPatternParamType()),
 )
 @click.option(
-    "-r",
-    "--remove",
-    "to_remove",
+    "-r", "--remove", "to_remove",
     help="Remove an item from a list.",
     multiple=True,
-    type=(str, papis.cli.FormatPatternParamType()),
+    type=(papis.cli.KeyParamType(), papis.cli.FormatPatternParamType()),
 )
 @click.option(
-    "-n",
-    "--rename",
-    "to_rename",
+    "-n", "--rename", "to_rename",
     help="Rename an item in a list.",
     multiple=True,
-    type=(str,
+    type=(papis.cli.KeyParamType(),
           papis.cli.FormatPatternParamType(),
           papis.cli.FormatPatternParamType()),
 )
@@ -496,7 +977,9 @@ def run(
     "--batch",
     help="Do not prompt, and skip documents containing errors."
 )
+@click.pass_context
 def cli(
+    ctx: click.Context,
     query: str,
     git: bool,
     doc_folder: tuple[str, ...],
@@ -505,37 +988,30 @@ def cli(
     batch: bool,
     auto: bool,
     auto_doctor: bool,
+    to_set: list[tuple[str, AnyString]],
+    to_reset: list[str],
+    to_drop: list[str],
+    to_append: list[tuple[str, AnyString]],
+    to_remove: list[tuple[str, AnyString]],
+    to_rename: list[tuple[str, AnyString, AnyString]],
     _all: bool,
     sort_field: str | None,
     sort_reverse: bool,
-    to_set: list[tuple[str, str]],
-    to_drop: list[str],
-    to_append: list[tuple[str, str]],
-    to_remove: list[tuple[str, str]],
-    to_rename: list[tuple[str, str, str]],
 ) -> None:
     """Update document metadata."""
     from papis.importer import (
-        Context,
         collect_from_importers,
         fetch_importers,
         get_available_importers,
         get_matching_importers_by_doc,
         get_matching_importers_by_name,
     )
+    from papis.tui.utils import confirm as ask_confirm
 
     if list_importers:
         from papis.commands.list import list_plugins
         for o in list_plugins(show_importers=True, verbose=True):
             click.echo(o)
-        return
-
-    known_importers = get_available_importers()
-    extra_importers = {name for name, _ in from_importer}.difference(known_importers)
-    if extra_importers:
-        logger.error("Unknown importers chosen with '--from': ['%s'].",
-                     "', '".join(extra_importers))
-        logger.error("Supported importers are: ['%s'].", "', '".join(known_importers))
         return
 
     # retrieve documents
@@ -547,56 +1023,108 @@ def cli(
         logger.warning(no_documents_retrieved_message)
         return
 
+    # retrieve importers
+    known_importers = get_available_importers()
+    extra_importers = {name for name, _ in from_importer}.difference(known_importers)
+    if extra_importers:
+        logger.error("Unknown importers chosen with '--from': ['%s'].",
+                     "', '".join(extra_importers))
+        logger.error("Supported importers are: ['%s'].", "', '".join(known_importers))
+        ctx.exit(1)
+        return
+
+    if from_importer:
+        from_importers = get_matching_importers_by_name(from_importer)
+    else:
+        from_importers = []
+
+    # retrieve user provided operations
+    operations = _process_command_line_operations(
+        ctx.obj["param"],
+        to_set=to_set,
+        to_reset=to_reset,
+        to_drop=to_drop,
+        to_append=to_append,
+        to_remove=to_remove,
+        to_rename=to_rename,
+    )
+
     from papis.document import get_document_field_types
     known_field_types = get_document_field_types()
 
-    success = True
-    processed_documents = []
-    for document in documents:
-        ctx = Context()
+    from papis.document import describe
 
-        ctx.data.update(document)
-        if to_set:
-            run_set(ctx.data, to_set, known_field_types)
+    ret = 0
+    for i, document in enumerate(documents):
+        logger.info("[%d/%d] Gathering metadata changes for document: %s.",
+                    i + 1, len(documents), describe(document))
 
-        if to_append and success:
-            success = run_append(ctx.data, to_append, known_field_types, batch)
+        # apply changes to document
+        try:
+            new_data = _apply_operations(
+                document, operations,
+                field_types=known_field_types,
+                continue_on_error=batch)
+        except OperationError:
+            # NOTE: this happens if the user interactively said they do not
+            # want to continue updating the document, so we just skip it
+            ret = 1
+            continue
+        except Exception:
+            # NOTE: this should generally not happen, unless there's a bug or
+            # the database is in an inconsistent state, so we just move on
+            logger.error("Failed to apply metadata changes to document: %s.",
+                         describe(document))
+            ret = 1
+            continue
 
-        if to_remove and success:
-            success, _ = run_remove(ctx.data, to_remove, batch)
+        # get metadata from importers and merge them all together
+        if from_importer:
+            importers = from_importers
+        elif auto:
+            importers = get_matching_importers_by_doc(document)
+        else:
+            importers = []
 
-        if to_drop and success:
-            run_drop(ctx.data, to_drop)
+        importers = fetch_importers(importers, download_files=False)
+        imported = collect_from_importers(importers, batch=batch, use_files=False)
 
-        if to_rename:
-            success = run_rename(ctx.data, to_rename, known_field_types, batch)
+        # merge user and importer data
+        # FIXME: add interactive merging to avoid overwriting user changes
+        new_data.update(imported.data)
 
-        if success:
-            from papis.document import describe
-            logger.info("Processing '%s.'", describe(document))
+        logger.info("[%d/%d] Applying metadata changes to document: %s.",
+                    i + 1, len(documents), describe(document))
 
-            # get metadata from importers and merge them all together
-            if from_importer:
-                importers = get_matching_importers_by_name(from_importer)
-            elif auto:
-                importers = get_matching_importers_by_doc(document)
+        try:
+            # NOTE: data contains all the fields in doc (modified by the flags),
+            # so we want to just overwrite it with them => overwrite=True
+            run(document, new_data, git=git, auto_doctor=auto_doctor, overwrite=True)
+        except OSError as exc:
+            logger.error("Failed to rename document files: %s",
+                         describe(document), exc_info=exc)
+            if batch:
+                continue
+
+            if ask_confirm(
+                "Failed to rename document files with the above error. Continue?"
+            ):
+                continue
             else:
-                importers = []
+                ctx.exit(1)
+                return
+        except Exception as exc:
+            logger.error("Failed to apply changes to document: %s",
+                         describe(document), exc_info=exc)
+            if batch:
+                continue
 
-            importers = fetch_importers(importers, download_files=False)
-            imported = collect_from_importers(importers, batch=batch, use_files=False)
+            if ask_confirm(
+                "Failed to apply document with the above error. Continue?"
+            ):
+                continue
+            else:
+                ctx.exit(1)
+                return
 
-            # TODO: add interactive merging to avoid overwriting user changes
-            ctx.data.update(imported.data)
-
-            processed_documents.append((document, ctx.data))
-
-        if not success and not batch:
-            processed_documents.clear()
-            logger.error(
-                "Aborting operation. No documents have been changed.",
-            )
-            break
-
-    for document, data in processed_documents:
-        run(document, data=data, git=git, auto_doctor=auto_doctor)
+    ctx.exit(ret)

--- a/papis/commands/update.py
+++ b/papis/commands/update.py
@@ -9,8 +9,11 @@ expressions can be used. See below examples for more information. The command
 also tries to sanitise filenames so that they don't contain any problematic
 characters.
 
-Normally, ``papis update`` will abort on encountering an error. If you want to
-skip errors and apply as many changes as possible, use the ``--batch`` flag.
+Normally, ``papis update`` will prompt you when it encounters an error. If you
+want to continue errors without input and apply as many changes as possible,
+use the ``--batch`` flag. With this in mind, the command is mostly meant to be
+used to apply sweeping changes to a larger number of documents. If you just
+want to update a single document, ``papis edit`` might be more appropriate.
 
 Examples
 ^^^^^^^^
@@ -33,8 +36,9 @@ Examples
         papis update --all --set journal "Mass and Energy" "journal:'Energy and Mass'"
 
 
-  The ``--all`` flag means that the tag is applied to all documents that match the
-  query, rather than allowing you to pick one individual document to update.
+  The ``--all`` flag means that the operation is applied to all documents that
+  match the query, rather than allowing you to pick one individual document to
+  update.
 
 - Update a document automatically and interactively (searching by DOI in
   Crossref or in other sources...):
@@ -43,14 +47,13 @@ Examples
 
         papis update --auto "author:dyson"
 
-- Update your library from a BibTeX file, where many entries may be listed:
+- Update your document from a DOI using the importer functionality as
 
     .. code:: sh
 
-        papis update --from bibtex libraryfile.bib
+        papis update --from doi '10.1103/PhysRev.47.777' 'author:einstein'
 
-  Papis will try to look for documents in your library that match these
-  entries and will ask you for each entry whether you want to update it.
+  For a list of all supported importers use ``papis update --list-importers``.
 
 - Add the ", Albert" to the author string of a documents matching 'Einstein':
 
@@ -60,71 +63,151 @@ Examples
 
   The ``papis update`` command tries to format input strings using the configured
   formatter. Here, it is used to get the existing author "Albert" and then add
-  the string ", Einstein" to end up with "Einstein, Albert"
+  the string ", Einstein" to end up with "Einstein, Albert".
 
-- The above can also be achieved with the ``--append`` option:
+- Reset keys to their default values using:
+
+    .. code:: sh
+
+        papis update --reset ref Einstein
+
+  This will reset the value to the default value defined for the key. In the
+  above case the "ref" is set to the format described by :confval:`ref-format`.
+  Other supported keys are: "author" (gets updated from ``author_list`` and
+  :confval:`multiple-authors-format`), "notes" (using :confval:`notes-name`),
+  and "files" (using :confval:`add-file-name`). Other keys do not support this
+  as they do not have any well-defined default.
+
+- The ``--append`` option can be used to append a string to an existing key:
 
     .. code:: sh
 
         papis update --append author ", Albert" Einstein
 
-    This appends ", Albert" to the existing author string.
+  This appends ", Albert" to the existing author value. Note that it will be
+  appended to the existing value only if it does not already end with that
+  exact string (case-sensitive). This avoids appending duplicates by mistake, as
+  in the case of lists (below).
 
 - You can also append an item to a list:
 
     .. code:: sh
 
-        papis update --append tags physics
+        papis update --append tags physics 'author:einstein'
 
-    This adds the tag 'physics' to the existing list of tags. If the list
-    doesn't yet exist, it will be created. All duplicate items will be removed
-    from the list.
+    This adds the tag "physics" to the existing list of tags. If the list
+    doesn't yet exist, it will be created. The new tag will only be appended to
+    the list if the tag does not already exist (as an exact case-sensitive match).
 
-    As you might have guessed, the ``--append`` flag needs to know the type of
-    the key it is appending to. It does this by looking at the
-    :confval:`document-field-types` (and :confval:`document-field-types-extend`)
-    configuration options. If the key you are appending to is not in that list,
-    the command will fail.
+    The ``--append`` flag needs to know the type of the key it is appending to.
+    If the key exists in the document, then the value set in the document
+    determines the type. If the key doesn't exist in the document, the command
+    looks at the list of types defined in the :confval:`document-field-types`
+    (and :confval:`document-field-types-extend`) configuration option. If the
+    type cannot be determined in either of these two ways, the command will
+    fail.
 
-- To remove an item from a list, use ``--remove``:
-
-    .. code:: sh
-
-        papis update --remove tags physics
-
-    If the tag "physics" is in the list of tags, this command removes it.
-
-- To remove a key-value pair entirely, use ``--drop``:
+- To remove an item from a list, use ``--remove``. For example, to remove the
+  "physics" tag from the list of document tags, use
 
     .. code:: sh
 
-        papis update --drop tags
+        papis update --remove tags physics 'author:einstein'
 
-    This removes all tags.
+- To remove a key-value pair entirely, use ``--drop``. For example, to remove all
+  tags from documents use
+
+    .. code:: sh
+
+        papis update --drop tags 'author:einstein'
 
 - There is also a convenience option ``--rename`` if you want to rename
-  a list item. It's equivalent to doing ``--remove`` and ``--append`` sequentially:
+  a list item. It's equivalent to doing ``--remove`` and ``--append``, but as
+  a single operation:
 
     .. code:: sh
 
         papis update --rename tags physics philosophy
 
-  This renames the tag 'physics' to 'philosophy'. Note that this option being a
-  combination of ``--remove`` and ``--append``, it will append the desired values
-  even if the value to be removed didn't exist. Thus, the above command will add
-  the tag "philosophy" even if the tag "physics" didn't exist before the
-  operation.
+  This renames the tag "physics" to "philosophy". Note that the new tag will
+  not be added to the list if the original tag doesn't exist.
 
-- As an advanced feature, ``papis update`` also supports the parsing of python
+- The ``--batch`` flag suppresses interactive prompts and skips any document
+  that cannot be fully updated. This is useful when applying the same operation
+  across many documents where some may not have the expected keys or values:
+
+    .. code:: sh
+
+        papis update --all --batch --remove tags obsolete "tags:obsolete"
+
+  Without ``--batch``, if a document does not have "obsolete" in its tag list
+  (or has no ``tags`` key at all), the command pauses and asks whether to
+  continue. With ``--batch``, an error is logged, the document is skipped and the
+  command moves on to the next one.
+
+  More specifically, ``--batch`` suppresses prompts in the following way:
+
+  * If an operation on a field fails (e.g. trying to ``--remove`` a value that is
+    not in the list, ``--append`` to a field of unknown type, or a type
+    conversion error from ``--set``), the next operation is tried automatically.
+    The affected field retains its original pre-failed-operation value and the
+    remaining fields for that document are still processed.
+  * If a file rename fails (e.g. the file on disk is missing or cannot be moved),
+    then the whole document is skipped. This generally signals some external failure,
+    so the user should just try again.
+
+  In all cases the command exits with a non-zero status if any document was
+  skipped.
+
+Advanced Examples
+^^^^^^^^^^^^^^^^^
+
+- When you update the ``files`` or ``notes`` keys, the corresponding files on
+  disk are also renamed to match the new value:
+
+    .. code:: sh
+
+        papis update --set notes "my-new-notes.tex" Einstein
+
+  This renames the ``notes`` file on disk from its current name to
+  ``my-new-notes.tex`` and updates the ``info.yaml`` file accordingly. The same
+  applies when updating ``files``:
+
+    .. code:: sh
+
+        papis update --set files 0:einstein-new.pdf Einstein
+
+  This renames the first file in the document's file list to ``einstein-new.pdf``
+  on disk. If the rename fails (e.g. the file does not exist or there is a
+  permissions error), the metadata is not updated and an error is reported.
+
+  Note that the ``--reset`` option also triggers a rename when used with
+  ``notes`` or ``files``. It renames the files to the names derived from the
+  configured :confval:`notes-name` and :confval:`add-file-name` formats
+  respectively.
+
+- As an advanced feature, ``papis update`` also supports the parsing of Python
   expressions (such as lists or dictionaries). This can be used as follows:
 
     .. code:: sh
 
         papis update --set author_list "[{'family': 'Einstein', 'given': 'Albert'}]"
 
-  Because the above string is a valid python expression, ``author_list`` is
-  updated to a set that contains a dictionary.
+  Because the above string is a valid Python expression, ``author_list`` is
+  updated to a list that contains a dictionary.
 
+- You can use ``--set`` to set a value into a list at a given position:
+
+    .. code:: sh
+
+        papis update --set files 0:some-new-file.pdf Einstein
+
+  This command will rename the first entry in the list of files. This special
+  syntax for ``--set`` only works with fields that are known to be lists (as
+  determined based on :confval:`document-field-types` and
+  :confval:`document-field-types-extend`). If the field is not a list, then the
+  value is treated as a string. This might be unexpected, so make sure you are
+  using it for list fields only.
 
 Command-line interface
 ^^^^^^^^^^^^^^^^^^^^^^
@@ -135,7 +218,9 @@ Command-line interface
 from __future__ import annotations
 
 import ast
-from typing import TYPE_CHECKING, Any
+import enum
+import os
+from typing import TYPE_CHECKING, Any, NamedTuple
 
 import click
 
@@ -144,262 +229,623 @@ import papis.config
 import papis.logging
 
 if TYPE_CHECKING:
-    from collections.abc import Sequence
+    from collections.abc import Iterable, Sequence
 
-    from papis.document import Document, DocumentLike
-    from papis.strings import AnyString
+    from papis.document import Document
+    from papis.strings import AnyString, FormatPattern
 
 logger = papis.logging.get_logger(__name__)
 
 
-def try_parsing_str(key: str, value: str) -> str:
-    """
-    Tries to parse the input string as a python expression.
+class OperationError(Exception):
+    """Error occurring during validation or application of an operation."""
 
-    :returns: The parsed input string if string is a python expression,
-        otherwise an unchanged string.
+
+@enum.unique
+class OperationType(enum.Enum):
+    """Supported types of operations on document fields."""
+    Set = enum.auto()
+    Reset = enum.auto()
+    Drop = enum.auto()
+    Append = enum.auto()
+    Remove = enum.auto()
+    Rename = enum.auto()
+
+
+class Operation(NamedTuple):
+    """Operation on document fields."""
+    optype: OperationType
+    key: str
+    value: FormatPattern
+
+    to_value: FormatPattern
+
+
+def _try_eval_value(key: str, value: str) -> Any:
+    """Try to use :func:`ast.literal_eval` to evaluate the given string.
+
+    :returns: *value* if the evaluation gives an error, and the evaluated value
+        otherwise.
     """
     try:
-        value = ast.literal_eval(value)
+        return ast.literal_eval(value)
     except (SyntaxError, ValueError):
-        logger.debug("Value '%s' of key '%s' is not a python expression.", value, key)
-    return value
+        logger.debug("Value for key '%s' is not a Python expression: '%s'", key, value)
+        return value
 
 
-def run_set(
-    document: DocumentLike,
-    to_set: Sequence[tuple[str, AnyString]],
-    field_types: dict[str, type],
-) -> None:
+def _try_parse_list_element(key: str, value: str) -> tuple[int | None, Any]:
+    """Parse a string of the form ``n:list_element`` from *value*.
+
+    :returns: a tuple ``(index, list_element)`` if the parsing succeeded or
+        a dummy value of ``(None, value)`` otherwise.
     """
-    Processes a list of ``to_set`` tuples and applies the resulting changes to the
-    input document. Each tuple is (KEY, VALUE) and results in setting the KEY to
-    the VALUE in the document.
-    """
-    from papis.format import format
-    from papis.paths import normalize_path_part
-    from papis.strings import process_format_pattern_pair
+    if ":" not in value:
+        return None, value
 
-    for orig_key, orig_value in to_set:
-        key, vformat = process_format_pattern_pair(orig_key, orig_value)
-        value = format(vformat, document, default=str(vformat))
-        value = try_parsing_str(key, value)
+    index, value = value.split(":", maxsplit=1)
+    if not index.isdigit():
+        return None, value
 
-        if isinstance(value, int) and field_types.get(key) is str:
-            value = str(value)
-        if key == "notes" and isinstance(value, str):
-            # TODO: handle renames/deletions of files on disk
-            document[key] = normalize_path_part(value)
-            logger.warning(
-                "Document note renamed in the info.yaml file. This does not "
-                "rename any files on disk."
-            )
-        elif key == "files" and isinstance(value, list):
-            # TODO: handle renames/deletions of files on disk
-            document[key] = []
-            for file in value:
-                if isinstance(file, str):
-                    document[key].append(normalize_path_part(file))
-                else:
-                    document[key].append(value)
-            logger.warning(
-                "Document files renamed in the info.yaml file. This does not "
-                "rename any files on disk."
-            )
-        elif key == "ref" and isinstance(value, str):
-            from papis.bibtex import ref_cleanup
-            document[key] = ref_cleanup(value)
-        else:
-            document[key] = value
+    return int(index), _try_eval_value(key, value)
 
 
-def run_append(
-    document: DocumentLike,
-    to_append: Sequence[tuple[str, AnyString]],
-    field_types: dict[str, type],
-    batch: bool,
-) -> bool:
-    """
-    Processes a list of ``to_append`` tuples and applies the resulting changes
-    to the input document. Each tuple is (KEY, VALUE) and results in appending
-    the VALUE to the KEY item.
+def _apply_operation_set(
+        data: dict[str, Any], key: str, vformat: FormatPattern, *,
+        field_types: dict[str, type]
+    ) -> None:
+    """Update the *key* with the given *vformat* in *data* (in place).
 
-    :returns: A boolean indicating whether the update was successful.
+    This function also supports some custom behavior:
+
+    * If setting the ``ref`` key, then :func:`papis.bibtex.ref_cleanup` is
+      automatically called to clean up the value.
+    * If the *key* has a known type (defined by :confval:`document-field-types`),
+      then the *value* is automatically converted to that type. This operation
+      can fail and an :exc:`OperationError` is raised.
+    * If the *value* has the special form ``n:element``, then this is used as an
+      indication to insert the ``element`` into the n-th position of the list
+      given by *key*.
+
+    The value is always evaluated to a Python expression using :func:`ast.literal_eval`
+    if possible.
+
+    :raises OperationError: if any of these operations is not possible or fails
+        in some way.
     """
     from papis.format import format
-    from papis.paths import normalize_path_part
-    from papis.strings import process_format_pattern_pair
+    value: Any = format(vformat, data, default=str(vformat))
 
-    success = True
-    processed_lists = set()
-    supported_keys = field_types.keys() | document
-    for orig_key, orig_value in to_append:
-        key, vformat = process_format_pattern_pair(orig_key, orig_value)
+    if key == "ref":
+        from papis.bibtex import ref_cleanup
+        value = ref_cleanup(value)
+    else:
+        eval_value = _try_eval_value(key, value)
+        if (cls := field_types.get(key)) is not None:
+            # NOTE: special syntax for lists: `n:value`, where `n` denotes
+            # the list index to insert this value at
+            doc_value = data.get(key)
+            if issubclass(cls, list):
+                index, list_value = _try_parse_list_element(key, value)
+                if index is not None:
+                    if not isinstance(doc_value, list):
+                        raise OperationError(
+                            f"cannot use list syntax 'n:value' for document key "
+                            f"'{key}' that is not a list ({type(doc_value)})")
 
-        if key not in supported_keys:
-            logger.error(
-                "We cannot append to key '%s', because we do not know the "
-                "intended type. Please use `papis update --set` instead or "
-                "add the key type to the `document-field-types` configuration "
-                "setting (or `document-field-types-extend`)",
-                key,
-            )
-            if not batch:
-                success = False
-                break
+                    if not 0 <= index < len(doc_value):
+                        raise OperationError(
+                            f"list index out of bounds for key '{key}' "
+                            f"in value '{value}' (length {len(doc_value)})"
+                        )
 
-        value = format(vformat, document, default=str(vformat))
-        type_doc = type(document.get(key))
-        type_conf = field_types.get(key)
-        if type_doc is str or (type_doc is type(None) and type_conf is str):
-            document[key] = document.setdefault(key, "") + value
-        elif type_doc is list or (type_doc is type(None) and type_conf is list):
-            value = try_parsing_str(key, value)
-            if key == "files":
-                value = normalize_path_part(str(value))
-            document.setdefault(key, []).append(value)
-            processed_lists.add(key)
-        else:
-            logger.error(
-                "Items of key '%s' have the type '%s', for which Papis "
-                "doesn't support the append operation.",
-                key,
-                type(document[key]).__name__
-                if document.get(key)
-                else field_types[key].__name__,
-            )
-            if not batch:
-                success = False
-                break
+                    eval_value = list(doc_value)
+                    eval_value[index] = list_value
 
-    for key in processed_lists:
-        document[key] = list(set(document[key]))
-
-    return success
-
-
-def run_remove(
-    document: DocumentLike,
-    to_remove: Sequence[tuple[str, AnyString]],
-    batch: bool
-) -> tuple[bool, bool]:
-    """
-    Processes a list of ``to_remove`` tuples and applies the resulting changes
-    to the input document. Each tuple is (KEY, VALUE) and results in removing
-    the VALUE from the KEY item.
-
-    :returns: A tuple of (success, any_removed) where success indicates whether
-        the operation completed without errors, and any_removed indicates whether
-        any items were actually removed.
-    """
-    from papis.strings import process_format_pattern_pair
-
-    success = True
-    any_removed = False
-    for orig_key, orig_value in to_remove:
-        key, value = process_format_pattern_pair(orig_key, orig_value)
-
-        if key in document:
-            if isinstance(document.get(key), list):
-                try:
-                    document[key].remove(value)
-                    any_removed = True
-                except ValueError:
-                    try:
-                        document[key].remove(int(str(value)))
-                        any_removed = True
-                    except ValueError:
-                        pass  # do nothing if there is nothing to remove
+            if type(eval_value) is cls:
+                value = eval_value
             else:
-                logger.error(
-                    "You're trying to remove an item from '%s', which has the "
-                    "type '%s'. `papis update --remove` only supports lists.",
-                    key,
-                    type(document.get(key)).__name__,
-                )
-                if not batch:
-                    success = False
-                    break
+                # TODO: this assumes that the constructor for cls is sufficiently
+                # simple to allow directly converting the value. Better way?
+                try:
+                    value = cls(value)
+                except Exception:
+                    try:
+                        value = cls(eval_value)
+                    except Exception:
+                        raise OperationError(
+                            f"failed to convert '{key}' value to {cls}: {value}"
+                        ) from None
         else:
-            logger.info(
-                "Document doesn't have key '%s', cannot remove '%s' from it. "
-                "Continuing...",
-                key,
-                value,
+            # TODO: do we want to do this? It seems a bit too smart for its own
+            # good. Maybe we should let the user decide using a `type:value`
+            # sort of syntax if they really want to do that.
+            value = eval_value
+
+    logger.debug("Setting key '%s': %s (%s)", key, value, type(value))
+    data[key] = value
+
+
+def _apply_operation_reset(
+        data: dict[str, Any], key: str, *,
+        folder: str
+    ) -> None:
+    """Reset the *key* to its default value (in place).
+
+    Most keys do not have a predefined default value. The following keys are
+    supported:
+    * ``ref``: the reference is recreated using :func:`papis.bibtex.create_reference`.
+    * ``author``: the author is regenerated from ``author_list``, if available.
+    * ``notes``: the notes file is renamed using :confval:`notes-name`.
+    * ``files``: all files are renamed using :confval:`add-file-name`
+
+    :raises OperationError: if any of these operations is not possible or fails
+        in some way.
+    """
+    from papis.format import format
+
+    if key == "ref":
+        from papis.bibtex import create_reference
+        value: Any = create_reference(data, force=True)
+    elif key == "author":
+        from papis.document import author_list_to_author
+        value = author_list_to_author(data)
+    elif key == "notes":
+        # NOTE: we do not check if the notes file exists, since it is usually
+        # created on demand using the name from the document
+        notes_name_format = papis.config.getformatpattern("notes-name")
+        value = format(notes_name_format, data)
+    elif key == "files":
+        # NOTE: we pop the document files so that `rename_document_files` thinks
+        # the new set we give is is brand new and starts the suffixes at 0
+        files = data.pop("files", None)
+        if files:
+            paths = [os.path.join(folder, filename) for filename in files]
+            for filename in paths:
+                if not os.path.exists(filename):
+                    # NOTE: restoring the file list as is on error
+                    data["files"] = files
+                    raise OperationError(
+                        f"file '{os.path.basename(filename)}' does not exist")
+
+            from papis.paths import rename_document_files
+            file_name_format = papis.config.getformatpattern("add-file-name")
+            if not file_name_format:
+                data["files"] = files
+                raise OperationError(
+                    "cannot reset 'files' ('add-file-name' not defined in config)")
+
+            value = rename_document_files(
+                data, paths, file_name_format=file_name_format
             )
-
-    return success, any_removed
-
-
-def run_drop(document: DocumentLike, to_remove: Sequence[str]) -> None:
-    """
-    Processes a list of ``to_drop`` strings and applies the resulting changes
-    to the input document. Each string is a KEY whose value is set to None
-    (and then later in ``run()`` dropped from the document entirely).
-
-    """
-    for key in to_remove:
-        if key in document:
-            document[key] = None
         else:
-            logger.info(
-                "Document doesn't have key '%s', cannot remove it. Continuing...", key
-            )
+            value = None
+    else:
+        raise OperationError(f"cannot reset '{key}' field (no known default)")
+
+    data[key] = value
 
 
-def run_rename(
-    document: DocumentLike,
-    to_rename: Sequence[
-        tuple[str, AnyString, AnyString]],
-    field_types: dict[str, type],
-    batch: bool,
-) -> bool:
+def _apply_operation_drop(
+        data: dict[str, Any], key: str
+    ) -> None:
+    """Remove the *key* from *data* (in place)."""
+    if key not in data:
+        raise OperationError(f"'{key}' field not in document")
+
+    _ = data.pop(key)
+
+
+def _apply_operation_append(
+        data: dict[str, Any], key: str, vformat: FormatPattern, *,
+        field_types: dict[str, type],
+    ) -> None:
+    """Append a *value* to the *key* in *data* (in place).
+
+    A key can only be appended to if its type is known through
+    :confval:`document-field-types`. This type must then match the actual type
+    of the value in *data*. If they match, then
+    * If the type is :class:`str`, then the *value* is simply concatenated at the
+      end of the string (no separator is added) if the string does not already
+      end with *value*.
+    * If the type is :class:`list`, then the *value* is appended to the list if
+      it does not exist in the list already.
+
+    The value is always evaluated to a Python expression using :func:`ast.literal_eval`
+    if possible.
+
+    :raises OperationError: if any of these operations is not possible or fails
+        in some way.
     """
-    Processes a list of ``to_rename`` tuples and applies the resulting changes
-    to the input document. Each tuple is (KEY, VALUE_OLD, VALUE_NEW) and results in
-    rename the KEY's VALUE_OLD to VALUE_NEW.
+    if key not in field_types and key not in data:
+        logger.info(
+            "Please use `papis update --set` instead or add the key type "
+            "to the `document-field-types` configuration setting "
+            "(or `document-field-types-extend`)."
+        )
+        raise OperationError(f"cannot append to '{key}' field (unknown type)")
+
+    from papis.format import format
+    value: Any = format(vformat, data, default=str(vformat))
+
+    field_type = field_types.get(key)
+    doc_type = type(data[key]) if key in data else None
+    if doc_type and field_type and doc_type is not field_type:
+        raise OperationError(
+            f"key '{key}' does not have expected type '{field_type.__name__}': "
+            f"{doc_type.__name__}"
+        )
+
+    field_type = field_type or doc_type
+    assert field_type is not None
+
+    if issubclass(field_type, str):
+        doc_value = data.get(key, "")
+        if not doc_value.endswith(value):
+            value = f"{doc_value}{value}"
+    elif issubclass(field_type, list):
+        doc_value = data.get(key, [])
+
+        # NOTE: ensure we do not add duplicates to the list, but if there are any
+        # just leave them alone (maybe a job for `papis doctor`)
+        if value in doc_value:
+            value = doc_value
+        else:
+            value = _try_eval_value(key, value)
+            if value in doc_value:
+                value = doc_value
+            else:
+                value = [*doc_value, value]
+    else:
+        raise OperationError(
+            f"cannot append to key '{key}' of type '{field_type.__name__}'")
+
+    data[key] = value
 
 
-    :returns: A boolean indicating whether the update was successful.
+def _apply_operation_remove(
+    data: dict[str, Any], key: str, vformat: FormatPattern
+    ) -> int:
+    """Remove the *value* from the *key* in *data* (in place).
+
+    This operation removes a given value from a list in *data*. If the given
+    key is not a list, then the operation is not allowed.
+
+    :raises OperationError: if any of these operations is not possible or fails
+        in some way.
     """
-    to_remove = [(x[0], x[1]) for x in to_rename]
-    to_append = [(x[0], x[2]) for x in to_rename]
 
-    success, any_removed = run_remove(document, to_remove, batch)
-    if success and any_removed:
-        success = run_append(document, to_append, field_types, batch)
-    return success
+    if key not in data:
+        raise OperationError(f"cannot remove from non-existent field '{key}'")
+
+    doc_value = data[key]
+    if not isinstance(doc_value, list):
+        raise OperationError(f"'{key}' field is not a list: {type(doc_value)}")
+
+    from papis.format import format
+    value = format(vformat, data, default=str(vformat))
+
+    try:
+        idx = doc_value.index(value)
+    except ValueError:
+        value = _try_eval_value(key, value)
+        try:
+            idx = doc_value.index(value)
+        except ValueError:
+            raise OperationError(f"'{key}' field does not contain '{value}'") from None
+
+    data[key].pop(idx)
+    return idx
+
+
+def _apply_operation_rename(
+        data: dict[str, Any],
+        key: str, from_vformat: FormatPattern, to_vformat: FormatPattern
+    ) -> None:
+    """Rename an element from a list in *data* (in place).
+
+    If the given *key* is not a list, then this operation is not allowed. Also,
+    if the value to be removed from the list does not exist, it will not be
+    added.
+
+    :raises OperationError: if any of these operations is not possible or fails
+        in some way.
+    """
+    from papis.format import format
+
+    idx = _apply_operation_remove(data, key, from_vformat)
+
+    # NOTE: if we get here, it means that the value was in the document, so we
+    # can proceed to insert it back in.
+    to_value: Any = format(to_vformat, data, default=str(to_vformat))
+    to_value = _try_eval_value(key, to_value)
+
+    data[key].insert(idx, to_value)
+
+
+def _process_command_line_operations(
+        options: Sequence[_Option], *,
+        to_set: Iterable[tuple[str, AnyString]],
+        to_reset: Iterable[str],
+        to_drop: Iterable[str],
+        to_append: Iterable[tuple[str, AnyString]],
+        to_remove: Iterable[tuple[str, AnyString]],
+        to_rename: Iterable[tuple[str, AnyString, AnyString]],
+    ) -> Sequence[tuple[str, Sequence[Operation]]]:
+    """
+    :returns: a sequence of ``(key, ops)`` aggregated from the input iterables.
+    """
+    from papis.strings import process_format_pattern_pair
+
+    to_set = iter(to_set)
+    to_reset = iter(to_reset)
+    to_drop = iter(to_drop)
+    to_append = iter(to_append)
+    to_remove = iter(to_remove)
+    to_rename = iter(to_rename)
+
+    ops: dict[str, list[Operation]] = {}
+    for option in options:
+        if option.name == "to_set":
+            key, value = next(to_set)
+            key, value = process_format_pattern_pair(key, value)
+
+            ops.setdefault(key, []).append(
+                Operation(OperationType.Set, key, value, value))
+        elif option.name == "to_reset":
+            key = next(to_reset)
+            key, value = process_format_pattern_pair(key, "")
+
+            ops.setdefault(key, []).append(
+                Operation(OperationType.Reset, key, value, value))
+        elif option.name in {"to_drop", "drop"}:
+            # NOTE: "drop" is added to handle `papis tag`, which just has a
+            # --drop flag, but not a `--drop key` type option
+            key = next(to_drop)
+            key, value = process_format_pattern_pair(key, "")
+
+            ops.setdefault(key, []).append(
+                Operation(OperationType.Drop, key, value, value))
+        elif option.name == "to_append":
+            key, value = next(to_append)
+            key, value = process_format_pattern_pair(key, value)
+
+            ops.setdefault(key, []).append(
+                Operation(OperationType.Append, key, value, value))
+        elif option.name == "to_remove":
+            key, value = next(to_remove)
+            key, value = process_format_pattern_pair(key, value)
+
+            ops.setdefault(key, []).append(
+                Operation(OperationType.Remove, key, value, value))
+        elif option.name == "to_rename":
+            key, from_value, to_value = next(to_rename)
+            key, from_value = process_format_pattern_pair(key, from_value)
+            key, to_value = process_format_pattern_pair(key, to_value)
+
+            ops.setdefault(key, []).append(
+                Operation(OperationType.Rename, key, from_value, to_value))
+        else:
+            logger.debug("Unsupported option: %s.", option.name)
+
+    return tuple((key, tuple(value)) for key, value in ops.items())
+
+
+@enum.unique
+class ApplyStatus(enum.Flag):
+    Changed = enum.auto()
+    Finished = enum.auto()
+    Failed = enum.auto()
+
+
+def _apply_operations(
+        document: Document,
+        key_ops: Sequence[tuple[str, Sequence[Operation]]], *,
+        field_types: dict[str, type] | None = None,
+    ) -> tuple[dict[str, Any], ApplyStatus]:
+    if field_types is None:
+        field_types = {}
+
+    # NOTE: we need to make a deepcopy here, since the document can have nested
+    # lists and dictionaries and we do not want to worry about it when applying
+    from copy import deepcopy
+    new_data = deepcopy(dict(document))
+
+    from papis.document import describe
+    folder = document.get_main_folder()
+
+    if not folder:
+        from papis.exceptions import DocumentFolderNotFound
+        raise DocumentFolderNotFound(describe(document))
+
+    status = ApplyStatus.Finished
+    for key, ops in key_ops:
+        for op in ops:
+            try:
+                if op.optype == OperationType.Set:
+                    _apply_operation_set(
+                        new_data, op.key, op.value, field_types=field_types)
+                elif op.optype == OperationType.Reset:
+                    _apply_operation_reset(
+                        new_data, op.key, folder=folder)
+                elif op.optype == OperationType.Drop:
+                    _apply_operation_drop(new_data, op.key)
+                elif op.optype == OperationType.Append:
+                    _apply_operation_append(
+                        new_data, op.key, op.value, field_types=field_types)
+                elif op.optype == OperationType.Remove:
+                    _apply_operation_remove(new_data, op.key, op.value)
+                elif op.optype == OperationType.Rename:
+                    _apply_operation_rename(new_data, op.key, op.value, op.to_value)
+                else:
+                    raise TypeError(f"unknown operation type: {type(op)}")
+            except OperationError as exc:
+                logger.error("Failed '--%s' operation on key '%s': %s.",
+                             op.optype.name.lower(), key, exc)
+
+                status |= ApplyStatus.Failed
+            else:
+                status |= ApplyStatus.Changed
+
+    return new_data, status
+
+
+def _rename_files_safely(folder: str,
+                         from_files: Sequence[str],
+                         to_files: Sequence[str]) -> None:
+    import shutil
+    import tempfile
+
+    # NOTE: this does a two-phase rename that is safe-ish against collisions
+    #
+    # Phase 1: move every original file into a temporary directory.
+    #   On error, if any of the moves fail, we roll back everything.
+    #
+    # Phase 2: move each file from the temp directory to its final destination.
+    #   On error, if any of the moves fails, we roll back everything.
+    #
+    # NOTE: the rollbacks can still fail, in which case we're in trouble. However,
+    # this is meant to guard against overwriting files, not against power blackouts
+    # or other catastrophic failures..
+
+    with tempfile.TemporaryDirectory(prefix="papis-update-tmp-") as tmpdirname:
+        to_rename: list[tuple[str, str]] = []
+
+        # Phase 1: move original out of the folder into temp
+        try:
+            for from_file, to_file in zip(from_files, to_files, strict=True):
+                if from_file == to_file:
+                    continue
+
+                orig_path = os.path.join(folder, from_file)
+                if not os.path.exists(orig_path):
+                    raise FileNotFoundError(f"document file not found: {from_file}")
+
+                tmp_path = os.path.join(tmpdirname, from_file)
+                shutil.move(orig_path, tmp_path)
+
+                to_rename.append((tmp_path, os.path.join(folder, to_file)))
+        except Exception:
+            # if an error occurred, just move back the files we've handled so far
+            for from_path, _ in to_rename:
+                from_file = os.path.basename(from_path)
+                to_path = os.path.join(folder, from_file)
+                shutil.move(from_path, to_path)
+
+            raise
+
+        # Phase 2: move from temp to final destinations.
+        renamed: list[tuple[str, str]] = []
+        try:
+            while to_rename:
+                from_path, to_path = to_rename[-1]
+                shutil.move(from_path, to_path)
+
+                to_rename.pop()
+                renamed.append((from_path, to_path))
+        except Exception:
+            # move back the files that got renamed into *folder*
+            for from_path, to_path in reversed(renamed):
+                from_file = os.path.basename(from_path)
+                orig_path = os.path.join(folder, from_file)
+                shutil.move(to_path, orig_path)
+
+            # move back the files still in the tmpdir back to *folder*
+            for from_path, _ in to_rename:
+                from_file = os.path.basename(from_path)
+                orig_path = os.path.join(folder, from_file)
+                shutil.move(from_path, orig_path)
+
+            raise
 
 
 def run(
     document: Document,
-    data: dict[str, Any] | None = None,
+    data: dict[str, Any] | None = None, *,
     git: bool = False,
     auto_doctor: bool = False,
+    overwrite: bool = False,
 ) -> None:
-    """
-    Updates the document in the Papis library.
+    """Updates a document in the Papis library with the given *data*.
 
-    :returns: None
+    The entries in *data* can be further modified or not ignored when updating
+    the *document*. The following rules apply:
+
+    * If a value in *data* is *None*, then it will be removed from the *document*.
+    * If *auto_doctor* is *True*, then all the default auto-fixers
+      (see :confval:`doctor-default-checks`) will be applied to the document. This
+      can modify keys that are not in *data*.
+    * If the *notes* or *files* keys are updated, any paths in *data* will be
+      further normalized using :func:`~papis.paths.normalize_path_part`.
     """
+    from papis.document import describe
+
     if data is None:
         data = {}
 
     folder = document.get_main_folder()
     info = document.get_info_file()
 
-    from papis.document import describe
-
     if not folder or not info:
         from papis.exceptions import DocumentFolderNotFound
 
         raise DocumentFolderNotFound(describe(document))
 
+    from papis.paths import normalize_path_part
+
+    # normalize new document files
+    if "files" in data:
+        data["files"] = [normalize_path_part(filename) for filename in data["files"]]
+
+    if "notes" in data:
+        data["notes"] = normalize_path_part(data["notes"])
+
+    # gather all files to rename
+    from_files = list(document.get("files", []))
+    to_files = list(data.get("files", []))
+
+    if to_files and len(set(to_files)) != len(to_files):
+        raise ValueError(f"updated files are not unique: {to_files}")
+
+    if from_files and len(set(from_files)) != len(from_files):
+        raise ValueError(f"existing files are not unique: {from_files}")
+
+    # NOTE: if they're not the same length, we do not want to rename files. This
+    # is done here, so that adding notes works as expected and they're all renamed
+    # atomically if possible. Note that this can never happen when calling from cli()
+    if len(from_files) != len(to_files):
+        from_files.clear()
+        to_files.clear()
+
+    if (to_notes := data.get("notes")) and (from_notes := document.get("notes")):
+        if os.path.exists(os.path.join(folder, from_notes)):
+            from_files.append(from_notes)
+            to_files.append(to_notes)
+
+    # rename files
+    # FIXME: this is not great, since len == len is a bad heuristic to figure out
+    # if files are renamed. Ideally, we would get a `update_files: dict[str, str]`
+    # argument to let us know exactly what needs renaming.
+    if from_files and len(from_files) == len(to_files):
+        _rename_files_safely(folder, from_files, to_files)
+
+    # update document metadata
+    if overwrite:
+        document.clear()
     document.update(data)
 
     # delete all keys that do not have a value
-    to_drop = [k for k, v in document.items() if not v]
-    [document.pop(k) for k in to_drop]
+    for key in list(document):
+        value = document[key]
+
+        # NOTE: remove any False-y keys from the document, but not:
+        # * 0 as an integer
+        # * False as a boolean
+        if (
+                value is None
+                or (isinstance(value, str) and not value)
+                or (isinstance(value, (list, dict)) and not value)):
+            del document[key]
 
     if auto_doctor:
         from papis.doctor import fix_errors
@@ -410,7 +856,6 @@ def run(
         fix_errors(document)
 
     from papis.api import save_doc
-
     save_doc(document)
 
     if git:
@@ -426,14 +871,50 @@ def run(
             logger.error("%s", exc)
 
 
-@click.command("update")
+# NOTE: these classes are a hack to allow us to recover the real argument order
+# from click. By default, when using `multiple=True`, click aggregates all the
+# flags into lists for the same type, so any order is lost. Only the parser
+# seems to know the original order, so we get it from there.
+
+class _Option(NamedTuple):
+    """A :class:`click.Option` look-alike that remembers the argument name."""
+    name: str | None
+
+
+class _TrackingOptionParser(click.parser._OptionParser):
+    """A modified option parser that remembers the argument order."""
+
+    def parse_args(self, args: list[str]) -> Any:
+        opts, args, order = super().parse_args(args)
+        if self.ctx is not None:
+            self.ctx.ensure_object(dict)
+            self.ctx.obj["param"] = [_Option(param.name) for param in order]
+
+        return opts, args, order
+
+
+class _OrderedCommand(click.Command):
+    """A modified command that uses ``_TrackingOptionParser``."""
+
+    def make_parser(self, ctx: click.Context) -> Any:
+        parser = _TrackingOptionParser(ctx)
+        for param in self.get_params(ctx):
+            param.add_to_parser(parser, ctx)
+
+        return parser
+
+
+@click.command("update", cls=_OrderedCommand)
 @click.help_option("--help", "-h")
 @papis.cli.git_option()
 @papis.cli.query_argument()
 @papis.cli.doc_folder_option()
 @papis.cli.all_option()
 @papis.cli.sort_option()
-@papis.cli.bool_flag("--auto", help="Try to gather metadata from different sources.")
+@papis.cli.bool_flag(
+    "--auto",
+    help="Automatically select importers and downloaders based on document metadata."
+)
 @papis.cli.bool_flag(
     "--auto-doctor/--no-auto-doctor",
     help="Apply automatic doctor fixes to newly added documents.",
@@ -450,44 +931,40 @@ def run(
 )
 @papis.cli.bool_flag("--list-importers", help="List all supported importers.")
 @click.option(
-    "-s",
-    "--set",
-    "to_set",
+    "-s", "--set", "to_set",
     help="Set the key to the given value.",
     multiple=True,
-    type=(str, papis.cli.FormatPatternParamType()),
+    type=(papis.cli.KeyParamType(), papis.cli.FormatPatternParamType()),
 )
 @click.option(
-    "-d",
-    "--drop",
-    "to_drop",
-    help="Drop a key from the document.",
+    "--reset", "to_reset",
+    help="Reset fields to their default values.",
     multiple=True,
-    type=str,
+    type=papis.cli.KeyParamType(),
 )
 @click.option(
-    "-p",
-    "--append",
-    "to_append",
-    help="Append a value to a document key.",
+    "-d", "--drop", "to_drop",
+    help="Drop a field from the document.",
     multiple=True,
-    type=(str, papis.cli.FormatPatternParamType()),
+    type=papis.cli.KeyParamType(),
 )
 @click.option(
-    "-r",
-    "--remove",
-    "to_remove",
+    "-p", "--append", "to_append",
+    help="Append a value to a document field.",
+    multiple=True,
+    type=(papis.cli.KeyParamType(), papis.cli.FormatPatternParamType()),
+)
+@click.option(
+    "-r", "--remove", "to_remove",
     help="Remove an item from a list.",
     multiple=True,
-    type=(str, papis.cli.FormatPatternParamType()),
+    type=(papis.cli.KeyParamType(), papis.cli.FormatPatternParamType()),
 )
 @click.option(
-    "-n",
-    "--rename",
-    "to_rename",
+    "-n", "--rename", "to_rename",
     help="Rename an item in a list.",
     multiple=True,
-    type=(str,
+    type=(papis.cli.KeyParamType(),
           papis.cli.FormatPatternParamType(),
           papis.cli.FormatPatternParamType()),
 )
@@ -496,7 +973,9 @@ def run(
     "--batch",
     help="Do not prompt, and skip documents containing errors."
 )
+@click.pass_context
 def cli(
+    ctx: click.Context,
     query: str,
     git: bool,
     doc_folder: tuple[str, ...],
@@ -505,18 +984,18 @@ def cli(
     batch: bool,
     auto: bool,
     auto_doctor: bool,
+    to_set: list[tuple[str, AnyString]],
+    to_reset: list[str],
+    to_drop: list[str],
+    to_append: list[tuple[str, AnyString]],
+    to_remove: list[tuple[str, AnyString]],
+    to_rename: list[tuple[str, AnyString, AnyString]],
     _all: bool,
     sort_field: str | None,
     sort_reverse: bool,
-    to_set: list[tuple[str, str]],
-    to_drop: list[str],
-    to_append: list[tuple[str, str]],
-    to_remove: list[tuple[str, str]],
-    to_rename: list[tuple[str, str, str]],
 ) -> None:
     """Update document metadata."""
     from papis.importer import (
-        Context,
         collect_from_importers,
         fetch_importers,
         get_available_importers,
@@ -530,14 +1009,6 @@ def cli(
             click.echo(o)
         return
 
-    known_importers = get_available_importers()
-    extra_importers = {name for name, _ in from_importer}.difference(known_importers)
-    if extra_importers:
-        logger.error("Unknown importers chosen with '--from': ['%s'].",
-                     "', '".join(extra_importers))
-        logger.error("Supported importers are: ['%s'].", "', '".join(known_importers))
-        return
-
     # retrieve documents
     documents = papis.cli.handle_doc_folder_query_all_sort(
         query, doc_folder, sort_field, sort_reverse, _all
@@ -547,56 +1018,126 @@ def cli(
         logger.warning(no_documents_retrieved_message)
         return
 
+    # retrieve importers
+    known_importers = get_available_importers()
+    extra_importers = {name for name, _ in from_importer}.difference(known_importers)
+    if extra_importers:
+        logger.error("Unknown importers chosen with '--from': ['%s'].",
+                     "', '".join(extra_importers))
+        logger.error("Supported importers are: ['%s'].", "', '".join(known_importers))
+        ctx.exit(1)
+        return
+
+    if from_importer:
+        from_importers = get_matching_importers_by_name(from_importer)
+    else:
+        from_importers = []
+
+    # retrieve user provided operations
+    operations = _process_command_line_operations(
+        ctx.obj["param"],
+        to_set=to_set,
+        to_reset=to_reset,
+        to_drop=to_drop,
+        to_append=to_append,
+        to_remove=to_remove,
+        to_rename=to_rename,
+    )
+
     from papis.document import get_document_field_types
     known_field_types = get_document_field_types()
 
-    success = True
-    processed_documents = []
-    for document in documents:
-        ctx = Context()
+    from papis.document import describe
+    from papis.tui.utils import confirm as ask_confirm
 
-        ctx.data.update(document)
-        if to_set:
-            run_set(ctx.data, to_set, known_field_types)
+    ret = 0
+    updated = 0
+    for i, document in enumerate(documents):
+        logger.info("[%d/%d] Gathering metadata changes for document: %s.",
+                    i + 1, len(documents), describe(document))
 
-        if to_append and success:
-            success = run_append(ctx.data, to_append, known_field_types, batch)
+        # apply changes to document
+        try:
+            new_data, status = _apply_operations(
+                document, operations,
+                field_types=known_field_types)
+        except Exception as exc:
+            # NOTE: this should generally not happen, unless there's a bug or
+            # the database is in an inconsistent state, so we just move on
+            logger.error("Failed to apply metadata changes to document: %s.",
+                         describe(document), exc_info=exc)
+            ret = 1
+            continue
 
-        if to_remove and success:
-            success, _ = run_remove(ctx.data, to_remove, batch)
+        if ApplyStatus.Failed in status:
+            ret = 1
 
-        if to_drop and success:
-            run_drop(ctx.data, to_drop)
+        # get metadata from importers and merge them all together
+        if from_importer:
+            importers = from_importers
+        elif auto:
+            importers = get_matching_importers_by_doc(document)
+        else:
+            importers = []
 
-        if to_rename:
-            success = run_rename(ctx.data, to_rename, known_field_types, batch)
+        importers = fetch_importers(importers, download_files=False)
+        imported = collect_from_importers(importers, batch=batch, use_files=False)
 
-        if success:
-            from papis.document import describe
-            logger.info("Processing '%s.'", describe(document))
+        # merge user and importer data
+        # FIXME: add interactive merging to avoid overwriting user changes
+        for key, value in imported.data.items():
+            if new_data.get(key) == value:
+                continue
 
-            # get metadata from importers and merge them all together
-            if from_importer:
-                importers = get_matching_importers_by_name(from_importer)
-            elif auto:
-                importers = get_matching_importers_by_doc(document)
+            new_data[key] = value
+            status |= ApplyStatus.Changed
+
+        if ApplyStatus.Changed not in status:
+            continue
+
+        if ApplyStatus.Failed in status:
+            if not batch and ask_confirm(
+                "Encountered errors while updating document. Skip it?"
+            ):
+                continue
+
+        logger.info("[%d/%d] Applying metadata changes to document: %s.",
+                    i + 1, len(documents), describe(document))
+
+        try:
+            # NOTE: data contains all the fields in doc (modified by the flags),
+            # so we want to just overwrite it with them => overwrite=True
+            run(document, new_data, git=git, auto_doctor=auto_doctor, overwrite=True)
+        except OSError as exc:
+            logger.error("Failed to rename files for document: %s",
+                         describe(document), exc_info=exc)
+            ret = 1
+            if batch:
+                continue
+
+            if ask_confirm(
+                "Failed to rename document files. Continue processing the "
+                "remaining documents?"
+            ):
+                continue
             else:
-                importers = []
+                break
+        except Exception as exc:
+            logger.error("Failed to apply changes to document: %s",
+                         describe(document), exc_info=exc)
+            ret = 1
+            if batch:
+                continue
 
-            importers = fetch_importers(importers, download_files=False)
-            imported = collect_from_importers(importers, batch=batch, use_files=False)
+            if ask_confirm(
+                "Failed to update document. Continue processing the "
+                "remaining documents?"
+            ):
+                continue
+            else:
+                break
 
-            # TODO: add interactive merging to avoid overwriting user changes
-            ctx.data.update(imported.data)
+        updated += 1
 
-            processed_documents.append((document, ctx.data))
-
-        if not success and not batch:
-            processed_documents.clear()
-            logger.error(
-                "Aborting operation. No documents have been changed.",
-            )
-            break
-
-    for document, data in processed_documents:
-        run(document, data=data, git=git, auto_doctor=auto_doctor)
+    logger.info("Updated %d / %d documents.", updated, len(documents))
+    ctx.exit(ret)

--- a/papis/commands/update.py
+++ b/papis/commands/update.py
@@ -1,19 +1,21 @@
 """
 This command allows you to update the document metadata stored in the
-``info.yaml`` file. With it, you can either change individual values manually
+``info.yaml`` file. With it, you can either set individual fields' values manually
 or update a document with information automatically retrieved from a variety
-of sources.
+of sources. The command also renames files and notes on disk when needed.
 
-When using it to add information, Papis formatting patterns and Python
-expressions can be used. See below examples for more information. The command
-also tries to sanitise filenames so that they don't contain any problematic
-characters.
+Papis formatting patterns and Python expressions can be used. See below examples
+for more information. The command also sanitises filenames so that they don't
+contain any problematic characters (see :confval:`doc-paths-extra-chars`).
 
-Normally, ``papis update`` will prompt you when it encounters an error. If you
-want to continue errors without input and apply as many changes as possible,
-use the ``--batch`` flag. With this in mind, the command is mostly meant to be
-used to apply sweeping changes to a larger number of documents. If you just
-want to update a single document, ``papis edit`` might be more appropriate.
+By default, ``papis update`` will prompt you when it encounters an error. If you
+want to skip errors automatically and apply as many changes as possible,
+use the ``--batch`` flag.
+
+This command is mostly meant to be used to apply sweeping changes across a large
+number of documents. If you just want to update a single document, ``papis edit``
+might be more appropriate.
+
 
 Examples
 ^^^^^^^^
@@ -37,25 +39,10 @@ Examples
 
 
   The ``--all`` flag means that the operation is applied to all documents that
-  match the query, rather than allowing you to pick one individual document to
+  match the query, rather than opening the picker to select individual documents to
   update.
 
-- Update a document automatically and interactively (searching by DOI in
-  Crossref or in other sources...):
-
-    .. code:: sh
-
-        papis update --auto "author:dyson"
-
-- Update your document from a DOI using the importer functionality as
-
-    .. code:: sh
-
-        papis update --from doi '10.1103/PhysRev.47.777' 'author:einstein'
-
-  For a list of all supported importers use ``papis update --list-importers``.
-
-- Add the ", Albert" to the author string of a documents matching 'Einstein':
+- Add ", Albert" to the author string of a documents matching 'Einstein':
 
     .. code:: sh
 
@@ -65,20 +52,19 @@ Examples
   formatter. Here, it is used to get the existing author "Albert" and then add
   the string ", Einstein" to end up with "Einstein, Albert".
 
-- Reset keys to their default values using:
+- Reset a field to its default value using:
 
     .. code:: sh
 
         papis update --reset ref Einstein
 
-  This will reset the value to the default value defined for the key. In the
-  above case the "ref" is set to the format described by :confval:`ref-format`.
-  Other supported keys are: "author" (gets updated from ``author_list`` and
-  :confval:`multiple-authors-format`), "notes" (using :confval:`notes-name`),
-  and "files" (using :confval:`add-file-name`). Other keys do not support this
-  as they do not have any well-defined default.
+  This will reset the value to the default value defined for the field. Here, the "ref"
+  is set to :confval:`ref-format`. Other fields that can be reset are: "author" (gets
+  updated from ``author_list`` and :confval:`multiple-authors-format`), "notes"
+  (using :confval:`notes-name`), and "files" (using :confval:`add-file-name`). Other
+  fields do not support this as they do not have any well-defined default.
 
-- The ``--append`` option can be used to append a string to an existing key:
+- The ``--append`` option can be used to append to a string value:
 
     .. code:: sh
 
@@ -99,9 +85,9 @@ Examples
     doesn't yet exist, it will be created. The new tag will only be appended to
     the list if the tag does not already exist (as an exact case-sensitive match).
 
-    The ``--append`` flag needs to know the type of the key it is appending to.
-    If the key exists in the document, then the value set in the document
-    determines the type. If the key doesn't exist in the document, the command
+    The ``--append`` flag needs to know the type of the field it is appending to.
+    If the field exists in the document, then the value set in the document
+    determines the type. If the field doesn't exist in the document, the command
     looks at the list of types defined in the :confval:`document-field-types`
     (and :confval:`document-field-types-extend`) configuration option. If the
     type cannot be determined in either of these two ways, the command will
@@ -114,7 +100,7 @@ Examples
 
         papis update --remove tags physics 'author:einstein'
 
-- To remove a key-value pair entirely, use ``--drop``. For example, to remove all
+- To remove a field entirely, use ``--drop``. For example, to remove all
   tags from documents use
 
     .. code:: sh
@@ -133,8 +119,8 @@ Examples
   not be added to the list if the original tag doesn't exist.
 
 - The ``--batch`` flag suppresses interactive prompts and skips any document
-  that cannot be fully updated. This is useful when applying the same operation
-  across many documents where some may not have the expected keys or values:
+  for which an update operation has failed. This is useful when applying the same
+  operation across many documents where some may not have the expected keys or values:
 
     .. code:: sh
 
@@ -156,35 +142,50 @@ Examples
     then the whole document is skipped. This generally signals some external failure,
     so the user should just try again.
 
-  In all cases the command exits with a non-zero status if any document was
-  skipped.
+  In all cases the command exits with a non-zero status (indicating a failure) if
+  any document was skipped.
 
-Advanced Examples
-^^^^^^^^^^^^^^^^^
+- Update a document automatically and interactively (searching by DOI in
+  Crossref or in other sources...):
 
-- When you update the ``files`` or ``notes`` keys, the corresponding files on
-  disk are also renamed to match the new value:
+    .. code:: sh
+
+        papis update --auto "author:dyson"
+
+- Update your document from a DOI using the importer functionality:
+
+    .. code:: sh
+
+        papis update --from doi '10.1103/PhysRev.47.777' 'author:einstein'
+
+  For a list of all supported importers use ``papis update --list-importers``.
+
+- When you update the ``files`` or ``notes`` fields, the corresponding files on
+  disk are renamed to match the new value:
 
     .. code:: sh
 
         papis update --set notes "my-new-notes.tex" Einstein
 
-  This renames the ``notes`` file on disk from its current name to
-  ``my-new-notes.tex`` and updates the ``info.yaml`` file accordingly. The same
-  applies when updating ``files``:
+  This updates the ``info.yaml`` file and renames the ``notes`` file on disk from
+  its current name to ``my-new-notes.tex``. The same applies when updating ``files``:
 
     .. code:: sh
 
-        papis update --set files 0:einstein-new.pdf Einstein
+        papis update --rename files einstein-old.pdf einstein-new.pdf Einstein
 
-  This renames the first file in the document's file list to ``einstein-new.pdf``
-  on disk. If the rename fails (e.g. the file does not exist or there is a
-  permissions error), the metadata is not updated and an error is reported.
+  This renames the file ``einstein-old.pdf`` to ``einstein-new.pdf`` in the
+  ``info.yaml`` file and on disk. If the rename fails (e.g. the file does not exist
+  or there is a permissions error), the metadata is not updated and an error is
+  reported.
 
   Note that the ``--reset`` option also triggers a rename when used with
   ``notes`` or ``files``. It renames the files to the names derived from the
   configured :confval:`notes-name` and :confval:`add-file-name` formats
   respectively.
+
+Advanced Examples
+^^^^^^^^^^^^^^^^^
 
 - As an advanced feature, ``papis update`` also supports the parsing of Python
   expressions (such as lists or dictionaries). This can be used as follows:
@@ -196,7 +197,7 @@ Advanced Examples
   Because the above string is a valid Python expression, ``author_list`` is
   updated to a list that contains a dictionary.
 
-- You can use ``--set`` to set a value into a list at a given position:
+- You can use ``--set`` to set a value in a list at a given position:
 
     .. code:: sh
 
@@ -215,6 +216,7 @@ Command-line interface
 .. click:: papis.commands.update:cli
     :prog: papis update
 """
+
 from __future__ import annotations
 
 import ast

--- a/papis/defaults.py
+++ b/papis/defaults.py
@@ -150,7 +150,7 @@ settings: dict[str, Any] = {
     "search-engine": "https://duckduckgo.com",
 
     # edit
-    "notes-name": "notes.tex",
+    "notes-name": _f("notes.tex"),
     "notes-template": "",
 
     # doctor

--- a/papis/document.py
+++ b/papis/document.py
@@ -168,6 +168,7 @@ def author_list_to_author(
 
     if separator is None:
         separator = papis.config.getstring("multiple-authors-separator")
+        separator = separator.strip("'").strip('"')
 
     if multiple_authors_format is None:
         multiple_authors_format = (

--- a/papis/paths.py
+++ b/papis/paths.py
@@ -179,12 +179,12 @@ def get_document_file_name(
         base_name_limit: int = 150) -> str:
     """Generate a file name based on *orig_path* for the document *doc*.
 
-    This function will generate a file name for the given file *path* (that
+    This function will generate a file name for the given file *orig_path* (that
     does not necessarily exist) based on the document data. If the document
     data does not provide the necessary keys for *file_name_format*, then the
     original path will be preserved.
 
-    If resulting path will have the same extension as *orig_path* and will be
+    The resulting path will have the same extension as *orig_path* and will be
     modified by :func:`normalize_path_part`. The extension is determined using
     :func:`~papis.filetype.get_document_extension`.
 
@@ -194,7 +194,7 @@ def get_document_file_name(
         from the document data (see :func:`papis.format.format`). This value
         defaults to :confval:`add-file-name` if not provided.
     :param base_name_limit: a maximum character length of the file name. This
-        is important on operating systems of filesystems that do not support
+        is important on operating systems or filesystems that do not support
         long file names.
     :returns: a new path based on the document data and the *orig_path*.
     """

--- a/papis/testing.py
+++ b/papis/testing.py
@@ -42,13 +42,17 @@ def create_random_file(filetype: str | None = None,
     if filetype is None:
         filetype = random.choice(["pdf", "epub", "djvu"])
 
+    import uuid
+    text = uuid.uuid4().hex
+
     # NOTE: these are chosen to match using 'filetype.guess' and are not valid
     # files otherwise
     filetype = filetype.lower()
     if filetype == "pdf":
-        buf = b"%PDF-1.5%\n"
+        buf = f"%PDF-1.5\n% nonce={text}".encode()
         suffix = ".pdf" if suffix is None else suffix
     elif filetype == "epub":
+        # FIXME: add some randomness to generated file
         buf = bytes(
             [0x50, 0x4B, 0x3, 0x4]
             + [0x00 for i in range(26)]
@@ -59,13 +63,14 @@ def create_random_file(filetype: str | None = None,
             )
         suffix = ".epub" if suffix is None else suffix
     elif filetype == "djvu":
+        # FIXME: add some randomness to generated file
         buf = bytes([
             0x41, 0x54, 0x26, 0x54, 0x46, 0x4F, 0x52, 0x4D,
             0x00, 0x00, 0x00, 0x00,
             0x44, 0x4A, 0x56, 0x4D])
         suffix = ".djvu" if suffix is None else suffix
     elif filetype == "text":
-        buf = b"papis-test-file-contents"
+        buf = f"papis-test-file-contents-{text}".encode()
     else:
         raise ValueError(f"Unknown file type: '{filetype}'")
 
@@ -125,6 +130,7 @@ PAPIS_TEST_DOCUMENTS = [
     {
         "address": "Scranton, PA, USA",
         "author": "Scott, Michael",
+        "author_list": [{"family": "Scott", "given": "Michael"}],
         "booktitle": "Humor in the Workplace",
         "editor_list": [{"family": "Halpert", "given": "Jim"},
                         {"family": "Beesly", "given": "Pam"}],
@@ -152,7 +158,7 @@ PAPIS_TEST_DOCUMENTS = [
 ]
 
 
-def populate_library(libdir: str) -> None:
+def populate_library(libdir: str, filetype: str | None = None) -> None:
     """Add temporary documents with random files into the folder *libdir*.
 
     :arg libdir: an existing empty library directory.
@@ -170,7 +176,7 @@ def populate_library(libdir: str) -> None:
         num_test_files = int(str(doc_data.pop("_test_files")))
         if num_test_files:
             doc_data["files"] = [
-                os.path.basename(create_random_file(dir=folder_path))
+                os.path.basename(create_random_file(filetype, dir=folder_path))
                 for _ in range(num_test_files)
                 ]
 
@@ -442,7 +448,8 @@ class TemporaryLibrary(TemporaryConfiguration):
     def __init__(self,
                  settings: dict[str, Any] | None = None,
                  use_git: bool = False,
-                 populate: bool = True) -> None:
+                 populate: bool = True,
+                 filetype: str | None = None) -> None:
         super().__init__(settings=settings)
 
         #: If *True*, a git repository is created in the library directory.
@@ -450,6 +457,9 @@ class TemporaryLibrary(TemporaryConfiguration):
         #: If *True*, the library is prepopulated with a set of documents that
         #: contain random files and keys, which can be used for testing.
         self.populate = populate
+        #: The file type that should be generated for the documents in the library.
+        #: If *None*, each document gets a random choice between the supported values.
+        self.filetype = filetype
 
     def __enter__(self) -> TemporaryLibrary:
         super().__enter__()
@@ -464,7 +474,7 @@ class TemporaryLibrary(TemporaryConfiguration):
 
         # populate library
         if self.populate:
-            populate_library(self.libdir)
+            populate_library(self.libdir, filetype=self.filetype)
 
         if self.use_git:
             from papis.utils import run

--- a/tests/commands/test_config.py
+++ b/tests/commands/test_config.py
@@ -36,7 +36,7 @@ def test_config_section(tmp_config: TemporaryConfiguration) -> None:
     assert "editor" not in result
     assert result == {
         "auto-read": papis.config.getstring("auto-read", section="bibtex"),
-        "notes-name": papis.config.getstring("notes-name"),
+        "notes-name": str(papis.config.getformatpattern("notes-name")),
         }
 
     # checks:
@@ -67,7 +67,7 @@ def test_config_section_defaults(tmp_config: TemporaryConfiguration) -> None:
     assert "editor" not in result
     assert result == {
         "editmode": papis.config.getstring("editmode", section="tui"),
-        "notes-name": papis.config.getstring("notes-name"),
+        "notes-name": str(papis.config.getformatpattern("notes-name")),
         }
 
     # checks:

--- a/tests/commands/test_edit.py
+++ b/tests/commands/test_edit.py
@@ -73,7 +73,7 @@ def test_edit_cli(tmp_library: TemporaryLibrary) -> None:
             == get_mock_script("ls"))
 
     # check --notes
-    notes_name = papis.config.getstring("notes-name")
+    notes_name = papis.config.getformatpattern("notes-name")
     assert notes_name
 
     result = cli_runner.invoke(
@@ -88,5 +88,5 @@ def test_edit_cli(tmp_library: TemporaryLibrary) -> None:
     folder = doc.get_main_folder()
     assert folder is not None
 
-    expected_notes_path = os.path.join(folder, notes_name)
+    expected_notes_path = os.path.join(folder, str(notes_name))
     assert os.path.exists(expected_notes_path)

--- a/tests/commands/test_tag.py
+++ b/tests/commands/test_tag.py
@@ -1,9 +1,13 @@
 from __future__ import annotations
 
 import os
+from typing import TYPE_CHECKING
 
 import papis.database
 from papis.testing import PapisRunner, TemporaryLibrary
+
+if TYPE_CHECKING:
+    import pytest
 
 
 def _get_resource_file(filename: str) -> str:
@@ -19,12 +23,14 @@ def _get_resource_file(filename: str) -> str:
 def test_tag_add_general_cli(tmp_library: TemporaryLibrary) -> None:
     from papis.commands.tag import cli
 
+    db = papis.database.get()
     cli_runner = PapisRunner()
 
     result = cli_runner.invoke(cli, ["__no_document__"])
     assert result.exit_code == 0
     assert not result.output
 
+    # check --add multiple tags
     result = cli_runner.invoke(
         cli, [
             "--add", "tag3",
@@ -34,7 +40,6 @@ def test_tag_add_general_cli(tmp_library: TemporaryLibrary) -> None:
     )
     assert result.exit_code == 0
 
-    db = papis.database.get()
     (doc,) = db.query_dict({"author": "Krishnamurti"})
     assert "tag1" in doc["tags"]
     assert 2345 in doc["tags"]
@@ -43,19 +48,16 @@ def test_tag_add_general_cli(tmp_library: TemporaryLibrary) -> None:
 def test_tag_add_to_new_key_cli(tmp_library: TemporaryLibrary) -> None:
     from papis.commands.tag import cli
 
+    db = papis.database.get()
     cli_runner = PapisRunner()
 
-    result = cli_runner.invoke(cli, ["__no_document__"])
-    assert result.exit_code == 0
-    assert not result.output
-
+    # check --add to a document without a tags key
     result = cli_runner.invoke(
         cli,
         ["--add", "tag3", "doc without files"],
     )
     assert result.exit_code == 0
 
-    db = papis.database.get()
     (doc,) = db.query_dict({"author": "doc without files"})
     assert doc["tags"] == ["tag3"]
 
@@ -65,19 +67,16 @@ def test_tag_add_del_duplicates_in_list_cli(
 ) -> None:
     from papis.commands.tag import cli
 
+    db = papis.database.get()
     cli_runner = PapisRunner()
 
-    result = cli_runner.invoke(cli, ["__no_document__"])
-    assert result.exit_code == 0
-    assert not result.output
-
+    # check --add same tag
     result = cli_runner.invoke(
         cli,
         ["--add", "tag3", "--add", "tag3", "krishnamurti"],
     )
     assert result.exit_code == 0
 
-    db = papis.database.get()
     (doc,) = db.query_dict({"author": "Krishnamurti"})
     assert doc["tags"].count("tag3") == 1
 
@@ -87,39 +86,37 @@ def test_tag_remove_general_cli(
 ) -> None:
     from papis.commands.tag import cli
 
+    db = papis.database.get()
     cli_runner = PapisRunner()
 
-    result = cli_runner.invoke(cli, ["__no_document__"])
-    assert result.exit_code == 0
-    assert not result.output
-
+    # check --remove existing tag
     result = cli_runner.invoke(
         cli,
         ["--remove", "tag1", "--remove", "1234", "krishnamurti"],
     )
     assert result.exit_code == 0
 
-    db = papis.database.get()
     (doc,) = db.query_dict({"author": "Krishnamurti"})
     assert doc.get("tags") is None
 
 
 def test_tag_remove_from_missing_key_cli(
     tmp_library: TemporaryLibrary,
+    monkeypatch: pytest.MonkeyPatch,
 ) -> None:
+    import papis.tui.utils
     from papis.commands.tag import cli
+
+    monkeypatch.setattr(papis.tui.utils, "confirm", lambda *args: False)
 
     cli_runner = PapisRunner()
 
-    result = cli_runner.invoke(cli, ["__no_document__"])
-    assert result.exit_code == 0
-    assert not result.output
-
+    # check --remove in document with no tags
     result = cli_runner.invoke(
         cli,
         ["--remove", "tag", "doc without files"],
     )
-    assert result.exit_code == 0
+    assert result.exit_code == 1
 
 
 def test_tag_drop_general_cli(
@@ -127,39 +124,37 @@ def test_tag_drop_general_cli(
 ) -> None:
     from papis.commands.tag import cli
 
+    db = papis.database.get()
     cli_runner = PapisRunner()
 
-    result = cli_runner.invoke(cli, ["__no_document__"])
-    assert result.exit_code == 0
-    assert not result.output
-
+    # check --drop existing tags
     result = cli_runner.invoke(
         cli,
         ["--drop", "krishnamurti"],
     )
     assert result.exit_code == 0
 
-    db = papis.database.get()
     (doc,) = db.query_dict({"author": "Krishnamurti"})
     assert doc.get("tags") is None
 
 
 def test_tag_drop_missing_key_cli(
     tmp_library: TemporaryLibrary,
+    monkeypatch: pytest.MonkeyPatch,
 ) -> None:
+    import papis.tui.utils
     from papis.commands.tag import cli
+
+    monkeypatch.setattr(papis.tui.utils, "confirm", lambda *args: False)
 
     cli_runner = PapisRunner()
 
-    result = cli_runner.invoke(cli, ["__no_document__"])
-    assert result.exit_code == 0
-    assert not result.output
-
+    # check --drop non-existing tags
     result = cli_runner.invoke(
         cli,
         ["--drop", "doc without files"],
     )
-    assert result.exit_code == 0
+    assert result.exit_code == 1
 
 
 def test_tag_rename_general_cli(
@@ -167,12 +162,10 @@ def test_tag_rename_general_cli(
 ) -> None:
     from papis.commands.tag import cli
 
+    db = papis.database.get()
     cli_runner = PapisRunner()
 
-    result = cli_runner.invoke(cli, ["__no_document__"])
-    assert result.exit_code == 0
-    assert not result.output
-
+    # check --rename multiple tags
     result = cli_runner.invoke(
         cli, [
             "--rename", "tag1", "tag_renamed1",
@@ -182,7 +175,6 @@ def test_tag_rename_general_cli(
     )
     assert result.exit_code == 0
 
-    db = papis.database.get()
     (doc,) = db.query_dict({"author": "Krishnamurti"})
     assert "tag_renamed1" in doc["tags"]
     assert 2345 in doc["tags"]
@@ -190,17 +182,18 @@ def test_tag_rename_general_cli(
 
 def test_tag_rename_missing_value_cli(
     tmp_library: TemporaryLibrary,
+    monkeypatch: pytest.MonkeyPatch,
 ) -> None:
+    import papis.tui.utils
     from papis.commands.tag import cli
+
+    monkeypatch.setattr(papis.tui.utils, "confirm", lambda *args: False)
 
     cli_runner = PapisRunner()
 
-    result = cli_runner.invoke(cli, ["__no_document__"])
-    assert result.exit_code == 0
-    assert not result.output
-
+    # check --rename missing tag
     result = cli_runner.invoke(
         cli,
         ["--rename", "tag_nonexistent", "tag_renamed1", "krishnamurti"],
     )
-    assert result.exit_code == 0
+    assert result.exit_code == 1

--- a/tests/commands/test_update.py
+++ b/tests/commands/test_update.py
@@ -3,12 +3,12 @@ from __future__ import annotations
 import os
 from typing import TYPE_CHECKING
 
+import pytest
+
 import papis.database
 from papis.testing import PapisRunner, ResourceCache, TemporaryLibrary
 
 if TYPE_CHECKING:
-    import pytest
-
     from papis.document import Document, DocumentLike
 
 
@@ -22,10 +22,21 @@ def _get_resource_file(filename: str) -> str:
     return filepath
 
 
-def update_doc_from_data_interactively(
+def _update_doc_from_data_interactively(
     document: Document, data: DocumentLike, data_name: str
 ) -> None:
     document.update(data)
+
+
+def _sha256sum(path: str, chunksize: int = 8192) -> str:
+    import hashlib
+
+    hash = hashlib.sha256()
+    with open(path, "rb") as f:
+        for chunk in iter(lambda: f.read(chunksize), b""):
+            hash.update(chunk)
+
+    return hash.hexdigest()
 
 
 def test_update_run(tmp_library: TemporaryLibrary) -> None:
@@ -48,12 +59,14 @@ def test_update_run(tmp_library: TemporaryLibrary) -> None:
 def test_update_set_general_cli(tmp_library: TemporaryLibrary) -> None:
     from papis.commands.update import cli
 
+    db = papis.database.get()
     cli_runner = PapisRunner()
 
     result = cli_runner.invoke(cli, ["__no_document__"])
     assert result.exit_code == 0
     assert not result.output
 
+    # check --set multiple values
     result = cli_runner.invoke(
         cli, [
             "--set", "doi", "10.213.phys.rev/213",
@@ -65,23 +78,33 @@ def test_update_set_general_cli(tmp_library: TemporaryLibrary) -> None:
     )
     assert result.exit_code == 0
 
-    db = papis.database.get()
     (doc,) = db.query_dict({"author": "Krishnamurti"})
     assert doc["doi"] == "10.213.phys.rev/213"
     assert doc["ref"] == "NewRef"
     assert doc["year"] == 1234
     assert doc["author_list"] == [{"family": "Krishnamurti", "given": "J."}]
 
+    # check --set multiple values to the same key
+    result = cli_runner.invoke(
+        cli, [
+            "--set", "ref", "NewRef",
+            "--set", "ref", "NewerRef",
+            "krishnamurti"
+        ],
+    )
+    assert result.exit_code == 0
+
+    (doc,) = db.query_dict({"author": "Krishnamurti"})
+    assert doc["ref"] == "NewerRef"
+
 
 def test_update_set_clean_cli(tmp_library: TemporaryLibrary) -> None:
     from papis.commands.update import cli
 
+    db = papis.database.get()
     cli_runner = PapisRunner()
 
-    result = cli_runner.invoke(cli, ["__no_document__"])
-    assert result.exit_code == 0
-    assert not result.output
-
+    # check --set cleans up file names
     result = cli_runner.invoke(
         cli, [
             "--set", "notes", "a note $ to be cleaned.md",
@@ -91,7 +114,6 @@ def test_update_set_clean_cli(tmp_library: TemporaryLibrary) -> None:
     )
     assert result.exit_code == 0
 
-    db = papis.database.get()
     (doc,) = db.query_dict({"author": "Krishnamurti"})
     assert doc["notes"] == "a-note-to-be-cleaned.md"
     assert doc["files"] == ["file-1.pdf", "file-.epub"]
@@ -100,12 +122,10 @@ def test_update_set_clean_cli(tmp_library: TemporaryLibrary) -> None:
 def test_update_set_force_str_cli(tmp_library: TemporaryLibrary) -> None:
     from papis.commands.update import cli
 
+    db = papis.database.get()
     cli_runner = PapisRunner()
 
-    result = cli_runner.invoke(cli, ["__no_document__"])
-    assert result.exit_code == 0
-    assert not result.output
-
+    # check --set converts to string for known keys
     result = cli_runner.invoke(
         cli, [
             "--set", "title", "1234",
@@ -114,20 +134,64 @@ def test_update_set_force_str_cli(tmp_library: TemporaryLibrary) -> None:
     )
     assert result.exit_code == 0
 
-    db = papis.database.get()
     (doc,) = db.query_dict({"author": "Krishnamurti"})
     assert doc["title"] == "1234"
+
+
+def test_update_set_list_item(
+    tmp_library: TemporaryLibrary,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    import papis.tui.utils
+    from papis.commands.update import cli
+
+    monkeypatch.setattr(papis.tui.utils, "confirm", lambda *args: False)
+
+    db = papis.database.get()
+    cli_runner = PapisRunner()
+
+    # check --set valid list item
+    result = cli_runner.invoke(
+        cli,
+        ["--set", "tags", "1:4321", "krishnamurti"],
+    )
+    assert result.exit_code == 0
+
+    (doc,) = db.query_dict({"author": "Krishnamurti"})
+    assert doc["tags"] == ["tag1", 4321]
+
+    # check --set out of bounds
+    result = cli_runner.invoke(
+        cli,
+        ["--set", "tags", "7:4321", "krishnamurti"],
+    )
+    assert result.exit_code == 1
+
+    (doc,) = db.query_dict({"author": "Krishnamurti"})
+    assert doc["tags"] == ["tag1", 4321]
+
+    # check --set non-list key
+    result = cli_runner.invoke(
+        cli,
+        ["--set", "funkykey", "['funkyvalue']",
+         "--set", "funkykey", "0:othervalue",
+         "krishnamurti"],
+    )
+    assert result.exit_code == 0
+
+    # NOTE: we do not expect that "funkykey" is a list, so we treat the --set
+    # as a normal set instead and overwrite the list with a string
+    (doc,) = db.query_dict({"author": "Krishnamurti"})
+    assert doc["funkykey"] == "0:othervalue"
 
 
 def test_update_append_general_cli(tmp_library: TemporaryLibrary) -> None:
     from papis.commands.update import cli
 
+    db = papis.database.get()
     cli_runner = PapisRunner()
 
-    result = cli_runner.invoke(cli, ["__no_document__"])
-    assert result.exit_code == 0
-    assert not result.output
-
+    # check --append to a string value
     result = cli_runner.invoke(
         cli, [
             "--append", "title", "appended",
@@ -136,7 +200,6 @@ def test_update_append_general_cli(tmp_library: TemporaryLibrary) -> None:
     )
     assert result.exit_code == 0
 
-    db = papis.database.get()
     (doc,) = db.query_dict({"author": "Krishnamurti"})
     assert doc["title"] == "Freedom from the knownappended"
 
@@ -144,12 +207,10 @@ def test_update_append_general_cli(tmp_library: TemporaryLibrary) -> None:
 def test_update_append_to_new_key_cli(tmp_library: TemporaryLibrary) -> None:
     from papis.commands.update import cli
 
+    db = papis.database.get()
     cli_runner = PapisRunner()
 
-    result = cli_runner.invoke(cli, ["__no_document__"])
-    assert result.exit_code == 0
-    assert not result.output
-
+    # check --append to non-existent key with known type
     result = cli_runner.invoke(
         cli, [
             "--append", "notes", "a-note.md",
@@ -158,70 +219,72 @@ def test_update_append_to_new_key_cli(tmp_library: TemporaryLibrary) -> None:
     )
     assert result.exit_code == 0
 
-    db = papis.database.get()
     (doc,) = db.query_dict({"author": "Krishnamurti"})
     assert doc["notes"] == "a-note.md"
 
 
-def test_update_append_to_int_cli(tmp_library: TemporaryLibrary) -> None:
+def test_update_append_to_int_cli(
+    tmp_library: TemporaryLibrary,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    import papis.tui.utils
     from papis.commands.update import cli
 
+    monkeypatch.setattr(papis.tui.utils, "confirm", lambda *args: False)
+
+    db = papis.database.get()
     cli_runner = PapisRunner()
 
-    result = cli_runner.invoke(cli, ["__no_document__"])
-    assert result.exit_code == 0
-    assert not result.output
-
+    # check --append to unsupported value
     result = cli_runner.invoke(
         cli, [
             "--append", "year", "123",
             "krishnamurti"
         ],
     )
-    assert result.exit_code == 0
+    assert result.exit_code == 1
 
-    db = papis.database.get()
     (doc,) = db.query_dict({"author": "Krishnamurti"})
     assert doc["year"] == 2009
 
 
-def test_update_append_str_to_empty_int_cli(tmp_library: TemporaryLibrary) -> None:
+def test_update_append_str_to_empty_int_cli(
+    tmp_library: TemporaryLibrary,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    import papis.tui.utils
     from papis.commands.update import cli
 
+    monkeypatch.setattr(papis.tui.utils, "confirm", lambda *args: False)
+
+    db = papis.database.get()
     cli_runner = PapisRunner()
 
-    result = cli_runner.invoke(cli, ["__no_document__"])
-    assert result.exit_code == 0
-    assert not result.output
-
+    # check --append to non-existent key with known type
     result = cli_runner.invoke(
         cli, [
             "--append", "year", "string",
             "popper"
         ],
     )
-    assert result.exit_code == 0
+    assert result.exit_code == 1
 
-    db = papis.database.get()
     (doc,) = db.query_dict({"author": "popper"})
-    assert doc.get("year") is None
+    assert "year" not in doc
 
 
 def test_update_append_clean_cli(tmp_library: TemporaryLibrary) -> None:
     from papis.commands.update import cli
 
+    db = papis.database.get()
     cli_runner = PapisRunner()
 
-    result = cli_runner.invoke(cli, ["__no_document__"])
-    assert result.exit_code == 0
-    assert not result.output
-
+    # check --append cleanup
     result = cli_runner.invoke(
         cli, ["--append", "files", "some file name.pdf", "krishnamurti"]
     )
     assert result.exit_code == 0
 
-    db = papis.database.get()
     (doc,) = db.query_dict({"author": "Krishnamurti"})
     assert "some-file-name.pdf" in doc["files"]
 
@@ -231,12 +294,13 @@ def test_update_append_del_duplicates_in_list_cli(
 ) -> None:
     from papis.commands.update import cli
 
+    db = papis.database.get()
     cli_runner = PapisRunner()
 
-    result = cli_runner.invoke(cli, ["__no_document__"])
-    assert result.exit_code == 0
-    assert not result.output
+    (doc,) = db.query_dict({"author": "Krishnamurti"})
+    nfiles = len(doc["files"])
 
+    # check --append multiple items to same key
     result = cli_runner.invoke(
         cli, [
             "--append", "files", "file1.pdf",
@@ -246,9 +310,9 @@ def test_update_append_del_duplicates_in_list_cli(
     )
     assert result.exit_code == 0
 
-    db = papis.database.get()
     (doc,) = db.query_dict({"author": "Krishnamurti"})
     assert doc["files"].count("file1.pdf") == 1
+    assert len(doc["files"]) == nfiles + 1
 
 
 def test_update_remove_general_cli(
@@ -256,12 +320,10 @@ def test_update_remove_general_cli(
 ) -> None:
     from papis.commands.update import cli
 
+    db = papis.database.get()
     cli_runner = PapisRunner()
 
-    result = cli_runner.invoke(cli, ["__no_document__"])
-    assert result.exit_code == 0
-    assert not result.output
-
+    # check --remove all items from a list
     result = cli_runner.invoke(
         cli, [
             "--remove", "tags", "tag1",
@@ -271,7 +333,6 @@ def test_update_remove_general_cli(
     )
     assert result.exit_code == 0
 
-    db = papis.database.get()
     (doc,) = db.query_dict({"author": "Krishnamurti"})
     assert doc.get("tags") is None
 
@@ -281,14 +342,14 @@ def test_update_remove_from_missing_key_cli(
 ) -> None:
     from papis.commands.update import cli
 
+    db = papis.database.get()
     cli_runner = PapisRunner()
 
-    result = cli_runner.invoke(cli, ["__no_document__"])
-    assert result.exit_code == 0
-    assert not result.output
-
+    # check --remove missing key and then --remove existing key
     result = cli_runner.invoke(
         cli, [
+            # NOTE: --batch makes it ignore the missingkey and pass through
+            "--batch",
             "--remove", "missingkey", "value",
             "--remove", "tags", "tag1",
             "krishnamurti"
@@ -296,29 +357,29 @@ def test_update_remove_from_missing_key_cli(
     )
     assert result.exit_code == 0
 
-    db = papis.database.get()
     (doc,) = db.query_dict({"author": "Krishnamurti"})
     assert doc["tags"] == [1234]
 
 
 def test_update_remove_from_str_cli(
     tmp_library: TemporaryLibrary,
+    monkeypatch: pytest.MonkeyPatch,
 ) -> None:
+    import papis.tui.utils
     from papis.commands.update import cli
 
+    monkeypatch.setattr(papis.tui.utils, "confirm", lambda *args: False)
+
+    db = papis.database.get()
     cli_runner = PapisRunner()
 
-    result = cli_runner.invoke(cli, ["__no_document__"])
-    assert result.exit_code == 0
-    assert not result.output
-
+    # check --remove from unsupported key type
     result = cli_runner.invoke(
         cli,
         ["--remove", "title", "known", "krishnamurti"],
     )
-    assert result.exit_code == 0
+    assert result.exit_code == 1
 
-    db = papis.database.get()
     (doc,) = db.query_dict({"author": "Krishnamurti"})
     assert doc["title"] == "Freedom from the known"
 
@@ -328,39 +389,252 @@ def test_update_drop_general_cli(
 ) -> None:
     from papis.commands.update import cli
 
+    db = papis.database.get()
     cli_runner = PapisRunner()
 
-    result = cli_runner.invoke(cli, ["__no_document__"])
-    assert result.exit_code == 0
-    assert not result.output
-
+    # check --drop existing key
     result = cli_runner.invoke(
         cli,
         ["--drop", "title", "krishnamurti"],
     )
     assert result.exit_code == 0
 
-    db = papis.database.get()
     (doc,) = db.query_dict({"author": "Krishnamurti"})
     assert doc.get("title") is None
 
 
 def test_update_drop_missing_key_cli(
     tmp_library: TemporaryLibrary,
+    monkeypatch: pytest.MonkeyPatch,
 ) -> None:
+    import papis.tui.utils
     from papis.commands.update import cli
+
+    monkeypatch.setattr(papis.tui.utils, "confirm", lambda *args: False)
 
     cli_runner = PapisRunner()
 
-    result = cli_runner.invoke(cli, ["__no_document__"])
-    assert result.exit_code == 0
-    assert not result.output
-
+    # check --drop non-existing key
     result = cli_runner.invoke(
         cli,
         ["--drop", "notes", "krishnamurti"],
     )
+    assert result.exit_code == 1
+
+
+def test_update_drop_batch_cli(
+    tmp_library: TemporaryLibrary,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    import papis.tui.utils
+    from papis.commands.update import cli
+
+    monkeypatch.setattr(papis.tui.utils, "confirm", lambda *args: False)
+
+    db = papis.database.get()
+    cli_runner = PapisRunner()
+
+    # check --drop of a missing key without --batch prompts and exits 1
+    result = cli_runner.invoke(
+        cli,
+        ["--drop", "notes", "krishnamurti"],
+    )
+    assert result.exit_code == 1
+
+    # check --drop of a missing key with --batch skips the error and exits 0
+    result = cli_runner.invoke(
+        cli,
+        ["--batch", "--drop", "notes", "krishnamurti"],
+    )
     assert result.exit_code == 0
+
+    # check that --batch skips a failing --drop but still applies subsequent ops
+    result = cli_runner.invoke(
+        cli, [
+            "--batch",
+            "--drop", "notes",   # notes doesn't exist: skipped
+            "--drop", "tags",    # tags exists: should be applied
+            "krishnamurti"
+        ],
+    )
+    assert result.exit_code == 0
+
+    (doc,) = db.query_dict({"author": "Krishnamurti"})
+    assert doc.get("tags") is None
+
+
+def test_update_reset_batch_cli(
+    tmp_library: TemporaryLibrary,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    import papis.config
+    import papis.tui.utils
+
+    monkeypatch.setattr(papis.tui.utils, "confirm", lambda *args: False)
+
+    papis.config.set("ref-format", "test-{doc[author]}-{doc[year]}")
+
+    from papis.commands.update import cli
+
+    db = papis.database.get()
+    cli_runner = PapisRunner()
+
+    # check --reset of an unsupported key without --batch exits 1
+    result = cli_runner.invoke(
+        cli,
+        ["--reset", "title", "krishnamurti"],
+    )
+    assert result.exit_code == 1
+
+    (doc,) = db.query_dict({"author": "Krishnamurti"})
+
+    # check --reset of an unsupported key with --batch skips and exits 0
+    result = cli_runner.invoke(
+        cli,
+        ["--batch", "--reset", "title", "krishnamurti"],
+    )
+    assert result.exit_code == 0
+
+    (doc,) = db.query_dict({"author": "Krishnamurti"})
+    assert doc.get("title") == "Freedom from the known"
+
+
+def test_update_reset_cli(
+    tmp_library: TemporaryLibrary,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    import papis.config
+    import papis.tui.utils
+
+    monkeypatch.setattr(papis.tui.utils, "confirm", lambda *args: False)
+
+    papis.config.set("ref-format", "test-{doc[author]}-{doc[year]}")
+    papis.config.set("add-file-name", "test - {doc[year]} - {doc[author]}")
+    papis.config.set("multiple-authors-format", "{au[given]} {au[family]} Jr.")
+
+    from papis.commands.update import cli
+
+    db = papis.database.get()
+    cli_runner = PapisRunner()
+
+    (doc,) = db.query_dict({"author": "Scott"})
+    assert doc["ref"] == "scott2008that"
+
+    folder = doc.get_main_folder()
+    orig_filename, = doc.get_files()
+    _, ext = os.path.splitext(orig_filename)
+    assert os.path.exists(orig_filename)
+    assert folder is not None
+
+    # check invalid key reset
+    result = cli_runner.invoke(
+        cli,
+        ["--reset", "missingkey", "scott"])
+    assert result.exit_code == 1
+
+    result = cli_runner.invoke(
+        cli,
+        ["--reset", "booktitle", "scott"])
+    assert result.exit_code == 1
+
+    # check refs get reset
+    expected_ref = "test_Scott_Michael_2008"
+    result = cli_runner.invoke(
+        cli,
+        ["--reset", "ref", "scott"])
+    assert result.exit_code == 0
+
+    (doc,) = db.query_dict({"author": "Scott"})
+    assert doc["ref"] == expected_ref
+
+    # check files get reset
+    expected_filename = f"test-2008-scott-michael{ext}"
+    result = cli_runner.invoke(
+        cli,
+        ["--reset", "files", "scott"])
+    assert result.exit_code == 0
+
+    (doc,) = db.query_dict({"author": "Scott"})
+    assert doc["files"] == [expected_filename]
+    assert os.path.exists(os.path.join(folder, expected_filename))
+    assert not os.path.exists(orig_filename)
+
+    # check author gets reset
+    result = cli_runner.invoke(
+        cli,
+        ["--reset", "author", "scott"])
+    assert result.exit_code == 0
+
+    (doc,) = db.query_dict({"author": "Scott"})
+    assert doc["author"] == "Michael Scott Jr."
+
+
+@pytest.mark.library_setup(filetype="pdf")
+def test_update_set_files_renames_on_disk(tmp_library: TemporaryLibrary) -> None:
+    from papis.commands.update import cli
+
+    db = papis.database.get()
+    cli_runner = PapisRunner()
+
+    (doc,) = db.query_dict({"author": "scott"})
+    folder = doc.get_main_folder()
+    assert folder is not None
+
+    orig_filename, = doc["files"]
+    orig_path = os.path.join(folder, orig_filename)
+    assert os.path.exists(orig_path)
+
+    new_filename = "renamed-by-set.pdf"
+    new_path = os.path.join(folder, new_filename)
+
+    # set the first (and only) file to a new name using the list-index syntax
+    result = cli_runner.invoke(
+        cli,
+        ["--set", "files", f"0:{new_filename}", "scott"],
+    )
+    assert result.exit_code == 0
+
+    # the old file should be gone and the new one should be in its place
+    assert not os.path.exists(orig_path)
+    assert os.path.exists(new_path)
+
+    # the metadata should reflect the rename
+    (doc,) = db.query_dict({"author": "scott"})
+    assert doc["files"] == [new_filename]
+
+
+@pytest.mark.library_setup(filetype="pdf")
+def test_update_reset_many_files_cli(tmp_library: TemporaryLibrary) -> None:
+    import papis.config
+    from papis.commands.addto import run as addto
+
+    db = papis.database.get()
+    papis.config.set("add-file-name", "{doc[author]}-{doc[title]}")
+
+    (doc,) = db.query_dict({"author": "scott"})
+
+    # NOTE: the files in this document will now be
+    #  0:some-randomly-generated-thing.ext
+    #  1:add-file-name.pdf
+    #  2:add-file-name-a.pdf
+    #  3:add-file-name-b.pdf
+    # Therefore, when trying to rename them, the files would overlap if done naively
+    addto(doc, [tmp_library.create_random_file("pdf") for _ in range(3)])
+    checksums = [_sha256sum(filename) for filename in doc.get_files()]
+
+    from papis.commands.update import cli
+
+    cli_runner = PapisRunner()
+
+    # check --reset for many files to make sure that they are not overwritten
+    result = cli_runner.invoke(
+        cli,
+        ["--reset", "files", "scott"])
+    assert result.exit_code == 0
+
+    (doc,) = db.query_dict({"author": "scott"})
+    assert len(doc["files"]) == 4
+    assert [_sha256sum(filename) for filename in doc.get_files()] == checksums
 
 
 def test_update_rename_general_cli(
@@ -368,12 +642,10 @@ def test_update_rename_general_cli(
 ) -> None:
     from papis.commands.update import cli
 
+    db = papis.database.get()
     cli_runner = PapisRunner()
 
-    result = cli_runner.invoke(cli, ["__no_document__"])
-    assert result.exit_code == 0
-    assert not result.output
-
+    # check --rename known keys with valid values
     result = cli_runner.invoke(
         cli, [
             "--rename", "tags", "tag1", "tag_renamed1",
@@ -383,30 +655,29 @@ def test_update_rename_general_cli(
     )
     assert result.exit_code == 0
 
-    db = papis.database.get()
     (doc,) = db.query_dict({"author": "Krishnamurti"})
-    assert "tag_renamed1" in doc["tags"]
-    assert 2345 in doc["tags"]
+    assert doc["tags"] == ["tag_renamed1", 2345]
 
 
 def test_update_rename_missing_value_cli(
     tmp_library: TemporaryLibrary,
+    monkeypatch: pytest.MonkeyPatch,
 ) -> None:
+    import papis.tui.utils
     from papis.commands.update import cli
+
+    monkeypatch.setattr(papis.tui.utils, "confirm", lambda *args: False)
 
     cli_runner = PapisRunner()
 
-    result = cli_runner.invoke(cli, ["__no_document__"])
-    assert result.exit_code == 0
-    assert not result.output
-
+    # check --rename non-existent key value
     result = cli_runner.invoke(
         cli, [
             "--rename", "tags", "tag_nonexistent", "tag_renamed1",
             "krishnamurti"
         ],
     )
-    assert result.exit_code == 0
+    assert result.exit_code == 1
 
 
 def test_update_batch_cli(
@@ -414,12 +685,10 @@ def test_update_batch_cli(
 ) -> None:
     from papis.commands.update import cli
 
+    db = papis.database.get()
     cli_runner = PapisRunner()
 
-    result = cli_runner.invoke(cli, ["__no_document__"])
-    assert result.exit_code == 0
-    assert not result.output
-
+    # check --batch in a series of operations
     result = cli_runner.invoke(
         cli, [
             "--batch",
@@ -431,7 +700,6 @@ def test_update_batch_cli(
     )
     assert result.exit_code == 0
 
-    db = papis.database.get()
     (doc,) = db.query_dict({"author": "Krishnamurti"})
     assert "tag3" in doc["tags"]
 
@@ -441,31 +709,29 @@ def test_update_yaml_cli(
     resource_cache: ResourceCache,
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
+    import papis.utils
     from papis.commands.update import cli
 
+    db = papis.database.get()
     cli_runner = PapisRunner()
 
     filename = os.path.join(resource_cache.cachedir, "update", "russell.yaml")
-
-    import papis.utils
 
     with monkeypatch.context() as m:
         m.setattr(
             papis.utils,
             "update_doc_from_data_interactively",
-            update_doc_from_data_interactively,
+            _update_doc_from_data_interactively,
         )
 
         result = cli_runner.invoke(cli, ["--from", "yaml", filename, "krishnamurti"])
         assert result.exit_code == 0
 
-    import papis.yaml
+    from papis.yaml import yaml_to_data
 
-    data = papis.yaml.yaml_to_data(filename)
+    data = yaml_to_data(filename)
 
-    db = papis.database.get()
     (doc,) = db.query_dict({"author": "Russell"})
-
     assert doc["doi"] == data["doi"]
 
 
@@ -474,29 +740,27 @@ def test_update_bibtex_cli(
     resource_cache: ResourceCache,
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
+    import papis.utils
     from papis.commands.update import cli
 
+    db = papis.database.get()
     cli_runner = PapisRunner()
 
     filename = os.path.join(resource_cache.cachedir, "update", "wannier.bib")
-
-    import papis.utils
 
     with monkeypatch.context() as m:
         m.setattr(
             papis.utils,
             "update_doc_from_data_interactively",
-            update_doc_from_data_interactively,
+            _update_doc_from_data_interactively,
         )
 
         result = cli_runner.invoke(cli, ["--from", "bibtex", filename, "krishnamurti"])
         assert result.exit_code == 0
 
-    import papis.bibtex
+    from papis.bibtex import bibtex_to_dict
 
-    (data,) = papis.bibtex.bibtex_to_dict(filename)
+    (data,) = bibtex_to_dict(filename)
 
-    db = papis.database.get()
     (doc,) = db.query_dict({"author": "Wannier"})
-
     assert doc["doi"] == data["doi"]

--- a/tests/commands/test_update.py
+++ b/tests/commands/test_update.py
@@ -3,12 +3,12 @@ from __future__ import annotations
 import os
 from typing import TYPE_CHECKING
 
+import pytest
+
 import papis.database
 from papis.testing import PapisRunner, ResourceCache, TemporaryLibrary
 
 if TYPE_CHECKING:
-    import pytest
-
     from papis.document import Document, DocumentLike
 
 
@@ -22,10 +22,21 @@ def _get_resource_file(filename: str) -> str:
     return filepath
 
 
-def update_doc_from_data_interactively(
+def _update_doc_from_data_interactively(
     document: Document, data: DocumentLike, data_name: str
 ) -> None:
     document.update(data)
+
+
+def _sha256sum(path: str, chunksize: int = 8192) -> str:
+    import hashlib
+
+    hash = hashlib.sha256()
+    with open(path, "rb") as f:
+        for chunk in iter(lambda: f.read(chunksize), b""):
+            hash.update(chunk)
+
+    return hash.hexdigest()
 
 
 def test_update_run(tmp_library: TemporaryLibrary) -> None:
@@ -48,12 +59,14 @@ def test_update_run(tmp_library: TemporaryLibrary) -> None:
 def test_update_set_general_cli(tmp_library: TemporaryLibrary) -> None:
     from papis.commands.update import cli
 
+    db = papis.database.get()
     cli_runner = PapisRunner()
 
     result = cli_runner.invoke(cli, ["__no_document__"])
     assert result.exit_code == 0
     assert not result.output
 
+    # check --set multiple values
     result = cli_runner.invoke(
         cli, [
             "--set", "doi", "10.213.phys.rev/213",
@@ -65,23 +78,33 @@ def test_update_set_general_cli(tmp_library: TemporaryLibrary) -> None:
     )
     assert result.exit_code == 0
 
-    db = papis.database.get()
     (doc,) = db.query_dict({"author": "Krishnamurti"})
     assert doc["doi"] == "10.213.phys.rev/213"
     assert doc["ref"] == "NewRef"
     assert doc["year"] == 1234
     assert doc["author_list"] == [{"family": "Krishnamurti", "given": "J."}]
 
+    # check --set multiple values to the same key
+    result = cli_runner.invoke(
+        cli, [
+            "--set", "ref", "NewRef",
+            "--set", "ref", "NewerRef",
+            "krishnamurti"
+        ],
+    )
+    assert result.exit_code == 0
+
+    (doc,) = db.query_dict({"author": "Krishnamurti"})
+    assert doc["ref"] == "NewerRef"
+
 
 def test_update_set_clean_cli(tmp_library: TemporaryLibrary) -> None:
     from papis.commands.update import cli
 
+    db = papis.database.get()
     cli_runner = PapisRunner()
 
-    result = cli_runner.invoke(cli, ["__no_document__"])
-    assert result.exit_code == 0
-    assert not result.output
-
+    # check --set cleans up file names
     result = cli_runner.invoke(
         cli, [
             "--set", "notes", "a note $ to be cleaned.md",
@@ -91,7 +114,6 @@ def test_update_set_clean_cli(tmp_library: TemporaryLibrary) -> None:
     )
     assert result.exit_code == 0
 
-    db = papis.database.get()
     (doc,) = db.query_dict({"author": "Krishnamurti"})
     assert doc["notes"] == "a-note-to-be-cleaned.md"
     assert doc["files"] == ["file-1.pdf", "file-.epub"]
@@ -100,12 +122,10 @@ def test_update_set_clean_cli(tmp_library: TemporaryLibrary) -> None:
 def test_update_set_force_str_cli(tmp_library: TemporaryLibrary) -> None:
     from papis.commands.update import cli
 
+    db = papis.database.get()
     cli_runner = PapisRunner()
 
-    result = cli_runner.invoke(cli, ["__no_document__"])
-    assert result.exit_code == 0
-    assert not result.output
-
+    # check --set converts to string for known keys
     result = cli_runner.invoke(
         cli, [
             "--set", "title", "1234",
@@ -114,20 +134,64 @@ def test_update_set_force_str_cli(tmp_library: TemporaryLibrary) -> None:
     )
     assert result.exit_code == 0
 
-    db = papis.database.get()
     (doc,) = db.query_dict({"author": "Krishnamurti"})
     assert doc["title"] == "1234"
+
+
+def test_update_set_list_item(
+    tmp_library: TemporaryLibrary,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    import papis.tui.utils
+    from papis.commands.update import cli
+
+    monkeypatch.setattr(papis.tui.utils, "confirm", lambda *args: False)
+
+    db = papis.database.get()
+    cli_runner = PapisRunner()
+
+    # check --set valid list item
+    result = cli_runner.invoke(
+        cli,
+        ["--set", "tags", "1:4321", "krishnamurti"],
+    )
+    assert result.exit_code == 0
+
+    (doc,) = db.query_dict({"author": "Krishnamurti"})
+    assert doc["tags"] == ["tag1", 4321]
+
+    # check --set out of bounds
+    result = cli_runner.invoke(
+        cli,
+        ["--set", "tags", "7:4321", "krishnamurti"],
+    )
+    assert result.exit_code == 1
+
+    (doc,) = db.query_dict({"author": "Krishnamurti"})
+    assert doc["tags"] == ["tag1", 4321]
+
+    # check --set non-list key
+    result = cli_runner.invoke(
+        cli,
+        ["--set", "funkykey", "['funkyvalue']",
+         "--set", "funkykey", "0:othervalue",
+         "krishnamurti"],
+    )
+    assert result.exit_code == 0
+
+    # NOTE: we do not expect that "funkykey" is a list, so we treat the --set
+    # as a normal set instead and overwrite the list with a string
+    (doc,) = db.query_dict({"author": "Krishnamurti"})
+    assert doc["funkykey"] == "0:othervalue"
 
 
 def test_update_append_general_cli(tmp_library: TemporaryLibrary) -> None:
     from papis.commands.update import cli
 
+    db = papis.database.get()
     cli_runner = PapisRunner()
 
-    result = cli_runner.invoke(cli, ["__no_document__"])
-    assert result.exit_code == 0
-    assert not result.output
-
+    # check --append to a string value
     result = cli_runner.invoke(
         cli, [
             "--append", "title", "appended",
@@ -136,7 +200,6 @@ def test_update_append_general_cli(tmp_library: TemporaryLibrary) -> None:
     )
     assert result.exit_code == 0
 
-    db = papis.database.get()
     (doc,) = db.query_dict({"author": "Krishnamurti"})
     assert doc["title"] == "Freedom from the knownappended"
 
@@ -144,12 +207,10 @@ def test_update_append_general_cli(tmp_library: TemporaryLibrary) -> None:
 def test_update_append_to_new_key_cli(tmp_library: TemporaryLibrary) -> None:
     from papis.commands.update import cli
 
+    db = papis.database.get()
     cli_runner = PapisRunner()
 
-    result = cli_runner.invoke(cli, ["__no_document__"])
-    assert result.exit_code == 0
-    assert not result.output
-
+    # check --append to non-existent key with known type
     result = cli_runner.invoke(
         cli, [
             "--append", "notes", "a-note.md",
@@ -158,70 +219,72 @@ def test_update_append_to_new_key_cli(tmp_library: TemporaryLibrary) -> None:
     )
     assert result.exit_code == 0
 
-    db = papis.database.get()
     (doc,) = db.query_dict({"author": "Krishnamurti"})
     assert doc["notes"] == "a-note.md"
 
 
-def test_update_append_to_int_cli(tmp_library: TemporaryLibrary) -> None:
+def test_update_append_to_int_cli(
+    tmp_library: TemporaryLibrary,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    import papis.tui.utils
     from papis.commands.update import cli
 
+    monkeypatch.setattr(papis.tui.utils, "confirm", lambda *args: False)
+
+    db = papis.database.get()
     cli_runner = PapisRunner()
 
-    result = cli_runner.invoke(cli, ["__no_document__"])
-    assert result.exit_code == 0
-    assert not result.output
-
+    # check --append to unsupported value
     result = cli_runner.invoke(
         cli, [
             "--append", "year", "123",
             "krishnamurti"
         ],
     )
-    assert result.exit_code == 0
+    assert result.exit_code == 1
 
-    db = papis.database.get()
     (doc,) = db.query_dict({"author": "Krishnamurti"})
     assert doc["year"] == 2009
 
 
-def test_update_append_str_to_empty_int_cli(tmp_library: TemporaryLibrary) -> None:
+def test_update_append_str_to_empty_int_cli(
+    tmp_library: TemporaryLibrary,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    import papis.tui.utils
     from papis.commands.update import cli
 
+    monkeypatch.setattr(papis.tui.utils, "confirm", lambda *args: False)
+
+    db = papis.database.get()
     cli_runner = PapisRunner()
 
-    result = cli_runner.invoke(cli, ["__no_document__"])
-    assert result.exit_code == 0
-    assert not result.output
-
+    # check --append to non-existent key with known type
     result = cli_runner.invoke(
         cli, [
             "--append", "year", "string",
             "popper"
         ],
     )
-    assert result.exit_code == 0
+    assert result.exit_code == 1
 
-    db = papis.database.get()
     (doc,) = db.query_dict({"author": "popper"})
-    assert doc.get("year") is None
+    assert "year" not in doc
 
 
 def test_update_append_clean_cli(tmp_library: TemporaryLibrary) -> None:
     from papis.commands.update import cli
 
+    db = papis.database.get()
     cli_runner = PapisRunner()
 
-    result = cli_runner.invoke(cli, ["__no_document__"])
-    assert result.exit_code == 0
-    assert not result.output
-
+    # check --append cleanup
     result = cli_runner.invoke(
         cli, ["--append", "files", "some file name.pdf", "krishnamurti"]
     )
     assert result.exit_code == 0
 
-    db = papis.database.get()
     (doc,) = db.query_dict({"author": "Krishnamurti"})
     assert "some-file-name.pdf" in doc["files"]
 
@@ -231,12 +294,13 @@ def test_update_append_del_duplicates_in_list_cli(
 ) -> None:
     from papis.commands.update import cli
 
+    db = papis.database.get()
     cli_runner = PapisRunner()
 
-    result = cli_runner.invoke(cli, ["__no_document__"])
-    assert result.exit_code == 0
-    assert not result.output
+    (doc,) = db.query_dict({"author": "Krishnamurti"})
+    nfiles = len(doc["files"])
 
+    # check --append multiple items to same key
     result = cli_runner.invoke(
         cli, [
             "--append", "files", "file1.pdf",
@@ -246,9 +310,9 @@ def test_update_append_del_duplicates_in_list_cli(
     )
     assert result.exit_code == 0
 
-    db = papis.database.get()
     (doc,) = db.query_dict({"author": "Krishnamurti"})
     assert doc["files"].count("file1.pdf") == 1
+    assert len(doc["files"]) == nfiles + 1
 
 
 def test_update_remove_general_cli(
@@ -256,12 +320,10 @@ def test_update_remove_general_cli(
 ) -> None:
     from papis.commands.update import cli
 
+    db = papis.database.get()
     cli_runner = PapisRunner()
 
-    result = cli_runner.invoke(cli, ["__no_document__"])
-    assert result.exit_code == 0
-    assert not result.output
-
+    # check --remove all items from a list
     result = cli_runner.invoke(
         cli, [
             "--remove", "tags", "tag1",
@@ -271,7 +333,6 @@ def test_update_remove_general_cli(
     )
     assert result.exit_code == 0
 
-    db = papis.database.get()
     (doc,) = db.query_dict({"author": "Krishnamurti"})
     assert doc.get("tags") is None
 
@@ -281,44 +342,44 @@ def test_update_remove_from_missing_key_cli(
 ) -> None:
     from papis.commands.update import cli
 
+    db = papis.database.get()
     cli_runner = PapisRunner()
 
-    result = cli_runner.invoke(cli, ["__no_document__"])
-    assert result.exit_code == 0
-    assert not result.output
-
+    # check --remove missing key and then --remove existing key
     result = cli_runner.invoke(
         cli, [
+            # NOTE: --batch makes it ignore the missingkey and pass through
+            "--batch",
             "--remove", "missingkey", "value",
             "--remove", "tags", "tag1",
             "krishnamurti"
         ],
     )
-    assert result.exit_code == 0
+    assert result.exit_code == 1
 
-    db = papis.database.get()
     (doc,) = db.query_dict({"author": "Krishnamurti"})
     assert doc["tags"] == [1234]
 
 
 def test_update_remove_from_str_cli(
     tmp_library: TemporaryLibrary,
+    monkeypatch: pytest.MonkeyPatch,
 ) -> None:
+    import papis.tui.utils
     from papis.commands.update import cli
 
+    monkeypatch.setattr(papis.tui.utils, "confirm", lambda *args: False)
+
+    db = papis.database.get()
     cli_runner = PapisRunner()
 
-    result = cli_runner.invoke(cli, ["__no_document__"])
-    assert result.exit_code == 0
-    assert not result.output
-
+    # check --remove from unsupported key type
     result = cli_runner.invoke(
         cli,
         ["--remove", "title", "known", "krishnamurti"],
     )
-    assert result.exit_code == 0
+    assert result.exit_code == 1
 
-    db = papis.database.get()
     (doc,) = db.query_dict({"author": "Krishnamurti"})
     assert doc["title"] == "Freedom from the known"
 
@@ -328,39 +389,252 @@ def test_update_drop_general_cli(
 ) -> None:
     from papis.commands.update import cli
 
+    db = papis.database.get()
     cli_runner = PapisRunner()
 
-    result = cli_runner.invoke(cli, ["__no_document__"])
-    assert result.exit_code == 0
-    assert not result.output
-
+    # check --drop existing key
     result = cli_runner.invoke(
         cli,
         ["--drop", "title", "krishnamurti"],
     )
     assert result.exit_code == 0
 
-    db = papis.database.get()
     (doc,) = db.query_dict({"author": "Krishnamurti"})
     assert doc.get("title") is None
 
 
 def test_update_drop_missing_key_cli(
     tmp_library: TemporaryLibrary,
+    monkeypatch: pytest.MonkeyPatch,
 ) -> None:
+    import papis.tui.utils
     from papis.commands.update import cli
+
+    monkeypatch.setattr(papis.tui.utils, "confirm", lambda *args: False)
 
     cli_runner = PapisRunner()
 
-    result = cli_runner.invoke(cli, ["__no_document__"])
-    assert result.exit_code == 0
-    assert not result.output
-
+    # check --drop non-existing key
     result = cli_runner.invoke(
         cli,
         ["--drop", "notes", "krishnamurti"],
     )
+    assert result.exit_code == 1
+
+
+def test_update_drop_batch_cli(
+    tmp_library: TemporaryLibrary,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    import papis.tui.utils
+    from papis.commands.update import cli
+
+    monkeypatch.setattr(papis.tui.utils, "confirm", lambda *args: False)
+
+    db = papis.database.get()
+    cli_runner = PapisRunner()
+
+    # check --drop of a missing key without --batch prompts and exits 1
+    result = cli_runner.invoke(
+        cli,
+        ["--drop", "notes", "krishnamurti"],
+    )
+    assert result.exit_code == 1
+
+    # check --drop of a missing key with --batch skips the error and exits 1
+    result = cli_runner.invoke(
+        cli,
+        ["--batch", "--drop", "notes", "krishnamurti"],
+    )
+    assert result.exit_code == 1
+
+    # check that --batch skips a failing --drop but still applies subsequent ops
+    result = cli_runner.invoke(
+        cli, [
+            "--batch",
+            "--drop", "notes",   # notes doesn't exist: skipped
+            "--drop", "tags",    # tags exists: should be applied
+            "krishnamurti"
+        ],
+    )
+    assert result.exit_code == 1
+
+    (doc,) = db.query_dict({"author": "Krishnamurti"})
+    assert doc.get("tags") is None
+
+
+def test_update_reset_batch_cli(
+    tmp_library: TemporaryLibrary,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    import papis.config
+    import papis.tui.utils
+
+    monkeypatch.setattr(papis.tui.utils, "confirm", lambda *args: False)
+
+    papis.config.set("ref-format", "test-{doc[author]}-{doc[year]}")
+
+    from papis.commands.update import cli
+
+    db = papis.database.get()
+    cli_runner = PapisRunner()
+
+    # check --reset of an unsupported key without --batch exits 1
+    result = cli_runner.invoke(
+        cli,
+        ["--reset", "title", "krishnamurti"],
+    )
+    assert result.exit_code == 1
+
+    (doc,) = db.query_dict({"author": "Krishnamurti"})
+
+    # check --reset of an unsupported key with --batch skips and exits 1
+    result = cli_runner.invoke(
+        cli,
+        ["--batch", "--reset", "title", "krishnamurti"],
+    )
+    assert result.exit_code == 1
+
+    (doc,) = db.query_dict({"author": "Krishnamurti"})
+    assert doc.get("title") == "Freedom from the known"
+
+
+def test_update_reset_cli(
+    tmp_library: TemporaryLibrary,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    import papis.config
+    import papis.tui.utils
+
+    monkeypatch.setattr(papis.tui.utils, "confirm", lambda *args: False)
+
+    papis.config.set("ref-format", "test-{doc[author]}-{doc[year]}")
+    papis.config.set("add-file-name", "test - {doc[year]} - {doc[author]}")
+    papis.config.set("multiple-authors-format", "{au[given]} {au[family]} Jr.")
+
+    from papis.commands.update import cli
+
+    db = papis.database.get()
+    cli_runner = PapisRunner()
+
+    (doc,) = db.query_dict({"author": "Scott"})
+    assert doc["ref"] == "scott2008that"
+
+    folder = doc.get_main_folder()
+    orig_filename, = doc.get_files()
+    _, ext = os.path.splitext(orig_filename)
+    assert os.path.exists(orig_filename)
+    assert folder is not None
+
+    # check invalid key reset
+    result = cli_runner.invoke(
+        cli,
+        ["--reset", "missingkey", "scott"])
+    assert result.exit_code == 1
+
+    result = cli_runner.invoke(
+        cli,
+        ["--reset", "booktitle", "scott"])
+    assert result.exit_code == 1
+
+    # check refs get reset
+    expected_ref = "test_Scott_Michael_2008"
+    result = cli_runner.invoke(
+        cli,
+        ["--reset", "ref", "scott"])
     assert result.exit_code == 0
+
+    (doc,) = db.query_dict({"author": "Scott"})
+    assert doc["ref"] == expected_ref
+
+    # check files get reset
+    expected_filename = f"test-2008-scott-michael{ext}"
+    result = cli_runner.invoke(
+        cli,
+        ["--reset", "files", "scott"])
+    assert result.exit_code == 0
+
+    (doc,) = db.query_dict({"author": "Scott"})
+    assert doc["files"] == [expected_filename]
+    assert os.path.exists(os.path.join(folder, expected_filename))
+    assert not os.path.exists(orig_filename)
+
+    # check author gets reset
+    result = cli_runner.invoke(
+        cli,
+        ["--reset", "author", "scott"])
+    assert result.exit_code == 0
+
+    (doc,) = db.query_dict({"author": "Scott"})
+    assert doc["author"] == "Michael Scott Jr."
+
+
+@pytest.mark.library_setup(filetype="pdf")
+def test_update_set_files_renames_on_disk(tmp_library: TemporaryLibrary) -> None:
+    from papis.commands.update import cli
+
+    db = papis.database.get()
+    cli_runner = PapisRunner()
+
+    (doc,) = db.query_dict({"author": "scott"})
+    folder = doc.get_main_folder()
+    assert folder is not None
+
+    orig_filename, = doc["files"]
+    orig_path = os.path.join(folder, orig_filename)
+    assert os.path.exists(orig_path)
+
+    new_filename = "renamed-by-set.pdf"
+    new_path = os.path.join(folder, new_filename)
+
+    # set the first (and only) file to a new name using the list-index syntax
+    result = cli_runner.invoke(
+        cli,
+        ["--set", "files", f"0:{new_filename}", "scott"],
+    )
+    assert result.exit_code == 0
+
+    # the old file should be gone and the new one should be in its place
+    assert not os.path.exists(orig_path)
+    assert os.path.exists(new_path)
+
+    # the metadata should reflect the rename
+    (doc,) = db.query_dict({"author": "scott"})
+    assert doc["files"] == [new_filename]
+
+
+@pytest.mark.library_setup(filetype="pdf")
+def test_update_reset_many_files_cli(tmp_library: TemporaryLibrary) -> None:
+    import papis.config
+    from papis.commands.addto import run as addto
+
+    db = papis.database.get()
+    papis.config.set("add-file-name", "{doc[author]}-{doc[title]}")
+
+    (doc,) = db.query_dict({"author": "scott"})
+
+    # NOTE: the files in this document will now be
+    #  0:some-randomly-generated-thing.ext
+    #  1:add-file-name.pdf
+    #  2:add-file-name-a.pdf
+    #  3:add-file-name-b.pdf
+    # Therefore, when trying to rename them, the files would overlap if done naively
+    addto(doc, [tmp_library.create_random_file("pdf") for _ in range(3)])
+    checksums = [_sha256sum(filename) for filename in doc.get_files()]
+
+    from papis.commands.update import cli
+
+    cli_runner = PapisRunner()
+
+    # check --reset for many files to make sure that they are not overwritten
+    result = cli_runner.invoke(
+        cli,
+        ["--reset", "files", "scott"])
+    assert result.exit_code == 0
+
+    (doc,) = db.query_dict({"author": "scott"})
+    assert len(doc["files"]) == 4
+    assert [_sha256sum(filename) for filename in doc.get_files()] == checksums
 
 
 def test_update_rename_general_cli(
@@ -368,12 +642,10 @@ def test_update_rename_general_cli(
 ) -> None:
     from papis.commands.update import cli
 
+    db = papis.database.get()
     cli_runner = PapisRunner()
 
-    result = cli_runner.invoke(cli, ["__no_document__"])
-    assert result.exit_code == 0
-    assert not result.output
-
+    # check --rename known keys with valid values
     result = cli_runner.invoke(
         cli, [
             "--rename", "tags", "tag1", "tag_renamed1",
@@ -383,30 +655,29 @@ def test_update_rename_general_cli(
     )
     assert result.exit_code == 0
 
-    db = papis.database.get()
     (doc,) = db.query_dict({"author": "Krishnamurti"})
-    assert "tag_renamed1" in doc["tags"]
-    assert 2345 in doc["tags"]
+    assert doc["tags"] == ["tag_renamed1", 2345]
 
 
 def test_update_rename_missing_value_cli(
     tmp_library: TemporaryLibrary,
+    monkeypatch: pytest.MonkeyPatch,
 ) -> None:
+    import papis.tui.utils
     from papis.commands.update import cli
+
+    monkeypatch.setattr(papis.tui.utils, "confirm", lambda *args: False)
 
     cli_runner = PapisRunner()
 
-    result = cli_runner.invoke(cli, ["__no_document__"])
-    assert result.exit_code == 0
-    assert not result.output
-
+    # check --rename non-existent key value
     result = cli_runner.invoke(
         cli, [
             "--rename", "tags", "tag_nonexistent", "tag_renamed1",
             "krishnamurti"
         ],
     )
-    assert result.exit_code == 0
+    assert result.exit_code == 1
 
 
 def test_update_batch_cli(
@@ -414,12 +685,10 @@ def test_update_batch_cli(
 ) -> None:
     from papis.commands.update import cli
 
+    db = papis.database.get()
     cli_runner = PapisRunner()
 
-    result = cli_runner.invoke(cli, ["__no_document__"])
-    assert result.exit_code == 0
-    assert not result.output
-
+    # check --batch in a series of operations
     result = cli_runner.invoke(
         cli, [
             "--batch",
@@ -429,11 +698,63 @@ def test_update_batch_cli(
             "krishnamurti"
         ],
     )
-    assert result.exit_code == 0
+    assert result.exit_code == 1
 
-    db = papis.database.get()
     (doc,) = db.query_dict({"author": "Krishnamurti"})
     assert "tag3" in doc["tags"]
+
+
+def test_update_batch_same_key_cli(
+    tmp_library: TemporaryLibrary,
+) -> None:
+    from papis.commands.update import cli
+
+    db = papis.database.get()
+    cli_runner = PapisRunner()
+
+    # check that --batch applies the successful operations even if another
+    # operation on the same key fails
+    result = cli_runner.invoke(
+        cli, [
+            "--batch",
+            "--remove", "tags", "tag_nonexistent",   # this fails
+            "--append", "tags", "philosophy",        # but this should still work
+            "krishnamurti"
+        ],
+    )
+    assert result.exit_code == 1
+
+    (doc,) = db.query_dict({"author": "Krishnamurti"})
+    assert "philosophy" in doc["tags"]
+    assert "tag_nonexistent" not in doc["tags"]
+
+
+def test_update_append_idempotent_cli(
+    tmp_library: TemporaryLibrary,
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    import logging
+    caplog.set_level(logging.INFO)
+
+    from papis.commands.update import cli
+
+    db = papis.database.get()
+    cli_runner = PapisRunner()
+
+    # appending a value that is already present is a no-op and should be
+    # reported as such, rather than counting as an "updated" document
+    result = cli_runner.invoke(
+        cli, [
+            "--append", "tags", "tag1", "krishnamurti",
+        ],
+    )
+    assert result.exit_code == 0
+
+    messages = [r.message for r in caplog.records]
+    assert any("Updated 1 / 1 documents." in msg for msg in messages)
+
+    (doc,) = db.query_dict({"author": "Krishnamurti"})
+    assert doc["tags"] == ["tag1", 1234]
 
 
 def test_update_yaml_cli(
@@ -441,31 +762,29 @@ def test_update_yaml_cli(
     resource_cache: ResourceCache,
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
+    import papis.utils
     from papis.commands.update import cli
 
+    db = papis.database.get()
     cli_runner = PapisRunner()
 
     filename = os.path.join(resource_cache.cachedir, "update", "russell.yaml")
-
-    import papis.utils
 
     with monkeypatch.context() as m:
         m.setattr(
             papis.utils,
             "update_doc_from_data_interactively",
-            update_doc_from_data_interactively,
+            _update_doc_from_data_interactively,
         )
 
         result = cli_runner.invoke(cli, ["--from", "yaml", filename, "krishnamurti"])
         assert result.exit_code == 0
 
-    import papis.yaml
+    from papis.yaml import yaml_to_data
 
-    data = papis.yaml.yaml_to_data(filename)
+    data = yaml_to_data(filename)
 
-    db = papis.database.get()
     (doc,) = db.query_dict({"author": "Russell"})
-
     assert doc["doi"] == data["doi"]
 
 
@@ -474,29 +793,27 @@ def test_update_bibtex_cli(
     resource_cache: ResourceCache,
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
+    import papis.utils
     from papis.commands.update import cli
 
+    db = papis.database.get()
     cli_runner = PapisRunner()
 
     filename = os.path.join(resource_cache.cachedir, "update", "wannier.bib")
-
-    import papis.utils
 
     with monkeypatch.context() as m:
         m.setattr(
             papis.utils,
             "update_doc_from_data_interactively",
-            update_doc_from_data_interactively,
+            _update_doc_from_data_interactively,
         )
 
         result = cli_runner.invoke(cli, ["--from", "bibtex", filename, "krishnamurti"])
         assert result.exit_code == 0
 
-    import papis.bibtex
+    from papis.bibtex import bibtex_to_dict
 
-    (data,) = papis.bibtex.bibtex_to_dict(filename)
+    (data,) = bibtex_to_dict(filename)
 
-    db = papis.database.get()
     (doc,) = db.query_dict({"author": "Wannier"})
-
     assert doc["doi"] == data["doi"]


### PR DESCRIPTION
This reworks `papis update` quite extensively to better handle error cases and rename files in different scenarios.

That being said, the way this works now is that
```sh
# sets the notes file to the given value/format pattern
papis update --set notes notes.md <QUERY>
# sets the notes file to the default pattern from `notes-name`
papis update --reset notes <QUERY>
```
If a "notes" file already exists, it's also renamed in both cases. If it doesn't exist, this just sets the value in the `info.yaml` file, so that it can be created on the next `papis edit` or whatever.

Then, for files, this updates it to work something like
```sh
# sets the n-th file in the files list to the given value/format pattern
papis update --set files n:my-file-name.pdf <QUERY>
# sets the whole files field to something
papis update --set files '["my-file-name.pdf"]' QUERY
# sets all the files in the files list to their default pattern from `add-files-name`
papis update --reset files <QUERY>
```
All the files are also normalized (exactly the same as in `papis add`), so the name on the command line may not always match what gets put in the document.

TODO:
- [x] Need a nice way to set all the files to the default.
- [x] Need some tests, since this is all a bit finicky.
- [x] Probably need to think of a more natural interface..

~@jghauser Like you said, none of the flags in `papis update` allow easily setting a thing to some existing default, so this is not particularly nice. Do you have any better ideas?~

cc @pmiam for some constructive criticism :grin:

Fixes #366