### PR TITLE
Add ruff rules for refurb, perflint, and flake8-pie

### DIFF
--- a/papis/arxiv.py
+++ b/papis/arxiv.py
@@ -232,7 +232,7 @@ _ARXIVID_REGEX = re.compile(
     r"(\"|')?"
     fr"(?P<arxivid>[^{_ARXIVID_FORBIDDEB_CHARACTERS}]+)"
     r'("|\'|\))?',
-    re.I
+    re.IGNORECASE
 )
 
 
@@ -249,7 +249,7 @@ def find_arxivid_in_text(text: str) -> str | None:
     """
     for match in _ARXIVID_REGEX.finditer(text):
         aid = match.group("arxivid")
-        aid = aid[:-4] if aid.endswith(".pdf") else aid
+        aid = aid.removesuffix(".pdf")
         return aid
 
     return None

--- a/papis/commands/bibtex.py
+++ b/papis/commands/bibtex.py
@@ -610,9 +610,7 @@ def cli_filter_cited(ctx: click.Context, _files: list[str]) -> None:
     for f in _files:
         with open(f, encoding="utf-8") as fd:
             text = fd.read()
-            for doc in ctx.obj["documents"]:
-                if re.search(doc["ref"], text):
-                    found.append(doc)
+            found.extend(doc for doc in ctx.obj["documents"] if re.search(doc["ref"], text))
 
     logger.info("Found %d cited documents.", len(found))
     ctx.obj["documents"] = found
@@ -640,9 +638,7 @@ def cli_iscited(ctx: click.Context, _files: list[str]) -> None:
     for f in _files:
         with open(f, encoding="utf-8") as fd:
             text = fd.read()
-            for doc in ctx.obj["documents"]:
-                if not re.search(doc["ref"], text):
-                    unfound.append(doc)
+            unfound.extend(doc for doc in ctx.obj["documents"] if not re.search(doc["ref"], text))
 
     logger.info("Found %s documents with no citations.", len(unfound))
 

--- a/papis/commands/config.py
+++ b/papis/commands/config.py
@@ -108,7 +108,7 @@ def parse_option(
             section = default_section
             key = option
         else:
-            section = parts[0] if parts[0] else None
+            section = parts[0] or None
             key = parts[1]
     else:
         raise ValueError(f"Unsupported option format: '{option}'")

--- a/papis/commands/default.py
+++ b/papis/commands/default.py
@@ -217,6 +217,6 @@ def run(ctx: click.Context,
 
         logger.debug("Setting '%s' to '%s' (section '%s').",
                      key, value,
-                     section if section else papis.config.GENERAL_SETTINGS_NAME)
+                     section or papis.config.GENERAL_SETTINGS_NAME)
 
         papis.config.set(key, value, section=section)

--- a/papis/commands/doctor.py
+++ b/papis/commands/doctor.py
@@ -639,7 +639,7 @@ BIBLATEX_KEY_CONVERT_NUMBER_REGEX = re.compile(
     # letter-hyphen-number, e.g. A-1, Suppl-A-3
     r"|[A-Za-z]+\s*[-–]\s*\d+"  # noqa: RUF001
     r")$",
-    re.I
+    re.IGNORECASE
 )
 
 
@@ -832,7 +832,7 @@ def key_type_check(doc: Document) -> list[Error]:
 
 
 # NOTE: https://www.w3schools.com/html/html_symbols.asp
-HTML_CODES_REGEX = re.compile(r"&([a-z0-9]+|#[0-9]{1,6}|#x[0-9a-fA-F]{1,6});", re.I)
+HTML_CODES_REGEX = re.compile(r"&([a-z0-9]+|#[0-9]{1,6}|#x[0-9a-fA-F]{1,6});", re.IGNORECASE)
 HTML_CODES_CHECK_NAME = "html-codes"
 
 

--- a/papis/commands/list.py
+++ b/papis/commands/list.py
@@ -58,6 +58,7 @@ import click
 import papis.cli
 import papis.config
 import papis.logging
+import pathlib
 
 if TYPE_CHECKING:
     from collections.abc import Sequence
@@ -190,8 +191,7 @@ def list_documents(documents: Sequence[Document],
                 logger.error("Template file '%s' not found.", template)
                 return []
 
-            with open(template, encoding="utf-8") as fd:
-                show_format = fd.read()
+            show_format = pathlib.Path(template).read_text(encoding="utf-8")
 
         from papis.document import describe
         from papis.format import format

--- a/papis/commands/serve.py
+++ b/papis/commands/serve.py
@@ -16,6 +16,7 @@ import click
 import papis.cli
 import papis.config
 import papis.logging
+from itertools import starmap
 
 if TYPE_CHECKING:
     from papis.document import Document
@@ -96,7 +97,7 @@ except ImportError:
                 max_num_fields=self.max_num_fields,
                 separator=self.separator)
 
-            self.list = [MiniFieldStorage(key, value) for key, value in query]
+            self.list = list(starmap(MiniFieldStorage, query))
 
         def getvalue(self, name: str) -> str:
             result = [fs for fs in self.list if fs.name == name]

--- a/papis/crossref.py
+++ b/papis/crossref.py
@@ -6,6 +6,7 @@ from typing import TYPE_CHECKING, Any
 
 import papis.config
 import papis.logging
+import operator
 
 if TYPE_CHECKING:
     from papis.document import KeyConversionPair
@@ -153,7 +154,7 @@ def _get_crossref_key_conversion() -> list[KeyConversionPair]:
             ],
         }]),
         KeyConversionPair("container-title", [
-            {"key": "journal", "action": lambda x: x[0]}]),
+            {"key": "journal", "action": operator.itemgetter(0)}]),
         KeyConversionPair("issue", [EmptyKeyConversion]),
         # "issued": {"key": "",},
         KeyConversionPair("language", [EmptyKeyConversion]),

--- a/papis/document.py
+++ b/papis/document.py
@@ -8,6 +8,7 @@ from typing import TYPE_CHECKING, Any, NamedTuple, TypeAlias, TypedDict
 
 import papis.config
 import papis.logging
+from collections import UserDict
 
 if TYPE_CHECKING:
     from collections.abc import Callable, Sequence
@@ -283,7 +284,7 @@ def split_authors_name(authors: str | list[str],
 
     author_list = []
     for subauthors in authors:
-        sep = separator if separator else guess_authors_separator(subauthors)
+        sep = separator or guess_authors_separator(subauthors)
         author_list.extend([
             split_author_name(author)
             for author in re.split(fr"\s*{sep}\s+", subauthors)
@@ -292,7 +293,7 @@ def split_authors_name(authors: str | list[str],
     return author_list
 
 
-class DocHtmlEscaped(dict[str, Any]):
+class DocHtmlEscaped(UserDict[str, Any]):
     """Small helper class to escape HTML elements in a document.
 
     >>> DocHtmlEscaped(from_data({"title": '> >< int & "" "'}))['title']
