### PR TITLE
Rename doctor-key-type-keys to document-field-types

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -263,8 +263,8 @@ string with a separator. You can quickly transform your tags into a list using
 ```sh
 papis \
     --set document-field-types '["tags:list"]' \
-    --set doctor-key-type-separator ' ' \
-    doctor --fix --all --explain -t key-type QUERY
+    --set doctor-field-type-separator ' ' \
+    doctor --fix --all --explain -t field-type QUERY
 ```
 
 where you may need to change the separator to match your choice.
@@ -310,7 +310,7 @@ engine to output well-formatted entries for each document type.
 
 Other smaller noteworthy changes:
 
-- `key-type`: added fixers that automatically convert some types
+- `field-type`: added fixers that automatically convert some types
   ([#652](https://github.com/papis/papis/pull/652)
   [#656](https://github.com/papis/papis/pull/656)).
 - `keys-exist`: added fixers for `author` and `author_list`

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -262,7 +262,7 @@ string with a separator. You can quickly transform your tags into a list using
 
 ```sh
 papis \
-    --set doctor-key-type-keys '["tags:list"]' \
+    --set document-field-types '["tags:list"]' \
     --set doctor-key-type-separator ' ' \
     doctor --fix --all --explain -t key-type QUERY
 ```

--- a/doc/source/default_settings.rst
+++ b/doc/source/default_settings.rst
@@ -236,8 +236,8 @@ General settings
 
 .. papis-config:: document-field-types
 
-   A list of strings ``key:type`` items defining expected types for document
-   keys. The type should be a builtin Python type. For example, this can be
+   A list of ``key:type`` strings defining expected types for document
+   fields. The type should be a builtin Python type. For example, this can be
    ``["year:int", "tags:list"]`` to check that the year is an integer and the
    tags are given as a list in a document. These values are used in the ``papis
    doctor`` check ``key-type``, in the ``papis update`` command, etc.
@@ -249,8 +249,8 @@ General settings
 .. papis-config:: document-field-types-extend
     :type: :class:`~typing.List` [:class:`str`]
 
-    A list of keys that extend the default ones from :confval:`document-field-types`.
-    This list extends instead of overwriting the given keys.
+    A list of ``key:type`` strings that extend the default ones from :confval:`document-field-types`.
+    By setting these, you can extend the defaults rather than overwriting them.
 
     **Note**: This configuration option was previously available as
     ``doctor-key-type-keys-extend``. This version is deprecated (starting with

--- a/doc/source/default_settings.rst
+++ b/doc/source/default_settings.rst
@@ -240,7 +240,7 @@ General settings
    fields. The type should be a builtin Python type. For example, this can be
    ``["year:int", "tags:list"]`` to check that the year is an integer and the
    tags are given as a list in a document. These values are used in the ``papis
-   doctor`` check ``key-type``, in the ``papis update`` command, etc.
+   doctor`` check ``field-type``, in the ``papis update`` command, etc.
 
    **Note**: This configuration option was previously available as
    ``doctor-key-type-keys`` and ``doctor-key-type-check-keys``. Both of
@@ -692,10 +692,10 @@ Doctor options
     :confval:`doctor-html-tags-keys`. This list extends instead of overwriting
     the given keys.
 
-.. papis-config:: doctor-key-type-separator
+.. papis-config:: doctor-field-type-separator
     :type: str
 
-    A separator used by the ``key-type`` check fixer. When converting from
+    A separator used by the ``field-type`` check fixer. When converting from
     :class:`str` to :class:`list`, it is used to split the string into a list,
     and when converting from :class:`list` to :class:`str`, it is used to join
     list items. The split will ignore additional whitespace around the separator

--- a/doc/source/default_settings.rst
+++ b/doc/source/default_settings.rst
@@ -184,7 +184,7 @@ General settings
     based on the Python formatter. These will need to all be specified explicitly
     if another formatter is chosen.
 
-    **Note** The older (misspelled) version ``"formater"`` is deprecated.
+    **Note**: The older (misspelled) version ``"formater"`` is deprecated.
 
 .. papis-config:: doc-paths-lowercase
     :type: bool
@@ -233,6 +233,28 @@ General settings
     The format of a library when shown in a picker, e.g. when using
     ``papis --pick-lib export --all``. The format takes a dictionary named
     ``library`` with the keys *name*, *dir*, and *paths*.
+
+.. papis-config:: document-field-types
+
+   A list of strings ``key:type`` items defining expected types for document
+   keys. The type should be a builtin Python type. For example, this can be
+   ``["year:int", "tags:list"]`` to check that the year is an integer and the
+   tags are given as a list in a document. These values are used in the ``papis
+   doctor`` check ``key-type``, in the ``papis update`` command, etc.
+
+   **Note**: This configuration option was previously available as
+   ``doctor-key-type-keys`` and ``doctor-key-type-check-keys``. Both of
+   these are deprecated (starting with Papis 0.16) and will be removed.
+
+.. papis-config:: document-field-types-extend
+    :type: :class:`~typing.List` [:class:`str`]
+
+    A list of keys that extend the default ones from :confval:`document-field-types`.
+    This list extends instead of overwriting the given keys.
+
+    **Note**: This configuration option was previously available as
+    ``doctor-key-type-keys-extend``. This version is deprecated (starting with
+    Papis 0.16) and will be removed.
 
 .. papis-config:: csl-style
 
@@ -668,21 +690,6 @@ Doctor options
 
     A list of keys that extend the default ones from
     :confval:`doctor-html-tags-keys`. This list extends instead of overwriting
-    the given keys.
-
-.. papis-config:: doctor-key-type-keys
-
-   A list of strings ``key:type`` used by the ``key-type`` check. This
-   check will show an error if the key does not have the corresponding type. The
-   type should be a builtin Python type. For example, this can be
-   ``["year:int", "tags:list"]`` to check that the year is an integer and the
-   tags are given as a list in a document.
-
-.. papis-config:: doctor-key-type-keys-extend
-    :type: :class:`~typing.List` [:class:`str`]
-
-    A list of keys that extend the default ones from
-    :confval:`doctor-key-type-keys`. This list extends instead of overwriting
     the given keys.
 
 .. papis-config:: doctor-key-type-separator

--- a/papis/commands/doctor.py
+++ b/papis/commands/doctor.py
@@ -31,10 +31,10 @@ implemented
   provided by :confval:`doctor-html-codes-keys`.
 * ``html-tags``: checks that no HTML or XML tags (e.g. ``<a>``) appear in the keys
   provided by :confval:`doctor-html-tags-keys`.
-* ``key-type``: checks the type of keys provided by
-  :confval:`document-field-types` (and :confval:`document-field-types-extend`), e.g.
-  year should be an ``int``. Lists can be automatically fixed (by splitting or
-  joining) using the :confval:`doctor-key-type-separator` setting.
+* ``field-type``: checks the type of fields provided by :confval:`document-field-types`
+  (and :confval:`document-field-types-extend`), e.g. year should be an ``int``.
+  Lists can be automatically fixed (by splitting or joining) using the
+  :confval:`doctor-field-type-separator` setting.
 * ``keys-missing``: checks that the keys provided by
   :confval:`doctor-keys-missing-keys` exist in the document.
 * ``refs``: checks that the document has a valid reference (i.e. one that would
@@ -698,7 +698,7 @@ def biblatex_key_convert_check(doc: Document) -> list[Error]:
     return results
 
 
-KEY_TYPE_CHECK_NAME = "key-type"
+FIELD_TYPE_CHECK_NAME = "field-type"
 
 
 def get_key_type_check_keys() -> dict[str, type]:
@@ -711,7 +711,7 @@ def get_key_type_check_keys() -> dict[str, type]:
     return get_document_field_types()
 
 
-def key_type_check(doc: Document) -> list[Error]:
+def field_type_check(doc: Document) -> list[Error]:
     """
     Check document keys have expected types.
 
@@ -724,10 +724,16 @@ def key_type_check(doc: Document) -> list[Error]:
     separator = papis.config.get("key-type-check-separator", section="doctor")
     if separator is NOT_SET:
         separator = papis.config.get("key-type-separator", section="doctor")
+        if separator is NOT_SET:
+            separator = papis.config.get("field-type-separator", section="doctor")
+        else:
+            logger.warning("The configuration option 'doctor-key-type-separator' "
+                           "is deprecated and will be removed in Papis 0.17. "
+                           "Use 'doctor-field-type-separator' instead.")
     else:
         logger.warning("The configuration option 'doctor-key-type-check-separator' "
-                       "is deprecated and will be removed in the next version. "
-                       "Use 'doctor-key-type-separator' instead.")
+                       "is deprecated and will be removed in Papis 0.17. "
+                       "Use 'doctor-field-type-separator' instead.")
 
     separator = separator.strip("'").strip('"') if separator else None
 
@@ -788,7 +794,7 @@ def key_type_check(doc: Document) -> list[Error]:
 
         if doc_value is not None and not isinstance(doc_value, cls):
             results.append(
-                make_error(doc, KEY_TYPE_CHECK_NAME,
+                make_error(doc, FIELD_TYPE_CHECK_NAME,
                            msg=(f"Key '{key}' should be of type '{cls.__name__}' "
                                 f"but got '{type(doc_value).__name__}': "
                                 f"{doc_value!r}"),
@@ -1046,11 +1052,11 @@ def string_cleaner_check(doc: Document) -> list[Error]:
 
     from papis.document import get_document_field_types
 
-    key_types = get_document_field_types()
+    field_types = get_document_field_types()
     results = []
 
     for key, value in doc.items():
-        if key_types.get(key) is not str:
+        if field_types.get(key) is not str:
             continue
 
         if not isinstance(value, str):
@@ -1106,11 +1112,12 @@ register_check(BIBLATEX_KEY_CONVERT_CHECK_NAME, biblatex_key_convert_check)
 register_check(REFS_CHECK_NAME, refs_check)
 register_check(HTML_CODES_CHECK_NAME, html_codes_check)
 register_check(HTML_TAGS_CHECK_NAME, html_tags_check)
-register_check(KEY_TYPE_CHECK_NAME, key_type_check)
+register_check(FIELD_TYPE_CHECK_NAME, field_type_check)
 register_check(STRING_CLEANER_CHECK_NAME, string_cleaner_check)
 
 DEPRECATED_CHECK_NAMES = {
     "keys-exist": "keys-missing",
+    "key-type": "field-type",
 }
 
 

--- a/papis/commands/doctor.py
+++ b/papis/commands/doctor.py
@@ -32,9 +32,9 @@ implemented
 * ``html-tags``: checks that no HTML or XML tags (e.g. ``<a>``) appear in the keys
   provided by :confval:`doctor-html-tags-keys`.
 * ``key-type``: checks the type of keys provided by
-  :confval:`doctor-key-type-keys`, e.g. year should be an ``int``.
-  Lists can be automatically fixed (by splitting or joining) using the
-  :confval:`doctor-key-type-separator` setting.
+  :confval:`document-field-types` (and :confval:`document-field-types-extend`), e.g.
+  year should be an ``int``. Lists can be automatically fixed (by splitting or
+  joining) using the :confval:`doctor-key-type-separator` setting.
 * ``keys-missing``: checks that the keys provided by
   :confval:`doctor-keys-missing-keys` exist in the document.
 * ``refs``: checks that the document has a valid reference (i.e. one that would
@@ -702,49 +702,13 @@ KEY_TYPE_CHECK_NAME = "key-type"
 
 
 def get_key_type_check_keys() -> dict[str, type]:
-    """
-    Check the ``doctor-key-type-keys`` configuration entry for correctness.
+    from warnings import warn
+    warn("'papis.commands.doctor.get_key_type_check_keys' is deprecated and will "
+         "be removed in Papis v0.17. Use 'papis.document.get_document_field_types' "
+         "instead.", DeprecationWarning, stacklevel=2)
 
-    The :confval:`doctor-key-type-keys` configuration entry
-    defines a mapping of keys and their expected types. If the desired type is
-    a list, the :confval:`doctor-key-type-separator` setting
-    can be used to split an existing string (and, similarly, if the desired type
-    is a string, it can be used to join a list of items).
-
-    :returns: A dictionary mapping key names to types.
-    """
-    import builtins
-
-    from papis.defaults import NOT_SET
-
-    keys = papis.config.get("key-type-check-keys", section="doctor")
-    if keys is NOT_SET:
-        keys = papis.config.getlist("key-type-keys", section="doctor")
-    else:
-        keys = papis.config.getlist("key-type-check-keys", section="doctor")
-        logger.warning("The configuration option 'doctor-key-type-check-keys' "
-                       "is deprecated and will be removed in the next version. "
-                       "Use 'doctor-key-type-keys' instead.")
-
-    keys.extend(papis.config.getlist("key-type-keys-extend", section="doctor"))
-    processed_keys: dict[str, type] = {}
-    for value in keys:
-        if ":" not in value:
-            logger.error("Invalid (key, type) pair: '%s'. Must be 'key:type'.",
-                         value)
-            continue
-        key, cls_name = value.split(":")
-        key, cls_name = key.strip(), cls_name.strip()
-
-        cls = getattr(builtins, cls_name, None)
-        if not isinstance(cls, type):
-            logger.error(
-                "Invalid type for key '%s': '%s'. Only builtin types are supported",
-                key, cls_name)
-            continue
-        processed_keys[key] = cls
-
-    return processed_keys
+    from papis.document import get_document_field_types
+    return get_document_field_types()
 
 
 def key_type_check(doc: Document) -> list[Error]:
@@ -816,8 +780,10 @@ def key_type_check(doc: Document) -> list[Error]:
         else:
             return fixer_convert_any
 
+    from papis.document import get_document_field_types
+
     results = []
-    for key, cls in get_key_type_check_keys().items():
+    for key, cls in get_document_field_types().items():
         doc_value = doc.get(key)
 
         if doc_value is not None and not isinstance(doc_value, cls):
@@ -1002,7 +968,7 @@ def string_cleaner_check(doc: Document) -> list[Error]:
     Check string keys in the document for various errors.
 
     This check goes through all the keys of the document that are known to be
-    keys, according to :confval:`doctor-key-type-keys`, and fixes any obvious
+    keys, according to :confval:`document-field-types`, and fixes any obvious
     errors. For example (not exhaustive):
 
     * Double spacing or any repeated whitespace.
@@ -1078,7 +1044,9 @@ def string_cleaner_check(doc: Document) -> list[Error]:
         doc["author"] = author_list_to_author(doc)
         logger.info("[FIX] Cleaning 'author' key for missing dots and spaces.")
 
-    key_types = get_key_type_check_keys()
+    from papis.document import get_document_field_types
+
+    key_types = get_document_field_types()
     results = []
 
     for key, value in doc.items():

--- a/papis/commands/tag.py
+++ b/papis/commands/tag.py
@@ -134,7 +134,7 @@ def cli(
 
     from papis.commands.update import run, run_append, run_drop, run_remove, run_rename
 
-    key_types: dict[str, type] = {"tags": list}
+    field_types: dict[str, type] = {"tags": list}
 
     from papis.importer import Context
 
@@ -148,7 +148,7 @@ def cli(
                 "The document with papis_id '%s' contains tags that aren't "
                 "defined as a list of items. As `papis tag` only supports "
                 "lists, tagging has been aborted and no documents have been "
-                "changed. You can use `papis doctor --checks key-type --fix` to "
+                "changed. You can use `papis doctor --checks field-type --fix` to "
                 "convert all your tags to use lists.",
                 document["papis_id"],
             )
@@ -162,7 +162,7 @@ def cli(
 
         if to_add and success:
             to_add_tuples = [("tags", tag) for tag in to_add]
-            success = run_append(ctx.data, to_add_tuples, key_types, False)
+            success = run_append(ctx.data, to_add_tuples, field_types, False)
 
         if to_remove and success:
             to_remove_tuples = [("tags", tag) for tag in to_remove]
@@ -172,7 +172,7 @@ def cli(
             to_rename_tuples = [
                 ("tags", old_tag, new_tag) for old_tag, new_tag in to_rename
             ]
-            success = run_rename(ctx.data, to_rename_tuples, key_types, False)
+            success = run_rename(ctx.data, to_rename_tuples, field_types, False)
 
         if success:
             from papis.document import describe

--- a/papis/commands/update.py
+++ b/papis/commands/update.py
@@ -82,7 +82,7 @@ Examples
 
     As you might have guessed, the ``--append`` flag needs to know the type of
     the key it is appending to. It does this by looking at the
-    :confval:`doctor-key-type-keys` (and :confval:`doctor-key-type-keys-extend`)
+    :confval:`document-field-types` (and :confval:`document-field-types-extend`)
     configuration options. If the key you are appending to is not in that list,
     the command will fail.
 
@@ -240,8 +240,8 @@ def run_append(
             logger.error(
                 "We cannot append to key '%s', because we do not know the "
                 "intended type. Please use `papis update --set` instead or "
-                "add the key type to the `doctor-key-type-keys` configuration "
-                "setting (or `doctor-key-type-keys-extend`)",
+                "add the key type to the `document-field-types` configuration "
+                "setting (or `document-field-types-extend`)",
                 key,
             )
             if not batch:
@@ -543,8 +543,8 @@ def cli(
         logger.warning(no_documents_retrieved_message)
         return
 
-    from papis.commands.doctor import get_key_type_check_keys
-    known_key_types = get_key_type_check_keys()
+    from papis.document import get_document_field_types
+    known_key_types = get_document_field_types()
 
     success = True
     processed_documents = []

--- a/papis/commands/update.py
+++ b/papis/commands/update.py
@@ -169,7 +169,7 @@ def try_parsing_str(key: str, value: str) -> str:
 def run_set(
     document: DocumentLike,
     to_set: Sequence[tuple[str, AnyString]],
-    key_types: dict[str, type],
+    field_types: dict[str, type],
 ) -> None:
     """
     Processes a list of ``to_set`` tuples and applies the resulting changes to the
@@ -185,7 +185,7 @@ def run_set(
         value = format(vformat, document, default=str(vformat))
         value = try_parsing_str(key, value)
 
-        if isinstance(value, int) and key_types.get(key) is str:
+        if isinstance(value, int) and field_types.get(key) is str:
             value = str(value)
         if key == "notes" and isinstance(value, str):
             # TODO: handle renames/deletions of files on disk
@@ -216,7 +216,7 @@ def run_set(
 def run_append(
     document: DocumentLike,
     to_append: Sequence[tuple[str, AnyString]],
-    key_types: dict[str, type],
+    field_types: dict[str, type],
     batch: bool,
 ) -> bool:
     """
@@ -232,7 +232,7 @@ def run_append(
 
     success = True
     processed_lists = set()
-    supported_keys = key_types.keys() | document
+    supported_keys = field_types.keys() | document
     for orig_key, orig_value in to_append:
         key, vformat = process_format_pattern_pair(orig_key, orig_value)
 
@@ -250,7 +250,7 @@ def run_append(
 
         value = format(vformat, document, default=str(vformat))
         type_doc = type(document.get(key))
-        type_conf = key_types.get(key)
+        type_conf = field_types.get(key)
         if type_doc is str or (type_doc is type(None) and type_conf is str):
             document[key] = document.setdefault(key, "") + value
         elif type_doc is list or (type_doc is type(None) and type_conf is list):
@@ -266,7 +266,7 @@ def run_append(
                 key,
                 type(document[key]).__name__
                 if document.get(key)
-                else key_types[key].__name__,
+                else field_types[key].__name__,
             )
             if not batch:
                 success = False
@@ -351,7 +351,7 @@ def run_rename(
     document: DocumentLike,
     to_rename: Sequence[
         tuple[str, AnyString, AnyString]],
-    key_types: dict[str, type],
+    field_types: dict[str, type],
     batch: bool,
 ) -> bool:
     """
@@ -367,7 +367,7 @@ def run_rename(
 
     success, any_removed = run_remove(document, to_remove, batch)
     if success and any_removed:
-        success = run_append(document, to_append, key_types, batch)
+        success = run_append(document, to_append, field_types, batch)
     return success
 
 
@@ -544,7 +544,7 @@ def cli(
         return
 
     from papis.document import get_document_field_types
-    known_key_types = get_document_field_types()
+    known_field_types = get_document_field_types()
 
     success = True
     processed_documents = []
@@ -553,10 +553,10 @@ def cli(
 
         ctx.data.update(document)
         if to_set:
-            run_set(ctx.data, to_set, known_key_types)
+            run_set(ctx.data, to_set, known_field_types)
 
         if to_append and success:
-            success = run_append(ctx.data, to_append, known_key_types, batch)
+            success = run_append(ctx.data, to_append, known_field_types, batch)
 
         if to_remove and success:
             success, _ = run_remove(ctx.data, to_remove, batch)
@@ -565,7 +565,7 @@ def cli(
             run_drop(ctx.data, to_drop)
 
         if to_rename:
-            success = run_rename(ctx.data, to_rename, known_key_types, batch)
+            success = run_rename(ctx.data, to_rename, known_field_types, batch)
 
         if success:
             from papis.document import describe

--- a/papis/defaults.py
+++ b/papis/defaults.py
@@ -38,6 +38,8 @@ settings: dict[str, Any] = {
     "doctor-keys-exist-keys": NOT_SET,
     "doctor-key-type-check-keys": NOT_SET,
     "doctor-key-type-check-separator": NOT_SET,
+    "doctor-key-type-keys": NOT_SET,
+    "doctor-key-type-keys-extend": NOT_SET,
 
     # general settings
     "local-config-file": ".papis.config",
@@ -72,6 +74,26 @@ settings: dict[str, Any] = {
         "<ansired>{library[name]}</ansired>"
         " <ansiblue>{library[paths]}</ansiblue>"
     ),
+    "document-field-types": [
+        "abstract:str",
+        "author:str",
+        "author_list:list",
+        "doi:str",
+        "files:list",
+        "isbn:str",
+        "journal:str",
+        "month:int",
+        "note:str",
+        "notes:str",
+        "publisher:str",
+        "ref:str",
+        "shorttitle:str",
+        "tags:list",
+        "title:str",
+        "type:str",
+        "year:int",
+    ],
+    "document-field-types-extend": [],
 
     # shell completions
     "prefix-only-completions": False,
@@ -137,26 +159,6 @@ settings: dict[str, Any] = {
     "doctor-html-codes-keys-extend": [],
     "doctor-html-tags-keys": ["title", "author", "abstract", "journal"],
     "doctor-html-tags-keys-extend": [],
-    "doctor-key-type-keys": [
-        "abstract:str",
-        "author:str",
-        "author_list:list",
-        "doi:str",
-        "files:list",
-        "isbn:str",
-        "journal:str",
-        "month:int",
-        "note:str",
-        "notes:str",
-        "publisher:str",
-        "ref:str",
-        "shorttitle:str",
-        "tags:list",
-        "title:str",
-        "type:str",
-        "year:int",
-    ],
-    "doctor-key-type-keys-extend": [],
     "doctor-key-type-separator": None,
 
     # open

--- a/papis/defaults.py
+++ b/papis/defaults.py
@@ -40,6 +40,7 @@ settings: dict[str, Any] = {
     "doctor-key-type-check-separator": NOT_SET,
     "doctor-key-type-keys": NOT_SET,
     "doctor-key-type-keys-extend": NOT_SET,
+    "doctor-key-type-separator": NOT_SET,
 
     # general settings
     "local-config-file": ".papis.config",
@@ -159,7 +160,7 @@ settings: dict[str, Any] = {
     "doctor-html-codes-keys-extend": [],
     "doctor-html-tags-keys": ["title", "author", "abstract", "journal"],
     "doctor-html-tags-keys-extend": [],
-    "doctor-key-type-separator": None,
+    "doctor-field-type-separator": None,
 
     # open
     "open-mark": False,

--- a/papis/document.py
+++ b/papis/document.py
@@ -292,6 +292,64 @@ def split_authors_name(authors: str | list[str],
     return author_list
 
 
+def get_document_field_types() -> dict[str, type]:
+    from papis.defaults import NOT_SET
+
+    # handle deprecated configuration options
+    keys = papis.config.get("key-type-check-keys", section="doctor")
+    if keys is NOT_SET:
+        keys = papis.config.get("key-type-keys", section="doctor")
+        if keys is NOT_SET:
+            keys = papis.config.getlist("document-field-types")
+        else:
+            logger.warning("The configuration option 'doctor-key-type-keys' is "
+                           "deprecated and will be removed in Papis v0.17. "
+                           "Use 'document-field-types' instead (with the same format).")
+            keys = papis.config.getlist("key-type-keys", section="doctor")
+    else:
+        logger.warning("The configuration option 'doctor-key-type-check-keys' "
+                       "is deprecated and will be removed in Papis v0.16. "
+                       "Use 'document-field-types' instead (with the same format).")
+        keys = papis.config.getlist("key-type-check-keys", section="doctor")
+
+    if keys is None:
+        keys = []
+
+    extra_keys = papis.config.get("key-type-keys-extend", section="doctor")
+    if extra_keys is NOT_SET:
+        extra_keys = papis.config.getlist("document-field-types-extend")
+    else:
+        logger.warning("The configuration option 'doctor-key-type-keys-extend' is "
+                       "deprecated and will be removed in Papis v0.17. Use "
+                       "'document-field-types-extend' instead (with the same format).")
+        extra_keys = papis.config.getlist("key-type-keys-extend", section="doctor")
+
+    keys.extend(extra_keys)
+
+    # parse configuration options
+    import builtins
+
+    result: dict[str, type] = {}
+    for value in keys:
+        if ":" not in value:
+            logger.error("Invalid (key, type) pair: '%s'. Must be 'key:type'.",
+                         value)
+            continue
+        key, cls_name = value.split(":", maxsplit=1)
+        key, cls_name = key.strip(), cls_name.strip()
+
+        cls = getattr(builtins, cls_name, None)
+        if not isinstance(cls, type):
+            logger.error(
+                "Invalid type for key '%s': '%s'. Only builtin types are supported",
+                key, cls_name)
+            continue
+
+        result[key] = cls
+
+    return result
+
+
 class DocHtmlEscaped(dict[str, Any]):
     """Small helper class to escape HTML elements in a document.
 

--- a/papis/testing.py
+++ b/papis/testing.py
@@ -198,7 +198,7 @@ def generate_random_bibtex_entry(bibtype: str | None = None) -> str:
         raise ValueError(f"unknown BibTeX entry type: '{bibtype}'")
 
     from papis.document import get_document_field_types
-    key_types = get_document_field_types()
+    field_types = get_document_field_types()
 
     import string
 
@@ -209,20 +209,20 @@ def generate_random_bibtex_entry(bibtype: str | None = None) -> str:
         return "".join(random.choices(string.ascii_lowercase, k=size)).capitalize()
 
     def generate_value(key: str) -> Any:
-        key_type = key_types.get(key, str)
+        cls = field_types.get(key, str)
 
-        if key_type is str:
+        if cls is str:
             if key == "author":
                 return " and ".join(f"{generate_word()} {generate_word()}"
                                     for _ in range(random.randint(1, 5)))
             else:
                 return " ".join(generate_word() for _ in range(random.randint(1, 15)))
-        elif key_type is int:
+        elif cls is int:
             return random.randint(1870, 2025)
-        elif key_type is list:
+        elif cls is list:
             return [generate_word() for _ in range(random.randint(2, 10))]
         else:
-            raise TypeError(f"unsupported key type: {key_type}")
+            raise TypeError(f"unsupported key type: {cls}")
 
     data = {
         "type": bibtype,

--- a/papis/testing.py
+++ b/papis/testing.py
@@ -197,8 +197,8 @@ def generate_random_bibtex_entry(bibtype: str | None = None) -> str:
     if bibtype not in bibtex_type_required_keys:
         raise ValueError(f"unknown BibTeX entry type: '{bibtype}'")
 
-    from papis.commands.doctor import get_key_type_check_keys
-    key_types = get_key_type_check_keys()
+    from papis.document import get_document_field_types
+    key_types = get_document_field_types()
 
     import string
 

--- a/tests/commands/test_add.py
+++ b/tests/commands/test_add.py
@@ -98,7 +98,7 @@ def test_add_auto_doctor_run(tmp_library: TemporaryLibrary) -> None:
     import papis.config
 
     # add document with auto-doctor on
-    papis.config.set("doctor-default-checks", ["keys-missing", "key-type", "refs"])
+    papis.config.set("doctor-default-checks", ["keys-missing", "field-type", "refs"])
     run(paths, data=data, auto_doctor=True)
 
     # check that all the broken fields are fixed

--- a/tests/test_doctor.py
+++ b/tests/test_doctor.py
@@ -219,8 +219,8 @@ def test_bibtex_type_check(tmp_config: TemporaryConfiguration) -> None:
         assert not errors
 
 
-def test_key_type_check(tmp_config: TemporaryConfiguration) -> None:
-    from papis.commands.doctor import key_type_check
+def test_field_type_check(tmp_config: TemporaryConfiguration) -> None:
+    from papis.commands.doctor import field_type_check
 
     doc = papis.document.from_data({
         "author_list": [{"given": "F.", "family": "Sanger"}],
@@ -231,50 +231,50 @@ def test_key_type_check(tmp_config: TemporaryConfiguration) -> None:
 
     # check: invalid setting parsing
     papis.config.set("document-field-types", ["year = WithoutColon"])
-    errors = key_type_check(doc)
+    errors = field_type_check(doc)
     assert not errors
 
     papis.config.set("document-field-types", ["year:NotBuiltin"])
-    errors = key_type_check(doc)
+    errors = field_type_check(doc)
     assert not errors
 
     # check: incorrect type
     papis.config.set("document-field-types", ["year:int"])
-    error, = key_type_check(doc)
+    error, = field_type_check(doc)
     assert error.payload == "year"
 
     # check: correct type
     papis.config.set("document-field-types", ["  author_list :    list"])
-    errors = key_type_check(doc)
+    errors = field_type_check(doc)
     assert not errors
 
     # check: fix int
     papis.config.set("document-field-types", ["year:int"])
-    error, = key_type_check(doc)
+    error, = field_type_check(doc)
     assert error.payload == "year"
     assert error.fix_action is not None
     error.fix_action()
     assert doc["year"] == 2023
 
     # check: fix list
-    papis.config.set("doctor-key-type-separator", " ")
+    papis.config.set("doctor-field-type-separator", " ")
     papis.config.set("document-field-types", ["projects:list"])
-    error, = key_type_check(doc)
+    error, = field_type_check(doc)
     assert error.payload == "projects"
     assert error.fix_action is not None
     error.fix_action()
     assert doc["projects"] == ["test-key-project"]
 
     papis.config.set("document-field-types", ["tags:list"])
-    error, = key_type_check(doc)
+    error, = field_type_check(doc)
     assert error.payload == "tags"
     assert error.fix_action is not None
     error.fix_action()
     assert doc["tags"] == ["test-key-tag-1", "test-key-tag-2", "test-key-tag-3"]
 
-    papis.config.set("doctor-key-type-separator", ",")
+    papis.config.set("doctor-field-type-separator", ",")
     doc["tags"] = "test-key-tag-1,test-key-tag-2    ,  test-key-tag-3"
-    error, = key_type_check(doc)
+    error, = field_type_check(doc)
     assert error.payload == "tags"
     assert error.fix_action is not None
     error.fix_action()
@@ -282,7 +282,7 @@ def test_key_type_check(tmp_config: TemporaryConfiguration) -> None:
 
     papis.config.set("document-field-types", [])
     papis.config.set("document-field-types-extend", ["tags:str"])
-    error, = key_type_check(doc)
+    error, = field_type_check(doc)
     assert error.payload == "tags"
     assert error.fix_action is not None
     error.fix_action()

--- a/tests/test_doctor.py
+++ b/tests/test_doctor.py
@@ -230,26 +230,26 @@ def test_key_type_check(tmp_config: TemporaryConfiguration) -> None:
         })
 
     # check: invalid setting parsing
-    papis.config.set("doctor-key-type-keys", ["year = WithoutColon"])
+    papis.config.set("document-field-types", ["year = WithoutColon"])
     errors = key_type_check(doc)
     assert not errors
 
-    papis.config.set("doctor-key-type-keys", ["year:NotBuiltin"])
+    papis.config.set("document-field-types", ["year:NotBuiltin"])
     errors = key_type_check(doc)
     assert not errors
 
     # check: incorrect type
-    papis.config.set("doctor-key-type-keys", ["year:int"])
+    papis.config.set("document-field-types", ["year:int"])
     error, = key_type_check(doc)
     assert error.payload == "year"
 
     # check: correct type
-    papis.config.set("doctor-key-type-keys", ["  author_list :    list"])
+    papis.config.set("document-field-types", ["  author_list :    list"])
     errors = key_type_check(doc)
     assert not errors
 
     # check: fix int
-    papis.config.set("doctor-key-type-keys", ["year:int"])
+    papis.config.set("document-field-types", ["year:int"])
     error, = key_type_check(doc)
     assert error.payload == "year"
     assert error.fix_action is not None
@@ -258,14 +258,14 @@ def test_key_type_check(tmp_config: TemporaryConfiguration) -> None:
 
     # check: fix list
     papis.config.set("doctor-key-type-separator", " ")
-    papis.config.set("doctor-key-type-keys", ["projects:list"])
+    papis.config.set("document-field-types", ["projects:list"])
     error, = key_type_check(doc)
     assert error.payload == "projects"
     assert error.fix_action is not None
     error.fix_action()
     assert doc["projects"] == ["test-key-project"]
 
-    papis.config.set("doctor-key-type-keys", ["tags:list"])
+    papis.config.set("document-field-types", ["tags:list"])
     error, = key_type_check(doc)
     assert error.payload == "tags"
     assert error.fix_action is not None
@@ -280,8 +280,8 @@ def test_key_type_check(tmp_config: TemporaryConfiguration) -> None:
     error.fix_action()
     assert doc["tags"] == ["test-key-tag-1", "test-key-tag-2", "test-key-tag-3"]
 
-    papis.config.set("doctor-key-type-keys", [])
-    papis.config.set("doctor-key-type-keys-extend", ["tags:str"])
+    papis.config.set("document-field-types", [])
+    papis.config.set("document-field-types-extend", ["tags:str"])
     error, = key_type_check(doc)
     assert error.payload == "tags"
     assert error.fix_action is not None


### PR DESCRIPTION
This moves `doctor-key-type-keys` to a more central location in `papis.document`. The config option is being used in more places to check things have expected types, so it deserves to be promoted.

cc @jghauser 