### PR TITLE
Fix/correct logging for testing

### DIFF
--- a/papis/logging.py
+++ b/papis/logging.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import copy
 import logging
 import os
 import sys
@@ -65,6 +66,9 @@ class ColoramaFormatter(logging.Formatter):
         into the message, removes the ``papis`` namespace from the name, etc. Any
         formatting of the logging output is made here.
         """
+
+        # Work on a copy so we don't mutate the shared record in place.
+        record = copy.copy(record)
 
         if isinstance(record.msg, str):
             record.msg = record.msg.format(c=c)

--- a/papis/testing.py
+++ b/papis/testing.py
@@ -410,6 +410,13 @@ class TemporaryConfiguration:
         for db in DATABASES.values():
             db.clear()
 
+        # NOTE: remove any handlers and reset the logger level
+        import logging
+        papis_logger = logging.getLogger("papis")
+        for handler in papis_logger.handlers[:]:
+            papis_logger.removeHandler(handler)
+        papis_logger.setLevel(logging.NOTSET)
+
         # cleanup
         if self._monkeypatch:
             self._monkeypatch.undo()


### PR DESCRIPTION
I ran into some troubles trying to add a test for the `papis init` hint discussed in #1182. Because that test would run the `run()` in `papis/commands/default.py` which sets up logging, it would cause other tests to fail.

**`logging.py`:** `ColoramaFormatter.format()` was mutating the shared `LogRecord` in place. Since this log record is used by every handler on the logger chain, this corrupted the record for downstream handlers. Pytest's `caplog` would for example see `"\x1b[1m\x1b[33mWARNING\x1b[0m"` instead of `"WARNING"`.

**`testing.py`:** `TemporaryConfiguration.__exit__` didn't clean up logging state. After any test that called `papis.logging.setup()`, the `papis` logger kept its handler and its level (INFO). This leaks into next tests, which made some of them fail (e.g. because it led to an unexpected number of logging messages).