@@ -311,7 +312,7 @@ class DocHtmlEscaped(dict[str, Any]):
             .replace('"', "&quot;"))
 
 
-class Document(dict[str, Any]):
+class Document(UserDict[str, Any]):
     """An abstract document in a ``papis`` library.
 
     This class inherits from a standard :class:`dict` and implements some

--- a/papis/downloaders/__init__.py
+++ b/papis/downloaders/__init__.py
@@ -7,6 +7,7 @@ from typing import TYPE_CHECKING, Any
 
 import papis.logging
 from papis.importer import Context, Importer, cache
+import pathlib
 
 if TYPE_CHECKING:
     from collections.abc import Sequence
@@ -217,8 +218,7 @@ class Downloader(Importer):
                     filename = _make_unique_file(
                         os.path.join(tempfile.gettempdir(), self.document_filename)
                     )
-                    with open(filename, mode="wb") as f:
-                        f.write(rawdata)
+                    pathlib.Path(filename).write_bytes(rawdata)
                 else:
                     extension = self.get_document_extension()
                     if extension:
@@ -336,8 +336,7 @@ class Downloader(Importer):
 
         if self.document_filename is not None:
             _, ext = os.path.splitext(self.document_filename)
-            if ext.startswith("."):
-                ext = ext[1:]
+            ext = ext.removeprefix(".")
 
             self.document_extension = ext
 
@@ -559,8 +558,7 @@ def download_document(
         root, _ = os.path.splitext(os.path.basename(filename))
         outfile = os.path.join(tempfile.gettempdir(), f"{root}{ext}")
 
-        with open(outfile, mode="wb") as f:
-            f.write(response.content)
+        pathlib.Path(outfile).write_bytes(response.content)
     else:
         with tempfile.NamedTemporaryFile(
                 mode="wb+",

--- a/papis/downloaders/base.py
+++ b/papis/downloaders/base.py
@@ -56,41 +56,41 @@ meta_equivalences: list[MetaEquivalence] = [
     # dc.{id} style
     {"tag": "meta",
         "key": "publisher",
-        "attrs": {"name": re.compile(r"dc.publisher", re.I)}},
+        "attrs": {"name": re.compile(r"dc.publisher", re.IGNORECASE)}},
     {"tag": "meta",
         "key": "publisher",
-        "attrs": {"name": re.compile(r".*st.publisher.*", re.I)}},
+        "attrs": {"name": re.compile(r".*st.publisher.*", re.IGNORECASE)}},
     {"tag": "meta",
-        "key": "date", "attrs": {"name": re.compile(r"dc.date", re.I)}},
+        "key": "date", "attrs": {"name": re.compile(r"dc.date", re.IGNORECASE)}},
     {"tag": "meta",
-        "key": "language", "attrs": {"name": re.compile(r"dc.language", re.I)}},
+        "key": "language", "attrs": {"name": re.compile(r"dc.language", re.IGNORECASE)}},
     {"tag": "meta",
         "key": "issue",
-        "attrs": {"name": re.compile(r"dc.citation.issue", re.I)}},
+        "attrs": {"name": re.compile(r"dc.citation.issue", re.IGNORECASE)}},
     {"tag": "meta",
             "key": "volume",
-            "attrs": {"name": re.compile(r"dc.citation.volume", re.I)}},
+            "attrs": {"name": re.compile(r"dc.citation.volume", re.IGNORECASE)}},
     {"tag": "meta",
             "key": "keywords",
-            "attrs": {"name": re.compile(r"dc.subject", re.I)}},
+            "attrs": {"name": re.compile(r"dc.subject", re.IGNORECASE)}},
     {"tag": "meta",
-            "key": "title", "attrs": {"name": re.compile(r"dc.title", re.I)}},
+            "key": "title", "attrs": {"name": re.compile(r"dc.title", re.IGNORECASE)}},
     {"tag": "meta",
-            "key": "type", "attrs": {"name": re.compile(r"dc.type", re.I)}},
-    {"tag": "meta",
-            "key": "abstract",
-            "attrs": {"name": re.compile(r"dc.description", re.I)}},
+            "key": "type", "attrs": {"name": re.compile(r"dc.type", re.IGNORECASE)}},
     {"tag": "meta",
             "key": "abstract",
-            "attrs": {"name": re.compile(r"dc.description.abstract", re.I)}},
+            "attrs": {"name": re.compile(r"dc.description", re.IGNORECASE)}},
+    {"tag": "meta",
+            "key": "abstract",
+            "attrs": {"name": re.compile(r"dc.description.abstract", re.IGNORECASE)}},
     {"tag": "meta",
             "key": "journal_abbrev",
-            "attrs": {"name": re.compile(r"dc.relation.ispartof", re.I)}},
+            "attrs": {"name": re.compile(r"dc.relation.ispartof", re.IGNORECASE)}},
     {"tag": "meta",
-            "key": "year", "attrs": {"name": re.compile(r"dc.issued", re.I)}},
+            "key": "year", "attrs": {"name": re.compile(r"dc.issued", re.IGNORECASE)}},
     {"tag": "meta",
             "key": "doi",
-            "attrs": {"name": re.compile(r"dc.identifier", re.I),
+            "attrs": {"name": re.compile(r"dc.identifier", re.IGNORECASE),
                       "scheme": "doi"}},
 ]
 
@@ -135,7 +135,7 @@ def parse_meta_authors(soup: BeautifulSoup) -> list[dict[str, Any]]:
     authors = soup.find_all(name="meta", attrs={"name": "citation_author"})
     if not authors:
         authors = soup.find_all(
-            name="meta", attrs={"name": re.compile(r"dc.creator", re.I)})
+            name="meta", attrs={"name": re.compile(r"dc.creator", re.IGNORECASE)})
 
     if not authors:
         return []

--- a/papis/exporters/csl.py
+++ b/papis/exporters/csl.py
@@ -6,6 +6,7 @@ from typing import TYPE_CHECKING, Any
 
 import papis.config
 import papis.logging
+import pathlib
 
 if TYPE_CHECKING:
     from citeproc.source import Date, Reference
@@ -26,8 +27,7 @@ def get_styles_folder() -> str:
 
 
 def _download_style(name: str) -> None:
-    if name.endswith(".csl"):
-        name = name[:-4]
+    name = name.removesuffix(".csl")
 
     styles_folder = get_styles_folder()
     style_path = os.path.join(styles_folder, f"{name}.csl")
@@ -48,8 +48,7 @@ def _download_style(name: str) -> None:
     if not os.path.exists(styles_folder):
         os.mkdir(styles_folder)
 
-    with open(style_path, mode="wb") as fout:
-        fout.write(response.content)
+    pathlib.Path(style_path).write_bytes(response.content)
 
     logger.info("Style '%s' downloaded to '%s'.", name, style_path)
 
@@ -141,8 +140,7 @@ def to_csl(doc: Document) -> Reference:
 
 def normalize_style_path(name: str) -> str:
     name = os.path.basename(name)
-    if name.endswith(".csl"):
-        name = name[:-4]
+    name = name.removesuffix(".csl")
 
     from citeproc import STYLES_PATH
 

--- a/papis/format/python.py
+++ b/papis/format/python.py
@@ -25,7 +25,7 @@ class _PythonStringFormatter(StringFormatter):
             try:
                 if "." in format_spec:
                     start, end = format_spec.split(".")
-                    start = start if start else "0"
+                    start = start or "0"
                 else:
                     start, end = "0", format_spec
 

--- a/papis/isbn.py
+++ b/papis/isbn.py
@@ -60,7 +60,7 @@ def data_to_papis(data: dict[str, Any]) -> dict[str, Any]:
             {"key": "isbn-13", "action": None},
         ]),
         KeyConversionPair("language", [
-            {"key": "language", "action": lambda x: x if x else "en"}
+            {"key": "language", "action": lambda x: x or "en"}
         ])
         ]
 

--- a/papis/logging.py
+++ b/papis/logging.py
@@ -75,8 +75,7 @@ class ColoramaFormatter(logging.Formatter):
                 f"{record.levelname}"
                 f"{c.Style.RESET_ALL}")
 
-        if record.name.startswith("papis."):
-            record.name = record.name[6:]
+        record.name = record.name.removeprefix("papis.")
 
         if record.exc_info and not self.full_tb:
             exc_text = self.formatException(record.exc_info)

--- a/papis/paths.py
+++ b/papis/paths.py
@@ -361,7 +361,7 @@ def get_document_unique_folder(
 
 
 def is_remote_file(uri: str) -> bool:
-    return uri.startswith("http://") or uri.startswith("https://")
+    return uri.startswith(("http://", "https://"))
 
 
 def download_remote_files(in_document_paths: Iterable[str]) -> list[str | None]:

--- a/papis/sphinx_ext.py
+++ b/papis/sphinx_ext.py
@@ -218,7 +218,7 @@ def remove_module_docstring(app: Sphinx,
     # we can show the module members in the `Developer API Reference` section
     # without the tutorial / examples parts.
     if what == "module" and ".commands." in name and options.get("members"):
-        del lines[:]
+        lines.clear()
 
 
 def process_autodoc_missing_reference(

--- a/papis/testing.py
+++ b/papis/testing.py
@@ -8,6 +8,7 @@ from typing import TYPE_CHECKING, Any, ClassVar
 import click
 import click.testing
 import pytest
+import pathlib
 
 if TYPE_CHECKING:
     from collections.abc import Iterator, Sequence
@@ -566,8 +567,7 @@ class ResourceCache:
             response = self.session.get(
                 url, params=params, headers=headers, cookies=cookies)
 
-            with open(filename, "w", encoding="utf-8") as f:
-                f.write(response.content.decode())
+            pathlib.Path(filename).write_text(response.content.decode(), encoding="utf-8")
 
         with open(filename, encoding="utf-8") as f:
             return f.read().encode()

--- a/papis/tui/diff.py
+++ b/papis/tui/diff.py
@@ -49,8 +49,7 @@ def prompt(text: str | FormattedText,
 
     action_texts = []
     for a in actions:
-        action_texts.append(("", a.name))
-        action_texts.append(("fg:ansiyellow", "[" + a.key + "] "))
+        action_texts.extend((("", a.name), ("fg:ansiyellow", "[" + a.key + "] ")))
 
     root_container = HSplit([
         Window(

--- a/papis/tui/picker/options_list.py
+++ b/papis/tui/picker/options_list.py
@@ -216,7 +216,7 @@ class OptionsList(ConditionalContainer, Generic[Option]):
             .replace("[", "\\[")
             .replace("]", "\\]")
         )
-        return re.compile(r".*" + re.sub(r"\s+", ".*", cleaned_search), re.I)
+        return re.compile(r".*" + re.sub(r"\s+", ".*", cleaned_search), re.IGNORECASE)
 
     def update(self, *args: Any) -> None:
         """Update the state"""

--- a/papis/tui/utils.py
+++ b/papis/tui/utils.py
@@ -194,7 +194,7 @@ def get_range(range_str: str) -> list[int]:
     range_regex = re.compile(r"(\d+)-?(\d+)?")
     try:
         return list(chain.from_iterable(
-            range(int(p[0]), int(p[1] if p[1] else p[0]) + 1)
+            range(int(p[0]), int(p[1] or p[0]) + 1)
             for p in range_regex.findall(range_str)))
     except ValueError:
         return []

--- a/papis/utils.py
+++ b/papis/utils.py
@@ -316,7 +316,7 @@ def locate_document(
     for d in documents:
         for key in comparing_keys:
             if key in document and key in d:
-                if re.match(document[key], d[key], re.I):
+                if re.match(document[key], d[key], re.IGNORECASE):
                     return d
 
     return None

--- a/papis/web/djvujs.py
+++ b/papis/web/djvujs.py
@@ -28,7 +28,7 @@ def widget(_unquoted_file_path: str, viewer_id: str = "djvuViewer") -> None:
     """
     t.div(id=viewer_id)
     t.script(tu.raw(
-        MAIN_CODE.substitute(**{"selector": viewer_id, "path": _unquoted_file_path})
+        MAIN_CODE.substitute(selector=viewer_id, path=_unquoted_file_path)
     ))
 
     t.script(src=DJVUJS_LIB_SRC)

