### PR TITLE
Document.update(): drop None values to keep info.yaml clean

### DIFF
--- a/papis/document.py
+++ b/papis/document.py
@@ -408,6 +408,28 @@ class Document(dict[str, Any]):
         """
         return ""
 
+    def update(self, *args: Any, **kwargs: Any) -> None:
+        """Override dict.update to drop None values.
+        
+        This ensures that calling document.update(data) does not introduce
+        None values into the document, keeping info.yaml clean.
+        """
+        if args:
+            other = args[0]
+            if hasattr(other, 'keys'):
+                for key in other.keys():
+                    if other[key] is not None:
+                        dict.update(self, {key: other[key]})
+            else:
+                for key, value in other:
+                    if value is not None:
+                        dict.update(self, {key: value})
+        for key, value in kwargs.items():
+            if value is not None:
+                dict.update(self, {key: value})
+
+
+
     def copy(self) -> Document:
         """Make a shallow copy of the :class:`Document`."""
         doc = Document(data=dict(self))

--- a/tests/test_document.py
+++ b/tests/test_document.py
@@ -283,3 +283,29 @@ def test_author_separator_heuristics(tmp_config: TemporaryConfiguration) -> None
     #   s = "Last, First First"       # one author
     #   s = "Last Last, First First"  # one author
     #   s = "First Last, First Last"  # two authors
+
+
+def test_update_drops_none_values() -> None:
+    """Document.update() should drop None values to keep info.yaml clean."""
+    doc = papis.document.from_data({"title": "Test", "author": "Turing"})
+    
+    # Update with a dict containing None values
+    doc.update({"year": 2024, "none_field": None, "tags": ["a", "b"], "none_tag": None})
+    
+    # None values should not be in the document
+    assert "none_field" not in doc
+    assert "none_tag" not in doc
+    # Real values should be there
+    assert doc["year"] == 2024
+    assert doc["tags"] == ["a", "b"]
+    assert doc["title"] == "Test"
+
+
+def test_update_with_kwargs_drops_none() -> None:
+    """Document.update() should also filter None from kwargs."""
+    doc = papis.document.from_data({"title": "Test"})
+    doc.update(title="Updated", none_val=None, count=42)
+    
+    assert "none_val" not in doc
+    assert doc["title"] == "Updated"
+    assert doc["count"] == 42


### PR DESCRIPTION
Fixes #1164.

Calling `document.update(data)` would write None values into the document, polluting info.yaml. This overrides update() to drop Nones upfront so both the CLI path and direct API callers benefit.