### PR TITLE
Remove trailing separator when joining authors

### DIFF
--- a/papis/document.py
+++ b/papis/document.py
@@ -181,7 +181,11 @@ def author_list_to_author(
 
     from papis.format import format
     return separator.join([
-        format(multiple_authors_format, author, doc_key="au")
+        # FIXME: that strip assumes either "Given Family" or "Family, Given", which
+        # is not particularly robust. It's needed so that separators in single-name
+        # authors don't end up in the author string, e.g.
+        #   https://doi.org/10.3389/fncom.2023.1215824
+        format(multiple_authors_format, author, doc_key="au").strip(" ,")
         for author in data["author_list"]
         ])
 

--- a/tests/test_document.py
+++ b/tests/test_document.py
@@ -310,6 +310,34 @@ def test_multiple_authors_separator(tmp_config: TemporaryConfiguration,
     assert result == "Cox and Little and O'Shea"
 
 
+@pytest.mark.parametrize("formatter", ["python", "jinja2"])
+def test_single_name_author(tmp_config: TemporaryConfiguration,
+                            formatter: str) -> None:
+    papis.config.set("formatter", formatter)
+
+    if formatter == "jinja2":
+        pytest.importorskip("jinja2")
+        multiple_authors_format = "{{ au.family }}, {{ au.given }}"
+    elif formatter == "python":
+        multiple_authors_format = "{au[family]}, {au[given]}"
+    else:
+        raise ValueError(f"Unknown formatter: '{formatter}'")
+
+    data = {
+        "author_list": [
+            {"family": "Turing", "given": "Alan"},
+            {"family": "Single"},
+        ],
+    }
+
+    from papis.document import author_list_to_author
+
+    result = author_list_to_author(data, separator=" and ",
+                                   multiple_authors_format=multiple_authors_format)
+
+    assert result == "Turing, Alan and Single"
+
+
 def test_author_separator_heuristics(tmp_config: TemporaryConfiguration) -> None:
     import re
 


### PR DESCRIPTION
Given an author list like `[{"given": "Bono", "family": None}, {"given": "John", "family": "Doe"}]`, this would give `, Bono and Doe, John`. This strips spaces and commas from the resulting strings and avoids this issue.

Not particularly happy with the fix, but it should work in most cases of interest..