### PR TITLE
fix: skip local paths in DOIImporter.match

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -83,6 +83,12 @@ user can abort, skip problematic moves, or fix collisions interactively. A new
 - Remove undocumented `dirs` option (only allow one `dir` per library).
   ([#1182](https://github.com/papis/papis/pull/1182)).
 
+## Bug Fixes
+
+- Fix crash in `papis add` when a given file path contains spaces (the DOI
+  importer no longer tries to resolve local paths on doi.org)
+  ([#1201](https://github.com/papis/papis/issues/1201)).
+
 # VERSION v0.15.0 (February 8th, 2026)
 
 ## Dependency Changes

--- a/papis/importer/doi.py
+++ b/papis/importer/doi.py
@@ -16,8 +16,8 @@ class DOIImporter(Importer):
     @classmethod
     def match(cls, uri: str) -> DOIImporter | None:
         # NOTE: a local path is never a DOI; skipping it avoids querying
-        # doi.org for every file handed to `papis add` (and paths with spaces
-        # make for an invalid URL that crashes `validate_doi` -- see #1201)
+        # doi.org (as `validate_doi` does) for every local file
+        # https://github.com/papis/papis/issues/1201
         if os.path.exists(uri):
             return None
 

--- a/papis/importer/doi.py
+++ b/papis/importer/doi.py
@@ -15,6 +15,12 @@ class DOIImporter(Importer):
 
     @classmethod
     def match(cls, uri: str) -> DOIImporter | None:
+        # NOTE: a local path is never a DOI; skipping it avoids querying
+        # doi.org for every file handed to `papis add` (and paths with spaces
+        # make for an invalid URL that crashes `validate_doi` -- see #1201)
+        if os.path.exists(uri):
+            return None
+
         from doi import validate_doi
 
         from papis.crossref import DOI_ORG_URL

--- a/tests/test_importer.py
+++ b/tests/test_importer.py
@@ -151,6 +151,21 @@ def test_matching_importers_by_uri(tmp_config: TemporaryConfiguration) -> None:
     assert isinstance(importers[1], USENIXDownloader)
 
 
+def test_doi_importer_does_not_match_local_paths(
+        tmp_config: TemporaryConfiguration) -> None:
+    import os
+
+    from papis.importer.doi import DOIImporter
+
+    # NOTE: a space makes the doi.org handle URL invalid, which used to crash
+    # the importer matching instead of skipping it (see #1201)
+    path = os.path.join(tmp_config.tmpdir, "some presentation.txt")
+    with open(path, "w", encoding="utf-8") as f:
+        f.write("this is not a doi\n")
+
+    assert DOIImporter.match(path) is None
+
+
 def test_matching_importers_by_doc(tmp_config: TemporaryConfiguration) -> None:
     from papis.importer import get_matching_importers_by_doc
     from papis.importer.doi import DOIImporter


### PR DESCRIPTION
A local file path handed to `papis add` is never a DOI, but
`DOIImporter.match` still sent every path to doi.org for validation.
For paths containing spaces (or other characters invalid in a URL),
`validate_doi` in python-doi raises an uncaught
`http.client.InvalidURL` and crashes the whole command.

Skip existing local paths before calling `validate_doi`, the same way
`DOIFromPDFImporter.match` already does. This also avoids a needless
network round-trip for every local file added.

Fixes #1201

Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>
