### PR TITLE
Allow colons in refs

### DIFF
--- a/papis/bibtex.py
+++ b/papis/bibtex.py
@@ -288,7 +288,7 @@ bibtex_ignore_keys = (
 
 #: A regex for acceptable characters to use in a reference string. These are
 #: used by :func:`ref_cleanup` to remove any undesired characters.
-ref_allowed_characters = r"([^a-zA-Z0-9._]+|(?<!\\)[._])"
+ref_allowed_characters = r"([^a-zA-Z0-9._:]+|(?<!\\)[._:])"
 
 #: A list of fields that should not be escaped. In general, these will be
 #: escaped by the BibTeX engine and should not be modified
@@ -397,7 +397,10 @@ def ref_cleanup(ref: str,
                           separator=ref_word_separator,
                           regex_pattern=ref_allowed_characters)
 
-    return str(ref).strip()
+    # FIXME: we generally allow escaping these characters using `\:`, but slugify
+    # seems to kindly replace the `\` by a `_` and leave the `:` alone in this case.
+    # Can we convince it to not do that?
+    return str(ref).strip().replace("_:", ":").replace("__", "_").replace("_.", ".")
 
 
 def create_reference(doc: DocumentLike, *,

--- a/tests/test_bibtex.py
+++ b/tests/test_bibtex.py
@@ -70,9 +70,10 @@ def test_clean_ref(tmp_config: TemporaryConfiguration) -> None:
     from papis.bibtex import ref_cleanup
 
     for (r, rc) in [
+            (r"Albert Einstein ()\:1923", "Albert_Einstein:1923"),
             ("Einstein über etwas und so 1923", "Einstein_uber_etwas_und_so_1923"),
             ("Äöasf () : Aλבert Eιنς€in", "Aoasf_Albert_EinsEURin"),  # noqa: RUF001
-            (r"Albert_Ein\_stein\.1923.b", "Albert_Ein__stein_.1923_b"),
+            (r"Albert_Ein\_stein\.1923.b", "Albert_Ein_stein.1923_b"),
             ]:
         assert rc == ref_cleanup(r)
 


### PR DESCRIPTION
This allows colons in refs, since it seems to be a somewhat used pattern.

Fixes #713.