### PR TITLE
Fix CSL export for some styles

### DIFF
--- a/papis/commands/add.py
+++ b/papis/commands/add.py
@@ -320,7 +320,8 @@ def run(paths: list[str],
         dup_text = " (duplicate) " if has_duplicate else " "
         text_area(
             dump(tmp_document),
-            title=f"This{dup_text}document will be added to your library",
+            title=f"This{dup_text}document will be added to the "
+                  f"'{papis.config.get_lib()}' library",
             lexer_name="yaml")
 
     if confirm:

--- a/papis/exporters/csl.py
+++ b/papis/exporters/csl.py
@@ -1,7 +1,6 @@
 from __future__ import annotations
 
 import os
-from contextlib import suppress
 from typing import TYPE_CHECKING, Any
 
 import papis.config
@@ -95,6 +94,7 @@ def to_csl(doc: Document) -> Reference:
     """
     from citeproc.source import Name
     from citeproc.source.bibtex import BibTeX
+    from citeproc.string import String
 
     # FIXME: we're using the fields from citeproc to make sure that we're
     # compatible with their CSL spec, but ideally this would map all BibTeX fields
@@ -107,9 +107,11 @@ def to_csl(doc: Document) -> Reference:
             continue
 
         csl_value: Any
-        if key in {"number", "volume"}:
-            with suppress(ValueError):
+        if key in {"number", "volume", "year"}:
+            try:
                 csl_value = int(value)
+            except ValueError:
+                csl_value = String(str(value))
         elif key == "pages":
             # NOTE: this just tries to remove any double dashes from the pages
             csl_value = "-".join([
@@ -124,7 +126,7 @@ def to_csl(doc: Document) -> Reference:
         else:
             # FIXME: citeproc seems to have some notion of MixedString that
             # allows keeping some words capitalized. We don't have that..
-            csl_value = str(value)
+            csl_value = String(str(value))
 
         result[csl_key] = csl_value
 

--- a/tests/test_csl.py
+++ b/tests/test_csl.py
@@ -29,7 +29,7 @@ def test_csl_export(tmp_config: TemporaryConfiguration) -> None:
     # NOTE: older versions used a "harvard" style and newer versions use a
     # "harvard-cite-them-right" style that's quite different, see:
     #   https://github.com/citeproc-py/citeproc-py/pull/197
-    version = tuple(int(v) for v in citeproc.__version__.split("."))
+    version = tuple(int(v) for v in citeproc.__version__.split("+")[0].split("."))
     if version < (0, 10, 3):
         assert result == (
             # ruff: ignore[ambiguous-unicode-character-string]


### PR DESCRIPTION
Not quite sure what the error is, but some styles would break when exporting strings, such as the title, because they expected them to be a `citeproc.string.String`. 

This converts strings when possible to avoid that. It seems like most styles work now. Tested with something like
```
papis --set csl-style apa-6th-edition --set csl-formatter plain export -f csl -a QUERY 
```
failed before this PR and works with it.