--- a/papis/web/docview.py
+++ b/papis/web/docview.py
@@ -164,8 +164,7 @@ def html(libname: str, doc: Document) -> t.html_tag:
                             if fpath.endswith("epub"):
                                 papis.web.epubjs.widget(unquoted_file_path)
 
-                            elif (fpath.endswith("png")
-                                  or fpath.endswith("jpg")):
+                            elif (fpath.endswith(("png", "jpg"))):
                                 with t.div():
                                     t.img(src=unquoted_file_path)
 

--- a/papis/web/html.py
+++ b/papis/web/html.py
@@ -56,8 +56,6 @@ def modal(body: HtmlGiver, id_: str) -> t.html_tag:
 def file_icon(filepath: str) -> t.html_tag:
     if filepath.endswith("pdf"):
         return icon("file-pdf")
-    if filepath.endswith("jpg") \
-       or filepath.endswith("png") \
-       or filepath.endswith("gif"):
+    if filepath.endswith(("jpg", "png", "gif")):
         return icon("file-image")
     return icon("file")

--- a/papis/web/info.py
+++ b/papis/web/info.py
@@ -8,6 +8,7 @@ import dominate.util as tu
 import papis.web.ace
 import papis.web.html as wh
 import papis.web.paths as wp
+import pathlib
 
 if TYPE_CHECKING:
     from papis.document import Document
