### PR TITLE
Use human-readable ruff rules

### DIFF
--- a/papis/bibtex.py
+++ b/papis/bibtex.py
@@ -222,7 +222,7 @@ bibtex_type_required_keys_aliases = {
 # NOTE: Zotero translator fields are defined in
 #   https://github.com/zotero/zotero-schema
 # and were extracted with
-#   curl -s https://raw.githubusercontent.com/zotero/zotero-schema/master/schema.json | jq ' .itemTypes[].itemType'  # noqa: E501
+#   curl -s https://raw.githubusercontent.com/zotero/zotero-schema/master/schema.json | jq ' .itemTypes[].itemType'  # ruff:ignore[line-too-long]
 
 #: A mapping of arbitrary types to BibLaTeX types in :data:`bibtex_types`. This
 #: mapping can be used when translating from other software, e.g. Zotero has

--- a/papis/cli.py
+++ b/papis/cli.py
@@ -30,7 +30,7 @@ class FormatPatternParamType(FormatPatternParamTypeBase):
     #: Name of the parameter type (shown in the command-line).
     name: str = "pattern"
 
-    def convert(self,  # noqa: PLR6301
+    def convert(self,  # ruff:ignore[no-self-use]
                 value: Any,
                 param: click.Parameter | None,
                 ctx: click.Context | None) -> str | FormatPattern:
@@ -50,7 +50,7 @@ class FormatPatternParamType(FormatPatternParamTypeBase):
 class LibraryParamType(LibraryParamTypeBase):
     name: str = "library"
 
-    def shell_complete(self,  # noqa: PLR6301
+    def shell_complete(self,  # ruff:ignore[no-self-use]
                        ctx: click.Context,
                        param: click.Parameter,
                        incomplete: str) -> list[CompletionItem]:

--- a/papis/commands/bibtex.py
+++ b/papis/commands/bibtex.py
@@ -279,7 +279,7 @@ def cli_update(ctx: click.Context, _all: bool,
         if fromdb:
             logger.info("Updating BibTeX entry from library.")
             if keys:
-                docs[j].update({k: libdoc[k] for k in keys if k in libdoc})  # noqa: PLR1736
+                docs[j].update({k: libdoc[k] for k in keys if k in libdoc})  # ruff:ignore[unnecessary-list-index-lookup]
             else:
                 docs[j] = libdoc.copy()
 

--- a/papis/commands/mv.py
+++ b/papis/commands/mv.py
@@ -320,7 +320,7 @@ def run(
 @click.option(
     "--target-library",
     help="Target library",
-    default=lambda: papis.config.get_lib_name(),  # noqa: PLW0108
+    default=lambda: papis.config.get_lib_name(),  # ruff:ignore[unnecessary-lambda]
     type=str,
 )
 @papis.cli.bool_flag(

--- a/papis/commands/serve.py
+++ b/papis/commands/serve.py
@@ -142,7 +142,7 @@ class PapisRequestHandler(http.server.BaseHTTPRequestHandler):
     The main request handler of the Papis web application.
     """
 
-    def log_message(self, fmt: str, *args: Any) -> None:  # noqa: PLR6301
+    def log_message(self, fmt: str, *args: Any) -> None:  # ruff:ignore[no-self-use]
         logger.info(fmt, *args)
 
     def _ok(self) -> None:
@@ -405,7 +405,7 @@ class PapisRequestHandler(http.server.BaseHTTPRequestHandler):
                                   f"Server path {self.path} not understood"
                                   )
 
-    def _handle_lib(self, libname: str) -> None:  # noqa: PLR6301
+    def _handle_lib(self, libname: str) -> None:  # ruff:ignore[no-self-use]
         from papis.api import set_lib_from_name
         set_lib_from_name(libname)
 

--- a/papis/crossref.py
+++ b/papis/crossref.py
@@ -172,7 +172,7 @@ def _get_crossref_key_conversion() -> list[KeyConversionPair]:
         }]),
         KeyConversionPair("link", [{
             "key": str(papis.config.getstring("doc-url-key-name")),
-            "action": lambda x: _crossref_link(x)  # noqa: PLW0108
+            "action": lambda x: _crossref_link(x)  # ruff:ignore[unnecessary-lambda]
         }]),
         KeyConversionPair("issued", [
             {"key": "year", "action": lambda x: _crossref_date_parts(x, 0)},
@@ -196,7 +196,7 @@ def _get_crossref_key_conversion() -> list[KeyConversionPair]:
             ]
         }]),
         KeyConversionPair("title", [
-            {"key": None, "action": lambda t: " ".join(t)}]),  # noqa: PLW0108
+            {"key": None, "action": lambda t: " ".join(t)}]),  # ruff:ignore[unnecessary-lambda]
         KeyConversionPair("type", [
             {"key": None, "action": lambda t: CROSSREF_TO_BIBTEX_CONVERTER[t]}]),
         KeyConversionPair("volume", [EmptyKeyConversion]),

--- a/papis/database/cache.py
+++ b/papis/database/cache.py
@@ -92,13 +92,13 @@ class PickleDatabase(Database):
         self.documents: list[Document] | None = None
         self.initialize()
 
-    def get_backend_name(self) -> str:  # noqa: PLR6301
+    def get_backend_name(self) -> str:  # ruff:ignore[no-self-use]
         return "papis"
 
     def get_cache_path(self) -> str:
         return self._get_cache_file_path()
 
-    def get_all_query_string(self) -> str:  # noqa: PLR6301
+    def get_all_query_string(self) -> str:  # ruff:ignore[no-self-use]
         return "."
 
     def initialize(self) -> None:

--- a/papis/database/sqlite.py
+++ b/papis/database/sqlite.py
@@ -207,13 +207,13 @@ class SQLiteDatabase(Database):
     def __del__(self) -> None:
         self._finalize_connection()
 
-    def get_backend_name(self) -> str:  # noqa: PLR6301
+    def get_backend_name(self) -> str:  # ruff:ignore[no-self-use]
         return "sqlite"
 
     def get_cache_path(self) -> str:
         return self.cache_file_name
 
-    def get_all_query_string(self) -> str:  # noqa: PLR6301
+    def get_all_query_string(self) -> str:  # ruff:ignore[no-self-use]
         return "*"
 
     def initialize(self) -> None:

--- a/papis/database/whoosh.py
+++ b/papis/database/whoosh.py
@@ -70,13 +70,13 @@ class WhooshDatabase(Database):
 
         self.initialize()
 
-    def get_backend_name(self) -> str:  # noqa: PLR6301
+    def get_backend_name(self) -> str:  # ruff:ignore[no-self-use]
         return "whoosh"
 
     def get_cache_path(self) -> str:
         return self.index_dir
 
-    def get_all_query_string(self) -> str:  # noqa: PLR6301
+    def get_all_query_string(self) -> str:  # ruff:ignore[no-self-use]
         return "*"
 
     def initialize(self) -> None:
@@ -247,13 +247,18 @@ class WhooshDatabase(Database):
         fields = self._get_schema_init_fields()
         return Schema(**fields)
 
-    def _get_schema_init_fields(self) -> dict[str, FieldType]:  # noqa: PLR6301
+    def _get_schema_init_fields(self) -> dict[str, FieldType]:  # ruff:ignore[no-self-use]
         """
         :returns: the keyword arguments to be passed to the Whoosh schema object
             (see :meth:`_create_schema`).
         """
         # NOTE: these are imported here so that `eval` sees them
-        from whoosh.fields import ID, KEYWORD, STORED, TEXT  # noqa: F401
+        from whoosh.fields import (  # ruff:ignore[unused-import]
+            ID,
+            KEYWORD,
+            STORED,
+            TEXT,
+        )
 
         # TODO: this is a security risk, find a way to fix it
         user_prototype = eval(papis.config.getstring("whoosh-schema-prototype"))

--- a/papis/docmatcher.py
+++ b/papis/docmatcher.py
@@ -208,32 +208,32 @@ class Pair(QueryItem):
 
 
 class QueryTransformer(Transformer[Any, QueryItem]):
-    def start(self, children: list[QueryItem]) -> QueryItem:  # noqa: PLR6301
+    def start(self, children: list[QueryItem]) -> QueryItem:  # ruff:ignore[no-self-use]
         if not children:
             return And([])
         return children[0]
 
-    def or_expr(self, children: list[QueryItem]) -> QueryItem:  # noqa: PLR6301
+    def or_expr(self, children: list[QueryItem]) -> QueryItem:  # ruff:ignore[no-self-use]
         return Or(children)
 
-    def and_expr(self, children: list[QueryItem]) -> QueryItem:  # noqa: PLR6301
+    def and_expr(self, children: list[QueryItem]) -> QueryItem:  # ruff:ignore[no-self-use]
         return And(children)
 
-    def not_op(self, children: list[QueryItem]) -> QueryItem:  # noqa: PLR6301
+    def not_op(self, children: list[QueryItem]) -> QueryItem:  # ruff:ignore[no-self-use]
         return Not(children[0])
 
-    def term(self, children: Sequence[Token]) -> Term:  # noqa: PLR6301
+    def term(self, children: Sequence[Token]) -> Term:  # ruff:ignore[no-self-use]
         term = str(children[0])
         return Term(term, get_regex_from_search(term))
 
-    def pair(self, children: Sequence[str]) -> Pair:  # noqa: PLR6301
+    def pair(self, children: Sequence[str]) -> Pair:  # ruff:ignore[no-self-use]
         key, value = children
         return Pair(key, value, get_regex_from_search(value))
 
-    def key(self, children: Sequence[Token]) -> str:  # noqa: PLR6301
+    def key(self, children: Sequence[Token]) -> str:  # ruff:ignore[no-self-use]
         return str(children[0])
 
-    def value(self, children: Sequence[Token]) -> str:  # noqa: PLR6301
+    def value(self, children: Sequence[Token]) -> str:  # ruff:ignore[no-self-use]
         return str(children[0])
 
 
@@ -269,7 +269,7 @@ def parse_query(query_string: str) -> QueryItem:
 
     :param query_string: a search string to parse into a structured format.
     :returns: a parsing result for the query string.
-    """  # noqa: E501
+    """  # ruff:ignore[line-too-long]
 
     logger.debug("Parsing query: '%s'.", query_string)
 

--- a/papis/doctor.py
+++ b/papis/doctor.py
@@ -488,11 +488,11 @@ BIBLATEX_KEY_CONVERT_NUMBER_REGEX = re.compile(
     r"^(?:(?:no\.?|nr\.?|suppl\.?)\s*)?"
     r"(?:"
     # pure numeric or range, e.g. 3, 3-4
-    r"\d+(?:\s*[-–]\s*\d+)?"  # noqa: RUF001
+    r"\d+(?:\s*[-–]\s*\d+)?"  # ruff:ignore[ambiguous-unicode-character-string]
     # letter+number combos, e.g. S1, 4B, 4es
     r"|[A-Za-z]?\s*\d+(?:[A-Za-z]+)?"
     # letter-hyphen-number, e.g. A-1, Suppl-A-3
-    r"|[A-Za-z]+\s*[-–]\s*\d+"  # noqa: RUF001
+    r"|[A-Za-z]+\s*[-–]\s*\d+"  # ruff:ignore[ambiguous-unicode-character-string]
     r")$",
     re.I
 )

--- a/papis/downloaders/get.py
+++ b/papis/downloaders/get.py
@@ -20,7 +20,7 @@ class DocumentDownloader(Downloader):
         False
         >>> DocumentDownloader.match('https://whatever?path?is?therefile') is None
         True
-        """  # noqa: E501
+        """  # ruff:ignore[line-too-long]
         endings = "pdf|djvu|epub|mobi|jpg|png|md"
         m = re.match(fr"^http.*\.({endings})$", url, re.IGNORECASE)
         if m:

--- a/papis/exporters/csl.py
+++ b/papis/exporters/csl.py
@@ -228,7 +228,7 @@ def exporter(documents: list[Document]) -> str:
     """Export documents using the CSL (Citation Style Language) styles."""
 
     try:
-        import citeproc  # noqa: F401
+        import citeproc  # ruff:ignore[unused-import]
     except ImportError:
         logger.error("CSL export requires the 'citeproc-py' package.")
         return ""

--- a/papis/exporters/typst.py
+++ b/papis/exporters/typst.py
@@ -25,7 +25,7 @@ def _get_hayagriva_key_conversions() -> list[KeyConversionPair]:
         }]),
         KeyConversionPair("author_list", [{
             "key": "author",
-            "action": lambda a: to_hayagriva_authors(a)  # noqa: PLW0108
+            "action": lambda a: to_hayagriva_authors(a)  # ruff:ignore[unnecessary-lambda]
         }]),
         KeyConversionPair("year", [{"key": "date", "action": None}]),
         KeyConversionPair("date", [{"key": "date", "action": None}]),
@@ -35,7 +35,7 @@ def _get_hayagriva_key_conversions() -> list[KeyConversionPair]:
         }]),
         KeyConversionPair("editor_list", [{
             "key": "editor",
-            "action": lambda a: to_hayagriva_authors(a)  # noqa: PLW0108
+            "action": lambda a: to_hayagriva_authors(a)  # ruff:ignore[unnecessary-lambda]
         }]),
         KeyConversionPair("publisher", [EmptyKeyConversion]),
         KeyConversionPair("location", [EmptyKeyConversion]),

--- a/papis/filetype.py
+++ b/papis/filetype.py
@@ -17,7 +17,7 @@ class DjVu(filetype.Type):      # type: ignore[misc]
     def __init__(self) -> None:
         super().__init__(mime=self.MIME, extension=self.EXTENSION)
 
-    def match(self, buf: bytes) -> bool:  # noqa: PLR6301
+    def match(self, buf: bytes) -> bool:  # ruff:ignore[no-self-use]
         # https://en.wikipedia.org/wiki/List_of_file_signatures
         # magic: AT&TFORMXXXXDJV[UM]
         return (

--- a/papis/format/jinja.py
+++ b/papis/format/jinja.py
@@ -53,7 +53,7 @@ class Jinja2Formatter(Formatter):
         super().__init__()
 
         try:
-            import jinja2  # noqa: F401
+            import jinja2  # ruff:ignore[unused-import]
         except ImportError as exc:
             logger.error(
                 "The 'jinja2' formatter requires the 'jinja2' library. "

--- a/papis/logging.py
+++ b/papis/logging.py
@@ -33,7 +33,7 @@ class ColoramaFormatter(logging.Formatter):
         #: used with ``logger.info(..., exc_info=ext)``.
         self.full_tb: bool = full_tb
 
-    def formatException(self, exc_info: tuple[Any, ...]) -> str:    # noqa: N802
+    def formatException(self, exc_info: tuple[Any, ...]) -> str:    # ruff:ignore[invalid-function-name]
         """Format and return the specified exception information as a string.
 
         If :attr:`full_tb` is *True*, then the full traceback is shown. Otherwise,

--- a/papis/pick/fzf.py
+++ b/papis/pick/fzf.py
@@ -55,7 +55,7 @@ class Browse(Command[T]):
     command = "become(echo browse {+n})"
     key = "ctrl-b"
 
-    def run(self, docs: list[T]) -> list[T]:  # noqa: PLR6301
+    def run(self, docs: list[T]) -> list[T]:  # ruff:ignore[no-self-use]
         from papis.commands.browse import run
         from papis.document import Document
 
@@ -70,7 +70,7 @@ class Choose(Command[T]):
     command = "become(echo choose {+n})"
     key = "enter"
 
-    def run(self, docs: list[T]) -> list[T]:  # noqa: PLR6301
+    def run(self, docs: list[T]) -> list[T]:  # ruff:ignore[no-self-use]
         return docs
 
 
@@ -79,7 +79,7 @@ class Edit(Command[T]):
     command = "become(echo edit {+n})"
     key = "ctrl-e"
 
-    def run(self, docs: list[T]) -> list[T]:  # noqa: PLR6301
+    def run(self, docs: list[T]) -> list[T]:  # ruff:ignore[no-self-use]
         from papis.commands.edit import run
         from papis.document import Document
 
@@ -94,7 +94,7 @@ class EditNote(Command[T]):
     command = "become(echo edit_notes {+n})"
     key = "ctrl-q"
 
-    def run(self, docs: list[T]) -> list[T]:  # noqa: PLR6301
+    def run(self, docs: list[T]) -> list[T]:  # ruff:ignore[no-self-use]
         from papis.commands.edit import edit_notes
         from papis.document import Document
 
@@ -109,7 +109,7 @@ class Open(Command[T]):
     command = "become(echo open {+n})"
     key = "ctrl-o"
 
-    def run(self, docs: list[T]) -> list[T]:  # noqa: PLR6301
+    def run(self, docs: list[T]) -> list[T]:  # ruff:ignore[no-self-use]
         from papis.commands.open import run
         from papis.document import Document
 

--- a/papis/sphinx_ext.py
+++ b/papis/sphinx_ext.py
@@ -102,7 +102,7 @@ class PapisConfig(Directive):
 
     def run(self) -> Any:
         # NOTE: these are imported to register additional config settings
-        import papis.commands.bibtex  # noqa: F401
+        import papis.commands.bibtex  # ruff:ignore[unused-import]
         from papis.config import get_default_settings, get_general_settings_name
 
         default_settings = get_default_settings()

--- a/papis/testing.py
+++ b/papis/testing.py
@@ -104,7 +104,7 @@ PAPIS_TEST_DOCUMENTS = [
         "journal": "Proceedings of the London Mathematical Society",
         "note": "First turing machine paper foundation of cs",
         "pages": "230--265",
-        "title": "On Computable Numbers with an Application to the Entscheidungsproblem",           # noqa: E501
+        "title": "On Computable Numbers with an Application to the Entscheidungsproblem",           # ruff:ignore[line-too-long]
         "url": "https://api.wiley.com/onlinelibrary/tdm/v1/articles/10.1112%2Fplms%2Fs2-42.1.230",
         "volume": "s2-42",
         "year": 1937,

--- a/papis/utils.py
+++ b/papis/utils.py
@@ -9,7 +9,7 @@ from warnings import warn
 
 try:
     # NOTE: multiprocessing is not available on some platforms (e.g. Android)
-    import multiprocessing.synchronize  # noqa: F401
+    import multiprocessing.synchronize  # ruff:ignore[unused-import]
     from multiprocessing import Pool
     HAS_MULTIPROCESSING = True
 except ImportError:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -290,22 +290,22 @@ select = [
 ]
 ignore = [
     # https://docs.astral.sh/ruff/rules/#rules
-    "N818",    # error-suffix-on-exception-name
-    "PLC0415", # import-outside-top-level
-    "PLC1901", # compare-to-empty-string
-    "PLR0904", # too-many-public-methods
-    "PLR0911", # too-many-return-statements
-    "PLR0912", # too-many-branches
-    "PLR0913", # too-many-arguments
-    "PLR0914", # too-many-local-variables
-    "PLR0915", # too-many-statements
-    "PLR0917", # too-many-positional
-    "PLR1702", # too-many-nested-blocks
-    "PLR2004", # magic-value-comparison
-    "PLR5501", # collapsible-else-if
-    "PLW0603", # global-statement
-    "PLW0717", # too-many-statements-in-try-clause
-    "RUF067",  # non-empty-init-module
+    "collapsible-else-if",
+    "compare-to-empty-string",
+    "error-suffix-on-exception-name",
+    "global-statement",
+    "import-outside-top-level",
+    "magic-value-comparison",
+    "non-empty-init-module",
+    "too-many-arguments",
+    "too-many-branches",
+    "too-many-locals",
+    "too-many-nested-blocks",
+    "too-many-positional-arguments",
+    "too-many-public-methods",
+    "too-many-return-statements",
+    "too-many-statements",
+    "too-many-statements-in-try-clause",
 ]
 task-tags = ["spell"]
 

--- a/tests/database/test_database.py
+++ b/tests/database/test_database.py
@@ -13,7 +13,7 @@ if TYPE_CHECKING:
 PAPIS_DB_BACKENDS = ["papis", "sqlite"]
 
 try:
-    import whoosh  # noqa: F401
+    import whoosh  # ruff:ignore[unused-import]
     PAPIS_DB_BACKENDS.append("whoosh")
 except ImportError:
     pass

--- a/tests/database/test_sqlite.py
+++ b/tests/database/test_sqlite.py
@@ -19,7 +19,9 @@ def test_schema_fields_extend_rebuilds_database(tmp_library: TemporaryLibrary) -
     cache_path = db.get_cache_path()
     assert os.path.exists(cache_path)
 
-    from papis.database.sqlite import _get_sqlite_fields  # noqa: PLC2701
+    from papis.database.sqlite import (
+        _get_sqlite_fields,  # ruff:ignore[import-private-name]
+    )
 
     initial_fields = _get_sqlite_fields(cache_path)
     assert "volume" not in initial_fields

--- a/tests/test_bibtex.py
+++ b/tests/test_bibtex.py
@@ -72,7 +72,7 @@ def test_clean_ref(tmp_config: TemporaryConfiguration) -> None:
     for (r, rc) in [
             (r"Albert Einstein ()\:1923", "Albert_Einstein:1923"),
             ("Einstein über etwas und so 1923", "Einstein_uber_etwas_und_so_1923"),
-            ("Äöasf () : Aλבert Eιنς€in", "Aoasf_Albert_EinsEURin"),  # noqa: RUF001
+            ("Äöasf () : Aλבert Eιنς€in", "Aoasf_Albert_EinsEURin"),  # ruff:ignore[ambiguous-unicode-character-string]
             (r"Albert_Ein\_stein\.1923.b", "Albert_Ein_stein.1923_b"),
             ]:
         assert rc == ref_cleanup(r)
@@ -161,7 +161,7 @@ def test_overridable(tmp_config: TemporaryConfiguration) -> None:
         "type": "report",
         "author": "Albert Einstein",
         "author_list": [{"given": "Albert", "family": "Einstein"}],
-        "title": "Ä α The Theory of Everything & Nothing",  # noqa: RUF001
+        "title": "Ä α The Theory of Everything & Nothing",  # ruff:ignore[ambiguous-unicode-character-string]
         "title_latex": r"The Theory of Everything \& Nothing",
         "journal": "Nature",
         "year": 2350,

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -81,8 +81,8 @@ def test_get(tmp_config: TemporaryConfiguration) -> None:
 
     # NOTE: float(str(x)) == x is always true, so we can check strict equality
     papis.config.set("test_getfloat", str(3.14))
-    assert papis.config.getfloat("test_getfloat") == 3.14  # noqa: RUF069
-    assert papis.config.getfloat("test_getfloat", section=section) == 3.14  # noqa: RUF069
+    assert papis.config.getfloat("test_getfloat") == 3.14  # ruff:ignore[float-equality-comparison]
+    assert papis.config.getfloat("test_getfloat", section=section) == 3.14  # ruff:ignore[float-equality-comparison]
     assert isinstance(papis.config.getfloat("test_getfloat", section=section), float)
 
     papis.config.set("test_getbool", "True")
@@ -117,7 +117,7 @@ def test_get_types(tmp_config: TemporaryConfiguration) -> None:
     papis.config.set("float_config", str(3.1415))
     val_float = papis.config.getfloat("float_config")
     assert isinstance(val_float, float)
-    assert val_float == 3.1415  # noqa: RUF069
+    assert val_float == 3.1415  # ruff:ignore[float-equality-comparison]
 
     papis.config.set("float_config", "not1")
     with pytest.raises(ValueError,

--- a/tests/test_deps.py
+++ b/tests/test_deps.py
@@ -19,23 +19,29 @@ def test_colorama() -> None:
 
 
 def test_prompt_toolkit() -> None:
-    from prompt_toolkit.application import Application  # noqa: F401
-    from prompt_toolkit.buffer import Buffer  # noqa: F401
-    from prompt_toolkit.enums import EditingMode  # noqa: F401
-    from prompt_toolkit.formatted_text.html import HTML, html_escape  # noqa: F401
-    from prompt_toolkit.history import FileHistory  # noqa: F401
-    from prompt_toolkit.key_binding import KeyBindings  # noqa: F401
-    from prompt_toolkit.layout.containers import HSplit, Window  # noqa: F401
-    from prompt_toolkit.layout.controls import (  # noqa: F401
+    from prompt_toolkit.application import Application  # ruff:ignore[unused-import]
+    from prompt_toolkit.buffer import Buffer  # ruff:ignore[unused-import]
+    from prompt_toolkit.enums import EditingMode  # ruff:ignore[unused-import]
+    from prompt_toolkit.formatted_text.html import (  # ruff:ignore[unused-import]
+        HTML,
+        html_escape,
+    )
+    from prompt_toolkit.history import FileHistory  # ruff:ignore[unused-import]
+    from prompt_toolkit.key_binding import KeyBindings  # ruff:ignore[unused-import]
+    from prompt_toolkit.layout.containers import (  # ruff:ignore[unused-import]
+        HSplit,
+        Window,
+    )
+    from prompt_toolkit.layout.controls import (  # ruff:ignore[unused-import]
         BufferControl,
         FormattedTextControl,
     )
-    from prompt_toolkit.layout.layout import Layout  # noqa: F401
-    from prompt_toolkit.widgets import HorizontalLine  # noqa: F401
+    from prompt_toolkit.layout.layout import Layout  # ruff:ignore[unused-import]
+    from prompt_toolkit.widgets import HorizontalLine  # ruff:ignore[unused-import]
 
     try:
         from prompt_toolkit.data_structures import Point
     except ImportError:
         from prompt_toolkit.layout.screen import (  # type: ignore[attr-defined]
-            Point,  # noqa: F401
+            Point,  # ruff:ignore[unused-import]
         )

--- a/tests/test_doctor.py
+++ b/tests/test_doctor.py
@@ -407,7 +407,7 @@ def test_biblatex_issue_to_number(tmp_config: TemporaryConfiguration) -> None:
         "number": "0",
         })
 
-    for value in (1, "3", "12", "No. 3", "1–2", "S1", "C2",  # noqa: RUF001
+    for value in (1, "3", "12", "No. 3", "1–2", "S1", "C2",  # ruff:ignore[ambiguous-unicode-character-string]
                   "4B", "4es", "A", "B", "A-1", "Suppl. 3"):
         del doc["number"]
         doc["issue"] = value
@@ -422,7 +422,9 @@ def test_biblatex_issue_to_number(tmp_config: TemporaryConfiguration) -> None:
 
 
 def test_string_cleaner_author_regex(tmp_config: TemporaryConfiguration) -> None:
-    from papis.doctor import _dotify_initials as dotify  # noqa: PLC2701
+    from papis.doctor import (
+        _dotify_initials as dotify,  # ruff:ignore[import-private-name]
+    )
 
     # basic ASCII
     assert dotify("F") == "F."
@@ -443,16 +445,16 @@ def test_string_cleaner_author_regex(tmp_config: TemporaryConfiguration) -> None
     assert dotify("Ñ Rodríguez") == "Ñ. Rodríguez"
 
     # cyrillic initials
-    assert dotify("А.С. Пушкин") == "А. С. Пушкин"  # noqa: RUF001
+    assert dotify("А.С. Пушкин") == "А. С. Пушкин"  # ruff:ignore[ambiguous-unicode-character-string]
     assert dotify("Л Толстой") == "Л. Толстой"
-    assert dotify("Ф.М. Достоевский") == "Ф. М. Достоевский"  # noqa: RUF001
+    assert dotify("Ф.М. Достоевский") == "Ф. М. Достоевский"  # ruff:ignore[ambiguous-unicode-character-string]
 
     # greek initials
-    assert dotify("Α.Β. Γεωργίου") == "Α. Β. Γεωργίου"  # noqa: RUF001
+    assert dotify("Α.Β. Γεωργίου") == "Α. Β. Γεωργίου"  # ruff:ignore[ambiguous-unicode-character-string]
 
     # mixed scripts (transliterated contexts)
     assert dotify("É.A. Müller") == "É. A. Müller"
-    assert dotify("Ç Yılmaz") == "Ç. Yılmaz"  # noqa: RUF001
+    assert dotify("Ç Yılmaz") == "Ç. Yılmaz"  # ruff:ignore[ambiguous-unicode-character-string]
     assert dotify("Ł.Ś. Kowalski") == "Ł. Ś. Kowalski"
 
     # mixed case
@@ -476,7 +478,7 @@ def test_string_cleaner(tmp_config: TemporaryConfiguration) -> None:
             "A new method for determining nucleotide sequences in DNA is described. "
             "It is similar to the “plus and minus” method [Sanger, F. & Coulson, "
             "A. R. (1975) J. Mol. Biol. 94, 441-448] but makes use of the "
-            "2′,3′-dideoxy and arabinonucleoside analogues of the normal "  # noqa: RUF001
+            "2′,3′-dideoxy and arabinonucleoside analogues of the normal "  # ruff:ignore[ambiguous-unicode-character-string]
             "deoxynucleoside triphosphates, which act as specific chain-terminating "
             "inhibitors of DNA polymerase. The technique has been applied to the "
             "DNA of bacteriophage ϕX174 and is more rapid and more accurate than "


### PR DESCRIPTION
New ruff `0.15.22` added rule `RUF105` to complain about `# noqa: CODE`. This moves everything to use `ruff:ignore[readable-name]`.