### PR TITLE
Feat/document update drop values v2

### DIFF
--- a/papis/commands/doctor.py
+++ b/papis/commands/doctor.py
@@ -31,6 +31,8 @@ implemented
   provided by :confval:`doctor-html-codes-keys`.
 * ``html-tags``: checks that no HTML or XML tags (e.g. ``<a>``) appear in the keys
   provided by :confval:`doctor-html-tags-keys`.
+* ``empty-fields``: checks that the document does not contain fields with
+  empty values (``None``, ``""``, ``[]``, ``{}``).
 * ``field-type``: checks the type of fields provided by :confval:`document-field-types`
   (and :confval:`document-field-types-extend`), e.g. year should be an ``int``.
   Lists can be automatically fixed (by splitting or joining) using the
@@ -941,6 +943,33 @@ def html_tags_check(doc: Document) -> list[Error]:
     return results
 
 
+EMPTY_FIELDS_CHECK_NAME = "empty-fields"
+
+
+def empty_fields_check(doc: Document) -> list[Error]:
+    """
+    Checks for fields with empty values (``None``, ``""``, ``[]``, ``{}``).
+
+    :returns: a :class:`list` of errors, one for each field with an empty value.
+    """
+    from papis.document import is_empty_value
+
+    def make_fixer(key: str) -> FixFn:
+        def fixer() -> None:
+            del doc[key]
+            logger.info("[FIX] Removing empty field '%s'.", key)
+
+        return fixer
+
+    return [
+        make_error(doc, EMPTY_FIELDS_CHECK_NAME,
+                   msg=f"Field '{key}' has an empty value ({doc[key]!r})",
+                   fix_action=make_fixer(key),
+                   payload=key)
+        for key in doc if is_empty_value(doc[key])
+    ]
+
+
 STRING_CLEANER_CHECK_NAME = "string-cleaner"
 
 # NOTE: matches all text with two or more consecutive whitespace characters
@@ -1113,6 +1142,7 @@ register_check(REFS_CHECK_NAME, refs_check)
 register_check(HTML_CODES_CHECK_NAME, html_codes_check)
 register_check(HTML_TAGS_CHECK_NAME, html_tags_check)
 register_check(FIELD_TYPE_CHECK_NAME, field_type_check)
