### PR TITLE
Add upper bound for Sphinx on the CI

### DIFF
--- a/tools/ci-install.sh
+++ b/tools/ci-install.sh
@@ -2,7 +2,10 @@
 
 set -o errexit -o noglob -o pipefail
 
-# NOTE: setuptools is needed as a runtime dependency of isbnlib
-python -m pip install --upgrade setuptools
 python -m pip install --upgrade pip hatchling wheel
 python -m pip install --editable '.[develop,docs,optional]'
+
+# NOTE: setuptools is needed as a runtime dependency of isbnlib
+python -m pip install --upgrade setuptools
+# NOTE: sphinx>=9.1.0 uses 3.12 syntax for typing and breaks mypy on the CI
+python -m pip install --upgrade 'sphinx<9.1.0'


### PR DESCRIPTION
The new Sphinx 9.1.0 started using Python 3.12+ only syntax. Luckily, this seems to only be in `TYPE_CHECKING` blocks, so it only breaks `mypy`.

For now, this modifies the `ci-install.sh` script to keep it to `<9.1.0`, so that `mypy` works properly on all versions. 