### PR TITLE
refactor: move non-interactive new doc creation code to `document.py`

### DIFF
--- a/papis/commands/add.py
+++ b/papis/commands/add.py
@@ -198,37 +198,52 @@ def run(paths: list[str],
         if not os.path.exists(p):
             raise FileNotFoundError(f"File '{p}' not found")
 
-    import tempfile
-
     in_document_paths = paths
-    temp_dir = tempfile.mkdtemp()
 
     from papis.database import get as get_database
 
     db = get_database()
 
-    from papis.document import Document, describe, dump
+    from papis.document import describe, dump
+    from papis.tui.utils import confirm as ask_confirm, text_area
+    from papis.utils import open_file as open_file_viewer
 
-    tmp_document = Document(folder=temp_dir, data=data)
-    db.maybe_compute_id(tmp_document)
+    approved_files: list[str]
+    if not batch:
+        approved_files = []
+        for in_file_path in in_document_paths:
+            if open_file:
+                open_file_viewer(in_file_path)
 
-    # reference building
-    # NOTE: this needs to go before any papis.format calls, so that those can
-    # potentially use the 'ref' key in the format patterns.
-    if "ref" not in data:
-        from papis.bibtex import create_reference
+            if confirm and not ask_confirm(
+                    f"Add file '{os.path.basename(in_file_path)}' to document?"):
+                continue
 
-        new_ref = create_reference(data)
-        if new_ref:
-            logger.info("Created reference '%s'.", new_ref)
-            tmp_document["ref"] = new_ref
+            approved_files.append(in_file_path)
+    else:
+        approved_files = list(in_document_paths)
 
-    if auto_doctor:
-        from papis.commands.doctor import fix_errors
+    from papis.document import new as new_document
 
-        logger.info("Running doctor auto-fixers on document: '%s'.",
-                    describe(tmp_document))
-        fix_errors(tmp_document)
+    tmp_document = new_document(
+        data,
+        approved_files,
+        mode="link" if link else "copy",
+        file_name_format=file_name,
+        auto_doctor=auto_doctor)
+
+    # Log per-file operations
+    if link:
+        verb = "Linking"
+    elif move:
+        verb = "Moving"
+    else:
+        verb = "Copying"
+
+    for in_file, out_name in zip(
+            approved_files, tmp_document["files"], strict=True):
+        logger.info(
+            "%s '%s' to '%s'.", verb, os.path.basename(in_file), out_name)
 
     # create a nice folder name for the new document
     if base_path is None:
@@ -236,49 +251,6 @@ def run(paths: list[str],
 
     if subfolder:
         base_path = os.path.join(base_path, subfolder)
-
-    # rename all the given file names
-    from papis.paths import rename_document_files, symlink
-
-    renamed_file_list = rename_document_files(
-        tmp_document, in_document_paths,
-        file_name_format=file_name, allow_remote=False)
-
-    import shutil
-
-    from papis.tui.utils import confirm as ask_confirm, text_area
-    from papis.utils import open_file as open_file_viewer
-
-    document_file_list = []
-    for in_file_path, out_file_name in (
-            zip(in_document_paths, renamed_file_list, strict=True)):
-        out_file_path = os.path.join(temp_dir, out_file_name)
-        if os.path.exists(out_file_path):
-            logger.warning("File '%s' already exists. Skipping...", out_file_path)
-            continue
-
-        if not batch and open_file:
-            open_file_viewer(in_file_path)
-
-        if not batch and confirm and not ask_confirm(
-                f"Add file '{os.path.basename(in_file_path)}' "
-                f"(renamed to '{os.path.basename(out_file_path)}') to document?"):
-            continue
-
-        if link:
-            logger.info("[LN] '%s' to '%s'.", in_file_path, out_file_name)
-            symlink(in_file_path, out_file_path)
-        elif move:
-            logger.info("[MV] '%s' to '%s'.", in_file_path, out_file_name)
-            shutil.copy(in_file_path, out_file_path)
-        else:
-            logger.info("[CP] '%s' to '%s'.", in_file_path, out_file_name)
-            shutil.copy(in_file_path, out_file_path)
-
-        document_file_list.append(out_file_name)
-
-    tmp_document["files"] = document_file_list
-    tmp_document.save()
 
     from papis.paths import get_document_unique_folder
 
@@ -288,7 +260,7 @@ def run(paths: list[str],
         folder_name_format=folder_name)
 
     logger.info("Document folder is '%s'.", out_folder_path)
-    logger.debug("Document includes files: '%s'.", "', '".join(document_file_list))
+    logger.debug("Document includes files: '%s'.", "', '".join(tmp_document["files"]))
 
     # Check if the user wants to edit before submitting the doc
     # to the library
@@ -357,7 +329,7 @@ def run(paths: list[str],
 
     from papis.document import move as move_doc
 
-    logger.info("[MV] '%s' to '%s'.", tmp_document.get_main_folder(), out_folder_path)
+    logger.info("Moving document to '%s'.", out_folder_path)
     move_doc(tmp_document, out_folder_path)
     db.add(tmp_document)
 
@@ -368,7 +340,7 @@ def run(paths: list[str],
             f"Add document '{describe(tmp_document)}'")
 
     if move:
-        for in_file_path in in_document_paths:
+        for in_file_path in approved_files:
             try:
                 os.remove(in_file_path)
             except Exception as exc:

--- a/papis/document.py
+++ b/papis/document.py
@@ -11,6 +11,7 @@ import papis.logging
 
 if TYPE_CHECKING:
     from collections.abc import Callable, Sequence
+    from typing import Literal
 
     from papis.strings import AnyString
 
@@ -697,33 +698,83 @@ def sort(docs: Sequence[Document], key: str, reverse: bool = False) -> list[Docu
     return sorted(docs, key=document_sort_key, reverse=reverse)
 
 
-def new(folder_path: str,
-        data: dict[str, Any],
-        files: Sequence[str] | None = None) -> Document:
-    """Creates a complete document with data and existing files.
+def new(
+        data: DocumentLike,
+        files: Sequence[str] = (), *,
+        mode: Literal["copy", "link"] = "copy",
+        file_name_format: AnyString | None = None,
+        auto_doctor: bool = False) -> Document:
+    """Create a new document from *data* and *files* in a temporary directory.
 
-    The document is saved to the filesystem at *folder_path* and all the given
-    files are copied over to the main folder.
+    This function handles all non-interactive steps of creating a document:
+    generating a Papis ID, creating a BibTeX reference, running auto-doctor
+    checks, renaming files, and copying or linking them into the document
+    folder.
 
-    :param folder_path: a main folder for the document.
+    The document is created in a temporary directory. The caller is
+    responsible for moving it to its final location and adding it to the
+    database.
+
     :param data: a :class:`dict` with key and values to be used as metadata
         in the document.
-    :param files: a sequence of files to add to the document.
-    :raises FileExistsError: if *folder_path* already exists.
+    :param files: a sequence of file paths to add to the document.
+    :param mode: how to place files into the document directory: ``"copy"``
+        copies files, ``"link"`` creates symbolic links to the originals.
+    :param file_name_format: a format pattern used to construct new file names
+        from the document data (defaults to :confval:`add-file-name`).
+    :param auto_doctor: if *True*, run the doctor auto-fixers on the document
+        before saving.
+    :returns: the new document, residing in a temporary directory.
     """
-
-    if files is None:
-        files = []
-
-    os.makedirs(folder_path)
-
     import shutil
-    doc = Document(folder=folder_path, data=data)
-    doc["files"] = []
+    import tempfile
 
-    for f in files:
-        shutil.copy(f, os.path.join(folder_path))
-        doc["files"].append(os.path.basename(f))
+    temp_dir = tempfile.mkdtemp()
+    doc = Document(folder=temp_dir, data=data)
 
+    # Compute a unique Papis ID for the document
+    from papis.database import get as get_database
+
+    db = get_database()
+    db.maybe_compute_id(doc)
+
+    # Create a BibTeX reference if missing
+    if "ref" not in doc:
+        from papis.bibtex import create_reference
+
+        new_ref = create_reference(doc)
+        if new_ref:
+            logger.info("Created reference '%s'.", new_ref)
+            doc["ref"] = new_ref
+
+    # Run auto-doctor if requested
+    if auto_doctor:
+        from papis.commands.doctor import fix_errors
+
+        logger.info("Running doctor auto-fixers on document: '%s'.",
+                    describe(doc))
+        fix_errors(doc)
+
+    # Rename files according to the format pattern
+    from papis.paths import rename_document_files, symlink
+
+    renamed_files = rename_document_files(
+        doc, files,
+        file_name_format=file_name_format, allow_remote=False)
+
+    # Copy or link files into the temporary directory
+    document_file_list: list[str] = []
+    for in_file_path, out_file_name in zip(files, renamed_files, strict=True):
+        out_file_path = os.path.join(temp_dir, out_file_name)
+
+        if mode == "link":
+            symlink(in_file_path, out_file_path)
+        else:
+            shutil.copy(in_file_path, out_file_path)
+
+        document_file_list.append(out_file_name)
+
+    doc["files"] = document_file_list
     doc.save()
+
     return doc

--- a/tests/test_document.py
+++ b/tests/test_document.py
@@ -19,27 +19,23 @@ def test_new(tmp_config: TemporaryConfiguration) -> None:
     nfiles = 10
     files = [tmp_config.create_random_file() for _ in range(nfiles)]
 
-    tmp = os.path.join(tmp_config.tmpdir, "doc1")
-    doc = papis.document.new(tmp, {"author": "hello"}, files)
-
-    folder = doc.get_main_folder()
-    assert folder is not None
-    assert os.path.exists(folder)
-    assert folder == tmp
-
-    files = doc.get_files()
-    assert len(files) == nfiles
-    assert all(os.path.exists(f) for f in files)
-
-    tmp = os.path.join(tmp_config.tmpdir, "doc2")
-    doc = papis.document.new(tmp, {"author": "hello"}, [])
+    doc = papis.document.new({"author": "hello"}, files)
     folder = doc.get_main_folder()
 
     assert folder is not None
     assert os.path.exists(folder)
-    assert folder == tmp
-    assert len(doc["files"]) == 0
-    assert len(doc.get_files()) == 0
+    doc_files = doc.get_files()
+    assert len(doc_files) == nfiles
+    assert all(os.path.exists(f) for f in doc_files)
+    assert doc["author"] == "hello"
+
+    doc2 = papis.document.new({"author": "hello"}, [])
+    folder2 = doc2.get_main_folder()
+
+    assert folder2 is not None
+    assert os.path.exists(folder2)
+    assert len(doc2["files"]) == 0
+    assert len(doc2.get_files()) == 0
 
 
 def test_from_data() -> None:


### PR DESCRIPTION
This factors out all the non-interactive parts about new document creation from `add.py`. The idea is that this code can then be used elsewhere (as in the API).

Functionality should be exactly as before, except in one message: when the user is asked to confirm adding files to the document, we can no longer tell them to what the file will be renamed. Unfortunately, this requires the various fields of the document to be present and we do not have them at this stage. I don't think this matters all that much (especially since they will be shown the final name when confirming adding the document at the end). We could add a note saying that the file will be renamed if you think it's currently confusing.

I decided against changing the place of the hook and duplication check.

I will add more tests if/when we're happy with how this works.