@@ -23,8 +24,7 @@ def widget(doc: Document, libname: str) -> None:
                                                          editor_name,
                                                          yaml_input_id)
 
-    with open(doc.get_info_file(), encoding="utf-8") as f:
-        yaml_content = f.read()
+    yaml_content = pathlib.Path(doc.get_info_file()).read_text(encoding="utf-8")
 
     with wh.flex("center"):
         with t.form(method="POST",

--- a/papis/web/notes.py
+++ b/papis/web/notes.py
@@ -9,6 +9,7 @@ import dominate.util as tu
 import papis.web.ace
 import papis.web.html as wh
 import papis.web.paths as wp
+import pathlib
 
 if TYPE_CHECKING:
     from papis.document import Document
@@ -31,8 +32,7 @@ def widget(libname: str, doc: Document) -> None:
     if has_notes(doc):
         filepath = notes_path(doc)
         if os.path.exists(filepath):
-            with open(filepath, encoding="utf-8") as fd:
-                notes_content = fd.read()
+            notes_content = pathlib.Path(filepath).read_text(encoding="utf-8")
 
     with wh.flex("center"):
         with t.form(method="POST",

--- a/papis/zenodo.py
+++ b/papis/zenodo.py
@@ -4,6 +4,7 @@ from functools import cache
 from typing import Any
 
 import papis.logging
+import operator
 
 logger = papis.logging.get_logger(__name__)
 
@@ -90,7 +91,7 @@ def _get_zenodo_key_conversion() -> list[papis.document.KeyConversionPair]:
                      lambda e: e["person_or_org"]["type"] == "organizational", x)},
             ],
         ),