+register_check(EMPTY_FIELDS_CHECK_NAME, empty_fields_check)
 register_check(STRING_CLEANER_CHECK_NAME, string_cleaner_check)
 
 DEPRECATED_CHECK_NAMES = {

--- a/papis/defaults.py
+++ b/papis/defaults.py
@@ -154,7 +154,8 @@ settings: dict[str, Any] = {
     "notes-template": "",
 
     # doctor
-    "doctor-default-checks": ["files", "biblatex-required-keys", "bibtex-type", "refs"],
+    "doctor-default-checks": ["files", "biblatex-required-keys", "bibtex-type", "refs",
+                              "empty-fields"],
     "doctor-default-checks-extend": [],
     "doctor-keys-missing-keys": ["title", "author", "author_list", "ref"],
     "doctor-keys-missing-keys-extend": [],

--- a/papis/document.py
+++ b/papis/document.py
@@ -370,6 +370,20 @@ class DocHtmlEscaped(dict[str, Any]):
             .replace('"', "&quot;"))
 
 
+def is_empty_value(value: Any) -> bool:
+    """Check if a value is empty and should be treated as missing.
+
+    Returns *True* for ``None``, empty strings, empty lists, and empty
+    dicts. Numeric values (including ``0``) and booleans are never
+    considered empty.
+    """
+    if value is None:
+        return True
+    if isinstance(value, (int, float, bool)):
+        return False
+    return not value
+
+
 class Document(dict[str, Any]):
     """An abstract document in a ``papis`` library.
 
@@ -410,15 +424,25 @@ class Document(dict[str, Any]):
         return ""
 
     def update(self, *args: Any, **kwargs: Any) -> None:
-        """Update the document, silently dropping keys with ``None`` values.
+        """Update the document, dropping fields set to empty values.
 
-        This overrides :meth:`dict.update` to ensure that fields with a
-        ``None`` value never leak into the document and get persisted to
-        its ``info.yaml`` file.
+        Empty values (``None``, ``""``, ``[]``, ``{}``) passed into this
+        call cause the corresponding field to be removed.  Pre-existing
+        empty values elsewhere in the document are left untouched.
+
+        This overrides :meth:`dict.update` to ensure that empty fields
+        never leak into the document and get persisted to its
+        ``info.yaml`` file.
         """
-        super().update(*args, **kwargs)
-        for key in [k for k in self if self[k] is None]:
-            del self[key]
+        incoming = dict(*args, **kwargs)
+        filtered: dict[str, Any] = {}
+        for key, value in incoming.items():
+            if is_empty_value(value):
+                self.pop(key, None)
+            else:
+                filtered[key] = value
+
+        super().update(filtered)
 
     def copy(self) -> Document:
         """Make a shallow copy of the :class:`Document`."""

--- a/tests/test_doctor.py
+++ b/tests/test_doctor.py
@@ -580,3 +580,67 @@ def test_string_cleaner_missing_author(tmp_config: TemporaryConfiguration) -> No
 
     error.fix_action()
     assert doc["author_list"][1]["given"] == "M."
+
+
+def test_empty_fields_check(tmp_config: TemporaryConfiguration) -> None:
+    from papis.commands.doctor import empty_fields_check
+
+    # check: no empty fields
+    doc = papis.document.from_data({
+        "title": "Test Title",
+        "author": "Doe, John",
+        "year": 2023,
+        })
+
+    errors = empty_fields_check(doc)
+    assert not errors
+
+    # check: empty string
+    doc["journal"] = ""
+    error, = empty_fields_check(doc)
+    assert error.payload == "journal"
+    assert "empty" in error.msg
+    assert error.fix_action is not None
+
+    error.fix_action()
+    assert "journal" not in doc
+
+    # check: empty list
+    doc["tags"] = []
+    error, = empty_fields_check(doc)
+    assert error.payload == "tags"
+    assert error.fix_action is not None
+
+    error.fix_action()
+    assert "tags" not in doc
+
+    # check: empty dict
+    doc["extra"] = {}
+    error, = empty_fields_check(doc)
+    assert error.payload == "extra"
+    assert error.fix_action is not None
+
+    error.fix_action()
+    assert "extra" not in doc
+
+    # check: None value
+    doc["note"] = None
+    error, = empty_fields_check(doc)
+    assert error.payload == "note"
+    assert error.fix_action is not None
+
+    error.fix_action()
+    assert "note" not in doc
+
+    # check: non-empty values are not flagged
+    doc = papis.document.from_data({
+        "title": "Test",
+        "year": 0,
+        "bool_field": False,
+        "count": -1,
+        "list": [1],
+        "dict": {"a": 1},
+        })
+
+    errors = empty_fields_check(doc)
+    assert not errors

--- a/tests/test_document.py
+++ b/tests/test_document.py
@@ -49,15 +49,81 @@ def test_from_folder() -> None:
     assert doc["author"] == "Russell, Bertrand"
 
 
-def test_update_drops_none_values() -> None:
-    """Document.update() must silently drop keys with None values."""
+def test_update_drops_empty_values() -> None:
+    """Document.update() must drop fields passed with empty values."""
     doc = papis.document.from_data({"title": "Hello", "author": "Turing"})
 
-    doc.update({"doi": None, "year": 1999, "abstract": None})
+    doc.update({
+        "doi": None,
+        "year": 1999,
+        "abstract": "",
+        "files": [],
+        "extra": {},
+        "pages": 0,
+        "valid": False,
+    })
+    assert "doi" not in doc
+    assert "abstract" not in doc
+    assert "files" not in doc
+    assert "extra" not in doc
+    assert doc["year"] == 1999
+    assert doc["pages"] == 0
+    assert doc["valid"] is False
+    assert doc["title"] == "Hello"
+
+    # passing an empty value for an existing field should remove it
+    doc.update({"title": ""})
+    assert "title" not in doc
+
+
+def test_update_does_not_touch_existing_empty() -> None:
+    """Document.update() must not remove pre-existing empty values."""
+    doc = papis.document.from_data({"title": "Hello"})
+
+    doc["notes"] = []
+    doc["extra"] = {}
+    doc["comment"] = ""
+
+    doc.update({"year": 1999})
+    # pre-existing empty values are left alone
+    assert "notes" in doc
+    assert doc["notes"] == []
+    assert "extra" in doc
+    assert doc["extra"] == {}
+    assert "comment" in doc
+    assert doc["comment"] == ""
+    assert doc["year"] == 1999
+
+
+def test_update_call_forms() -> None:
+    """Document.update() must drop empty values regardless of call form."""
+    # via dict
+    doc = papis.document.from_data({"title": "Hello"})
+    doc.update({"doi": None, "abstract": "", "year": 1999})
     assert "doi" not in doc
     assert "abstract" not in doc
     assert doc["year"] == 1999
-    assert doc["title"] == "Hello"
+
+    # via iterable of pairs
+    doc = papis.document.from_data({"title": "Hello"})
+    doc.update([("doi", None), ("abstract", ""), ("year", 1999)])
+    assert "doi" not in doc
+    assert "abstract" not in doc
+    assert doc["year"] == 1999
+
+    # via keyword arguments
+    doc = papis.document.from_data({"title": "Hello"})
+    doc.update(doi=None, abstract="", year=1999)
+    assert "doi" not in doc
+    assert "abstract" not in doc
+    assert doc["year"] == 1999
+
+    # mixed: dict + kwargs
+    doc = papis.document.from_data({"title": "Hello"})
+    doc.update({"doi": None}, abstract="", year=1999)
+    assert "doi" not in doc
+    assert "abstract" not in doc
+    assert doc["year"] == 1999
 
 
 def test_main_features() -> None:


### PR DESCRIPTION
Follow-up to #1164, implementing the features discussed there.

1. `update()` drops empty fields, but leaves pre-existing fields alone
2. `empty-field` doctor check removes all empty fields
3. `empty-field` check is added to default checks (though happy to change that)

It seems bibtex/biblatex/hayagriva all handle empty fields the same as missing ones, which is why we shouldn't have them in our `info.yaml` files. Here is some evidence for this:
- [CSL suppresses all groups that are empty](https://docs.citationstyles.org/en/stable/specification.html#group).
- [BibTeX's default style template](http://mirrors.ctan.org/biblio/bibtex/base/btxbst.doc) explicitly says missing and empty values are treated the same and [BibLaTeX's punctuation tracker serves to suppress output for missing/empty fields](https://tex.stackexchange.com/questions/405173/biblatex-punctuation-and-empty-field)