### PR TITLE
fix(add): abort 'papis add --edit' when the editor exits with an error

### DIFF
--- a/papis/api.py
+++ b/papis/api.py
@@ -135,21 +135,20 @@ def open_dir(dir_path: str, wait: bool = True) -> None:
     general_open(dir_path, "file-browser", wait=wait)
 
 
-def edit_file(file_path: str,
-              wait: bool = True,
-              raise_on_error: bool = False) -> None:
+def edit_file(file_path: str, wait: bool = True) -> None:
     """
     Edit the given file using the configured ``editor``.
 
     :param file_path: a path to a file.
     :param wait: if *True*, wait for the completion of the editor before
         continuing execution (blocking behavior).
-    :param raise_on_error: if *True*, a non-zero exit code of the editor is
-        raised as a :class:`subprocess.CalledProcessError`.
+
+    :raises subprocess.CalledProcessError: if the editor exits with a non-zero
+        exit code (only possible when *wait* is *True*).
     """
 
     from papis.utils import general_open
-    general_open(file_path, "editor", wait=wait, raise_on_error=raise_on_error)
+    general_open(file_path, "editor", wait=wait)
 
 
 def get_all_documents_in_lib(

--- a/papis/api.py
+++ b/papis/api.py
@@ -135,17 +135,21 @@ def open_dir(dir_path: str, wait: bool = True) -> None:
     general_open(dir_path, "file-browser", wait=wait)
 
 
-def edit_file(file_path: str, wait: bool = True) -> None:
+def edit_file(file_path: str,
+              wait: bool = True,
+              raise_on_error: bool = False) -> None:
     """
     Edit the given file using the configured ``editor``.
 
     :param file_path: a path to a file.
     :param wait: if *True*, wait for the completion of the editor before
         continuing execution (blocking behavior).
+    :param raise_on_error: if *True*, a non-zero exit code of the editor is
+        raised as a :class:`subprocess.CalledProcessError`.
     """
 
     from papis.utils import general_open
-    general_open(file_path, "editor", wait=wait)
+    general_open(file_path, "editor", wait=wait, raise_on_error=raise_on_error)
 
 
 def get_all_documents_in_lib(

--- a/papis/commands/add.py
+++ b/papis/commands/add.py
@@ -275,6 +275,13 @@ def run(paths: list[str],
             logger.error(
                 "Editor exited with code %d. No new document is created.",
                 exc.returncode)
+
+            import shutil
+
+            tmp_folder = tmp_document.get_main_folder()
+            if tmp_folder is not None:
+                shutil.rmtree(tmp_folder, ignore_errors=True)
+
             return
 
         tmp_document.load()

--- a/papis/commands/add.py
+++ b/papis/commands/add.py
@@ -270,7 +270,7 @@ def run(paths: list[str],
 
         import subprocess
         try:
-            edit_file(tmp_document.get_info_file(), wait=True, raise_on_error=True)
+            edit_file(tmp_document.get_info_file(), wait=True)
         except subprocess.CalledProcessError as exc:
             logger.error(
                 "Editor exited with code %d. No new document is created.",

--- a/papis/commands/add.py
+++ b/papis/commands/add.py
@@ -268,7 +268,15 @@ def run(paths: list[str],
         from papis.api import edit_file
         logger.info("Editing file before adding it.")
 
-        edit_file(tmp_document.get_info_file(), wait=True)
+        import subprocess
+        try:
+            edit_file(tmp_document.get_info_file(), wait=True, raise_on_error=True)
+        except subprocess.CalledProcessError as exc:
+            logger.error(
+                "Editor exited with code %d. No new document is created.",
+                exc.returncode)
+            return
+
         tmp_document.load()
 
     from papis.hooks import run as run_hook

--- a/papis/commands/edit.py
+++ b/papis/commands/edit.py
@@ -37,8 +37,15 @@ def run(document: Document,
 
     old_dict = to_dict(document)
 
+    import subprocess
+
     from papis.utils import general_open
-    general_open(info_file_path, "editor", wait=wait)
+    try:
+        general_open(info_file_path, "editor", wait=wait)
+    except subprocess.CalledProcessError as exc:
+        logger.error("Editor exited with code %d. Document is not updated.",
+                     exc.returncode)
+        return
 
     document.load()
     new_dict = to_dict(document)
@@ -85,8 +92,15 @@ def edit_notes(document: Document,
     from papis.notes import notes_path_ensured
     notes_path = notes_path_ensured(document)
 
+    import subprocess
+
     from papis.api import edit_file
-    edit_file(notes_path)
+    try:
+        edit_file(notes_path)
+    except subprocess.CalledProcessError as exc:
+        logger.error("Editor exited with code %d. Notes are not updated.",
+                     exc.returncode)
+        return
 
     if git:
         from papis.git import GitError, add_and_commit as git_add_and_commit

--- a/papis/utils.py
+++ b/papis/utils.py
@@ -194,8 +194,7 @@ def run(cmd: Sequence[str],
 def general_open(file_name: str,
                  key: str,
                  default_opener: str | None = None,
-                 wait: bool = True,
-                 raise_on_error: bool = False) -> None:
+                 wait: bool = True) -> None:
     """Open a file with a configured open tool (executable).
 
     :param file_name: a file path to open.
@@ -206,9 +205,9 @@ def general_open(file_name: str,
         *key*, if any, or the default ``papis`` opener are used.
     :param wait: if *True* wait for the process to finish, otherwise detach the
         process and return immediately.
-    :param raise_on_error: if *True*, a non-zero exit code of the opener is
-        raised as a :class:`subprocess.CalledProcessError` instead of only
-        being logged as a warning.
+
+    :raises subprocess.CalledProcessError: if the opener exits with a non-zero
+        exit code (only possible when *wait* is *True*).
     """
     from papis.exceptions import DefaultSettingValueMissing
 
@@ -228,20 +227,11 @@ def general_open(file_name: str,
     cmd = [*shlex.split(str(opener), posix=not is_windows), file_name]
 
     import shutil
-    import subprocess
     if shutil.which(cmd[0]) is None:
         raise FileNotFoundError(
             f"Command not found for '{key}': '{opener}'")
 
-    try:
-        run(cmd, wait=wait)  # type: ignore[call-overload]
-    except subprocess.CalledProcessError as exc:
-        if raise_on_error:
-            raise
-
-        logger.warning(
-            "Opener for '%s' exited with code %d.",
-            key, exc.returncode)
+    run(cmd, wait=wait)  # type: ignore[call-overload]
 
 
 def open_file(file_path: str, wait: bool = True) -> None:
@@ -251,7 +241,13 @@ def open_file(file_path: str, wait: bool = True) -> None:
     :param wait: if *True* wait for the process to finish, otherwise detach the
         process and return immediately.
     """
-    general_open(file_name=file_path, key="opentool", wait=wait)
+    import subprocess
+
+    try:
+        general_open(file_name=file_path, key="opentool", wait=wait)
+    except subprocess.CalledProcessError as exc:
+        logger.warning("Opener for 'opentool' exited with code %d.",
+                       exc.returncode)
 
 
 def get_folders(folder: str) -> list[str]:

--- a/papis/utils.py
+++ b/papis/utils.py
@@ -194,7 +194,8 @@ def run(cmd: Sequence[str],
 def general_open(file_name: str,
                  key: str,
                  default_opener: str | None = None,
-                 wait: bool = True) -> None:
+                 wait: bool = True,
+                 raise_on_error: bool = False) -> None:
     """Open a file with a configured open tool (executable).
 
     :param file_name: a file path to open.
@@ -205,6 +206,9 @@ def general_open(file_name: str,
         *key*, if any, or the default ``papis`` opener are used.
     :param wait: if *True* wait for the process to finish, otherwise detach the
         process and return immediately.
+    :param raise_on_error: if *True*, a non-zero exit code of the opener is
+        raised as a :class:`subprocess.CalledProcessError` instead of only
+        being logged as a warning.
     """
     from papis.exceptions import DefaultSettingValueMissing
 
@@ -232,6 +236,9 @@ def general_open(file_name: str,
     try:
         run(cmd, wait=wait)  # type: ignore[call-overload]
     except subprocess.CalledProcessError as exc:
+        if raise_on_error:
+            raise
+
         logger.warning(
             "Opener for '%s' exited with code %d.",
             key, exc.returncode)

--- a/tests/commands/test_add.py
+++ b/tests/commands/test_add.py
@@ -348,3 +348,25 @@ def test_add_set_invalid_format_cli(tmp_library: TemporaryLibrary) -> None:
     doc, = db.query_dict({"author": "Bertrand Russell"})
     assert doc["title"] == "Principia"
     assert not doc.get_files()
+
+
+@pytest.mark.skipif(
+    not shutil.which("false"),
+    reason="Test requires 'false' executable to be in the PATH")
+def test_add_edit_failure(tmp_library: TemporaryLibrary) -> None:
+    import papis.config
+    from papis.commands.add import run
+
+    papis.config.set("editor", "false")
+
+    from papis.testing import create_random_file
+    filename = create_random_file(dir=tmp_library.tmpdir)
+
+    run([filename],
+        data={"author": "Whitehead", "title": "Process and Reality"},
+        edit=True)
+
+    import papis.database
+
+    db = papis.database.get()
+    assert not db.query_dict({"author": "Whitehead"})

--- a/tests/commands/test_add.py
+++ b/tests/commands/test_add.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 import os
 import shutil
 import sys
+from typing import Any
 
 import pytest
 
@@ -353,11 +354,25 @@ def test_add_set_invalid_format_cli(tmp_library: TemporaryLibrary) -> None:
 @pytest.mark.skipif(
     not shutil.which("false"),
     reason="Test requires 'false' executable to be in the PATH")
-def test_add_edit_failure(tmp_library: TemporaryLibrary) -> None:
+def test_add_edit_failure(
+        tmp_library: TemporaryLibrary,
+        monkeypatch: pytest.MonkeyPatch) -> None:
+    import tempfile
+
     import papis.config
     from papis.commands.add import run
 
     papis.config.set("editor", "false")
+
+    temp_dirs = []
+    mkdtemp = tempfile.mkdtemp
+
+    def record_mkdtemp(*args: Any, **kwargs: Any) -> str:
+        path = mkdtemp(*args, **kwargs)
+        temp_dirs.append(path)
+        return path
+
+    monkeypatch.setattr(tempfile, "mkdtemp", record_mkdtemp)
 
     from papis.testing import create_random_file
     filename = create_random_file(dir=tmp_library.tmpdir)
@@ -370,3 +385,7 @@ def test_add_edit_failure(tmp_library: TemporaryLibrary) -> None:
 
     db = papis.database.get()
     assert not db.query_dict({"author": "Whitehead"})
+
+    # the temporary document folder should not be left behind (see gh-1211)
+    assert temp_dirs
+    assert not [d for d in temp_dirs if os.path.exists(d)]

--- a/tests/commands/test_add.py
+++ b/tests/commands/test_add.py
@@ -368,7 +368,7 @@ def test_add_edit_failure(
     mkdtemp = tempfile.mkdtemp
 
     def record_mkdtemp(*args: Any, **kwargs: Any) -> str:
-        path = mkdtemp(*args, **kwargs)
+        path: str = mkdtemp(*args, **kwargs)
         temp_dirs.append(path)
         return path
 

--- a/tests/commands/test_edit.py
+++ b/tests/commands/test_edit.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import os
+import shutil
 
 import pytest
 
@@ -90,3 +91,24 @@ def test_edit_cli(tmp_library: TemporaryLibrary) -> None:
 
     expected_notes_path = os.path.join(folder, notes_name)
     assert os.path.exists(expected_notes_path)
+
+
+@pytest.mark.skipif(
+    not shutil.which("false"),
+    reason="Test requires 'false' executable to be in the PATH")
+@pytest.mark.library_setup(settings={"editor": "false"})
+def test_edit_run_failure(tmp_library: TemporaryLibrary) -> None:
+    from papis.commands.edit import run
+
+    db = papis.database.get()
+    docs = db.get_all_documents()
+    doc = docs[0]
+
+    old_title = doc["title"]
+    run(doc)
+
+    db.clear()
+    db.initialize()
+
+    doc, = db.query_dict({"title": old_title})
+    assert doc["title"] == old_title


### PR DESCRIPTION
Closes #1117

`papis add --edit` ignored a dirty exit from `$EDITOR` (e.g. `:cq` in vim) and added the document anyway, because `general_open` only logs a warning on a non-zero exit code. `general_open`/`api.edit_file` now take an opt-in `raise_on_error` flag and `add` uses it to abort without creating the document; all other callers keep the warn-only behaviour.