-        KeyConversionPair("license", [{"key": "license", "action": lambda x: x["id"]}]),
+        KeyConversionPair("license", [{"key": "license", "action": operator.itemgetter("id")}]),
         KeyConversionPair("notes", [{"key": "note", "action": get_text_from_html}]),
         KeyConversionPair("publisher", [{"key": "publisher", "action": None}]),
         KeyConversionPair("title", [{"key": "title", "action": None}]),
@@ -113,13 +114,13 @@ def _get_zenodo_key_conversion() -> list[papis.document.KeyConversionPair]:
             [{"key": "pubstate", "action": get_text_from_html}]),
         KeyConversionPair(
             "resource_type",
-            [{"key": "type", "action": lambda x: x["type"]}]
+            [{"key": "type", "action": operator.itemgetter("type")}]
         ),
         KeyConversionPair("version", [{"key": "version", "action": None}]),
         # extra fields
         KeyConversionPair("keywords", [{"key": "tags", "action": None}]),
         KeyConversionPair("revision", [{"key": "revision", "action": None}]),
-        KeyConversionPair("links", [{"key": "url", "action": lambda x: x["self"]}]),
+        KeyConversionPair("links", [{"key": "url", "action": operator.itemgetter("self")}]),
         KeyConversionPair("method", [{"key": "method", "action": get_text_from_html}]),
     ]
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -277,24 +277,30 @@ line-length = 88
 
 [tool.ruff.lint]
 select = [
-    "B",   # flake8-bugbear
-    "C4",  # flake8-comprehensions
-    "E",   # pycodestyle
-    "F",   # pyflakes
-    "G",   # flake8-logging-format
-    "I",   # flake8-isort
-    "N",   # pep8-naming
-    "PGH", # pygrep-hooks
-    "PL",  # pylint
-    "Q",   # flake8-quotes
-    "RUF", # ruff
-    "TC",  # flake8-type-checking
-    "UP",  # pyupgrade
-    "W",   # pycodestyle
+    "B",    # flake8-bugbear
+    "C4",   # flake8-comprehensions
+    "E",    # pycodestyle
+    "F",    # pyflakes
+    "FURB", # refurb 
+    "G",    # flake8-logging-format
+    "I",    # flake8-isort
+    "N",    # pep8-naming
+    "PERF", # perflint
+    "PGH",  # pygrep-hooks
+    "PIE",  # flake8-pie
+    "PL",   # pylint
+    "Q",    # flake8-quotes
+    "RUF",  # ruff
+    "TC",   # flake8-type-checking
+    "UP",   # pyupgrade
+    "W",    # pycodestyle
 ]
 ignore = [
     # https://docs.astral.sh/ruff/rules/#rules
+    "FURB101", # read-whole-file
+    "FURB152", # math-constant
     "N818",    # error-suffix-on-exception-name
+    "PERF203", # try-except-in-loop
     "PLC0415", # import-outside-top-level
     "PLC1901", # compare-to-empty-string
     "PLR0904", # too-many-public-methods

--- a/tests/commands/test_add.py
+++ b/tests/commands/test_add.py
@@ -8,6 +8,7 @@ import pytest
 
 from papis.document import Document
 from papis.testing import PapisRunner, TemporaryLibrary
+import pathlib
 
 
 def make_document(name: str, dir: str, nfiles: int = 0) -> Document:
@@ -242,8 +243,7 @@ def test_add_bibtex_cli(tmp_library: TemporaryLibrary,
     )
 
     bibfile = os.path.join(tmp_library.tmpdir, "test-add.bib")
-    with open(bibfile, "w", encoding="utf-8") as f:
-        f.write(bibtex_string)
+    pathlib.Path(bibfile).write_text(bibtex_string, encoding="utf-8")
 
     import papis.tui.utils
     import papis.utils

--- a/tests/commands/test_addto.py
+++ b/tests/commands/test_addto.py
@@ -6,6 +6,7 @@ from typing import TYPE_CHECKING, Any
 
 import papis.database
 from papis.testing import PapisRunner, TemporaryLibrary, create_random_file
+from itertools import starmap
 
 if TYPE_CHECKING:
     import pytest
@@ -79,7 +80,7 @@ def test_addto_cli(tmp_library: TemporaryLibrary, nfiles: int = 5) -> None:
         return outfile.startswith(normalize_path(infile))
 
     assert (
-        all(eq(a, b) for a, b in zip(files, inputfiles, strict=True))), (
+        all(starmap(eq, zip(files, inputfiles, strict=True)))), (
         list(zip(files, inputfiles, strict=True)))
 
 

--- a/tests/commands/test_explore.py
+++ b/tests/commands/test_explore.py
@@ -4,6 +4,7 @@ import re
 import tempfile
 
 from papis.testing import PapisRunner, TemporaryLibrary
+import pathlib
 
 
 def test_explore_cli(tmp_library: TemporaryLibrary) -> None:
@@ -33,8 +34,7 @@ def test_explore_bibtex_cli(tmp_library: TemporaryLibrary) -> None:
         ["lib", "krishnamurti", "export", "--format", "bibtex", "--out", path])
     assert result.exit_code == 0
 
