### PR TITLE
Unmask config lookup failure, fix test

### DIFF
--- a/.readthedocs.yml
+++ b/.readthedocs.yml
@@ -4,9 +4,9 @@ sphinx:
   configuration: doc/source/conf.py
 
 build:
-  os: ubuntu-22.04
+  os: ubuntu-24.04
   tools:
-    python: "3.11"
+    python: "3.14"
 
 python:
   install:

--- a/doc/source/developer_reference.rst
+++ b/doc/source/developer_reference.rst
@@ -66,6 +66,12 @@ Developer API reference
 .. automodule:: papis.docmatcher
     :members:
 
+``papis.doctor``
+----------------
+
+.. automodule:: papis.doctor
+    :members:
+
 ``papis.document``
 ------------------
 

--- a/papis/commands/default.py
+++ b/papis/commands/default.py
@@ -197,12 +197,11 @@ def run(ctx: click.Context,
                 "configuration file.",
                 library, library.path)
     elif ctx.invoked_subcommand != "init":
-        logger.error("No configuration file exists at '%s'.", config_file)
-        logger.error("Create a configuration file and define your "
-                     "libraries before using Papis. You can use "
-                     "'papis init /path/to/my/library' for a quick "
-                     "interactive setup.")
-        raise click.FileError(config_file, hint="No configuration file exists there")
+        logger.warning("No configuration file exists at '%s'.", config_file)
+        logger.warning("Create a configuration file and define your "
+                       "libraries before using Papis. You can use "
+                       "'papis init /path/to/my/library' for a quick "
+                       "interactive setup.")
 
     # read in configuration from command-line
     sections = configuration.sections()

--- a/papis/commands/default.py
+++ b/papis/commands/default.py
@@ -182,26 +182,27 @@ def run(ctx: click.Context,
         raise SystemExit(1) from None
 
     configuration = papis.config.get_configuration()
-    if os.path.isdir(library.path):
-        # Check if there's a local configuration file in the library, and if so,
-        # merge its contents
-        local_config_file = papis.config.getstring("local-config-file")
-        local_config_path = os.path.join(library.path, local_config_file)
-        papis.config.merge_configuration_from_path(local_config_path, configuration)
-    else:
-        config_file = papis.config.get_config_file()
-        if os.path.exists(config_file):
+    config_file = papis.config.get_config_file()
+    if os.path.isfile(config_file):
+        if os.path.isdir(library.path):
+            # Check if there's a local configuration file in the library, and if so,
+            # merge its contents
+            local_config_file = papis.config.getstring("local-config-file")
+            local_config_path = os.path.join(library.path, local_config_file)
+            papis.config.merge_configuration_from_path(local_config_path, configuration)
+        else:
             logger.error(
                 "Library '%s' directory '%s' does not exist. Please "
                 "create it or update the 'dir' setting in the "
                 "configuration file.",
                 library, library.path)
-        elif ctx.invoked_subcommand != "init":
-            logger.warning("No configuration file exists at '%s'.", config_file)
-            logger.warning("Create a configuration file and define your "
-                           "libraries before using Papis. You can use "
-                           "'papis init /path/to/my/library' for a quick "
-                           "interactive setup.")
+    elif ctx.invoked_subcommand != "init":
+        logger.error("No configuration file exists at '%s'.", config_file)
+        logger.error("Create a configuration file and define your "
+                     "libraries before using Papis. You can use "
+                     "'papis init /path/to/my/library' for a quick "
+                     "interactive setup.")
+        raise click.FileError(config_file, hint="No configuration file exists there")
 
     # read in configuration from command-line
     sections = configuration.sections()

--- a/papis/document.py
+++ b/papis/document.py
@@ -666,41 +666,57 @@ def describe(document: Document | dict[str, Any]) -> str:
         document, default=document.get("title", str(document)))
 
 
-def move(document: Document, path: str) -> None:
+def move(document: Document, path: str, *, dirumask: int | None = None) -> None:
     """Move the *document* to a new main folder at *path*.
 
-    This supposes that the document exists in the location
-    ``document.get_main_folder()`` and will change the folder in the input
-    *document* as a result.
+    This assumes that the document exists in the location given by
+    :meth:`~Document.get_main_folder`. It will move the document from there to
+    *path* and also change the main folder in the input *document*.
 
     :param path: absolute path where the document should be moved to. This
         path is expected to not exist yet and will be created by this function.
+    :param dirumask: a umask used by the new document folder. This defaults to
+        :confval:`dir-umask` or ``0o600`` if that is *None*.
 
+    >>> import tempfile
     >>> doc = from_data({'title': 'Hello World'})
-    >>> doc.set_folder('path/to/folder')
-    >>> import tempfile; newfolder = tempfile.mkdtemp()
+    >>> doc.set_folder(tempfile.mkdtemp())
+    >>> newfolder = tempfile.mkdtemp()
     >>> move(doc, newfolder)
     Traceback (most recent call last):
     ...
-    FileExistsError: There is already...
+    FileExistsError: cannot move document to directory...
     """
     folder = document.get_main_folder()
     if not folder:
         return
 
+    if not os.path.exists(folder):
+        raise FileNotFoundError(f"document main folder does not exist: '{folder}'")
+
     path = os.path.expanduser(path)
     if os.path.exists(path):
