### PR TITLE
Match existing libs in get_lib_from_name

### DIFF
--- a/papis/config.py
+++ b/papis/config.py
@@ -653,7 +653,7 @@ def set_lib_from_name(libname: str) -> None:
     set_lib(get_lib_from_name(libname))
 
 
-def get_lib_from_name(libname: str) -> Library:
+def get_lib_from_name(libname_or_path: str) -> Library:
     """Get a library object from a name.
 
     :param libname: the name of a library in the configuration file or a path
@@ -665,22 +665,33 @@ def get_lib_from_name(libname: str) -> Library:
 
     from papis.library import Library, from_paths
 
-    if libname not in libs:
-        if os.path.isdir(libname):
-            logger.warning("Setting path '%s' as the main library folder.", libname)
+    if libname_or_path not in libs:
+        path = os.path.abspath(os.path.expanduser(libname_or_path))
 
-            lib = from_paths([libname])
+        # first check if this path corresponds to an existing library
+        for libname in libs:
+            lib = get_lib_from_name(libname)
+            if path in lib.paths:
+                return lib
+
+        if os.path.isdir(path):
+            logger.warning("Setting path '%s' as the main library folder.",
+                           libname_or_path)
+
             # NOTE: can't use set(...) here due to cyclic dependencies
-            config[lib.name] = {"dirs": str([escape_interp(libname)])}
+            lib = from_paths([path])
+            config[lib.name] = {"dirs": str([escape_interp(path)])}
         else:
             raise InvalidLibraryError(
-                f"Library '{libname}' does not seem to exist. ",
+                f"Library '{libname_or_path}' does not seem to exist. ",
                 "To add a library simply write the following "
                 f"in your configuration file located at '{get_config_file()}'\n\n"
-                f"\t[{libname}]\n"
-                f"\tdir = path/to/your/{libname}/folder"
+                f"\t[{libname_or_path}]\n"
+                f"\tdir = path/to/your/{libname_or_path}/folder"
                 )
     else:
+        libname = libname_or_path
+
         if libname in default_settings and libname not in config:
             config[libname] = default_settings[libname]
 

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -197,8 +197,9 @@ def test_set_lib_from_path(tmp_config: TemporaryConfiguration) -> None:
 
     assert tmp_config.libdir is not None
 
+    # NOTE: this libdir is that of the default library
     papis.config.set_lib_from_name(tmp_config.libdir)
-    assert papis.config.get_lib_name() == tmp_config.libdir
+    assert tmp_config.libdir in papis.config.get_lib_dirs()
 
 
 def test_set_lib_from_real_lib(tmp_config: TemporaryConfiguration) -> None:
@@ -214,6 +215,21 @@ def test_set_lib_from_real_lib(tmp_config: TemporaryConfiguration) -> None:
 
     papis.config.set_lib_from_name(libname)
     assert papis.config.get_lib_name() == libname
+
+
+def test_get_lib_from_name_matches_existing_lib(
+        tmp_config: TemporaryConfiguration) -> None:
+    import papis.config
+
+    assert tmp_config.libdir is not None
+
+    libname = "mylib"
+    papis.config.set("dir",
+                     papis.config.escape_interp(tmp_config.libdir),
+                     section=libname)
+
+    lib = papis.config.get_lib_from_name(tmp_config.libdir)
+    assert lib.name == libname
 
 
 def test_reset_configuration(tmp_config: TemporaryConfiguration) -> None:


### PR DESCRIPTION
When a path got passed to `get_lib_from_name`, it would always make a new library just with that folder. It now checks if an existing library has that `dir` and returns that instead.