-    with open(path, encoding="utf-8") as fd:
-        exported_bibtex = fd.read()
+    exported_bibtex = pathlib.Path(path).read_text(encoding="utf-8")
 
     assert exported_bibtex == (
         "@article{Freedom_from_th_J_Kri_2009,\n"
@@ -57,8 +57,7 @@ def test_explore_yaml_cli(tmp_library: TemporaryLibrary) -> None:
         ["lib", "popper", "export", "--format", "yaml", "--out", path])
     assert result.exit_code == 0
 
-    with open(path, encoding="utf-8") as fd:
-        exported_yaml = fd.read()
+    exported_yaml = pathlib.Path(path).read_text(encoding="utf-8")
 
     assert re.match(
         r"author: K. Popper\n"
@@ -82,7 +81,6 @@ def test_explore_citations_and_json_cli(tmp_library: TemporaryLibrary) -> None:
         ["citations", "krishnamurti", "export", "--format", "json", "--out", path])
     assert result.exit_code == 0
 
-    with open(path, encoding="utf-8") as fd:
-        exported_json = fd.read()
+    exported_json = pathlib.Path(path).read_text(encoding="utf-8")
 
     assert exported_json == "[]"

--- a/tests/commands/test_export.py
+++ b/tests/commands/test_export.py
@@ -5,6 +5,7 @@ import tempfile
 
 import papis.database
 from papis.testing import PapisRunner, TemporaryLibrary
