### PR TITLE
Fix database cache to key by library name instead of `Library` identity

### DIFF
--- a/papis/database/__init__.py
+++ b/papis/database/__init__.py
@@ -11,7 +11,7 @@ if TYPE_CHECKING:
 
 logger = papis.logging.get_logger(__name__)
 
-DATABASES: dict[Library, Database] = {}
+DATABASES: dict[str, Database] = {}
 
 
 def _instantiate_database(backend_name: str,
@@ -47,10 +47,10 @@ def get_database(library_name: str | None = None) -> Database:
 
     backend = papis.config.getstring("database-backend") or "papis"
     try:
-        database = DATABASES[library]
+        database = DATABASES[library.name]
     except KeyError:
         database = _instantiate_database(backend, library)
-        DATABASES[library] = database
+        DATABASES[library.name] = database
 
     return database
 

--- a/tests/database/test_database.py
+++ b/tests/database/test_database.py
@@ -94,3 +94,18 @@ def test_database_add(tmp_library: TemporaryLibrary) -> None:
 
         ndocs_after_add = len(db.get_all_documents())
         assert ndocs == ndocs_after_add - 1
+
+
+@pytest.mark.parametrize("tmp_library", PAPIS_DB_SETTINGS, indirect=True)
+def test_database_cache_same_library_via_different_paths(
+    tmp_library: TemporaryLibrary,
+) -> None:
+    """:func:`papis.database.get` returns the same library instance regardless of
+    whether it was resolved via :func:`~papis.config.get_lib` or
+    :func:`~papis.config.get_lib_from_name`."""
+    db_via_current = papis.database.get()
+    lib_name = papis.config.get_lib_name()
+
+    db_via_name = papis.database.get(library_name=lib_name)
+
+    assert db_via_current is db_via_name


### PR DESCRIPTION
This is an issue I discovered while figuring out why the CI kept failing. I had a hacky workaround there that made Windows specifically fail. This here I think is the proper fix.

Basically, `papis.database.get_database` has a `DATABASES` cache keyed by `Library` objects. Since `Library` uses identity-based hashing and `get_lib_from_name()` creates a fresh `Library` object on every call, two lookups for the same library can land in different cache slots and produce separate `Database` instances.

When we switch back and forth between libraries (because of cross library document moving) we would get new `Library` objects. For same-library moves this meant `delete` mutated one instance while `add` mutated another. The fix is to index `DATABASES` by `library.name` (string) rather than `Library` (object). Now the same library always hits the same cache entry regardless of how the `Library` object was obtained.