### PR TITLE
Allow passing `PAPIS_DATABASE_BACKEND` to the container when running `papis-run-container-tests`

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -157,7 +157,8 @@
                   +
                   # bash
                   ''
-                    "$container_cmd" run -v "$(pwd)":/papis --rm -it papisdev
+                    "$container_cmd" run --env PAPIS_DATABASE_BACKEND \
+                      -v "$(pwd)":/papis --rm -it papisdev
                   '';
               };
 

--- a/flake.nix
+++ b/flake.nix
@@ -73,11 +73,15 @@
                 attrs
                 // {
                   # Because we're following main, use the git rev as version
-                  version = if (self ? rev)
-                    then "${project.pyproject.project.version}+git.${self.shortRev}"
-                    else self.dirtyShortRev;
+                  version =
+                    if (self ? rev) then
+                      "${project.pyproject.project.version}+git.${self.shortRev}"
+                    else
+                      "${project.pyproject.project.version}+git.${
+                        builtins.replaceStrings [ "-" ] [ "." ] self.dirtyShortRev
+                      }";
 
-                  nativeBuildInputs = (attrs.nativeBuildInputs or []) ++ [
+                  nativeBuildInputs = (attrs.nativeBuildInputs or [ ]) ++ [
                     final.pyprojectVersionPatchHook
                   ];
                 }


### PR DESCRIPTION
I wanted to be able to pass the `PAPIS_DATABASE_BACKEND` env to the container when running the tests so I can test the different backends.

This also surfaced a bug with the version strings being incompatible with PEP440 requirements.