### PR TITLE
Rename normalize_path to normalize_path_part

### DIFF
--- a/doc/source/default_settings.rst
+++ b/doc/source/default_settings.rst
@@ -197,14 +197,13 @@ General settings
 
     By default document paths in Papis libraries can contain only a limited set
     of characters. This is mainly to exclude characters that are invalid for
-    file paths on any operating system or possibly unprintable. Allowed
-    characters are:
+    file paths on any operating system or possibly unprintable. Currently, the
+    following character sets are hardcoded:
 
-    * latin letters (a to z)
-    * arabic digits (0 to 9)
-    * dots (for file extensions)
-    * directory separators (usually ``/`` on UNIX-like systems and ``\\``
-      on Windows)
+    * lowercase ASCII letters (a to z),
+    * uppercase ASCII letters (A to Z) if :confval:`doc-paths-lowercase` is *False*,
+    * digits (0 to 9),
+    * dots (for file extensions).
 
     This setting allows to append additional characters to this set. It expects
     a string containing all additional valid characters. A possible value would

--- a/papis/commands/rename.py
+++ b/papis/commands/rename.py
@@ -148,14 +148,14 @@ def cli(query: str,
         return
 
     from papis.format import format
-    from papis.paths import normalize_path
+    from papis.paths import normalize_path_part
     from papis.tui.utils import confirm
 
     renames = []
     for document in documents:
         current_name = document.get_main_folder_name()
         new_name = format(folder_name, document)
-        new_name = normalize_path(new_name)
+        new_name = normalize_path_part(new_name)
 
         if not batch and not confirm(f"Rename '{current_name}' to '{new_name}'?"):
             continue

--- a/papis/commands/update.py
+++ b/papis/commands/update.py
@@ -177,7 +177,7 @@ def run_set(
     the VALUE in the document.
     """
     from papis.format import format
-    from papis.paths import normalize_path
+    from papis.paths import normalize_path_part
     from papis.strings import process_format_pattern_pair
 
     for orig_key, orig_value in to_set:
@@ -189,7 +189,7 @@ def run_set(
             value = str(value)
         if key == "notes" and isinstance(value, str):
             # TODO: handle renames/deletions of files on disk
-            document[key] = normalize_path(value)
+            document[key] = normalize_path_part(value)
             logger.warning(
                 "Document note renamed in the info.yaml file. This does not "
                 "rename any files on disk."
@@ -199,7 +199,7 @@ def run_set(
             document[key] = []
             for file in value:
                 if isinstance(file, str):
-                    document[key].append(normalize_path(file))
+                    document[key].append(normalize_path_part(file))
                 else:
                     document[key].append(value)
             logger.warning(
@@ -227,7 +227,7 @@ def run_append(
     :returns: A boolean indicating whether the update was successful.
     """
     from papis.format import format
-    from papis.paths import normalize_path
+    from papis.paths import normalize_path_part
     from papis.strings import process_format_pattern_pair
 
     success = True
@@ -256,7 +256,7 @@ def run_append(
         elif type_doc is list or (type_doc is type(None) and type_conf is list):
             value = try_parsing_str(key, value)
             if key == "files":
-                value = normalize_path(str(value))
+                value = normalize_path_part(str(value))
             document.setdefault(key, []).append(value)
             processed_lists.add(key)
         else:

--- a/papis/format/python.py
+++ b/papis/format/python.py
@@ -51,8 +51,8 @@ class _PythonStringFormatter(StringFormatter):
         if conversion == "c":
             return str(value).capitalize()
         if conversion == "y":
-            from papis.paths import normalize_path
-            return normalize_path(str(value))
+            from papis.paths import normalize_path_part
+            return normalize_path_part(str(value))
 
         return super().convert_field(value, conversion)
 
@@ -87,7 +87,7 @@ class PythonFormatter(Formatter):
     The following special conversions are implemented: "l" for :meth:`str.lower`,
     "u" for :meth:`str.upper`, "t" for :meth:`str.title`, "c" for
     :meth:`str.capitalize`, "y" that uses ``slugify`` (through
-    :func:`papis.paths.normalize_path`). Additionally, the following
+    :func:`papis.paths.normalize_path_part`). Additionally, the following
     syntax is available to select subsets from a string:
 
     .. code:: python

--- a/papis/notes.py
+++ b/papis/notes.py
@@ -35,8 +35,8 @@ def notes_path(doc: Document) -> str:
             papis.config.getformatpattern("notes-name"), doc,
             default="notes.tex")
 
-        from papis.paths import normalize_path
-        doc["notes"] = normalize_path(notes_name)
+        from papis.paths import normalize_path_part
+        doc["notes"] = normalize_path_part(notes_name)
 
         from papis.api import save_doc
         save_doc(doc)

--- a/papis/paths.py
+++ b/papis/paths.py
@@ -60,14 +60,35 @@ def unique_suffixes(chars: str | None = None, skip: int = 0) -> Iterator[str]:
     yield from islice(ids(), max(skip, 0), None)
 
 
-def normalize_path(path: str, *,
-                   lowercase: bool | None = None,
-                   extra_chars: str | None = None,
-                   separator: str | None = None) -> str:
+def normalize_path(
+        path: str, *,
+        lowercase: bool | None = None,
+        extra_chars: str | None = None,
+        separator: str | None = None) -> str:
+    from warnings import warn
+    warn("'papis.paths.normalize_path' is deprecated and will be removed in Papis "
+         "0.17. Prefer 'papis.paths.normalize_path_part' instead.",
+         DeprecationWarning, stacklevel=2)
+
+    return normalize_path_part(
+        path,
+        lowercase=lowercase,
+        extra_chars=extra_chars,
+        separator=separator
+    )
+
+
+def normalize_path_part(
+        path: str, *,
+        lowercase: bool | None = None,
+        extra_chars: str | None = None,
+        separator: str | None = None) -> str:
     """Clean a path to only contain visible ASCII characters.
 
     This function will create ASCII strings that can be safely used as file names
-    or printed to consoles that do not necessarily support full unicode.
+    or printed to consoles that do not necessarily support full unicode. This is
+    mainly meant to be used to normalize document directory names and document
+    files in Papis and should not be used with a full path.
 
     :arg lowercase: if *True*, the resulting string will always be lowercased
         (defaults to :confval:`doc-paths-lowercase`).
@@ -164,7 +185,7 @@ def get_document_file_name(
     original path will be preserved.
 
     If resulting path will have the same extension as *orig_path* and will be
-    modified by :func:`normalize_path`. The extension is determined using
+    modified by :func:`normalize_path_part`. The extension is determined using
     :func:`~papis.filetype.get_document_extension`.
 
     :param orig_path: an input file path
@@ -196,9 +217,9 @@ def get_document_file_name(
     file_name_base = format(file_name_format, doc, default="")
 
     # ensure the file name is valid and within limits
-    file_name_base = normalize_path(file_name_base)
+    file_name_base = normalize_path_part(file_name_base)
     if not file_name_base:
-        file_name_base = normalize_path(orig_path.name)
+        file_name_base = normalize_path_part(orig_path.name)
 
     if len(file_name_base) > base_name_limit:
         logger.warning(
@@ -290,7 +311,7 @@ def get_document_folder(
                 components.clear()
                 break
             else:
-                components.append(normalize_path(tmp_component))
+                components.append(normalize_path_part(tmp_component))
 
             tmp_path = os.path.dirname(tmp_path)
 

--- a/papis/utils.py
+++ b/papis/utils.py
@@ -246,14 +246,14 @@ def create_identifier(input_list: str | None = None, skip: int = 0) -> Iterator[
 
 def clean_document_name(doc_path: str, is_path: bool = True) -> str:
     warn("'papis.utils.clean_document_name' is deprecated and will be removed in "
-         "Papis v0.16. Use 'papis.paths.normalize_path' instead.",
+         "Papis v0.16. Use 'papis.paths.normalize_path_part' instead.",
          DeprecationWarning, stacklevel=2)
 
     if is_path:
         doc_path = os.path.basename(doc_path)
 
-    from papis.paths import normalize_path
-    return normalize_path(doc_path)
+    from papis.paths import normalize_path_part
+    return normalize_path_part(doc_path)
 
 
 def locate_document_in_lib(document: Document,

--- a/tests/commands/test_addto.py
+++ b/tests/commands/test_addto.py
@@ -71,12 +71,12 @@ def test_addto_cli(tmp_library: TemporaryLibrary, nfiles: int = 5) -> None:
     doc, = db.query_dict({"author": "krishnamurti"})
     files = [os.path.basename(f) for f in doc.get_files()][-nfiles:]
 
-    from papis.paths import normalize_path
+    from papis.paths import normalize_path_part
 
     def eq(outfile: str, infile: str) -> bool:
         outfile, _ = os.path.splitext(os.path.basename(outfile))
         infile, _ = os.path.splitext(os.path.basename(infile))
-        return outfile.startswith(normalize_path(infile))
+        return outfile.startswith(normalize_path_part(infile))
 
     assert (
         all(eq(a, b) for a, b in zip(files, inputfiles, strict=True))), (

--- a/tests/test_paths.py
+++ b/tests/test_paths.py
@@ -27,60 +27,62 @@ def test_unique_suffixes() -> None:
 
 
 def test_normalize_path(tmp_config: TemporaryConfiguration) -> None:
-    from papis.paths import normalize_path
+    from papis.paths import normalize_path_part
 
     assert (
-        normalize_path("{{] __ }}albert )(*& $ß $+_ einstein (*]")
+        normalize_path_part("{{] __ }}albert )(*& $ß $+_ einstein (*]")
         == "albert-ss-einstein"
     )
     assert (
-        normalize_path(
+        normalize_path_part(
             os.path.basename('/ashfd/df/  #$%@#$ }{_+"[ ]hello öworld--- .pdf')
         )
         == "hello-oworld-.pdf"
     )
-    assert normalize_path("масса и енергиа.pdf") == "massa-i-energia.pdf"
-    assert normalize_path("الامير الصغير.pdf") == "lmyr-lsgyr.pdf"
+    assert normalize_path_part("масса и енергиа.pdf") == "massa-i-energia.pdf"
+    assert normalize_path_part("الامير الصغير.pdf") == "lmyr-lsgyr.pdf"
 
     assert (
-        normalize_path("post-truth: a meta-analysis", extra_chars=" ", separator="")
+        normalize_path_part(
+            "post-truth: a meta-analysis", extra_chars=" ", separator="")
         == "posttruth a metaanalysis"
     )
     assert (
-        normalize_path("post-truth: a meta-analysis", extra_chars="-", separator=" ")
+        normalize_path_part(
+            "post-truth: a meta-analysis", extra_chars="-", separator=" ")
         == "post-truth a meta-analysis"
     )
 
 
 def test_normalize_path_config(tmp_config: TemporaryConfiguration) -> None:
     import papis.config
-    from papis.paths import normalize_path
+    from papis.paths import normalize_path_part
 
     papis.config.set("doc-paths-lowercase", "False")
     assert (
-        normalize_path("{{] __ }}Albert )(*& $ß $+_ Einstein (*]")
+        normalize_path_part("{{] __ }}Albert )(*& $ß $+_ Einstein (*]")
         == "Albert-ss-Einstein"
     )
 
     papis.config.set("doc-paths-extra-chars", "_")
     assert (
-        normalize_path("{{] __ }}Albert )(*& $ß $+_ Einstein (*]")
+        normalize_path_part("{{] __ }}Albert )(*& $ß $+_ Einstein (*]")
         == "__-Albert-ss-_-Einstein"
     )
     assert (
-        normalize_path("{{] __Albert )(*& $ß $+_ Einstein (*]")
+        normalize_path_part("{{] __Albert )(*& $ß $+_ Einstein (*]")
         == "__Albert-ss-_-Einstein"
     )
 
     papis.config.set("doc-paths-word-separator", "_")
     assert (
-        normalize_path("{{] __ }}Albert )(*& $ß $+_ Einstein (*]")
+        normalize_path_part("{{] __ }}Albert )(*& $ß $+_ Einstein (*]")
         == "___Albert_ss___Einstein"
     )
 
     papis.config.set("doc-paths-lowercase", "True")
     assert (
-        normalize_path("{{] __ }}Albert )(*& $ß $+_ Einstein (*]")
+        normalize_path_part("{{] __ }}Albert )(*& $ß $+_ Einstein (*]")
         == "___albert_ss___einstein"
     )
 
@@ -262,7 +264,7 @@ def test_rename_document_files(tmp_config: TemporaryConfiguration) -> None:
                                       file_name_format=False,
                                       allow_remote=False)
 
-    from papis.paths import normalize_path
+    from papis.paths import normalize_path_part
     assert new_files == [
-        normalize_path(os.path.basename(filename)) for filename in orig_files
+        normalize_path_part(os.path.basename(filename)) for filename in orig_files
         ]


### PR DESCRIPTION
`normalize_path` did not work on paths (either as strings or as `pathlib.Path`), so the name was quite confusing. This adds a little `_part` to it and updates the documentation to hopefully make it clearer.

cc @jghauser 