### PR TITLE
doctor: Add pointer to BibTeX manual

### DIFF
--- a/papis/commands/doctor.py
+++ b/papis/commands/doctor.py
@@ -683,7 +683,8 @@ def biblatex_key_convert_check(doc: Document) -> list[Error]:
         fix_action = None
         if key == "issue":
             if is_number_like(value):
-                msg = f"Document key 'issue' looks like a 'number': '{value}'"
+                msg = (f"Document key 'issue' looks like a 'number'"
+                       f" (see BibLaTeX manual §2.3.11): '{value}'")
                 fix_action = issue_to_number_fixer
 
         if fix_action is None:


### PR DESCRIPTION

The Reason given for biblatex-key-convert is unclear unless one has previously read the discussion on the topic in the manual.
The location of the discussion appears in the code -- show it to the user for clarity.
Am unsure of the best shape of the message, in particular:
- whether the `(see manual)` should appear at the end of the line or before the colon
- if we shouldn't strengthen the language to `'issue' should be 'number'`