### PR TITLE
Ignore new RUF067 error

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -309,6 +309,7 @@ ignore = [
     "PLR2004", # magic-value-comparison
     "PLR5501", # collapsible-else-if
     "PLW0603", # global-statement
+    "RUF067",  # non-empty-init-module
 ]
 task-tags = ["spell"]
 


### PR DESCRIPTION
ruff 0.14.11 added a new `RUF067` rule that disallows code in `__init__.py` files. We use that quite extensively and I'm not sure we'd gain much from refactoring, so it gets disabled.