### PR TITLE
refactor: make `paths._make_unique_file` public

### DIFF
--- a/papis/downloaders/__init__.py
+++ b/papis/downloaders/__init__.py
@@ -212,9 +212,9 @@ class Downloader(Importer):
             rawdata = self.get_document_data()
             if rawdata and self.check_document_format():
                 if self.document_filename:
-                    from papis.paths import _make_unique_file
+                    from papis.paths import make_unique_file
 
-                    filename = _make_unique_file(
+                    filename = make_unique_file(
                         os.path.join(tempfile.gettempdir(), self.document_filename)
                     )
                     with open(filename, mode="wb") as f:

--- a/papis/paths.py
+++ b/papis/paths.py
@@ -350,7 +350,8 @@ def _make_unique_folder(out_folder_path: PathLike) -> str:
     return out_folder_path_suffix
 
 
-def _make_unique_file(filename: PathLike) -> str:
+def make_unique_file(filename: PathLike) -> str:
+    """Add a suffix to the basename of *filename* until it is unique."""
     if not os.path.exists(filename):
         return str(filename)
 


### PR DESCRIPTION
I use this in various places in the new FastAPI server. And it's already used in the downloaders, so should be public anyway.