### PR TITLE
`document.update()` should remove fields set to `None`

### DIFF
--- a/papis/document.py
+++ b/papis/document.py
@@ -408,6 +408,17 @@ class Document(dict[str, Any]):
         """
         return ""
 
+    def update(self, *args: Any, **kwargs: Any) -> None:
+        """Update the document, silently dropping keys with ``None`` values.
+
+        This overrides :meth:`dict.update` to ensure that fields with a
+        ``None`` value never leak into the document and get persisted to
+        its ``info.yaml`` file.
+        """
+        super().update(*args, **kwargs)
+        for key in [k for k in self if self[k] is None]:
+            del self[key]
+
     def copy(self) -> Document:
         """Make a shallow copy of the :class:`Document`."""
         doc = Document(data=dict(self))

--- a/tests/test_document.py
+++ b/tests/test_document.py
@@ -53,6 +53,17 @@ def test_from_folder() -> None:
     assert doc["author"] == "Russell, Bertrand"
 
 
+def test_update_drops_none_values() -> None:
+    """Document.update() must silently drop keys with None values."""
+    doc = papis.document.from_data({"title": "Hello", "author": "Turing"})
+
+    doc.update({"doi": None, "year": 1999, "abstract": None})
+    assert "doi" not in doc
+    assert "abstract" not in doc
+    assert doc["year"] == 1999
+    assert doc["title"] == "Hello"
+
+
 def test_main_features() -> None:
     doc = papis.document.from_data({
         "title": "Hello World",


### PR DESCRIPTION
Does what it says on the tin. We don't want fields set to `None` to be left in our `info.yaml`. This change makes behaviour consistent across the codebase so that e.g. `papis update` doesn't have to implement it separately.

fixes #1164