### PR TITLE
Better subprocess error handling (in git and beyond)

### DIFF
--- a/papis/commands/add.py
+++ b/papis/commands/add.py
@@ -334,8 +334,8 @@ def run(paths: list[str],
     db.add(tmp_document)
 
     if git:
-        from papis.git import add_and_commit_resource
-        add_and_commit_resource(
+        from papis.git import add_and_commit
+        add_and_commit(
             out_folder_path, ".",
             f"Add document '{describe(tmp_document)}'")
 

--- a/papis/commands/add.py
+++ b/papis/commands/add.py
@@ -334,10 +334,14 @@ def run(paths: list[str],
     db.add(tmp_document)
 
     if git:
-        from papis.git import add_and_commit
-        add_and_commit(
-            out_folder_path, ".",
-            f"Add document '{describe(tmp_document)}'")
+        from papis.git import GitError, add_and_commit as git_add_and_commit
+
+        try:
+            git_add_and_commit(
+                out_folder_path, ".",
+                f"Add document '{describe(tmp_document)}'")
+        except GitError as exc:
+            logger.error("%s", exc)
 
     if move:
         for in_file_path in approved_files:

--- a/papis/commands/addto.py
+++ b/papis/commands/addto.py
@@ -117,12 +117,15 @@ def run(document: Document,
     save_doc(document)
 
     if git:
-        from papis.git import add_and_commit
+        from papis.git import GitError, add_and_commit as git_add_and_commit
 
-        add_and_commit(
-            doc_folder,
-            [*new_filenames, document.get_info_file()],
-            f"Add new files to '{describe(document)}'")
+        try:
+            git_add_and_commit(
+                doc_folder,
+                [*new_filenames, document.get_info_file()],
+                f"Add new files to '{describe(document)}'")
+        except GitError as exc:
+            logger.error("%s", exc)
 
 
 @click.command("addto")

--- a/papis/commands/addto.py
+++ b/papis/commands/addto.py
@@ -117,9 +117,9 @@ def run(document: Document,
     save_doc(document)
 
     if git:
-        from papis.git import add_and_commit_resources
+        from papis.git import add_and_commit
 
-        add_and_commit_resources(
+        add_and_commit(
             doc_folder,
             [*new_filenames, document.get_info_file()],
             f"Add new files to '{describe(document)}'")

--- a/papis/commands/edit.py
+++ b/papis/commands/edit.py
@@ -56,8 +56,8 @@ def run(document: Document,
     db.update(document)
 
     if git:
-        from papis.git import add_and_commit_resource
-        add_and_commit_resource(
+        from papis.git import add_and_commit
+        add_and_commit(
             str(document.get_main_folder()),
             info_file_path,
             f"Update information for '{describe(document)}'")
@@ -85,14 +85,14 @@ def edit_notes(document: Document,
     edit_file(notes_path)
 
     if git:
-        from papis.git import add_and_commit_resources
+        from papis.git import add_and_commit
 
         folder = document.get_main_folder()
         if folder:
             msg = f"Update notes for '{describe(document)}'"
-            add_and_commit_resources(folder,
-                                     [notes_path, document.get_info_file()],
-                                     msg)
+            add_and_commit(folder,
+                           [notes_path, document.get_info_file()],
+                           msg)
 
 
 @click.command("edit")

--- a/papis/commands/edit.py
+++ b/papis/commands/edit.py
@@ -56,11 +56,15 @@ def run(document: Document,
     db.update(document)
 
     if git:
-        from papis.git import add_and_commit
-        add_and_commit(
-            str(document.get_main_folder()),
-            info_file_path,
-            f"Update information for '{describe(document)}'")
+        from papis.git import GitError, add_and_commit as git_add_and_commit
+
+        try:
+            git_add_and_commit(
+                str(document.get_main_folder()),
+                info_file_path,
+                f"Update information for '{describe(document)}'")
+        except GitError as exc:
+            logger.error("%s", exc)
 
 
 def edit_notes(document: Document,
@@ -85,14 +89,17 @@ def edit_notes(document: Document,
     edit_file(notes_path)
 
     if git:
-        from papis.git import add_and_commit
+        from papis.git import GitError, add_and_commit as git_add_and_commit
 
-        folder = document.get_main_folder()
-        if folder:
-            msg = f"Update notes for '{describe(document)}'"
-            add_and_commit(folder,
-                           [notes_path, document.get_info_file()],
-                           msg)
+        try:
+            folder = document.get_main_folder()
+            if folder:
+                msg = f"Update notes for '{describe(document)}'"
+                git_add_and_commit(folder,
+                               [notes_path, document.get_info_file()],
+                               msg)
+        except GitError as exc:
+            logger.error("%s", exc)
 
 
 @click.command("edit")

--- a/papis/commands/explore.py
+++ b/papis/commands/explore.py
@@ -176,10 +176,13 @@ def add(ctx: click.Context) -> None:
 
 
 @cli.command("cmd")
+@papis.cli.bool_flag(
+    "--batch",
+    help="Skip documents containing errors rather than aborting.")
 @click.pass_context
 @click.help_option("-h", "--help")
 @click.argument("command", type=papis.cli.FormatPatternParamType())
-def cmd(ctx: click.Context, command: str) -> None:
+def cmd(ctx: click.Context, command: str, batch: bool) -> None:
     """
     Run a general command on the document list.
 
@@ -203,10 +206,13 @@ def cmd(ctx: click.Context, command: str) -> None:
         try:
             run(shlex.split(fcommand))
         except subprocess.CalledProcessError as exc:
-            logger.error(
-                "Command failed for '%s': exited with code %d.",
-                fcommand, exc.returncode)
-            raise
+            msg = "Command failed for `%s`: exited with code %d."
+            if batch:
+                logger.warning(msg, fcommand, exc.returncode)
+                continue
+            else:
+                logger.error(msg, fcommand, exc.returncode)
+                raise
 
 
 @cli.command("export")

--- a/papis/commands/explore.py
+++ b/papis/commands/explore.py
@@ -98,6 +98,7 @@ Command-line interface
 from __future__ import annotations
 
 import shlex
+import subprocess
 
 import click
 
@@ -199,7 +200,13 @@ def cmd(ctx: click.Context, command: str) -> None:
     docs = ctx.obj["documents"]
     for doc in docs:
         fcommand = format(command, doc, default="")
-        run(shlex.split(fcommand))
+        try:
+            run(shlex.split(fcommand))
+        except subprocess.CalledProcessError as exc:
+            logger.error(
+                "Command failed for '%s': exited with code %d.",
+                fcommand, exc.returncode)
+            raise
 
 
 @cli.command("export")

--- a/papis/commands/external.py
+++ b/papis/commands/external.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 
 import os
 import re
+import subprocess
 from typing import Any
 
 import click
@@ -84,4 +85,9 @@ def external_cli(ctx: click.core.Context, query: str, flags: list[str]) -> None:
 
     from papis.utils import run
 
-    run(cmd, env=environ)
+    try:
+        run(cmd, env=environ)
+    except subprocess.CalledProcessError as exc:
+        logger.error("External script '%s' exited with code %d.",
+                     cmd[0], exc.returncode)
+        ctx.exit(exc.returncode)

--- a/papis/commands/init.py
+++ b/papis/commands/init.py
@@ -72,25 +72,6 @@ INIT_PROMPTS = [
 ]
 
 
-def _is_git_repository(path: str) -> bool:
-    path = os.path.abspath(path)
-
-    while True:
-        # check if a '.git' subdirectory exists
-        git_path = os.path.join(path, ".git")
-        if os.path.exists(git_path):
-            return True
-
-        # check if we reached the root
-        parent = os.path.dirname(path)
-        if parent == path:
-            break
-
-        path = parent
-
-    return False
-
-
 @click.command("init")
 @click.help_option("--help", "-h")
 @click.argument(
@@ -169,7 +150,9 @@ def cli(dir_path: str | None) -> None:
 
     papis.config.set_lib_from_name(library_name)
     use_git = papis.config.getboolean("use-git")
-    if use_git and not _is_git_repository(library_path):
+    from papis.git import is_git_repo
+
+    if use_git and not is_git_repo(library_path):
         if confirm(f"Library '{library_path}' is not a git repository and 'use-git' "
                    "is enabled. Would you like to initialize a git repository?"):
             from papis.git import add as git_add, commit as git_commit, init as git_init

--- a/papis/commands/init.py
+++ b/papis/commands/init.py
@@ -150,16 +150,25 @@ def cli(dir_path: str | None) -> None:
 
     papis.config.set_lib_from_name(library_name)
     use_git = papis.config.getboolean("use-git")
-    from papis.git import is_git_repo
 
-    if use_git and not is_git_repo(library_path):
-        if confirm(f"Library '{library_path}' is not a git repository and 'use-git' "
-                   "is enabled. Would you like to initialize a git repository?"):
-            from papis.git import add as git_add, commit as git_commit, init as git_init
+    if use_git:
+        from papis.git import (
+            GitError,
+            add as git_add,
+            commit as git_commit,
+            init as git_init,
+            is_repo as git_is_repo,
+        )
 
-            git_init(library_path)
-            git_add(library_path, ".")
-            git_commit(library_path, f"Initialized library '{library_name}'")
+        if not git_is_repo(library_path):
+            if confirm(f"Library '{library_path}' is not a git repository and 'use-git'"
+                       " is enabled. Would you like to initialize a git repository?"):
+                try:
+                    git_init(library_path)
+                    git_add(library_path, ".")
+                    git_commit(library_path, f"Initialize library '{library_name}'")
+                except GitError as exc:
+                    logger.error("%s", exc)
 
     if confirm("Do you want to save?"):
         config_folder = papis.config.get_config_folder()

--- a/papis/commands/mv.py
+++ b/papis/commands/mv.py
@@ -254,30 +254,9 @@ def run(
     papis.config.set_lib_from_name(source_library)
 
     if target_lib_dir == source_lib_dir:
-        if git:
-            papis.git.mv_and_commit_resource(
-                str(main_folder_old),
-                str(main_folder_new),
-                f"Move '{papis.document.describe(document)}'",
-            )
-        else:
-            shutil.move(main_folder_old, main_folder_new)
+        shutil.move(main_folder_old, main_folder_new)
     else:
         shutil.move(doc_folder_old, main_folder_new)
-
-        if git:
-            papis.git.remove(str(source_lib_dir), str(main_folder_old))
-            papis.git.commit(
-                str(source_lib_dir),
-                f"Remove '{papis.document.describe(document)}' "
-                f"(moved to '{target_library}' library)",
-            )
-
-            papis.git.add_and_commit_resource(
-                str(target_lib_dir),
-                str(main_folder_new),
-                f"Add '{papis.document.describe(document)}'",
-            )
 
     source_db = papis.database.get()
     source_db.delete(document)
@@ -287,6 +266,32 @@ def run(
     document.set_folder(str(main_folder_new))
 
     target_db.add(document)
+
+    if git:
+        if target_lib_dir == source_lib_dir:
+            papis.git.rm_cached(str(source_lib_dir),
+                                str(main_folder_old),
+                                recursive=True)
+            papis.git.add(str(source_lib_dir), str(main_folder_new))
+            papis.git.commit(
+                str(source_lib_dir),
+                f"Move '{papis.document.describe(document)}'",
+            )
+        else:
+            papis.git.rm_cached(str(source_lib_dir),
+                                str(main_folder_old),
+                                recursive=True)
+            papis.git.commit(
+                str(source_lib_dir),
+                f"Remove '{papis.document.describe(document)}' "
+                f"(moved to '{target_library}' library)",
+            )
+
+            papis.git.add_and_commit(
+                str(target_lib_dir),
+                str(main_folder_new),
+                f"Add '{papis.document.describe(document)}'",
+            )
 
     logger.info(
         "Moved document '%s' to '%s' (library '%s').",

--- a/papis/commands/mv.py
+++ b/papis/commands/mv.py
@@ -98,7 +98,6 @@ import papis.cli
 import papis.config
 import papis.database
 import papis.document
-import papis.git
 import papis.logging
 import papis.paths
 import papis.tui.utils
@@ -268,30 +267,38 @@ def run(
     target_db.add(document)
 
     if git:
-        if target_lib_dir == source_lib_dir:
-            papis.git.rm_cached(str(source_lib_dir),
-                                str(main_folder_old),
-                                recursive=True)
-            papis.git.add(str(source_lib_dir), str(main_folder_new))
-            papis.git.commit(
-                str(source_lib_dir),
-                f"Move '{papis.document.describe(document)}'",
-            )
-        else:
-            papis.git.rm_cached(str(source_lib_dir),
-                                str(main_folder_old),
-                                recursive=True)
-            papis.git.commit(
-                str(source_lib_dir),
-                f"Remove '{papis.document.describe(document)}' "
-                f"(moved to '{target_library}' library)",
-            )
+        from papis.git import (
+            GitError,
+            add as git_add,
+            add_and_commit as git_add_and_commit,
+            commit as git_commit,
+            rm_cached as git_rm_cached,
+        )
 
-            papis.git.add_and_commit(
-                str(target_lib_dir),
-                str(main_folder_new),
-                f"Add '{papis.document.describe(document)}'",
-            )
+        try:
+            git_rm_cached(str(source_lib_dir),
+                                str(main_folder_old),
+                                recursive=True)
+            if target_lib_dir == source_lib_dir:
+                git_add(str(source_lib_dir), str(main_folder_new))
+                git_commit(
+                    str(source_lib_dir),
+                    f"Move '{papis.document.describe(document)}'",
+                )
+            else:
+                git_commit(
+                    str(source_lib_dir),
+                    f"Remove '{papis.document.describe(document)}' "
+                    f"(moved to '{target_library}' library)",
+                )
+
+                git_add_and_commit(
+                    str(target_lib_dir),
+                    str(main_folder_new),
+                    f"Add '{papis.document.describe(document)}'",
+                )
+        except GitError as exc:
+            logger.error("%s", exc)
 
     logger.info(
         "Moved document '%s' to '%s' (library '%s').",

--- a/papis/commands/rename.py
+++ b/papis/commands/rename.py
@@ -93,17 +93,18 @@ def run(document: Document,
         return
 
     logger.info("Rename '%s' to '%s'.", folder, new_folder_name)
-    if git:
-        from papis.git import mv_and_commit_resource
-        mv_and_commit_resource(
-            folder, new_folder_path,
-            f"Rename '{folder}' to '{new_folder_name}'")
-    else:
-        shutil.move(folder, new_folder_path)
+    shutil.move(folder, new_folder_path)
 
     db.delete(document)
     document.set_folder(new_folder_path)
     db.add(document)
+
+    if git:
+        from papis.git import add as git_add, commit as git_commit, rm_cached as git_rm_cached
+        git_rm_cached(parent, folder, recursive=True)
+        git_add(parent, new_folder_path)
+        git_commit(parent,
+                   f"Rename '{folder}' to '{new_folder_name}'")
 
 
 @click.command("rename")

--- a/papis/commands/rename.py
+++ b/papis/commands/rename.py
@@ -100,11 +100,22 @@ def run(document: Document,
     db.add(document)
 
     if git:
-        from papis.git import add as git_add, commit as git_commit, rm_cached as git_rm_cached
-        git_rm_cached(parent, folder, recursive=True)
-        git_add(parent, new_folder_path)
-        git_commit(parent,
-                   f"Rename '{folder}' to '{new_folder_name}'")
+        from papis.git import (
+            GitError,
+            add as git_add,
+            commit as git_commit,
+            rm_cached as git_rm_cached,
+        )
+
+        try:
+            git_rm_cached(parent, folder, recursive=True)
+            git_add(parent, new_folder_path)
+            git_commit(
+                parent,
+                f"Rename '{folder}' to '{new_folder_name}'",
+            )
+        except GitError as exc:
+            logger.error("%s", exc)
 
 
 @click.command("rename")

--- a/papis/commands/rm.py
+++ b/papis/commands/rm.py
@@ -43,7 +43,11 @@ def run(document: Document,
         from papis.exceptions import DocumentFolderNotFound
         raise DocumentFolderNotFound(describe(document))
 
-    from papis.git import add as git_add, commit as git_commit, remove as git_rm
+    from papis.git import (
+        add as git_add,
+        commit as git_commit,
+        rm_cached as git_rm_cached,
+    )
 
     if filepath is not None:
         os.remove(filepath)
@@ -51,7 +55,7 @@ def run(document: Document,
         document.save()
         db.update(document)
         if git:
-            git_rm(doc_folder, filepath)
+            git_rm_cached(doc_folder, filepath)
             git_add(doc_folder, document.get_info_file())
             git_commit(doc_folder, f"Remove file '{filepath}'")
 
@@ -61,22 +65,21 @@ def run(document: Document,
         document.save()
         db.update(document)
         if git:
-            git_rm(doc_folder, notespath)
+            git_rm_cached(doc_folder, notespath)
             git_add(doc_folder, document.get_info_file())
             git_commit(doc_folder, f"Remove notes file '{notespath}'")
 
     # if neither files nor notes were deleted -> delete whole document
     if not (filepath or notespath):
+        delete(document)
+        db.delete(document)
+
         if git:
             topfolder = os.path.dirname(os.path.abspath(doc_folder))
-            git_rm(doc_folder, doc_folder, recursive=True)
+            git_rm_cached(topfolder, doc_folder, recursive=True)
             git_commit(
                 topfolder,
                 f"Remove document '{describe(document)}'")
-        else:
-            delete(document)
-
-        db.delete(document)
 
 
 @click.command("rm")

--- a/papis/commands/rm.py
+++ b/papis/commands/rm.py
@@ -38,16 +38,16 @@ def run(document: Document,
     doc_folder = document.get_main_folder()
 
     from papis.document import delete, describe
-
-    if not doc_folder:
-        from papis.exceptions import DocumentFolderNotFound
-        raise DocumentFolderNotFound(describe(document))
-
     from papis.git import (
+        GitError,
         add as git_add,
         commit as git_commit,
         rm_cached as git_rm_cached,
     )
+
+    if not doc_folder:
+        from papis.exceptions import DocumentFolderNotFound
+        raise DocumentFolderNotFound(describe(document))
 
     if filepath is not None:
         os.remove(filepath)
@@ -55,9 +55,12 @@ def run(document: Document,
         document.save()
         db.update(document)
         if git:
-            git_rm_cached(doc_folder, filepath)
-            git_add(doc_folder, document.get_info_file())
-            git_commit(doc_folder, f"Remove file '{filepath}'")
+            try:
+                git_rm_cached(doc_folder, filepath)
+                git_add(doc_folder, document.get_info_file())
+                git_commit(doc_folder, f"Remove file '{filepath}'")
+            except GitError as exc:
+                logger.error("%s", exc)
 
     if notespath is not None:
         os.remove(notespath)
@@ -65,9 +68,12 @@ def run(document: Document,
         document.save()
         db.update(document)
         if git:
-            git_rm_cached(doc_folder, notespath)
-            git_add(doc_folder, document.get_info_file())
-            git_commit(doc_folder, f"Remove notes file '{notespath}'")
+            try:
+                git_rm_cached(doc_folder, notespath)
+                git_add(doc_folder, document.get_info_file())
+                git_commit(doc_folder, f"Remove notes file '{notespath}'")
+            except GitError as exc:
+                logger.error("%s", exc)
 
     # if neither files nor notes were deleted -> delete whole document
     if not (filepath or notespath):
@@ -75,11 +81,14 @@ def run(document: Document,
         db.delete(document)
 
         if git:
-            topfolder = os.path.dirname(os.path.abspath(doc_folder))
-            git_rm_cached(topfolder, doc_folder, recursive=True)
-            git_commit(
-                topfolder,
-                f"Remove document '{describe(document)}'")
+            try:
+                topfolder = os.path.dirname(os.path.abspath(doc_folder))
+                git_rm_cached(topfolder, doc_folder, recursive=True)
+                git_commit(
+                    topfolder,
+                    f"Remove document '{describe(document)}'")
+            except GitError as exc:
+                logger.error("%s", exc)
 
 
 @click.command("rm")

--- a/papis/commands/run.py
+++ b/papis/commands/run.py
@@ -52,6 +52,9 @@ Command-line interface
 """
 from __future__ import annotations
 
+import shlex
+import subprocess
+
 import click
 
 import papis.cli
@@ -66,7 +69,13 @@ def run(folder: str, command: list[str] | None = None) -> None:
         return
 
     from papis.utils import run as run_command
-    run_command(command, cwd=folder, wait=True)
+
+    try:
+        run_command(command, cwd=folder, wait=True)
+    except subprocess.CalledProcessError as exc:
+        logger.error("Command '%s' exited with code %d.",
+                     shlex.join(exc.cmd), exc.returncode)
+        raise SystemExit(exc.returncode) from exc
 
 
 @click.command("run", context_settings={"ignore_unknown_options": True})

--- a/papis/commands/update.py
+++ b/papis/commands/update.py
@@ -414,8 +414,8 @@ def run(
     save_doc(document)
 
     if git:
-        from papis.git import add_and_commit_resource
-        add_and_commit_resource(
+        from papis.git import add_and_commit
+        add_and_commit(
             folder,
             info,
             f"Update information for '{describe(document)}'",

--- a/papis/commands/update.py
+++ b/papis/commands/update.py
@@ -414,12 +414,16 @@ def run(
     save_doc(document)
 
     if git:
-        from papis.git import add_and_commit
-        add_and_commit(
-            folder,
-            info,
-            f"Update information for '{describe(document)}'",
-        )
+        from papis.git import GitError, add_and_commit as git_add_and_commit
+
+        try:
+            git_add_and_commit(
+                folder,
+                info,
+                f"Update information for '{describe(document)}'",
+            )
+        except GitError as exc:
+            logger.error("%s", exc)
 
 
 @click.command("update")

--- a/papis/git.py
+++ b/papis/git.py
@@ -1,5 +1,5 @@
 """
-This module serves as an lightweight interface for ``git`` related functions.
+This module serves as a lightweight interface for ``git`` related functions.
 
 Note that these git functions do not touch the file system. The caller must always
 manipulate the filesystem first and then use the git functions to record the changes
@@ -7,9 +7,11 @@ to the index. This means that failure of a git operation always just means a fai
 of committing changes.
 
 """
+
 from __future__ import annotations
 
 import os
+import subprocess
 from typing import TYPE_CHECKING
 
 import papis.logging
@@ -17,13 +19,54 @@ import papis.logging
 if TYPE_CHECKING:
     from collections.abc import Sequence
 
+    from papis.paths import PathLike
+
 logger = papis.logging.get_logger(__name__)
 
 
-def is_git_repo(
-    path: str | os.PathLike[str],
+class GitError(Exception):
+    """Raised when a git operation fails."""
+
+    def __init__(self, message: str, returncode: int) -> None:
+        self.returncode = returncode
+        super().__init__(message)
+
+
+def _normalize_resources(
+    resources: PathLike | Sequence[PathLike],
+) -> list[str]:
+    """Convert a resource or sequence of resources to a list of strings."""
+    if isinstance(resources, (str, os.PathLike)):
+        return [str(resources)]
+    return [str(r) for r in resources]
+
+
+def git(*args: str, cwd: PathLike) -> str:
+    """Run a git command and return its stdout.
+
+    :param args: arguments to pass to the ``git`` command.
+    :param cwd: a folder with an existing git repository.
+
+    :raises GitError: if the git command fails.
+    :returns: the stdout of the git command.
+    """
+    from papis.utils import run
+
+    try:
+        result = run(["git", *args], cwd=str(cwd), capture_output=True)
+    except subprocess.CalledProcessError as exc:
+        stderr = exc.stderr.strip() if exc.stderr else "(no output)"
+        raise GitError(
+            f"[GIT] 'git {' '.join(args)}' failed in '{cwd}': {stderr}",
+            exc.returncode,
+        ) from exc
+    return result.stdout.strip()
+
+
+def is_repo(
+    path: PathLike,
     *,
-    root: str | os.PathLike[str] | None = None,
+    root: PathLike | None = None,
 ) -> bool:
     """Check if *path* is inside a git repository.
 
@@ -48,73 +91,58 @@ def is_git_repo(
         path = parent
 
 
-def init(path: str | os.PathLike[str]) -> None:
+def init(path: PathLike) -> None:
     """Initialize a git repository at *path*."""
-    from papis.utils import run
-
-    logger.info("Initializing git repository: '%s'.", path)
-    run(["git", "init"], cwd=str(path))
+    git("init", cwd=path)
 
 
 def add(
-    path: str | os.PathLike[str],
-    resource: str | Sequence[str],
+    path: PathLike,
+    resources: PathLike | Sequence[PathLike],
 ) -> None:
     """Stage a resource (or resources) in the git repository at *path*.
 
     :param path: a folder with an existing git repository.
-    :param resource: a resource to add to the index (e.g. ``info.yaml``),
+    :param resources: a resource to add to the index (e.g. ``info.yaml``),
         or a sequence of resources.
     """
-    from papis.utils import run
-
-    if isinstance(resource, str):
-        resource = [resource]
-
-    logger.info("Adding %s to '%s'.", ", ".join(resource), path)
-    run(["git", "add", *resource], cwd=str(path))
+    git("add", "--", *_normalize_resources(resources), cwd=path)
 
 
-def commit(path: str | os.PathLike[str], message: str) -> None:
+def commit(path: PathLike, message: str) -> None:
     """Commit staged changes in the git repository at *path*.
 
     :param path: a folder with an existing git repository.
     :param message: a commit message.
     """
-    from papis.utils import run
-
-    logger.info("Committing '%s' with message '%s'.", path, message)
-    run(["git", "commit", "-m", message], cwd=str(path))
+    logger.info("[GIT] %s", message)
+    git("commit", "-m", message, cwd=path)
 
 
 def rm_cached(
-    path: str | os.PathLike[str],
-    resource: str | os.PathLike[str],
+    path: PathLike,
+    resources: PathLike | Sequence[PathLike],
     *,
     recursive: bool = False,
 ) -> None:
-    """Remove a *resource* from the git index without touching the
+    """Remove a *resources* from the git index without touching the
     working tree. The caller must have already deleted or moved the
     files on disk.
 
     :param path: a folder with an existing git repository.
-    :param resource: a resource to remove from the index.
+    :param resources: a resource to remove from the index or a sequence of resources.
     :param recursive: if *True*, remove the resource recursively.
     """
-    from papis.utils import run
-
-    logger.info("Removing '%s' from index (cwd: '%s').", resource, path)
-
     flags = ["--cached"]
     if recursive:
         flags.append("-r")
 
-    run(["git", "rm", *flags, str(resource)], cwd=str(path))
+    git("rm", *flags, "--", *_normalize_resources(resources), cwd=path)
 
 
 def add_and_commit(
-    path: str | os.PathLike[str],
-    resources: str | Sequence[str],
+    path: PathLike,
+    resources: PathLike | Sequence[PathLike],
     message: str,
 ) -> None:
     """Stage *resources* and commit with *message*.

--- a/papis/git.py
+++ b/papis/git.py
@@ -1,8 +1,15 @@
 """
 This module serves as an lightweight interface for ``git`` related functions.
+
+Note that these git functions do not touch the file system. The caller must always
+manipulate the filesystem first and then use the git functions to record the changes
+to the index. This means that failure of a git operation always just means a failure
+of committing changes.
+
 """
 from __future__ import annotations
 
+import os
 from typing import TYPE_CHECKING
 
 import papis.logging
@@ -13,28 +20,63 @@ if TYPE_CHECKING:
 logger = papis.logging.get_logger(__name__)
 
 
-def init(path: str) -> None:
+def is_git_repo(
+    path: str | os.PathLike[str],
+    *,
+    root: str | os.PathLike[str] | None = None,
+) -> bool:
+    """Check if *path* is inside a git repository.
+
+    :param path: starting path.
+    :param root: optional boundary directory (inclusive).
+    """
+    path = os.path.abspath(path)
+    if root is not None:
+        root = os.path.abspath(root)
+
+    while True:
+        if os.path.exists(os.path.join(path, ".git")):
+            return True
+
+        parent = os.path.dirname(path)
+        if parent == path:
+            return False  # hit filesystem root
+
+        if root is not None and path == root:
+            return False  # hit boundary, don't go above
+
+        path = parent
+
+
+def init(path: str | os.PathLike[str]) -> None:
     """Initialize a git repository at *path*."""
     from papis.utils import run
 
     logger.info("Initializing git repository: '%s'.", path)
-    run(["git", "init"], cwd=path)
+    run(["git", "init"], cwd=str(path))
 
 
-def add(path: str, resource: str) -> None:
-    """Adds changes in the *path* to the git index with a *message*.
+def add(
+    path: str | os.PathLike[str],
+    resource: str | Sequence[str],
+) -> None:
+    """Stage a resource (or resources) in the git repository at *path*.
 
     :param path: a folder with an existing git repository.
-    :param resource: a resource (e.g. ``info.yaml`` file) to add to the index.
+    :param resource: a resource to add to the index (e.g. ``info.yaml``),
+        or a sequence of resources.
     """
     from papis.utils import run
 
-    logger.info("Adding '%s'.", path)
-    run(["git", "add", resource], cwd=path)
+    if isinstance(resource, str):
+        resource = [resource]
+
+    logger.info("Adding %s to '%s'.", ", ".join(resource), path)
+    run(["git", "add", *resource], cwd=str(path))
 
 
-def commit(path: str, message: str) -> None:
-    """Commits changes in the *path* with a *message*.
+def commit(path: str | os.PathLike[str], message: str) -> None:
+    """Commit staged changes in the git repository at *path*.
 
     :param path: a folder with an existing git repository.
     :param message: a commit message.
@@ -42,72 +84,45 @@ def commit(path: str, message: str) -> None:
     from papis.utils import run
 
     logger.info("Committing '%s' with message '%s'.", path, message)
-    run(["git", "commit", "-m", message], cwd=path)
+    run(["git", "commit", "-m", message], cwd=str(path))
 
 
-def mv(from_path: str, to_path: str) -> None:
-    """Renames (moves) the path *from_path* to *to_path*.
+def rm_cached(
+    path: str | os.PathLike[str],
+    resource: str | os.PathLike[str],
+    *,
+    recursive: bool = False,
+) -> None:
+    """Remove a *resource* from the git index without touching the
+    working tree. The caller must have already deleted or moved the
+    files on disk.
 
-    :param from_path: path to be moved (the source).
-    :param to_path: destination where *from_path* is moved. If this is in the
-        same parent directory as *from_path*, it is a simple rename.
+    :param path: a folder with an existing git repository.
+    :param resource: a resource to remove from the index.
+    :param recursive: if *True*, remove the resource recursively.
     """
     from papis.utils import run
 
-    logger.info("Moving '%s' to '%s'.", from_path, to_path)
-    run(["git", "mv", from_path, to_path], cwd=from_path)
+    logger.info("Removing '%s' from index (cwd: '%s').", resource, path)
+
+    flags = ["--cached"]
+    if recursive:
+        flags.append("-r")
+
+    run(["git", "rm", *flags, str(resource)], cwd=str(path))
 
 
-def remove(path: str, resource: str,
-           recursive: bool = False,
-           force: bool = True) -> None:
-    """Remove a *resource* from the git repository at *path*.
-
-    :param path: a folder with an existing git repository.
-    :param resource: a resource (e.g. ``info.yaml`` file) to remove from git.
-    :param recursive: if *True*, the given resource is removed recursively.
-    :param force: if *True*, the removal is forced so any errors (e.g. file
-        does not exist) are silently ignored.
-    """
-    from papis.utils import run
-
-    logger.info("Removing '%s'.", path)
-
-    flag_rec = "-r" if recursive else ""
-    flag_force = "-f" if force else ""
-    run(["git", "rm", flag_force, flag_rec, resource], cwd=path)
-
-
-def add_and_commit_resource(path: str, resource: str, message: str) -> None:
-    """Adds and commits a single *resource*.
+def add_and_commit(
+    path: str | os.PathLike[str],
+    resources: str | Sequence[str],
+    message: str,
+) -> None:
+    """Stage *resources* and commit with *message*.
 
     :param path: a folder with an existing git repository.
-    :param resource: a resource (e.g. ``info.yaml`` file) to remove from git.
+    :param resources: a resource (e.g. ``info.yaml`` file) or sequence of
+        resources to add.
     :param message: a commit message.
     """
-    add(path, resource)
-    commit(path, message)
-
-
-def mv_and_commit_resource(from_path: str, to_path: str, message: str) -> None:
-    """Moves *from_path* and commits the change.
-
-    :param from_path: path to be moved (the source).
-    :param to_path: destination where *from_path* is moved.
-    :param message: a commit message.
-    """
-    mv(from_path, to_path)
-    commit(to_path, message)
-
-
-def add_and_commit_resources(path: str,
-                             resources: Sequence[str],
-                             message: str) -> None:
-    """Add and commit multiple resources (see :func:`add_and_commit_resource`).
-
-    Note that a single commit message is generated for all the resources.
-    """
-    for resource in resources:
-        add(path, resource)
-
+    add(path, resources)
     commit(path, message)

--- a/papis/utils.py
+++ b/papis/utils.py
@@ -2,8 +2,9 @@ from __future__ import annotations
 
 import os
 import re
+import subprocess
 import sys
-from typing import TYPE_CHECKING, Any, TypeVar
+from typing import TYPE_CHECKING, Any, Literal, TypeVar, overload
 from warnings import warn
 
 try:
@@ -98,10 +99,34 @@ def parmap(f: Callable[[A], B],
         return list(map(f, xs))
 
 
+@overload
+def run(
+    cmd: Sequence[str],
+    wait: Literal[True] = True,
+    env: dict[str, Any] | None = None,
+    cwd: str | None = None,
+    *,
+    capture_output: bool = False,
+) -> subprocess.CompletedProcess[str]: ...
+
+
+@overload
+def run(
+    cmd: Sequence[str],
+    wait: Literal[False],
+    env: dict[str, Any] | None = None,
+    cwd: str | None = None,
+    *,
+    capture_output: bool = False,
+) -> None: ...
+
+
 def run(cmd: Sequence[str],
         wait: bool = True,
         env: dict[str, Any] | None = None,
-        cwd: str | None = None) -> None:
+        cwd: str | None = None,
+        *,
+        capture_output: bool = False) -> subprocess.CompletedProcess[str] | None:
     """Run a given command with :mod:`subprocess`.
 
     This is a simple wrapper around :class:`subprocess.Popen` with custom
@@ -114,11 +139,14 @@ def run(cmd: Sequence[str],
     :param env: a mapping that defines additional environment variables for
         the child process.
     :param cwd: current working directory in which to run the command.
+    :param capture_output: if *True*, capture stdout and stderr so they can
+        be inspected via :class:`~subprocess.CalledProcessError`. When *False*
+        (default), output streams to the terminal.
     """
 
     cmd = list(cmd)
     if not cmd:
-        return
+        return None
 
     if cwd:
         cwd = os.path.expanduser(cwd)
@@ -132,10 +160,11 @@ def run(cmd: Sequence[str],
     if not shutil.which(cmd[0]):
         raise FileNotFoundError(f"Command not found: '{cmd[0]}'")
 
-    import subprocess
     if wait:
         logger.debug("Waiting for process to finish.")
-        subprocess.call(cmd, shell=False, cwd=cwd, env=env)
+        return subprocess.run(cmd, shell=False, cwd=cwd, env=env,
+                              check=True, capture_output=capture_output,
+                              text=True)
     else:
         # NOTE: detach process so that the terminal can be closed without also
         # closing the 'opentool' itself with the open document
@@ -159,6 +188,7 @@ def run(cmd: Sequence[str],
                          stdout=subprocess.DEVNULL,
                          stderr=subprocess.DEVNULL,
                          **platform_kwargs)
+        return None
 
 
 def general_open(file_name: str,
@@ -194,11 +224,17 @@ def general_open(file_name: str,
     cmd = [*shlex.split(str(opener), posix=not is_windows), file_name]
 
     import shutil
+    import subprocess
     if shutil.which(cmd[0]) is None:
         raise FileNotFoundError(
             f"Command not found for '{key}': '{opener}'")
 
-    run(cmd, wait=wait)
+    try:
+        run(cmd, wait=wait)  # type: ignore[call-overload]
+    except subprocess.CalledProcessError as exc:
+        logger.warning(
+            "Opener for '%s' exited with code %d.",
+            key, exc.returncode)
 
 
 def open_file(file_path: str, wait: bool = True) -> None:

--- a/tests/commands/test_explore.py
+++ b/tests/commands/test_explore.py
@@ -1,7 +1,10 @@
 from __future__ import annotations
 
 import re
+import subprocess
 import tempfile
+
+import pytest
 
 from papis.testing import PapisRunner, TemporaryLibrary
 
@@ -86,3 +89,18 @@ def test_explore_citations_and_json_cli(tmp_library: TemporaryLibrary) -> None:
         exported_json = fd.read()
 
     assert exported_json == "[]"
+
+
+def test_explore_cmd_batch(tmp_library: TemporaryLibrary) -> None:
+    from papis.commands.explore import cli
+    cli_runner = PapisRunner()
+
+    result = cli_runner.invoke(
+        cli,
+        ["lib", "krishnamurti", "cmd", "--batch", "sh -c 'exit 1'"])
+    assert result.exit_code == 0
+
+    with pytest.raises(subprocess.CalledProcessError):
+        cli_runner.invoke(
+            cli,
+            ["lib", "krishnamurti", "cmd", "sh -c 'exit 1'"])

--- a/tests/commands/test_run.py
+++ b/tests/commands/test_run.py
@@ -1,6 +1,5 @@
 from __future__ import annotations
 
-import os
 import sys
 from typing import TYPE_CHECKING
 
@@ -16,9 +15,8 @@ def test_run_run(tmp_library: TemporaryLibrary) -> None:
     from papis.commands.run import run
 
     libdir = papis.config.get_lib().path
-    # Use a mock scriptlet
-    script = os.path.join(os.path.dirname(__file__), "scripts.py")
-    run(libdir, command=[sys.executable, script, "ls"])
+    # Use a trivial no-op command that always succeeds
+    run(libdir, command=[sys.executable, "-c", "pass"])
 
     with pytest.raises(FileNotFoundError):
         run(libdir, command=["nonexistent"])

--- a/tests/test_git.py
+++ b/tests/test_git.py
@@ -1,0 +1,153 @@
+from __future__ import annotations
+
+import os
+import shutil
+import tempfile
+from typing import TYPE_CHECKING
+
+import pytest
+
+from papis.git import (
+    GitError,
+    add as git_add,
+    add_and_commit as git_add_and_commit,
+    commit as git_commit,
+    git as git_cmd,
+    init as git_init,
+    is_repo as git_is_repo,
+    rm_cached as git_rm_cached,
+)
+
+if TYPE_CHECKING:
+    from papis.testing import TemporaryLibrary
+
+pytestmark = pytest.mark.skipif(
+    not shutil.which("git"),
+    reason="Test requires 'git' executable to be in the PATH",
+)
+
+
+def _git_commits(cwd: str) -> int:
+    stdout = git_cmd("log", "--oneline", cwd=cwd)
+    return len(stdout.split("\n")) if stdout else 0
+
+
+@pytest.mark.library_setup(use_git=True)
+def test_is_git_repo(tmp_library: TemporaryLibrary) -> None:
+    libdir = tmp_library.libdir
+    assert git_is_repo(libdir)
+
+    # works for subdirectories too
+    sub = os.path.join(libdir, "sub")
+    os.makedirs(sub, exist_ok=True)
+    assert git_is_repo(sub)
+
+    # a plain directory that is not inside any git repo
+    with tempfile.TemporaryDirectory() as tmp:
+        assert not git_is_repo(tmp)
+
+
+@pytest.mark.library_setup(use_git=True)
+def test_is_git_repo_root_boundary(tmp_library: TemporaryLibrary) -> None:
+    libdir = tmp_library.libdir
+    sub = os.path.join(libdir, "sub")
+    os.makedirs(sub, exist_ok=True)
+
+    # boundary at libdir: subdir finds .git above it
+    assert git_is_repo(sub, root=libdir)
+    # boundary at libdir: libdir itself has .git
+    assert git_is_repo(libdir, root=libdir)
+    # boundary at sub: stops there, doesn't go up to libdir
+    assert not git_is_repo(sub, root=sub)
+
+
+def test_init(tmp_library: TemporaryLibrary) -> None:
+    """git_init creates a .git directory."""
+    target = os.path.join(tmp_library.tmpdir, "new_repo")
+    os.makedirs(target)
+    git_init(target)
+    assert os.path.isdir(os.path.join(target, ".git"))
+
+
+@pytest.mark.library_setup(use_git=True)
+def test_add_commit_roundtrip(tmp_library: TemporaryLibrary) -> None:
+    libdir = tmp_library.libdir
+
+    test_file = os.path.join(libdir, "test.txt")
+    with open(test_file, "w", encoding="utf-8") as f:
+        f.write("hello")
+
+    git_add(libdir, "test.txt")
+    git_commit(libdir, "add test file")
+
+    commits = _git_commits(libdir)
+    assert commits == 2  # initial + ours
+
+
+@pytest.mark.library_setup(use_git=True)
+def test_add_and_commit(tmp_library: TemporaryLibrary) -> None:
+    libdir = tmp_library.libdir
+
+    f1 = os.path.join(libdir, "a.txt")
+    f2 = os.path.join(libdir, "b.txt")
+    for f in (f1, f2):
+        with open(f, "w", encoding="utf-8") as fh:
+            fh.write("x")
+
+    git_add_and_commit(libdir, ["a.txt", "b.txt"], "add two files")
+
+    commits = _git_commits(libdir)
+    assert commits == 2  # initial + ours
+
+
+@pytest.mark.library_setup(use_git=True)
+def test_rm_cached_file(tmp_library: TemporaryLibrary) -> None:
+    libdir = tmp_library.libdir
+
+    test_file = os.path.join(libdir, "remove_me.txt")
+    with open(test_file, "w", encoding="utf-8") as f:
+        f.write("goodbye")
+
+    git_add(libdir, "remove_me.txt")
+    git_commit(libdir, "add file to remove")
+
+    # Simulate FS/DB-first: delete on disk, then rm_cached from index
+    os.remove(test_file)
+    git_rm_cached(libdir, "remove_me.txt")
+    git_commit(libdir, "remove file")
+
+    stdout = git_cmd("log", "-1", "--format=%B", cwd=libdir)
+    assert "remove file" in stdout
+
+    stdout = git_cmd("ls-files", "remove_me.txt", cwd=libdir)
+    assert stdout == ""
+
+
+@pytest.mark.library_setup(use_git=True)
+def test_rm_cached_recursive(tmp_library: TemporaryLibrary) -> None:
+    libdir = tmp_library.libdir
+
+    subdir = os.path.join(libdir, "subdir")
+    os.makedirs(subdir)
+    for name in ("a.txt", "b.txt"):
+        with open(os.path.join(subdir, name), "w", encoding="utf-8") as f:
+            f.write(name)
+
+    git_add(libdir, "subdir")
+    git_commit(libdir, "add subdir")
+
+    # FS/DB-first: delete the directory, then rm_cached --recursive
+    shutil.rmtree(subdir)
+    git_rm_cached(libdir, "subdir", recursive=True)
+    git_commit(libdir, "remove subdir")
+
+    # Files should be gone from the index
+    stdout = git_cmd("ls-files", "subdir", cwd=libdir)
+    assert stdout == ""
+
+
+@pytest.mark.library_setup(use_git=True)
+def test_git_operations_raise_on_failure(tmp_library: TemporaryLibrary) -> None:
+    with tempfile.TemporaryDirectory() as tmp:
+        with pytest.raises(GitError):
+            git_commit(tmp, "not a repo — should fail")


### PR DESCRIPTION
I was adding git functionality to the API and realised that the current `papis/git.py` functions aren't really useful (mostly because they silence errors). I then realised that in order to fix that, I have to fix the `run()` function in `utils.py`, and once that allowed us to catch stdout/stderr, there were the various call sites that needed fixing. Which is to say, this got a little out of hand. I tried to put it all into more or less coherent commits, but the PR as such touches on quite a few things.

Main points:
 - Uniform git pattern: every mutation does filesystem + database first, then attempts git tracking. Failure just means uncommitted. This means `git.py` is now index-only: `rm_cached` replaces `remove`. `mv`/`mv_and_commit` removed. Here we rely on rm+add = mv.
 - Centralized error logging: `_run_git` catches, logs git stderr through papis, re-raises. Call sites just pass.
 - `--batch` for explore cmd: Once we had error handling for `subprocess.run()`, it just made sense to add this.
 - `is_git_repo` lifted from `init.py` with optional root boundary (for server/API safety).

One question: Currently, any failures in git operations just pass, which means Papis continues, but the git state is wrong. Should we do that differently? There's two other options:
1. Raise errors. This might be unexpected for `--batch` operations and maybe too strict given that git failures don't leave the db in a bad state
2. Pass `batch` to all command `run()` functions and distinguish batch from no-batch. Maybe not worth the hassle