-        raise FileExistsError(
-            f"There is already a document at '{path}' that should be checked. "
-            f"A temporary document has been stored at '{folder}'"
+        if os.path.isdir(path):
+            raise FileExistsError(f"cannot move document to directory '{path}'")
+        else:
+            raise NotADirectoryError(f"cannot move document to '{path}'")
+
+    # NOTE: we check this because shutil.move will automatically create the whole
+    # directory tree if the parents do not exist. We do not want this, because
+    # it usually means that the library dir does not exist or something like that!
+    if not os.path.isdir(os.path.dirname(path)):
+        raise NotADirectoryError(
+            f"cannot move document to a path whose parent does not exist: '{path}'"
         )
+
+    if dirumask is None:
+        # NOTE: 0o600 is used for temporary folders usually, so it's a good default
+        dirumask = papis.config.getint("dir-umask") or 0o600
 
     import shutil
     shutil.move(folder, path)
 
-    # Let us chmod it because it might come from a temp folder
-    # and temp folders are per default 0o600
-    os.chmod(path, papis.config.getint("dir-umask") or 0o600)
+    os.chmod(path, dirumask)
     document.set_folder(path)
 
 

--- a/papis/document.py
+++ b/papis/document.py
@@ -10,8 +10,8 @@ import papis.config
 import papis.logging
 
 if TYPE_CHECKING:
+    import pathlib
     from collections.abc import Callable, Sequence
-    from pathlib import Path
     from typing import Literal
 
     from papis.strings import AnyString
@@ -584,7 +584,7 @@ def from_folder(folder_path: str) -> Document:
     return Document(folder=folder_path)
 
 
-def is_document_folder(path: Path) -> bool:
+def is_document_folder(path: pathlib.Path) -> bool:
     """Check whether *path* is an existing document folder.
 
     A folder is considered a document folder if it contains an info file

--- a/tests/commands/test_default.py
+++ b/tests/commands/test_default.py
@@ -1,24 +1,46 @@
 from __future__ import annotations
 
+import os
 import shutil
+
+import platformdirs
+import pytest
 
 from papis.testing import PapisRunner, TemporaryConfiguration, TemporaryLibrary
 
 
-def test_no_config_shows_init_hint(tmp_config: TemporaryConfiguration) -> None:
+@pytest.mark.parametrize("with_library", [False, True])
+def test_no_config_shows_init_hint(tmp_config: TemporaryConfiguration,
+                                   monkeypatch: pytest.MonkeyPatch,
+                                   with_library: bool) -> None:
     import papis.config
     from papis.commands.default import run as cli
 
-    shutil.rmtree(tmp_config.configdir)
-    shutil.rmtree(tmp_config.libdir)
-    papis.config.reset_configuration()
+    with monkeypatch.context() as m:
+        # NOTE: this is the default directory set in
+        #   papis.config::Configuration.__init__
+        # See https://github.com/papis/papis/issues/1227
+        m.setattr(platformdirs, "user_documents_dir",
+                  lambda: os.path.join(tmp_config.tmpdir, "Documents"))
+        libdir = os.path.join(platformdirs.user_documents_dir(), "papers")
 
-    cli_runner = PapisRunner()
-    result = cli_runner.invoke(cli, ["list", "-c", tmp_config.configfile])
+        if with_library:
+            os.makedirs(libdir)
+        else:
+            assert not os.path.isdir(libdir)
 
-    assert result.exit_code == 1
-    assert "No configuration file exists at" in result.output
-    assert "papis init" in result.output
+        shutil.rmtree(tmp_config.configdir)
+        papis.config.reset_configuration()
+
+        cli_runner = PapisRunner()
+        result = cli_runner.invoke(cli, ["list"])
+
+        assert result.exit_code == 0
+        assert "No configuration file exists at" in result.output
+        assert "papis init" in result.output
+
+        if with_library:
+            os.rmdir(libdir)
 
 
 def test_default_cli(tmp_library: TemporaryLibrary) -> None:

--- a/tests/commands/test_default.py
+++ b/tests/commands/test_default.py
@@ -10,12 +10,13 @@ def test_no_config_shows_init_hint(tmp_config: TemporaryConfiguration) -> None:
     from papis.commands.default import run as cli
 
     shutil.rmtree(tmp_config.configdir)
+    shutil.rmtree(tmp_config.libdir)
     papis.config.reset_configuration()
 
     cli_runner = PapisRunner()
-    result = cli_runner.invoke(cli, ["list"])
+    result = cli_runner.invoke(cli, ["list", "-c", tmp_config.configfile])
 
-    assert result.exit_code == 0
+    assert result.exit_code == 1
     assert "No configuration file exists at" in result.output
     assert "papis init" in result.output
 


### PR DESCRIPTION

The default command's lookup order for config files was inverted, first looking up the local config file, and only then checking if the global config file exists. Moreover, it would entirely skip the check for the global config file if the selected library existed.
In addition, the test that was supposed to exercise this path was resetting the temporary configuration fixture it was receiving, so that if in the test environment the default library path `~/Documents/papers` existed, the error would be erroneously masked.
Finally, despite the absence of the global configuration file being an error, papis would only warn about it and not abort.

Instead, reverse the conditionals to get the correct behaviour and make this situation an error.
As for the test, resetting the configuration is actually *correct*, since there is no way in regular operation to mutate papis's internal state to monkeypatch in the expected erroneous configuration.
Rather, explicitly set papis to try to load a nonexistent config file instead.

Closes: #1227
