### PR TITLE
Only allow one `dir` per library (remove `dirs`)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -55,6 +55,11 @@ papis open 'title:^Quantum'
 Note that this new query syntax still uses the `match-format` configuration setting
 for free-form terms in the query (i.e. ones not using a `key:value` format).
 
+## Other noteworthy features
+
+- Remove undocumented `dirs` option (only allow one `dir` per library).
+  ([#1182](https://github.com/papis/papis/pull/1182)).
+
 # VERSION v0.15.0 (February 8th, 2026)
 
 ## Dependency Changes

--- a/examples/scripts/papis-ga.py
+++ b/examples/scripts/papis-ga.py
@@ -26,7 +26,7 @@ logger = papis.logging.get_logger("papis.commands.ga")
 
 
 def add(doc: papis.document.Document) -> None:
-    path = os.path.expanduser(papis.config.get_lib_dirs()[0])
+    path = os.path.expanduser(papis.config.get_lib().path)
     cmd = ["git", "-C", path, "add", *doc.get_files(), doc.get_info_file()]
 
     logger.info("Running command: '%s'", " ".join(cmd))

--- a/papis/api.py
+++ b/papis/api.py
@@ -57,7 +57,7 @@ def get_libraries() -> list[str]:
     Get all the libraries declared in the configuration files.
 
     A library in the configuration files is a section that has the ``dir``
-    or ``dirs`` key defined.
+    key defined.
 
     :returns: a :class:`list` of library names.
 

--- a/papis/commands/add.py
+++ b/papis/commands/add.py
@@ -232,7 +232,7 @@ def run(paths: list[str],
 
     # create a nice folder name for the new document
     if base_path is None:
-        base_path = os.path.expanduser(papis.config.get_lib_dirs()[0])
+        base_path = os.path.expanduser(papis.config.get_lib().path)
 
     if subfolder:
         base_path = os.path.join(base_path, subfolder)

--- a/papis/commands/default.py
+++ b/papis/commands/default.py
@@ -158,15 +158,14 @@ def run(ctx: click.Context,
     if lib is None:
         # NOTE: check if the current folder is a configured library
         libdir = os.getcwd()
-        config_lib_dirs = {
-            path: libname
+        config_lib_paths = {
+            papis.config.get_lib_from_name(libname).path: libname
             for libname in papis.config.get_libs()
-            for path in papis.config.get_lib_from_name(libname).paths
         }
 
         while libdir != (nextlibdir := os.path.dirname(libdir)):
-            if libdir in config_lib_dirs:
-                lib = config_lib_dirs[libdir]
+            if libdir in config_lib_paths:
+                lib = config_lib_paths[libdir]
                 break
 
             libdir = nextlibdir
@@ -183,21 +182,20 @@ def run(ctx: click.Context,
         raise SystemExit(1) from None
 
     configuration = papis.config.get_configuration()
-    if library.paths:
-        # Now the library should be set, let us check if there is a
-        # local configuration file there, and if there is one, then
+    if os.path.isdir(library.path):
+        # Check if there's a local configuration file in the library, and if so,
         # merge its contents
         local_config_file = papis.config.getstring("local-config-file")
-        for path in library.paths:
-            local_config_path = os.path.join(path, local_config_file)
-            papis.config.merge_configuration_from_path(local_config_path, configuration)
+        local_config_path = os.path.join(library.path, local_config_file)
+        papis.config.merge_configuration_from_path(local_config_path, configuration)
     else:
         config_file = papis.config.get_config_file()
         if os.path.exists(config_file):
             logger.error(
-                "Library '%s' does not have any folders attached to it. Please "
-                "create and add the required paths to the configuration file.",
-                library)
+                "Library '%s' directory '%s' does not exist. Please "
+                "create it or update the 'dir' setting in the "
+                "configuration file.",
+                library, library.path)
         elif ctx.invoked_subcommand != "init":
             logger.warning("No configuration file exists at '%s'.", config_file)
             logger.warning("Create a configuration file and define your "

--- a/papis/commands/external.py
+++ b/papis/commands/external.py
@@ -35,7 +35,7 @@ def get_exported_variables(ctx: dict[str, Any] | None = None) -> dict[str, str]:
     """
     exports = {
         "PAPIS_LIB": papis.config.get_lib().name,
-        "PAPIS_LIB_PATH": papis.config.get_lib().path_format(),
+        "PAPIS_LIB_PATH": papis.config.get_lib().path,
         "PAPIS_CONFIG_PATH": papis.config.get_config_folder(),
         "PAPIS_CONFIG_FILE": papis.config.get_config_file(),
         "PAPIS_SCRIPTS_PATH": papis.config.get_scripts_folder(),

--- a/papis/commands/mv.py
+++ b/papis/commands/mv.py
@@ -81,7 +81,7 @@ def cli(query: str,
 
     document = documents[0]
 
-    lib_dir = os.path.expanduser(papis.config.get_lib_dirs()[0])
+    lib_dir = os.path.expanduser(papis.config.get_lib().path)
 
     completer = prompt_toolkit.completion.PathCompleter(
         only_directories=True,

--- a/papis/commands/run.py
+++ b/papis/commands/run.py
@@ -120,7 +120,7 @@ def cli(run_command: list[str],
     if documents:
         folders = [d for d in [d.get_main_folder() for d in documents] if d]
     else:
-        folders = papis.config.get_lib_dirs()
+        folders = [papis.config.get_lib().path]
 
     for folder in folders:
         cmd = ([prefix] if prefix else []) + list(run_command)

--- a/papis/commands/serve.py
+++ b/papis/commands/serve.py
@@ -202,7 +202,7 @@ class PapisRequestHandler(http.server.BaseHTTPRequestHandler):
             if papis.config.getboolean("serve-empty-query-get-all-documents"):
                 docs = get_all_documents_in_lib(libname)
 
-        libfolder = papis.config.get_lib_from_name(libname).paths[0]
+        libfolder = papis.config.get_lib_from_name(libname).path
         placeholder = QUERY_PLACEHOLDER
         page = html(documents=docs,
                     libname=libname,
@@ -310,7 +310,7 @@ class PapisRequestHandler(http.server.BaseHTTPRequestHandler):
         self._ok()
         self._header_json()
         self.end_headers()
-        self._send_json({"name": lib.name, "paths": lib.paths})
+        self._send_json({"name": lib.name, "path": lib.path})
 
     def get_all_documents(self, libname: str) -> None:
         self._handle_lib(libname)
@@ -374,7 +374,7 @@ class PapisRequestHandler(http.server.BaseHTTPRequestHandler):
         self._send_json(fmts)
 
     def send_local_document_file(self, libname: str, localpath: str) -> None:
-        libfolder = papis.config.get_lib_from_name(libname).paths[0]
+        libfolder = papis.config.get_lib_from_name(libname).path
         path = os.path.join(libfolder, localpath)
         if os.path.exists(path):
             self._ok()

--- a/papis/config.py
+++ b/papis/config.py
@@ -638,8 +638,7 @@ def set_lib(library: Library) -> None:
 
     if library.name not in config:
         # NOTE: can't use set(...) here due to cyclic dependencies
-        paths = [escape_interp(path) for path in library.paths]
-        config[library.name] = {"dirs": str(paths)}
+        config[library.name] = {"dir": escape_interp(library.path)}
 
     CURRENT_LIBRARY = library
 
@@ -656,14 +655,14 @@ def set_lib_from_name(libname: str) -> None:
 def get_lib_from_name(libname_or_path: str) -> Library:
     """Get a library object from a name.
 
-    :param libname: the name of a library in the configuration file or a path
-        to an existing folder that should be considered a library.
+    :param libname_or_path: the name of a library in the configuration file
+        or a path to an existing folder that should be considered a library.
     """
     config = get_configuration()
     default_settings = get_default_settings()
     libs = get_libs_from_config(config)
 
-    from papis.library import Library, from_paths
+    from papis.library import Library
 
     if libname_or_path not in libs:
         path = os.path.abspath(os.path.expanduser(libname_or_path))
@@ -671,16 +670,16 @@ def get_lib_from_name(libname_or_path: str) -> Library:
         # first check if this path corresponds to an existing library
         for libname in libs:
             lib = get_lib_from_name(libname)
-            if path in lib.paths:
+            if path == lib.path:
                 return lib
 
+        lib = Library(libname_or_path, path)
         if os.path.isdir(path):
             logger.warning("Setting path '%s' as the main library folder.",
                            libname_or_path)
 
             # NOTE: can't use set(...) here due to cyclic dependencies
-            lib = from_paths([path])
-            config[lib.name] = {"dirs": str([escape_interp(path)])}
+            config[lib.name] = {"dir": escape_interp(path)}
         else:
             raise InvalidLibraryError(
                 f"Library '{libname_or_path}' does not seem to exist. ",
@@ -697,27 +696,48 @@ def get_lib_from_name(libname_or_path: str) -> Library:
 
         try:
             # NOTE: can't use `getstring(...)` due to cyclic dependency
-            paths = [os.path.expanduser(config[libname]["dir"])]
+            path = os.path.expanduser(config[libname]["dir"])
         except KeyError:
-            try:
-                # NOTE: can't use `getlist(...)` due to cyclic dependency
-                paths = eval(config[libname]["dirs"])
-                paths = [os.path.expanduser(d) for d in paths]
-            except Exception as exc:
-                raise MissingLibraryDirectoryError(
-                    "To define a library you have to set either 'dir' or 'dirs' "
-                    "in the configuration file.\n"
-                    "\t'dir' must be a path to an existing folder.\n"
-                    "\t'dirs' must be a list of paths.") from exc
+            if "dirs" in config[libname]:
+                from warnings import warn
 
-        lib = Library(libname, paths)
+                warn(
+                    f"Library '{libname}' uses the 'dirs' setting, which is "
+                    "deprecated and will be removed in Papis 0.17. "
+                    "Use 'dir' with a single path instead. "
+                    "Only the first path in 'dirs' will be used.",
+                    DeprecationWarning, stacklevel=2)
+                try:
+                    # NOTE: can't use `getlist(...)` due to cyclic dependency
+                    dirs = eval(config[libname]["dirs"])
+                    path = os.path.expanduser(dirs[0])
+                except Exception as exc:
+                    raise MissingLibraryDirectoryError(
+                        "To define a library you have to set 'dir' "
+                        "in the configuration file.\n"
+                        "\t'dir' must be a path to an existing folder.") from exc
+            else:
+                raise MissingLibraryDirectoryError(
+                    "To define a library you have to set 'dir' "
+                    "in the configuration file.\n"
+                    "\t'dir' must be a path to an existing folder.") from None
+
+        lib = Library(libname, path)
 
     return lib
 
 
 def get_lib_dirs() -> list[str]:
     """Get the directories of the current library."""
-    return get_lib().paths
+    from warnings import warn
+
+    warn(
+        "'papis.config.get_lib_dirs' is deprecated "
+        "and will be removed in Papis 0.17. "
+        "Use 'papis.config.get_lib().path' instead.",
+        DeprecationWarning, stacklevel=2)
+
+    return [get_lib().path]
 
 
 def get_lib_name() -> str:
@@ -764,14 +784,24 @@ def get_libs() -> list[str]:
 def get_libs_from_config(config: Configuration) -> list[str]:
     """Get all library names from the given *configuration*.
 
-    In the configuration file, any sections that contain a ``"dir"`` or a
-    ``"dirs"`` key are considered to be libraries.
+    In the configuration file, any sections that contain a ``"dir"`` key
+    are considered to be libraries.
     """
 
     libs = []
     for section in config:
         sec = config[section]
-        if "dir" in sec or "dirs" in sec:
+        if "dir" in sec:
+            libs.append(section)
+        elif "dirs" in sec:
+            from warnings import warn
+
+            warn(
+                f"Library '{section}' uses the 'dirs' setting, which is "
+                "deprecated and will be removed in Papis 0.17. "
+                "Use 'dir' with a single path instead. "
+                "Only the first path in 'dirs' will be used.",
+                DeprecationWarning, stacklevel=2)
             libs.append(section)
 
     # NOTE: also look through default settings in case they were registered
@@ -781,7 +811,17 @@ def get_libs_from_config(config: Configuration) -> list[str]:
         if name in config:
             continue
 
-        if "dir" in values or "dirs" in values:
+        if "dir" in values:
+            libs.append(name)
+        elif "dirs" in values:
+            from warnings import warn
+
+            warn(
+                f"Library '{name}' uses the 'dirs' setting, which is "
+                "deprecated and will be removed in Papis 0.17. "
+                "Use 'dir' with a single path instead. "
+                "Only the first path in 'dirs' will be used.",
+                DeprecationWarning, stacklevel=2)
             libs.append(name)
 
     return sorted(libs)

--- a/papis/database/base.py
+++ b/papis/database/base.py
@@ -9,11 +9,11 @@ if TYPE_CHECKING:
     from papis.library import Library
 
 
-def get_cache_file_name(libpaths: str) -> str:
+def get_cache_file_name(libpath: str) -> str:
     """Create a cache file name out of the path of a given directory.
 
-    :param libpaths: folder names to be used as a seed for the cache name.
-    :returns: a name for the cache file specific to *libpaths*.
+    :param libpath: folder name to be used as a seed for the cache name.
+    :returns: a name for the cache file specific to *libpath*.
 
     >>> get_cache_file_name('path/to/my/lib')
     'a8c689820a94babec20c5d6269c7d488-lib'
@@ -22,18 +22,18 @@ def get_cache_file_name(libpaths: str) -> str:
     """
     import hashlib
 
-    digest = hashlib.md5(libpaths.encode()).hexdigest()
-    return f"{digest}-{os.path.basename(libpaths)}"
+    digest = hashlib.md5(libpath.encode()).hexdigest()
+    return f"{digest}-{os.path.basename(libpath)}"
 
 
-def get_cache_file_path(libpaths: str) -> str:
+def get_cache_file_path(libpath: str) -> str:
     """Get the full path to the cache file.
 
-    :param libpaths: a cache file specific for the given library paths.
+    :param libpath: a cache file specific for the given library path.
     """
     from papis.utils import get_cache_home
 
-    cache_name = get_cache_file_name(libpaths)
+    cache_name = get_cache_file_name(libpath)
     folder = os.path.join(get_cache_home(), "database")
     if not os.path.exists(folder):
         os.makedirs(folder)
@@ -165,10 +165,10 @@ class Database(ABC):
 
         warn(f"Calling '{type(self).__name__}.get_dirs' directly is deprecated "
              "and will be removed in the next version of Papis (after 0.15). Use "
-             "the 'self.lib.paths' member directly.",
+             "the 'self.lib.path' member directly.",
              DeprecationWarning, stacklevel=2)
 
-        return self.lib.paths
+        return [self.lib.path]
 
     @staticmethod
     def get_id_key() -> str:

--- a/papis/database/cache.py
+++ b/papis/database/cache.py
@@ -197,11 +197,11 @@ class PickleDatabase(Database):
             import pickle
             with open(cache_path, "rb") as fd:
                 self.documents = pickle.load(fd)
-        elif self.lib.paths:
+        elif self.lib.path:
             from papis.utils import folders_to_documents, get_folders
 
             logger.info("Indexing library. This might take a while...")
-            folders = [f for path in self.lib.paths for f in get_folders(path)]
+            folders = get_folders(self.lib.path)
             self.documents = folders_to_documents(folders)
 
             from papis.id import ID_KEY_NAME
@@ -228,7 +228,7 @@ class PickleDatabase(Database):
             pickle.dump(docs, fd)
 
     def _get_cache_file_path(self) -> str:
-        return get_cache_file_path(self.lib.path_format())
+        return get_cache_file_path(self.lib.path)
 
     def _locate_document(self,
                          document: Document

--- a/papis/database/sqlite.py
+++ b/papis/database/sqlite.py
@@ -167,7 +167,7 @@ class SQLiteDatabase(Database):
         self.cache_dir = os.path.join(get_cache_home(), "database", "sqlite")
         self.cache_file_name = os.path.join(
             self.cache_dir,
-            f"{get_cache_file_name(self.lib.path_format())}.sqlite")
+            f"{get_cache_file_name(self.lib.path)}.sqlite")
 
         self.initialize()
 
@@ -354,7 +354,7 @@ class SQLiteDatabase(Database):
         from papis.utils import folders_to_documents, get_folders
 
         logger.info("Indexing library. This might take a while...")
-        folders = [f for path in self.lib.paths for f in get_folders(path)]
+        folders = get_folders(self.lib.path)
         documents = folders_to_documents(folders)
 
         from papis.document import describe

--- a/papis/database/whoosh.py
+++ b/papis/database/whoosh.py
@@ -65,7 +65,7 @@ class WhooshDatabase(Database):
 
         self.cache_dir = os.path.join(get_cache_home(), "database", "whoosh")
         self.index_dir = os.path.expanduser(
-            os.path.join(self.cache_dir, get_cache_file_name(self.lib.path_format()))
+            os.path.join(self.cache_dir, get_cache_file_name(self.lib.path))
             )
 
         self.initialize()
@@ -222,7 +222,7 @@ class WhooshDatabase(Database):
         from papis.utils import folders_to_documents, get_folders
 
         logger.debug("Indexing the library, this might take a while...")
-        folders = [f for path in self.lib.paths for f in get_folders(path)]
+        folders = get_folders(self.lib.path)
         documents = folders_to_documents(folders)
 
         schema_keys = self._get_schema_init_fields().keys()

--- a/papis/defaults.py
+++ b/papis/defaults.py
@@ -73,7 +73,7 @@ settings: dict[str, Any] = {
     "ref-word-separator": "_",
     "library-header-format": _f(
         "<ansired>{library[name]}</ansired>"
-        " <ansiblue>{library[paths]}</ansiblue>"
+        " <ansiblue>{library[dir]}</ansiblue>"
     ),
     "document-field-types": [
         "abstract:str",

--- a/papis/exceptions.py
+++ b/papis/exceptions.py
@@ -37,4 +37,4 @@ class InvalidLibraryError(RuntimeError):
 
 
 class MissingLibraryDirectoryError(InvalidLibraryError):
-    """Exception raised when a library does not have 'dir' or 'dirs' set."""
+    """Exception raised when a library does not have 'dir' set."""

--- a/papis/library.py
+++ b/papis/library.py
@@ -1,40 +1,17 @@
 from __future__ import annotations
 
-import glob
 import os
-from typing import TYPE_CHECKING
-
-if TYPE_CHECKING:
-    from collections.abc import Sequence
 
 
 class Library:
     """A class containing library information."""
 
-    def __init__(self, name: str, paths: Sequence[str]) -> None:
-        from itertools import chain
-
+    def __init__(self, name: str, path: str) -> None:
         #: The name of the library, as it appears in the configuration file if
         #: defined there.
         self.name: str = name
-        #: A list of paths with documents that form the library.
-        self.paths: list[str] = list(
-            chain.from_iterable(glob.glob(os.path.expanduser(p)) for p in paths)
-            )
-
-    def path_format(self) -> str:
-        """
-        :return: a string containing all the paths in the library concatenated
-            using a colon.
-        """
-        return ":".join(self.paths)
+        #: The path with documents that form the library.
+        self.path: str = os.path.abspath(os.path.expanduser(path))
 
     def __str__(self) -> str:
         return self.name
-
-
-def from_paths(paths: Sequence[str]) -> Library:
-    """Create a library from a list of paths."""
-
-    name = ":".join(paths)
-    return Library(name, paths)

--- a/papis/pick/__init__.py
+++ b/papis/pick/__init__.py
@@ -178,8 +178,8 @@ def pick_subfolder_from_lib(libname: str) -> list[str]:
 
     # get all document directories
     folders = [os.path.dirname(str(d.get_main_folder())) for d in documents]
-    # get all library directories
-    folders.extend(papis.config.get_lib_from_name(libname).paths)
+    # get the library directory
+    folders.append(papis.config.get_lib_from_name(libname).path)
     # remove duplicates and sort paths
     folders = sorted(set(folders))
 
@@ -209,8 +209,8 @@ def pick_library(libs: list[str] | None = None, *,
         library = papis.config.get_lib_from_name(lib)
         return format(header_format, {
             "name": library.name,
-            "dir": library.paths[0],
-            "paths": library.paths
+            "dir": library.path,
+            "paths": [library.path],
             }, doc_key="library", additional={"c": colorama})
 
     return pick(libs,

--- a/papis/testing.py
+++ b/papis/testing.py
@@ -449,7 +449,7 @@ class TemporaryLibrary(TemporaryConfiguration):
 
         # initialize library
         from papis.library import Library
-        lib = Library(self.libname, [self.libdir])
+        lib = Library(self.libname, self.libdir)
 
         import papis.config
         papis.config.set("default-library", self.libname)

--- a/papis/web/docview.py
+++ b/papis/web/docview.py
@@ -43,7 +43,7 @@ def html(libname: str, doc: Document) -> t.html_tag:
 
     checks = registered_checks_names()
     errors = gather_errors([doc], checks)
-    libfolder = get_lib_from_name(libname).paths[0]
+    libfolder = get_lib_from_name(libname).path
 
     from papis.exporters.bibtex import exporter as bibtex
 

--- a/tests/commands/test_default.py
+++ b/tests/commands/test_default.py
@@ -1,6 +1,23 @@
 from __future__ import annotations
 
-from papis.testing import PapisRunner, TemporaryLibrary
+import shutil
+
+from papis.testing import PapisRunner, TemporaryConfiguration, TemporaryLibrary
+
+
+def test_no_config_shows_init_hint(tmp_config: TemporaryConfiguration) -> None:
+    import papis.config
+    from papis.commands.default import run as cli
+
+    shutil.rmtree(tmp_config.configdir)
+    papis.config.reset_configuration()
+
+    cli_runner = PapisRunner()
+    result = cli_runner.invoke(cli, ["list"])
+
+    assert result.exit_code == 0
+    assert "No configuration file exists at" in result.output
+    assert "papis init" in result.output
 
 
 def test_default_cli(tmp_library: TemporaryLibrary) -> None:

--- a/tests/commands/test_git.py
+++ b/tests/commands/test_git.py
@@ -21,5 +21,5 @@ def test_git_cli(tmp_library: TemporaryLibrary) -> None:
         ["init"])
     assert result.exit_code == 0
 
-    folder, = papis.config.get_lib_dirs()
+    folder = papis.config.get_lib().path
     assert os.path.exists(os.path.join(folder, ".git"))

--- a/tests/commands/test_run.py
+++ b/tests/commands/test_run.py
@@ -15,7 +15,7 @@ if TYPE_CHECKING:
 def test_run_run(tmp_library: TemporaryLibrary) -> None:
     from papis.commands.run import run
 
-    libdir, = papis.config.get_lib_dirs()
+    libdir = papis.config.get_lib().path
     # Use a mock scriptlet
     script = os.path.join(os.path.dirname(__file__), "scripts.py")
     run(libdir, command=[sys.executable, script, "ls"])

--- a/tests/database/test_database.py
+++ b/tests/database/test_database.py
@@ -28,7 +28,7 @@ def test_database_paths(tmp_library: TemporaryLibrary) -> None:
     assert db is not None
     assert db.get_backend_name() == papis.config.getstring("database-backend")
     assert db.lib.name == papis.config.get_lib_name()
-    assert db.lib.paths == papis.config.get_lib_dirs()
+    assert db.lib.path == papis.config.get_lib().path
     assert db.get_all_query_string() == papis.database.get_all_query_string()
 
     docs = db.get_all_documents()

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -199,7 +199,7 @@ def test_set_lib_from_path(tmp_config: TemporaryConfiguration) -> None:
 
     # NOTE: this libdir is that of the default library
     papis.config.set_lib_from_name(tmp_config.libdir)
-    assert tmp_config.libdir in papis.config.get_lib_dirs()
+    assert tmp_config.libdir == papis.config.get_lib().path
 
 
 def test_set_lib_from_real_lib(tmp_config: TemporaryConfiguration) -> None:


### PR DESCRIPTION
Papis currently allows having multiple directories (`dirs`) per library. However, the feature was never documented, badly supported, and little used. This PR would remove this functionality to reduce complexity.

We'll let this sit here for a while in case there are after all people who depend on this :smile:.