### PR TITLE
Fix/new doc no empty files field

### DIFF
--- a/papis/document.py
+++ b/papis/document.py
@@ -829,7 +829,8 @@ def new(
 
         document_file_list.append(out_file_name)
 
-    doc["files"] = document_file_list
+    if document_file_list:
+        doc["files"] = document_file_list
     doc.save()
 
     return doc

--- a/tests/test_document.py
+++ b/tests/test_document.py
@@ -38,6 +38,18 @@ def test_new(tmp_config: TemporaryConfiguration) -> None:
     assert len(doc2.get_files()) == 0
 
 
+def test_new_empty_files_not_persisted(tmp_config: TemporaryConfiguration) -> None:
+    """Creating a document without files must not persist an empty 'files' key."""
+    doc = papis.document.new({"author": "hello"}, [])
+
+    assert "files" not in doc
+
+    info_file = doc.get_info_file()
+    assert os.path.exists(info_file)
+    with open(info_file, encoding="utf-8") as f:
+        assert "files" not in f.read()
+
+
 def test_new_derives_author_list(tmp_config: TemporaryConfiguration) -> None:
     # NOTE: a flat 'author' (e.g. from `papis add --set author ...`) should be
     # parsed into a structured 'author_list' so that formats using it work


### PR DESCRIPTION
Fix `document.new()` so  we don't end up with an empty list of files when creating a doc without files.