### PR TITLE
Update test for new citeproc default style

### DIFF
--- a/tests/test_csl.py
+++ b/tests/test_csl.py
@@ -9,7 +9,7 @@ if TYPE_CHECKING:
 
 
 def test_csl_export(tmp_config: TemporaryConfiguration) -> None:
-    pytest.importorskip("citeproc")
+    citeproc = pytest.importorskip("citeproc")
 
     from papis.document import from_data
     from papis.exporters.csl import export_document
@@ -21,10 +21,25 @@ def test_csl_export(tmp_config: TemporaryConfiguration) -> None:
         "title": "The Theory of Everything",
         "journal": "Nature",
         "year": 2350,
+        "pages": "1-24",
         "ref": "MyDocument"})
 
     result = export_document(doc, style_name="harvard1", formatter_name="rst")
-    assert result == "Einstein, A., 2350. The Theory of Everything. :emphasis:`Nature`."
+
+    # NOTE: older versions used a "harvard" style and newer versions use a
+    # "harvard-cite-them-right" style that's quite different, see:
+    #   https://github.com/citeproc-py/citeproc-py/pull/197
+    version = tuple(int(v) for v in citeproc.__version__.split("."))
+    if version < (0, 10, 3):
+        assert result == (
+            # ruff: ignore[ambiguous-unicode-character-string]
+            "Einstein, A., 2350. The Theory of Everything. :emphasis:`Nature`, pp.1–24."
+        )
+    else:
+        assert result == (
+            # ruff: ignore[ambiguous-unicode-character-string,line-too-long]
+            "Einstein, A. (2350) “The Theory of Everything”, :emphasis:`Nature`, pp. 1–24."
+        )
 
 
 def test_csl_style_download(tmp_config: TemporaryConfiguration) -> None:


### PR DESCRIPTION
They changed from an older `harvard1` style to a newer `harvard-cite-them-right` style, that messed up our check.