### PR TITLE
Fix unreliable floating point equality (RUF069)

### DIFF
--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -80,8 +80,8 @@ def test_get(tmp_config: TemporaryConfiguration) -> None:
     assert isinstance(papis.config.getint("test_getint", section=section), int)
 
     papis.config.set("test_getfloat", "3.14")
-    assert papis.config.getfloat("test_getfloat") == 3.14
-    assert papis.config.getfloat("test_getfloat", section=section) == 3.14
+    assert papis.config.getfloat("test_getfloat") == 3.14  # noqa: RUF069
+    assert papis.config.getfloat("test_getfloat", section=section) == 3.14  # noqa: RUF069
     assert isinstance(papis.config.getfloat("test_getfloat", section=section), float)
 
     papis.config.set("test_getbool", "True")
@@ -115,7 +115,7 @@ def test_get_types(tmp_config: TemporaryConfiguration) -> None:
     papis.config.set("float_config", "3.1415")
     val_float = papis.config.getfloat("float_config")
     assert isinstance(val_float, float)
-    assert val_float == 3.1415
+    assert val_float == 3.1415  # noqa: RUF069
 
     papis.config.set("float_config", "not1")
     with pytest.raises(ValueError,


### PR DESCRIPTION
These are all equalities on purposes, so we just ignore the new ruff check :grin: