### PR TITLE
Add `man papis` and other manpage improvements

### DIFF
--- a/doc/source/conf.py
+++ b/doc/source/conf.py
@@ -283,8 +283,10 @@ latex_documents = [
 # One entry per manual page. List of tuples
 # (source start file, name, description, authors, manual section).
 man_pages = [
-    ("configuration", "papis-config-settings", "Papis configuration",
+    ("commands/default", "papis", "Papis",
      [papis.__author__], 1),
+    ("configuration", "papis", "Papis configuration",
+     [papis.__author__], 5),
     ("library_structure", "papis-library-structure", "Papis library structure",
      [papis.__author__], 1),
     ("info_file", "papis-info-file", "Papis info.yaml file",


### PR DESCRIPTION
Draft for #1096

### Motivation

- make the manpages discoverable, currently `papis(1)` doesn't exist, which easily makes it seem there are no manpages
- get to config options as easy as possible:
    - `man 5 papis` instead of `man papis-config-settings`
    
### Todos/notes    

I think it would be best to rework `papis-default(1)` into `papis(1)`

Could take example from `git(1)`

Or have essentially the `papis --help` message but in manpage form with additional linkages to other pages?

To be investigated:

https://github.com/papis/papis/issues/1096#issuecomment-3515334987

> Section 7 should also be more appropriate for the library structure description and whatnot.

If there are many pages that could go into section 7, should they be combined into one?

**Edit:** probably not, look at how git does the section 7 pages:

<img width="929" height="71" alt="image" src="https://github.com/user-attachments/assets/6bce2946-7269-4205-aa96-65f351d3b76f" />

I think adding a `SEE ALSO` section at the bottom just like that would be great, with also the `papis(5)` (config page) mentioned there.