+import pathlib
 
 
 def test_export_run(tmp_library: TemporaryLibrary) -> None:
@@ -137,8 +138,7 @@ def test_export_bibtex_append(tmp_library: TemporaryLibrary) -> None:
     assert result.exit_code == 0
     assert os.path.exists(outfile)
 
-    with open(outfile, encoding="utf-8") as fd:
-        single_text = fd.read()
+    single_text = pathlib.Path(outfile).read_text(encoding="utf-8")
 
     single_data = papis.bibtex.bibtex_to_dict(single_text)
     assert len(single_data) == 1
@@ -150,8 +150,7 @@ def test_export_bibtex_append(tmp_library: TemporaryLibrary) -> None:
     assert result.exit_code == 0
     assert os.path.exists(outfile)
 
-    with open(outfile, encoding="utf-8") as fd:
-        appended_text = fd.read()
+    appended_text = pathlib.Path(outfile).read_text(encoding="utf-8")
 
     appended_data = papis.bibtex.bibtex_to_dict(appended_text)
     assert len(appended_data) == len(data)

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -7,6 +7,7 @@ import sys
 import pytest
 
 from papis.testing import TemporaryConfiguration
+import pathlib
 
 
 def test_default_opener(tmp_config: TemporaryConfiguration) -> None:
@@ -158,12 +159,11 @@ def test_merge_configuration_from_path(tmp_config: TemporaryConfiguration) -> No
     assert tmp_config.configdir is not None
     configpath = os.path.join(tmp_config.configdir, "config_extra")
 
-    with open(configpath, "w", encoding="utf-8") as configfile:
-        configfile.write("""
+    pathlib.Path(configpath).write_text("""
 [settings]
 some-nice-setting = 42
 some-other-setting = mandragora
-        """)
+        """, encoding="utf-8")
 
     import papis.config
     import papis.exceptions

--- a/tests/test_doctor.py
+++ b/tests/test_doctor.py
@@ -8,6 +8,7 @@ import pytest
 
 import papis.api
 import papis.document
+import pathlib
 
 if TYPE_CHECKING:
     from papis.testing import TemporaryConfiguration
@@ -378,13 +379,9 @@ def test_html_tags_check_jats(tmp_config: TemporaryConfiguration,
                               basename: str) -> None:
     from papis.commands.doctor import html_tags_check
 
