### PR TITLE
fix(export): make YAML export appendable

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -92,6 +92,10 @@ user can abort, skip problematic moves, or fix collisions interactively. A new
 - Fix crash in `papis add` when a given file path contains spaces (the DOI
   importer no longer tries to resolve local paths on doi.org)
   ([#1201](https://github.com/papis/papis/issues/1201)).
+- The YAML exporter now starts each document with an explicit `---` marker, so
+  that `papis export --format yaml --append` produces a valid multi-document
+  file instead of merging the documents together
+  ([#1038](https://github.com/papis/papis/issues/1038)).
 
 # VERSION v0.15.0 (February 8th, 2026)
 

--- a/papis/exporters/yaml.py
+++ b/papis/exporters/yaml.py
@@ -12,8 +12,12 @@ def exporter(documents: list[Document]) -> str:
 
     from papis.document import to_dict
 
+    # NOTE: 'explicit_start' adds a '---' marker before every document, so that
+    # the result can be safely concatenated with an existing YAML file, e.g. by
+    # 'papis export --append'.
     string = yaml.dump_all(
         [to_dict(document) for document in documents],
-        allow_unicode=True)
+        allow_unicode=True,
+        explicit_start=True)
 
     return str(string)

--- a/tests/commands/test_explore.py
+++ b/tests/commands/test_explore.py
@@ -64,6 +64,7 @@ def test_explore_yaml_cli(tmp_library: TemporaryLibrary) -> None:
         exported_yaml = fd.read()
 
     assert re.match(
+        r"---\n"
         r"author: K. Popper\n"
         r"doi: 10.1021/ct5004252\n"
         r"papis_id: .*\n"

--- a/tests/commands/test_export.py
+++ b/tests/commands/test_export.py
@@ -200,3 +200,23 @@ def test_export_folder_all_cli(tmp_library: TemporaryLibrary) -> None:
     for d in dirs:
         assert os.path.exists(d)
         assert os.path.isdir(d)
+
+
+def test_export_yaml_append(tmp_library: TemporaryLibrary) -> None:
+    from papis.commands.export import cli
+
+    cli_runner = PapisRunner()
+    outfile = os.path.join(tmp_library.tmpdir, "test_append.yaml")
+
+    for query in ("krishnamurti", "popper"):
+        result = cli_runner.invoke(
+            cli,
+            ["--append", "--format", "yaml", "--out", outfile, query])
+        assert result.exit_code == 0
+
+    from papis.yaml import yaml_to_list
+    data = yaml_to_list(outfile, raise_exception=True)
+
+    assert len(data) == 2
+    assert "Krishnamurti" in data[0]["author"]
+    assert "Popper" in data[1]["author"]


### PR DESCRIPTION
Closes #1038 (the YAML part).

`export --append` concatenates the exporter output onto the existing file, but the YAML exporter emitted no document separator, so the result parsed as a single merged document — appending a second document silently overwrote the first one's keys rather than adding to the file.

Passing `explicit_start=True` to `yaml.dump_all` prefixes every document with `---`, which makes the output safe to concatenate. New `test_export_yaml_append` fails on `main` (1 document parsed instead of 2) and passes with the fix.