-    with open(os.path.join(DOCTOR_RESOURCES, f"{basename}.xml"),
-              encoding="utf-8") as f:
-        abstract = f.read()
+    abstract = pathlib.Path(os.path.join(DOCTOR_RESOURCES, f"{basename}.xml")).read_text(encoding="utf-8")
 
-    with open(os.path.join(DOCTOR_RESOURCES, f"{basename}_out.txt"),
-              encoding="utf-8") as f:
-        expected = f.read()
+    expected = pathlib.Path(os.path.join(DOCTOR_RESOURCES, f"{basename}_out.txt")).read_text(encoding="utf-8")
 
     doc = papis.document.from_data({"abstract": abstract})
 

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -6,6 +6,7 @@ import tempfile
 from typing import TYPE_CHECKING
 
 import pytest
+import pathlib
 
 if TYPE_CHECKING:
     from papis.testing import TemporaryConfiguration
@@ -42,8 +43,7 @@ def test_general_open_with_spaces(tmp_config: TemporaryConfiguration) -> None:
         wait=True
     )
 
-    with open(filename, encoding="utf-8") as fd:
-        content = fd.read()
+    content = pathlib.Path(filename).read_text(encoding="utf-8")
 
     assert content == "Sume cuntent"
     os.unlink(filename)

--- a/tests/tui/test_options_list.py
+++ b/tests/tui/test_options_list.py
@@ -37,14 +37,14 @@ def test_basic() -> None:
         ("class:options_list.unselected_margin", " ")]
     assert ol.get_line_prefix(0, 0) == [
         ("class:options_list.marked_margin", "#")]
-    assert ol.search_regex == re.compile(r".*", re.I)
+    assert ol.search_regex == re.compile(r".*", re.IGNORECASE)
 
     ol.search_buffer.text = "l"
-    assert ol.search_regex == re.compile(r".*l", re.I)
+    assert ol.search_regex == re.compile(r".*l", re.IGNORECASE)
     assert ol.indices == [0, 1]
 
     ol.search_buffer.text = "l  "
-    assert ol.search_regex == re.compile(r".*l.*", re.I)
+    assert ol.search_regex == re.compile(r".*l.*", re.IGNORECASE)
     assert ol.indices == [0, 1]
     assert len(ol.get_options()) == 3
 

--- a/tests/tui/test_utils.py
+++ b/tests/tui/test_utils.py
@@ -53,7 +53,7 @@ def test_get_range() -> None:
 
     assert get_range("2") == [2]
     assert get_range("2, 3") == [2, 3] == get_range("2  3") == get_range("2-3")
-    assert get_range("0, 1 2-20 21-200") == list(range(0, 201))
+    assert get_range("0, 1 2-20 21-200") == list(range(201))
     assert get_range("0, 2-20 1 21-200") == [0, *range(2, 21), 1, *range(21, 201)]
     assert get_range("hello") == []
 

--- a/tools/extract-changelog.py
+++ b/tools/extract-changelog.py
@@ -8,8 +8,7 @@ def main(filename: pathlib.Path, *, outfile: pathlib.Path | None = None) -> int:
         print(f"ERROR: Filename does not exist: '{filename}'")
         return 1
 
-    with open(filename, encoding="utf-8") as inf:
-        contents = inf.read()
+    contents = pathlib.Path(filename).read_text(encoding="utf-8")
 
     result = contents.split("\n# ")
     if not result:


### PR DESCRIPTION
% `ruff check --select=FURB,PERF,PIE --statistics`
```
23	FURB167	[*] regex-flag-alias
22	FURB101	[-] read-whole-file
 6	FURB103	[*] write-whole-file
 6	FURB110	[-] if-exp-instead-of-or-operator
 5	FURB188	[*] slice-to-remove-prefix-or-suffix
 5	PERF203	[ ] try-except-in-loop
 4	FURB118	[ ] reimplemented-operator
 3	FURB152	[*] math-constant
 3	PIE810 	[ ] multiple-starts-ends-with
 2	FURB140	[*] reimplemented-starmap
 2	FURB189	[ ] subclass-builtin
 2	PERF401	[ ] manual-list-comprehension
 1	FURB113	[ ] repeated-append
 1	FURB131	[ ] delete-full-slice
 1	PIE804 	[*] unnecessary-dict-kwargs
 1	PIE808 	[*] unnecessary-range-start
Found 87 errors.
```